### PR TITLE
[BACKUP] az backup policy create: Added support for IaaSVM backup policy creation from CLI

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -178,6 +178,7 @@ def set_policy(client, resource_group_name, vault_name, policy, policy_name):
 
     return client.create_or_update(vault_name, resource_group_name, policy_name, policy_object)
 
+
 def create_policy(client, resource_group_name, vault_name, name, policy):
     policy_object = _get_policy_from_json(client, policy)
     policy_object.name = name

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -178,10 +178,10 @@ def set_policy(client, resource_group_name, vault_name, policy, policy_name):
     return client.create_or_update(vault_name, resource_group_name, policy_name, policy_object)
 
 
-def create_policy(client, resource_group_name, vault_name, name, policy, backup_management_type="AzureIaasVM"):
+def create_policy(client, resource_group_name, vault_name, name, policy):
     policy_object = _get_policy_from_json(client, policy)
     policy_object.name = name
-    policy_object.properties.backup_management_type = backup_management_type
+    policy_object.properties.backup_management_type = "AzureIaasVM"
     return client.create_or_update(vault_name, resource_group_name, name, policy_object)
 
 

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -32,7 +32,6 @@ from azure.cli.command_modules.backup._client_factory import (
 logger = get_logger(__name__)
 
 fabric_name = "Azure"
-backup_management_type = "AzureIaasVM"
 default_policy_name = "DefaultPolicy"
 os_windows = 'Windows'
 os_linux = 'Linux'
@@ -179,11 +178,10 @@ def set_policy(client, resource_group_name, vault_name, policy, policy_name):
     return client.create_or_update(vault_name, resource_group_name, policy_name, policy_object)
 
 
-def create_policy(client, resource_group_name, vault_name, name, policy):
+def create_policy(client, resource_group_name, vault_name, name, policy, backup_management_type="AzureIaasVM"):
     policy_object = _get_policy_from_json(client, policy)
     policy_object.name = name
-    if backup_management_type is not None:
-        policy_object.properties.backup_management_type = backup_management_type
+    policy_object.properties.backup_management_type = backup_management_type
     return client.create_or_update(vault_name, resource_group_name, name, policy_object)
 
 

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -32,6 +32,7 @@ from azure.cli.command_modules.backup._client_factory import (
 logger = get_logger(__name__)
 
 fabric_name = "Azure"
+backup_management_type = "AzureIaasVM"
 default_policy_name = "DefaultPolicy"
 os_windows = 'Windows'
 os_linux = 'Linux'
@@ -176,6 +177,13 @@ def set_policy(client, resource_group_name, vault_name, policy, policy_name):
         policy_object.properties.instant_rp_details = additional_properties['instantRpDetails']
 
     return client.create_or_update(vault_name, resource_group_name, policy_name, policy_object)
+
+def create_policy(client, resource_group_name, vault_name, name, policy):
+    policy_object = _get_policy_from_json(client, policy)
+    policy_object.name = name
+    if backup_management_type is not None:
+        policy_object.properties.backup_management_type = backup_management_type
+    return client.create_or_update(vault_name, resource_group_name, name, policy_object)
 
 
 def delete_policy(client, resource_group_name, vault_name, name):

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
@@ -40,6 +40,8 @@ def create_policy(client, resource_group_name, vault_name, name, policy, backup_
         if workload_type is None:
             raise CLIError("Please provide workload type.")
         return custom_wl.create_policy(client, resource_group_name, vault_name, name, policy, workload_type)
+    if backup_management_type.lower() == "azureiaasvm":
+        return custom.create_policy(client, resource_group_name, vault_name, name, policy)
     return None
 
 

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_policy.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_policy.yaml
@@ -25,16 +25,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2016-06-01
   response:
     body:
-      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-15T12%3A01%3A54.6287001Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-16T05%3A29%3A07.145647Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '539'
+      - '538'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:01:54 GMT
+      - Fri, 16 Oct 2020 05:29:07 GMT
       expires:
       - '-1'
       pragma:
@@ -72,7 +72,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -81,7 +81,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:01:55 GMT
+      - Fri, 16 Oct 2020 05:29:08 GMT
       expires:
       - '-1'
       pragma:
@@ -104,9 +104,9 @@ interactions:
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
       "instantRPDetails": {}, "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-15T22:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-16T15:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2020-10-15T22:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2020-10-16T15:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 2,
       "timeZone": "UTC"}}'
     headers:
@@ -133,7 +133,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -142,7 +142,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:01:57 GMT
+      - Fri, 16 Oct 2020 05:29:10 GMT
       expires:
       - '-1'
       pragma:
@@ -186,7 +186,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -195,7 +195,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:01:57 GMT
+      - Fri, 16 Oct 2020 05:29:10 GMT
       expires:
       - '-1'
       pragma:
@@ -218,9 +218,9 @@ interactions:
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
       "instantRPDetails": {}, "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-15T22:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-16T15:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2020-10-15T22:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2020-10-16T15:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 3,
       "timeZone": "UTC"}}'
     headers:
@@ -247,7 +247,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -256,7 +256,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:01:59 GMT
+      - Fri, 16 Oct 2020 05:29:11 GMT
       expires:
       - '-1'
       pragma:
@@ -300,7 +300,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-10-15T12:01:49Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-10-16T05:28:47Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -309,7 +309,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:02:01 GMT
+      - Fri, 16 Oct 2020 05:29:13 GMT
       expires:
       - '-1'
       pragma:
@@ -388,36 +388,35 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:02:01 GMT
+      - Fri, 16 Oct 2020 05:29:13 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Thu, 15 Oct 2020 12:07:01 GMT
+      - Fri, 16 Oct 2020 05:34:13 GMT
       source-age:
-      - '226'
+      - '189'
       strict-transport-security:
       - max-age=31536000
       vary:
       - Authorization,Accept-Encoding, Accept-Encoding
       via:
-      - 1.1 varnish (Varnish/6.0)
-      - 1.1 varnish
+      - 1.1 varnish (Varnish/6.0), 1.1 varnish
       x-cache:
-      - MISS, HIT
+      - HIT, HIT
       x-cache-hits:
-      - 0, 1
+      - 1, 1
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 45948d8154d08f12eb943ae2fbd3f04504256584
+      - 27fff518321187f8ee72e45b2aa60b340266aa97
       x-frame-options:
       - deny
       x-github-request-id:
-      - 99C2:0B9D:34BC9F:36FDF4:5F88184D
+      - DC7E:0B12:4A95DE:4DC35F:5F892705
       x-served-by:
-      - cache-sin18040-SIN
+      - cache-sin18046-SIN
       x-timer:
-      - S1602763321.493768,VS0,VE1
+      - S1602826153.489359,VS0,VE1
       x-xss-protection:
       - 1; mode=block
     status:
@@ -454,7 +453,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:02:01 GMT
+      - Fri, 16 Oct 2020 05:29:13 GMT
       expires:
       - '-1'
       pragma:
@@ -530,18 +529,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_yXNE922pgsZ78v3R9zarZklQpGmyTjq6","name":"vm_deploy_yXNE922pgsZ78v3R9zarZklQpGmyTjq6","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3886864059066874618","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-10-15T12:02:04.1937028Z","duration":"PT1.1831765S","correlationId":"6fa68cb4-9388-4892-9b19-02542c4295d2","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_LblmknQB0pWh5nHbaVtVBeLxN4R7JEDs","name":"vm_deploy_LblmknQB0pWh5nHbaVtVBeLxN4R7JEDs","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13015436836767274265","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-10-16T05:29:17.1406527Z","duration":"PT1.5470011S","correlationId":"d64bbe73-f954-4289-8752-600d85fa0a47","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_yXNE922pgsZ78v3R9zarZklQpGmyTjq6/operationStatuses/08585988435624671102?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_LblmknQB0pWh5nHbaVtVBeLxN4R7JEDs/operationStatuses/08585987807298839815?api-version=2020-06-01
       cache-control:
       - no-cache
       content-length:
-      - '2960'
+      - '2961'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:02:04 GMT
+      - Fri, 16 Oct 2020 05:29:17 GMT
       expires:
       - '-1'
       pragma:
@@ -551,7 +550,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -572,7 +571,7 @@ interactions:
       - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585988435624671102?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987807298839815?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -584,7 +583,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:02:34 GMT
+      - Fri, 16 Oct 2020 05:29:48 GMT
       expires:
       - '-1'
       pragma:
@@ -615,7 +614,7 @@ interactions:
       - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585988435624671102?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987807298839815?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -627,7 +626,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:03:04 GMT
+      - Fri, 16 Oct 2020 05:30:18 GMT
       expires:
       - '-1'
       pragma:
@@ -661,16 +660,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_yXNE922pgsZ78v3R9zarZklQpGmyTjq6","name":"vm_deploy_yXNE922pgsZ78v3R9zarZklQpGmyTjq6","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3886864059066874618","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-10-15T12:02:39.7969155Z","duration":"PT36.7863892S","correlationId":"6fa68cb4-9388-4892-9b19-02542c4295d2","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_LblmknQB0pWh5nHbaVtVBeLxN4R7JEDs","name":"vm_deploy_LblmknQB0pWh5nHbaVtVBeLxN4R7JEDs","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13015436836767274265","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-10-16T05:30:04.0652158Z","duration":"PT48.4715642S","correlationId":"d64bbe73-f954-4289-8752-600d85fa0a47","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4085'
+      - '4086'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:03:05 GMT
+      - Fri, 16 Oct 2020 05:30:18 GMT
       expires:
       - '-1'
       pragma:
@@ -710,16 +709,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"b31a8a63-848b-4851-8c82-9c996a0a2755\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"7ccc9165-6cd3-40d1-8bb6-4cb02b5a57e9\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_16ed0e55accb490c962364721012bf88\",\r\n
+        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_02f440ce872d4de78211c272f3754297\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGSU6WBHXJEGODSHFZVKKKWBWBQWLTIRZRBG7F3Z2XQMLE7UD4WLFIHR4KHRVGU4NJV/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_16ed0e55accb490c962364721012bf88\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGH7TBWBUWFRI37VDBUT7ZGGUBEXVPNMXE2H7UB6PMZXENT2OP74YSRLC44KJ4O6WIC/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_02f440ce872d4de78211c272f3754297\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000005\",\r\n
         \     \"adminUsername\": \"clitest-vm000005\",\r\n      \"windowsConfiguration\":
@@ -733,16 +732,16 @@ interactions:
         \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
         \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
         Ready\",\r\n            \"message\": \"VM status blob is found but not yet
-        populated.\",\r\n            \"time\": \"2020-10-15T12:03:06+00:00\"\r\n          }\r\n
+        populated.\",\r\n            \"time\": \"2020-10-16T05:30:19+00:00\"\r\n          }\r\n
         \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
-        \"clitest-vm000005_disk1_16ed0e55accb490c962364721012bf88\",\r\n          \"statuses\":
+        \"clitest-vm000005_disk1_02f440ce872d4de78211c272f3754297\",\r\n          \"statuses\":
         [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-10-15T12:02:12.9298726+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-10-16T05:29:34.9533737+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded/osProvisioningInProgress\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"OS provisioning
-        in progress\",\r\n          \"time\": \"2020-10-15T12:02:36.3360881+00:00\"\r\n
+        in progress\",\r\n          \"time\": \"2020-10-16T05:30:01.5940158+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -754,7 +753,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:03:06 GMT
+      - Fri, 16 Oct 2020 05:30:19 GMT
       expires:
       - '-1'
       pragma:
@@ -771,7 +770,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3992,Microsoft.Compute/LowCostGet30Min;31971
+      - Microsoft.Compute/LowCostGet3Min;3996,Microsoft.Compute/LowCostGet30Min;31996
     status:
       code: 200
       message: OK
@@ -798,14 +797,14 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000005VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic\",\r\n
-        \ \"etag\": \"W/\\\"f05e66c0-751d-4704-bd74-022278576137\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"69a41db6-02fa-4e3b-8598-49880f6f45c0\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"9c549e30-3406-4d36-8521-d7cb01b6ec57\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"ed56204f-56d6-486e-8649-a1b69cf5834c\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigclitest-vm000005\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic/ipConfigurations/ipconfigclitest-vm000005\",\r\n
-        \       \"etag\": \"W/\\\"f05e66c0-751d-4704-bd74-022278576137\\\"\",\r\n
+        \       \"etag\": \"W/\\\"69a41db6-02fa-4e3b-8598-49880f6f45c0\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
@@ -814,8 +813,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"ylvaamdqdzwelpfmyxoaqemlob.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-C8-AD-E1\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"qfhfmtfhhw0ulpubid53k3cyag.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-22-48-56-6F-8E\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -829,9 +828,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:03:06 GMT
+      - Fri, 16 Oct 2020 05:30:19 GMT
       etag:
-      - W/"f05e66c0-751d-4704-bd74-022278576137"
+      - W/"69a41db6-02fa-4e3b-8598-49880f6f45c0"
       expires:
       - '-1'
       pragma:
@@ -848,7 +847,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - f4635dba-9e75-4c34-914f-c394b527b60d
+      - 2f5968ca-2b44-4c41-8c21-d82672a6efef
     status:
       code: 200
       message: OK
@@ -875,13 +874,13 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000005PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"e4ef18d0-88a9-4985-b538-731a65587f08\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"622e5343-b043-4157-99a7-3ad197fa7651\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"b48999e5-a7ab-47df-a3ff-40c557cdb9a3\",\r\n
-        \   \"ipAddress\": \"52.237.127.139\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"5d3e6174-b570-44d7-b57d-13211634be82\",\r\n
+        \   \"ipAddress\": \"23.101.23.36\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic/ipConfigurations/ipconfigclitest-vm000005\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -889,13 +888,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1183'
+      - '1181'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:03:06 GMT
+      - Fri, 16 Oct 2020 05:30:19 GMT
       etag:
-      - W/"e4ef18d0-88a9-4985-b538-731a65587f08"
+      - W/"622e5343-b043-4157-99a7-3ad197fa7651"
       expires:
       - '-1'
       pragma:
@@ -912,7 +911,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 7e460074-7bc4-4c78-9428-696ec612420b
+      - c597f71a-e246-426b-b2dc-3678bd396c79
     status:
       code: 200
       message: OK
@@ -938,7 +937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-10-15T12:01:49Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-10-16T05:28:47Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -947,7 +946,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:03:06 GMT
+      - Fri, 16 Oct 2020 05:30:20 GMT
       expires:
       - '-1'
       pragma:
@@ -1026,13 +1025,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:03:07 GMT
+      - Fri, 16 Oct 2020 05:30:20 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Thu, 15 Oct 2020 12:08:07 GMT
+      - Fri, 16 Oct 2020 05:35:20 GMT
       source-age:
-      - '292'
+      - '256'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -1041,21 +1040,21 @@ interactions:
       - 1.1 varnish (Varnish/6.0)
       - 1.1 varnish
       x-cache:
-      - MISS, HIT
+      - HIT, HIT
       x-cache-hits:
-      - 0, 1
+      - 1, 2
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - f63822bc17d8505b7f05a61d32b1d03a9b1bcc5a
+      - 1631544cdcb3e6afb30adb55526925788dfe740a
       x-frame-options:
       - deny
       x-github-request-id:
-      - 99C2:0B9D:34BC9F:36FDF4:5F88184D
+      - DC7E:0B12:4A95DE:4DC35F:5F892705
       x-served-by:
-      - cache-sin18038-SIN
+      - cache-sin18022-SIN
       x-timer:
-      - S1602763388.632259,VS0,VE1
+      - S1602826221.794112,VS0,VE0
       x-xss-protection:
       - 1; mode=block
     status:
@@ -1085,17 +1084,17 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"clitest-vm000005VNET\",\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET\",\r\n
-        \     \"etag\": \"W/\\\"0d432fb9-30e5-441d-8193-41b800b1b692\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"1fd8b62a-469d-4083-9ed3-1f8e140a97ee\\\"\",\r\n      \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"southeastasia\",\r\n
         \     \"tags\": {\r\n        \"MabUsed\": \"Yes\",\r\n        \"Owner\": \"sisi\",\r\n
         \       \"Purpose\": \"CLITest\",\r\n        \"DeleteBy\": \"12-2099\",\r\n
         \       \"AutoShutdown\": \"No\"\r\n      },\r\n      \"properties\": {\r\n
         \       \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\":
-        \"3000eac2-1e70-456c-bcac-c5dc08118b71\",\r\n        \"addressSpace\": {\r\n
+        \"4c564e81-3da7-45b5-be81-40ffd5745806\",\r\n        \"addressSpace\": {\r\n
         \         \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n          ]\r\n
         \       },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
         \"clitest-vm000005Subnet\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET/subnets/clitest-vm000005Subnet\",\r\n
-        \           \"etag\": \"W/\\\"0d432fb9-30e5-441d-8193-41b800b1b692\\\"\",\r\n
+        \           \"etag\": \"W/\\\"1fd8b62a-469d-4083-9ed3-1f8e140a97ee\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"ipConfigurations\":
         [\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic/ipConfigurations/ipconfigclitest-vm000005\"\r\n
@@ -1111,7 +1110,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:03:07 GMT
+      - Fri, 16 Oct 2020 05:30:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1128,7 +1127,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e1523580-6d1d-4f42-9e42-2f23e45ac6ee
+      - a39796a1-74ee-40f5-bafd-012230962a6e
     status:
       code: 200
       message: OK
@@ -1188,18 +1187,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_pffzmSHD7GntALI1csEynkkKniM2L4v3","name":"vm_deploy_pffzmSHD7GntALI1csEynkkKniM2L4v3","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10583422459871746912","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-10-15T12:03:11.2607644Z","duration":"PT1.6667742S","correlationId":"bd228961-10cd-4aad-82ce-227c26a6b10f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_3Dd8TDm5Tc0ebfTdToVOovsazY3DUAlE","name":"vm_deploy_3Dd8TDm5Tc0ebfTdToVOovsazY3DUAlE","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5836018288145087110","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-10-16T05:30:26.4320979Z","duration":"PT1.4184497S","correlationId":"ac5092ff-5be8-44a0-8821-a00905c5d4a0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_pffzmSHD7GntALI1csEynkkKniM2L4v3/operationStatuses/08585988434958836401?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_3Dd8TDm5Tc0ebfTdToVOovsazY3DUAlE/operationStatuses/08585987806604639877?api-version=2020-06-01
       cache-control:
       - no-cache
       content-length:
-      - '2592'
+      - '2591'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:03:11 GMT
+      - Fri, 16 Oct 2020 05:30:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1230,7 +1229,7 @@ interactions:
       - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585988434958836401?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987806604639877?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1242,7 +1241,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:03:41 GMT
+      - Fri, 16 Oct 2020 05:30:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1273,7 +1272,7 @@ interactions:
       - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585988434958836401?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987806604639877?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1285,7 +1284,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:04:11 GMT
+      - Fri, 16 Oct 2020 05:31:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1319,16 +1318,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_pffzmSHD7GntALI1csEynkkKniM2L4v3","name":"vm_deploy_pffzmSHD7GntALI1csEynkkKniM2L4v3","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10583422459871746912","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-10-15T12:03:50.2682534Z","duration":"PT40.6742632S","correlationId":"bd228961-10cd-4aad-82ce-227c26a6b10f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_3Dd8TDm5Tc0ebfTdToVOovsazY3DUAlE","name":"vm_deploy_3Dd8TDm5Tc0ebfTdToVOovsazY3DUAlE","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5836018288145087110","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-10-16T05:31:09.8314694Z","duration":"PT44.8178212S","correlationId":"ac5092ff-5be8-44a0-8821-a00905c5d4a0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3501'
+      - '3500'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:04:12 GMT
+      - Fri, 16 Oct 2020 05:31:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1368,16 +1367,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"6d83da7c-a3ea-47e9-b895-556468c9079e\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"b08e97ce-23a7-4cb7-91af-ee82db850472\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000006_disk1_e2d41f81017c419894183e18226cde7c\",\r\n
+        \"Windows\",\r\n        \"name\": \"clitest-vm000006_disk1_c23b4ada5ca448e5b8707480ec12111a\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGSU6WBHXJEGODSHFZVKKKWBWBQWLTIRZRBG7F3Z2XQMLE7UD4WLFIHR4KHRVGU4NJV/providers/Microsoft.Compute/disks/clitest-vm000006_disk1_e2d41f81017c419894183e18226cde7c\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGH7TBWBUWFRI37VDBUT7ZGGUBEXVPNMXE2H7UB6PMZXENT2OP74YSRLC44KJ4O6WIC/providers/Microsoft.Compute/disks/clitest-vm000006_disk1_c23b4ada5ca448e5b8707480ec12111a\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000006\",\r\n
         \     \"adminUsername\": \"clitest-vm000006\",\r\n      \"windowsConfiguration\":
@@ -1391,16 +1390,16 @@ interactions:
         \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
         \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
         Ready\",\r\n            \"message\": \"VM status blob is found but not yet
-        populated.\",\r\n            \"time\": \"2020-10-15T12:04:13+00:00\"\r\n          }\r\n
+        populated.\",\r\n            \"time\": \"2020-10-16T05:31:29+00:00\"\r\n          }\r\n
         \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
-        \"clitest-vm000006_disk1_e2d41f81017c419894183e18226cde7c\",\r\n          \"statuses\":
+        \"clitest-vm000006_disk1_c23b4ada5ca448e5b8707480ec12111a\",\r\n          \"statuses\":
         [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-10-15T12:03:28.3674339+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-10-16T05:30:44.8439691+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
-        \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2020-10-15T12:03:46.8830207+00:00\"\r\n
+        \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded/osProvisioningInProgress\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"OS provisioning
+        in progress\",\r\n          \"time\": \"2020-10-16T05:31:07.5783444+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -1408,11 +1407,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '3419'
+      - '3449'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:04:13 GMT
+      - Fri, 16 Oct 2020 05:31:28 GMT
       expires:
       - '-1'
       pragma:
@@ -1429,7 +1428,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3990,Microsoft.Compute/LowCostGet30Min;31967
+      - Microsoft.Compute/LowCostGet3Min;3992,Microsoft.Compute/LowCostGet30Min;31992
     status:
       code: 200
       message: OK
@@ -1456,14 +1455,14 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000006VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic\",\r\n
-        \ \"etag\": \"W/\\\"362dac27-26ae-4f27-a3b5-0fd538cce1be\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"52e241a6-c907-471a-956c-699d43fc6c5a\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"c4b2f7c1-f8cb-4967-9e3f-b7c4ae541fa8\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"e81fc5ae-de7e-493f-b8e9-677a0dd5f7ca\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigclitest-vm000006\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic/ipConfigurations/ipconfigclitest-vm000006\",\r\n
-        \       \"etag\": \"W/\\\"362dac27-26ae-4f27-a3b5-0fd538cce1be\\\"\",\r\n
+        \       \"etag\": \"W/\\\"52e241a6-c907-471a-956c-699d43fc6c5a\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
@@ -1472,8 +1471,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"ylvaamdqdzwelpfmyxoaqemlob.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-C8-F6-4B\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"qfhfmtfhhw0ulpubid53k3cyag.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-22-48-56-B8-06\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -1487,9 +1486,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:04:13 GMT
+      - Fri, 16 Oct 2020 05:31:29 GMT
       etag:
-      - W/"362dac27-26ae-4f27-a3b5-0fd538cce1be"
+      - W/"52e241a6-c907-471a-956c-699d43fc6c5a"
       expires:
       - '-1'
       pragma:
@@ -1506,7 +1505,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 46d1db21-a1ac-45d8-9540-72947b8cf0b2
+      - 79f05fea-4ff1-4f27-91ca-43739dfc048e
     status:
       code: 200
       message: OK
@@ -1533,12 +1532,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000006PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"f1be6ddc-df0f-436d-846a-8293a5890aa8\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"f6cbab28-f2fe-4659-97c8-3013eb155cc2\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"b43585f8-f29d-4456-976a-1d7d96647ca5\",\r\n
-        \   \"ipAddress\": \"52.237.121.3\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"9c554d46-f5b7-4e75-b35a-6ab1b192c36e\",\r\n
+        \   \"ipAddress\": \"23.101.28.116\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
         \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic/ipConfigurations/ipconfigclitest-vm000006\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
@@ -1547,13 +1546,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1181'
+      - '1182'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:04:13 GMT
+      - Fri, 16 Oct 2020 05:31:29 GMT
       etag:
-      - W/"f1be6ddc-df0f-436d-846a-8293a5890aa8"
+      - W/"f6cbab28-f2fe-4659-97c8-3013eb155cc2"
       expires:
       - '-1'
       pragma:
@@ -1570,7 +1569,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - a8fe9107-6392-401b-a274-d395872c3726
+      - da9822dc-22bd-4482-8341-f19621914c0e
     status:
       code: 200
       message: OK
@@ -1600,16 +1599,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"b31a8a63-848b-4851-8c82-9c996a0a2755\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"7ccc9165-6cd3-40d1-8bb6-4cb02b5a57e9\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_16ed0e55accb490c962364721012bf88\",\r\n
+        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_02f440ce872d4de78211c272f3754297\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGSU6WBHXJEGODSHFZVKKKWBWBQWLTIRZRBG7F3Z2XQMLE7UD4WLFIHR4KHRVGU4NJV/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_16ed0e55accb490c962364721012bf88\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGH7TBWBUWFRI37VDBUT7ZGGUBEXVPNMXE2H7UB6PMZXENT2OP74YSRLC44KJ4O6WIC/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_02f440ce872d4de78211c272f3754297\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000005\",\r\n
         \     \"adminUsername\": \"clitest-vm000005\",\r\n      \"windowsConfiguration\":
@@ -1627,7 +1626,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:04:13 GMT
+      - Fri, 16 Oct 2020 05:31:29 GMT
       expires:
       - '-1'
       pragma:
@@ -1644,7 +1643,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3989,Microsoft.Compute/LowCostGet30Min;31966
+      - Microsoft.Compute/LowCostGet3Min;3991,Microsoft.Compute/LowCostGet30Min;31991
     status:
       code: 200
       message: OK
@@ -1670,16 +1669,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2016-06-01
   response:
     body:
-      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-15T12%3A01%3A54.6287001Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-16T05%3A29%3A07.145647Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '539'
+      - '538'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:14 GMT
+      - Fri, 16 Oct 2020 05:31:30 GMT
       expires:
       - '-1'
       pragma:
@@ -1719,7 +1718,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -1728,7 +1727,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:15 GMT
+      - Fri, 16 Oct 2020 05:31:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1779,7 +1778,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:16 GMT
+      - Fri, 16 Oct 2020 05:31:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1826,17 +1825,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2019-05-13-preview
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:04:17 GMT
+      - Fri, 16 Oct 2020 05:31:33 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -1869,7 +1868,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -1879,11 +1878,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:04:18 GMT
+      - Fri, 16 Oct 2020 05:31:33 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -1914,7 +1913,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -1924,11 +1923,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:04:20 GMT
+      - Fri, 16 Oct 2020 05:31:34 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -1959,7 +1958,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -1969,11 +1968,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:04:21 GMT
+      - Fri, 16 Oct 2020 05:31:36 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2004,7 +2003,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2014,11 +2013,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:04:22 GMT
+      - Fri, 16 Oct 2020 05:31:37 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2049,7 +2048,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2059,11 +2058,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:04:23 GMT
+      - Fri, 16 Oct 2020 05:31:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2094,7 +2093,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2104,11 +2103,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:04:24 GMT
+      - Fri, 16 Oct 2020 05:31:39 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2139,7 +2138,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2149,11 +2148,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:04:26 GMT
+      - Fri, 16 Oct 2020 05:31:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2184,7 +2183,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2194,11 +2193,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:04:27 GMT
+      - Fri, 16 Oct 2020 05:31:42 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2229,7 +2228,52 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Fri, 16 Oct 2020 05:31:43 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2237,7 +2281,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 15 Oct 2020 12:04:28 GMT
+      - Fri, 16 Oct 2020 05:31:44 GMT
       expires:
       - '-1'
       pragma:
@@ -2273,7 +2317,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2016-12-01&$filter=backupManagementType%20eq%20%27AzureIaasVM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;akneema;akneema-hana-vm/protectableItems/vm;iaasvmcontainerv2;akneema;akneema-hana-vm","name":"iaasvmcontainerv2;akneema;akneema-hana-vm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema/providers/Microsoft.Compute/virtualMachines/akneema-hana-vm","virtualMachineVersion":"Compute","resourceGroup":"akneema","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"akneema-hana-vm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;asebvtrg;asebvtseavm3/protectableItems/vm;iaasvmcontainerv2;asebvtrg;asebvtseavm3","name":"iaasvmcontainerv2;asebvtrg;asebvtseavm3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ASEBVTRG/providers/Microsoft.Compute/virtualMachines/asebvtseavm3","virtualMachineVersion":"Compute","resourceGroup":"ASEBVTRG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"asebvtseavm3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testcanarygeetasql/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testcanarygeetasql","name":"iaasvmcontainerv2;chandrikarg;testcanarygeetasql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testcanarygeetasql","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testcanarygeetasql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchg","name":"iaasvmcontainerv2;chandrikarg;testvmchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchgsql3/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchgsql3","name":"iaasvmcontainerv2;chandrikarg;testvmchgsql3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchgsql3","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchgsql3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmsqlchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmsqlchg","name":"iaasvmcontainerv2;chandrikarg;testvmsqlchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmsqlchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmsqlchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000005","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000006","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2014/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2014","name":"iaasvmcontainerv2;containerautoprotection;shrja-2014","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2014","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2014","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2019/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2019","name":"iaasvmcontainerv2;containerautoprotection;shrja-2019","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2019","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2019","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja2012r2/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja2012r2","name":"iaasvmcontainerv2;containerautoprotection;shrja2012r2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja2012R2","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2012R2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","name":"iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetasqlvmbanner14","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetasqlvmbanner14","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","name":"iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetsqlvmbanner1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetsqlvmbanner1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner10/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner10","name":"iaasvmcontainerv2;gesahoo;gesahoobanner10","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner10","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner10","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner11/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner11","name":"iaasvmcontainerv2;gesahoo;gesahoobanner11","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner11","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner11","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner12/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner12","name":"iaasvmcontainerv2;gesahoo;gesahoobanner12","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner12","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner12","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner5","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner5","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner6","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner6","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner7","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner7","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner8","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner9","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner9","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbannervm4","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbannervm4","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress2","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","name":"iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlvminprogress3","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlvminprogress3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","name":"iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlautobackupgeeta","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlautobackupgeeta","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","name":"iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlbannergeetacanary","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlbannergeetacanary","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testgesahoosql/protectableItems/vm;iaasvmcontainerv2;gesahoo;testgesahoosql","name":"iaasvmcontainerv2;gesahoo;testgesahoosql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testgesahoosql","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testgesahoosql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testprodgesahoo/protectableItems/vm;iaasvmcontainerv2;gesahoo;testprodgesahoo","name":"iaasvmcontainerv2;gesahoo;testprodgesahoo","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testProdGesahoo","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testProdGesahoo","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;nilay-rg;nilsha-test/protectableItems/vm;iaasvmcontainerv2;nilay-rg;nilsha-test","name":"iaasvmcontainerv2;nilay-rg;nilsha-test","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Nilay-RG/providers/Microsoft.Compute/virtualMachines/nilsha-test","virtualMachineVersion":"Compute","resourceGroup":"Nilay-RG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"nilsha-test","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8/protectableItems/vm;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","name":"iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pstestwlRG1bca8/providers/Microsoft.Compute/virtualMachines/pstestwlvm1bca8","virtualMachineVersion":"Compute","resourceGroup":"pstestwlRG1bca8","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"pstestwlvm1bca8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sarath-rg;sarathpstest001/protectableItems/vm;iaasvmcontainerv2;sarath-rg;sarathpstest001","name":"iaasvmcontainerv2;sarath-rg;sarathpstest001","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Compute/virtualMachines/sarathPSTest001","virtualMachineVersion":"Compute","resourceGroup":"sarath-rg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sarathPSTest001","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shrja2008_group;shrja2008/protectableItems/vm;iaasvmcontainerv2;shrja2008_group;shrja2008","name":"iaasvmcontainerv2;shrja2008_group;shrja2008","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shrja2008_group/providers/Microsoft.Compute/virtualMachines/shrja2008","virtualMachineVersion":"Compute","resourceGroup":"shrja2008_group","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2008","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","name":"iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/dsadsa","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"dsadsa","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;sddsds/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;sddsds","name":"iaasvmcontainerv2;shswain-rg-restoredata;sddsds","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/sddsds","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sddsds","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sisi-rsv;sisi-mercury/protectableItems/vm;iaasvmcontainerv2;sisi-rsv;sisi-mercury","name":"iaasvmcontainerv2;sisi-rsv;sisi-mercury","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sisi-RSV/providers/Microsoft.Compute/virtualMachines/sisi-mercury","virtualMachineVersion":"Compute","resourceGroup":"sisi-RSV","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sisi-mercury","protectionState":"NotProtected"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;akneema;akneema-hana-vm/protectableItems/vm;iaasvmcontainerv2;akneema;akneema-hana-vm","name":"iaasvmcontainerv2;akneema;akneema-hana-vm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema/providers/Microsoft.Compute/virtualMachines/akneema-hana-vm","virtualMachineVersion":"Compute","resourceGroup":"akneema","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"akneema-hana-vm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;asebvtrg;asebvtseavm3/protectableItems/vm;iaasvmcontainerv2;asebvtrg;asebvtseavm3","name":"iaasvmcontainerv2;asebvtrg;asebvtseavm3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ASEBVTRG/providers/Microsoft.Compute/virtualMachines/asebvtseavm3","virtualMachineVersion":"Compute","resourceGroup":"ASEBVTRG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"asebvtseavm3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testcanarygeetasql/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testcanarygeetasql","name":"iaasvmcontainerv2;chandrikarg;testcanarygeetasql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testcanarygeetasql","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testcanarygeetasql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchg","name":"iaasvmcontainerv2;chandrikarg;testvmchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchgsql3/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchgsql3","name":"iaasvmcontainerv2;chandrikarg;testvmchgsql3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchgsql3","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchgsql3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmsqlchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmsqlchg","name":"iaasvmcontainerv2;chandrikarg;testvmsqlchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmsqlchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmsqlchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000006","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000005","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2014/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2014","name":"iaasvmcontainerv2;containerautoprotection;shrja-2014","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2014","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2014","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2019/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2019","name":"iaasvmcontainerv2;containerautoprotection;shrja-2019","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2019","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2019","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja2012r2/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja2012r2","name":"iaasvmcontainerv2;containerautoprotection;shrja2012r2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja2012R2","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2012R2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","name":"iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetasqlvmbanner14","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetasqlvmbanner14","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","name":"iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetsqlvmbanner1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetsqlvmbanner1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner10/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner10","name":"iaasvmcontainerv2;gesahoo;gesahoobanner10","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner10","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner10","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner11/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner11","name":"iaasvmcontainerv2;gesahoo;gesahoobanner11","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner11","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner11","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner12/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner12","name":"iaasvmcontainerv2;gesahoo;gesahoobanner12","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner12","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner12","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner5","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner5","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner6","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner6","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner7","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner7","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner8","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner9","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner9","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbannervm4","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbannervm4","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress2","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","name":"iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlvminprogress3","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlvminprogress3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","name":"iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlautobackupgeeta","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlautobackupgeeta","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","name":"iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlbannergeetacanary","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlbannergeetacanary","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testgesahoosql/protectableItems/vm;iaasvmcontainerv2;gesahoo;testgesahoosql","name":"iaasvmcontainerv2;gesahoo;testgesahoosql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testgesahoosql","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testgesahoosql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testprodgesahoo/protectableItems/vm;iaasvmcontainerv2;gesahoo;testprodgesahoo","name":"iaasvmcontainerv2;gesahoo;testprodgesahoo","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testProdGesahoo","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testProdGesahoo","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;nilay-rg;nilsha-test/protectableItems/vm;iaasvmcontainerv2;nilay-rg;nilsha-test","name":"iaasvmcontainerv2;nilay-rg;nilsha-test","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Nilay-RG/providers/Microsoft.Compute/virtualMachines/nilsha-test","virtualMachineVersion":"Compute","resourceGroup":"Nilay-RG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"nilsha-test","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8/protectableItems/vm;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","name":"iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pstestwlRG1bca8/providers/Microsoft.Compute/virtualMachines/pstestwlvm1bca8","virtualMachineVersion":"Compute","resourceGroup":"pstestwlRG1bca8","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"pstestwlvm1bca8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sarath-rg;sarathpstest001/protectableItems/vm;iaasvmcontainerv2;sarath-rg;sarathpstest001","name":"iaasvmcontainerv2;sarath-rg;sarathpstest001","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Compute/virtualMachines/sarathPSTest001","virtualMachineVersion":"Compute","resourceGroup":"sarath-rg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sarathPSTest001","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shrja2008_group;shrja2008/protectableItems/vm;iaasvmcontainerv2;shrja2008_group;shrja2008","name":"iaasvmcontainerv2;shrja2008_group;shrja2008","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shrja2008_group/providers/Microsoft.Compute/virtualMachines/shrja2008","virtualMachineVersion":"Compute","resourceGroup":"shrja2008_group","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2008","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","name":"iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/dsadsa","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"dsadsa","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;sddsds/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;sddsds","name":"iaasvmcontainerv2;shswain-rg-restoredata;sddsds","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/sddsds","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sddsds","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sisi-rsv;sisi-mercury/protectableItems/vm;iaasvmcontainerv2;sisi-rsv;sisi-mercury","name":"iaasvmcontainerv2;sisi-rsv;sisi-mercury","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sisi-RSV/providers/Microsoft.Compute/virtualMachines/sisi-mercury","virtualMachineVersion":"Compute","resourceGroup":"sisi-RSV","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sisi-mercury","protectionState":"NotProtected"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -2282,7 +2326,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:29 GMT
+      - Fri, 16 Oct 2020 05:31:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2333,17 +2377,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationsStatus/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationsStatus/55954780-b347-453a-b66e-3192a4cfb620?api-version=2019-06-15
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:04:30 GMT
+      - Fri, 16 Oct 2020 05:31:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationResults/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationResults/55954780-b347-453a-b66e-3192a4cfb620?api-version=2019-06-15
       pragma:
       - no-cache
       strict-transport-security:
@@ -2351,7 +2395,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -2376,19 +2420,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:31 GMT
+      - Fri, 16 Oct 2020 05:31:47 GMT
       expires:
       - '-1'
       pragma:
@@ -2427,19 +2471,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:32 GMT
+      - Fri, 16 Oct 2020 05:31:49 GMT
       expires:
       - '-1'
       pragma:
@@ -2478,19 +2522,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:33 GMT
+      - Fri, 16 Oct 2020 05:31:50 GMT
       expires:
       - '-1'
       pragma:
@@ -2529,19 +2573,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:35 GMT
+      - Fri, 16 Oct 2020 05:31:51 GMT
       expires:
       - '-1'
       pragma:
@@ -2580,19 +2624,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:36 GMT
+      - Fri, 16 Oct 2020 05:31:52 GMT
       expires:
       - '-1'
       pragma:
@@ -2631,19 +2675,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:37 GMT
+      - Fri, 16 Oct 2020 05:31:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2682,19 +2726,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:38 GMT
+      - Fri, 16 Oct 2020 05:31:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2733,19 +2777,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:40 GMT
+      - Fri, 16 Oct 2020 05:31:56 GMT
       expires:
       - '-1'
       pragma:
@@ -2784,19 +2828,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:41 GMT
+      - Fri, 16 Oct 2020 05:31:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2835,19 +2879,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:42 GMT
+      - Fri, 16 Oct 2020 05:31:58 GMT
       expires:
       - '-1'
       pragma:
@@ -2886,19 +2930,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:43 GMT
+      - Fri, 16 Oct 2020 05:31:59 GMT
       expires:
       - '-1'
       pragma:
@@ -2937,19 +2981,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:44 GMT
+      - Fri, 16 Oct 2020 05:32:01 GMT
       expires:
       - '-1'
       pragma:
@@ -2988,19 +3032,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:45 GMT
+      - Fri, 16 Oct 2020 05:32:02 GMT
       expires:
       - '-1'
       pragma:
@@ -3039,19 +3083,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:47 GMT
+      - Fri, 16 Oct 2020 05:32:03 GMT
       expires:
       - '-1'
       pragma:
@@ -3090,19 +3134,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:48 GMT
+      - Fri, 16 Oct 2020 05:32:04 GMT
       expires:
       - '-1'
       pragma:
@@ -3141,19 +3185,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:50 GMT
+      - Fri, 16 Oct 2020 05:32:05 GMT
       expires:
       - '-1'
       pragma:
@@ -3192,19 +3236,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:51 GMT
+      - Fri, 16 Oct 2020 05:32:07 GMT
       expires:
       - '-1'
       pragma:
@@ -3243,19 +3287,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:52 GMT
+      - Fri, 16 Oct 2020 05:32:08 GMT
       expires:
       - '-1'
       pragma:
@@ -3294,19 +3338,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:54 GMT
+      - Fri, 16 Oct 2020 05:32:09 GMT
       expires:
       - '-1'
       pragma:
@@ -3345,19 +3389,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:55 GMT
+      - Fri, 16 Oct 2020 05:32:10 GMT
       expires:
       - '-1'
       pragma:
@@ -3396,19 +3440,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:56 GMT
+      - Fri, 16 Oct 2020 05:32:11 GMT
       expires:
       - '-1'
       pragma:
@@ -3447,19 +3491,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:58 GMT
+      - Fri, 16 Oct 2020 05:32:13 GMT
       expires:
       - '-1'
       pragma:
@@ -3498,19 +3542,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:04:59 GMT
+      - Fri, 16 Oct 2020 05:32:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3549,19 +3593,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:00 GMT
+      - Fri, 16 Oct 2020 05:32:15 GMT
       expires:
       - '-1'
       pragma:
@@ -3600,19 +3644,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"Succeeded","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"2020-10-15T12:04:30.5360642Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"0fd4821d-5b23-4675-b805-953f4a6638ac"}}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:01 GMT
+      - Fri, 16 Oct 2020 05:32:16 GMT
       expires:
       - '-1'
       pragma:
@@ -3651,20 +3695,122 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/0fd4821d-5b23-4675-b805-953f4a6638ac?api-version=2019-06-15
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/0fd4821d-5b23-4675-b805-953f4a6638ac","name":"0fd4821d-5b23-4675-b805-953f4a6638ac","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT30.9612716S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000005","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"2020-10-15T12:05:01.4973358Z","activityId":"8ad17eb0-0ede-11eb-9e60-c8f750f92764"}}'
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '968'
+      - '187'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:02 GMT
+      - Fri, 16 Oct 2020 05:32:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"Succeeded","startTime":"2020-10-16T05:31:47.348742Z","endTime":"2020-10-16T05:31:47.348742Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"51dd6221-43ae-4c29-9334-9fe0cf4a2255"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '302'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:32:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/51dd6221-43ae-4c29-9334-9fe0cf4a2255?api-version=2019-06-15
+  response:
+    body:
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/51dd6221-43ae-4c29-9334-9fe0cf4a2255","name":"51dd6221-43ae-4c29-9334-9fe0cf4a2255","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT31.0033595S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000005","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-10-16T05:31:47.348742Z","endTime":"2020-10-16T05:32:18.3521015Z","activityId":"d7dd48aa-0f70-11eb-bce6-c8f750f92764"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '967'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:32:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3711,16 +3857,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"6d83da7c-a3ea-47e9-b895-556468c9079e\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"b08e97ce-23a7-4cb7-91af-ee82db850472\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000006_disk1_e2d41f81017c419894183e18226cde7c\",\r\n
+        \"Windows\",\r\n        \"name\": \"clitest-vm000006_disk1_c23b4ada5ca448e5b8707480ec12111a\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGSU6WBHXJEGODSHFZVKKKWBWBQWLTIRZRBG7F3Z2XQMLE7UD4WLFIHR4KHRVGU4NJV/providers/Microsoft.Compute/disks/clitest-vm000006_disk1_e2d41f81017c419894183e18226cde7c\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGH7TBWBUWFRI37VDBUT7ZGGUBEXVPNMXE2H7UB6PMZXENT2OP74YSRLC44KJ4O6WIC/providers/Microsoft.Compute/disks/clitest-vm000006_disk1_c23b4ada5ca448e5b8707480ec12111a\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000006\",\r\n
         \     \"adminUsername\": \"clitest-vm000006\",\r\n      \"windowsConfiguration\":
@@ -3738,7 +3884,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 15 Oct 2020 12:05:02 GMT
+      - Fri, 16 Oct 2020 05:32:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3755,7 +3901,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3987,Microsoft.Compute/LowCostGet30Min;31963
+      - Microsoft.Compute/LowCostGet3Min;3988,Microsoft.Compute/LowCostGet30Min;31988
     status:
       code: 200
       message: OK
@@ -3781,16 +3927,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2016-06-01
   response:
     body:
-      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-15T12%3A01%3A54.6287001Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-16T05%3A29%3A07.145647Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '539'
+      - '538'
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:02 GMT
+      - Fri, 16 Oct 2020 05:32:21 GMT
       expires:
       - '-1'
       pragma:
@@ -3830,7 +3976,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":1}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":1}}'
     headers:
       cache-control:
       - no-cache
@@ -3839,7 +3985,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:03 GMT
+      - Fri, 16 Oct 2020 05:32:21 GMT
       expires:
       - '-1'
       pragma:
@@ -3890,7 +4036,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:04 GMT
+      - Fri, 16 Oct 2020 05:32:21 GMT
       expires:
       - '-1'
       pragma:
@@ -3941,7 +4087,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:04 GMT
+      - Fri, 16 Oct 2020 05:32:22 GMT
       expires:
       - '-1'
       pragma:
@@ -3992,17 +4138,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationsStatus/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationsStatus/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2019-06-15
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:05:05 GMT
+      - Fri, 16 Oct 2020 05:32:23 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationResults/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationResults/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2019-06-15
       pragma:
       - no-cache
       strict-transport-security:
@@ -4010,7 +4156,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-powered-by:
       - ASP.NET
     status:
@@ -4035,10 +4181,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4047,7 +4193,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:06 GMT
+      - Fri, 16 Oct 2020 05:32:25 GMT
       expires:
       - '-1'
       pragma:
@@ -4086,10 +4232,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4098,7 +4244,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:07 GMT
+      - Fri, 16 Oct 2020 05:32:26 GMT
       expires:
       - '-1'
       pragma:
@@ -4137,10 +4283,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4149,7 +4295,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:09 GMT
+      - Fri, 16 Oct 2020 05:32:27 GMT
       expires:
       - '-1'
       pragma:
@@ -4188,10 +4334,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4200,7 +4346,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:10 GMT
+      - Fri, 16 Oct 2020 05:32:28 GMT
       expires:
       - '-1'
       pragma:
@@ -4239,10 +4385,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4251,7 +4397,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:11 GMT
+      - Fri, 16 Oct 2020 05:32:29 GMT
       expires:
       - '-1'
       pragma:
@@ -4290,10 +4436,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4302,7 +4448,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:12 GMT
+      - Fri, 16 Oct 2020 05:32:31 GMT
       expires:
       - '-1'
       pragma:
@@ -4341,10 +4487,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4353,7 +4499,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:14 GMT
+      - Fri, 16 Oct 2020 05:32:32 GMT
       expires:
       - '-1'
       pragma:
@@ -4392,10 +4538,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4404,7 +4550,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:15 GMT
+      - Fri, 16 Oct 2020 05:32:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4443,10 +4589,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4455,7 +4601,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:16 GMT
+      - Fri, 16 Oct 2020 05:32:34 GMT
       expires:
       - '-1'
       pragma:
@@ -4494,10 +4640,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4506,7 +4652,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:17 GMT
+      - Fri, 16 Oct 2020 05:32:36 GMT
       expires:
       - '-1'
       pragma:
@@ -4545,10 +4691,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4557,7 +4703,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:18 GMT
+      - Fri, 16 Oct 2020 05:32:37 GMT
       expires:
       - '-1'
       pragma:
@@ -4596,10 +4742,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4608,7 +4754,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:20 GMT
+      - Fri, 16 Oct 2020 05:32:38 GMT
       expires:
       - '-1'
       pragma:
@@ -4647,10 +4793,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4659,7 +4805,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:21 GMT
+      - Fri, 16 Oct 2020 05:32:39 GMT
       expires:
       - '-1'
       pragma:
@@ -4698,10 +4844,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4710,7 +4856,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:22 GMT
+      - Fri, 16 Oct 2020 05:32:40 GMT
       expires:
       - '-1'
       pragma:
@@ -4749,10 +4895,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4761,7 +4907,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:23 GMT
+      - Fri, 16 Oct 2020 05:32:42 GMT
       expires:
       - '-1'
       pragma:
@@ -4800,10 +4946,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4812,7 +4958,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:26 GMT
+      - Fri, 16 Oct 2020 05:32:43 GMT
       expires:
       - '-1'
       pragma:
@@ -4851,10 +4997,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4863,7 +5009,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:27 GMT
+      - Fri, 16 Oct 2020 05:32:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4902,10 +5048,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4914,7 +5060,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:28 GMT
+      - Fri, 16 Oct 2020 05:32:45 GMT
       expires:
       - '-1'
       pragma:
@@ -4953,10 +5099,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4965,7 +5111,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:29 GMT
+      - Fri, 16 Oct 2020 05:32:47 GMT
       expires:
       - '-1'
       pragma:
@@ -5004,10 +5150,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5016,7 +5162,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:30 GMT
+      - Fri, 16 Oct 2020 05:32:48 GMT
       expires:
       - '-1'
       pragma:
@@ -5055,10 +5201,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5067,7 +5213,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:31 GMT
+      - Fri, 16 Oct 2020 05:32:49 GMT
       expires:
       - '-1'
       pragma:
@@ -5106,10 +5252,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5118,7 +5264,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:32 GMT
+      - Fri, 16 Oct 2020 05:32:50 GMT
       expires:
       - '-1'
       pragma:
@@ -5157,10 +5303,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5169,7 +5315,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:34 GMT
+      - Fri, 16 Oct 2020 05:32:52 GMT
       expires:
       - '-1'
       pragma:
@@ -5208,10 +5354,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5220,7 +5366,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:35 GMT
+      - Fri, 16 Oct 2020 05:32:53 GMT
       expires:
       - '-1'
       pragma:
@@ -5259,10 +5405,61 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"Succeeded","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"2020-10-15T12:05:06.1164156Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"7c3071ac-ba83-4a23-8d57-3b1adaac672c"}}'
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:32:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"Succeeded","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"2020-10-16T05:32:24.0288301Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"7ae5838e-e774-4f2d-98ce-8042698180f2"}}'
     headers:
       cache-control:
       - no-cache
@@ -5271,7 +5468,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:36 GMT
+      - Fri, 16 Oct 2020 05:32:55 GMT
       expires:
       - '-1'
       pragma:
@@ -5310,11 +5507,11 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7c3071ac-ba83-4a23-8d57-3b1adaac672c?api-version=2019-06-15
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7ae5838e-e774-4f2d-98ce-8042698180f2?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7c3071ac-ba83-4a23-8d57-3b1adaac672c","name":"7c3071ac-ba83-4a23-8d57-3b1adaac672c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT30.8145486S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000006","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"2020-10-15T12:05:36.9309642Z","activityId":"a7e36bb3-0ede-11eb-b2fa-c8f750f92764"}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7ae5838e-e774-4f2d-98ce-8042698180f2","name":"7ae5838e-e774-4f2d-98ce-8042698180f2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT30.9870907S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000006","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"2020-10-16T05:32:55.0159208Z","activityId":"f62a190a-0f70-11eb-82de-c8f750f92764"}}'
     headers:
       cache-control:
       - no-cache
@@ -5323,7 +5520,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:37 GMT
+      - Fri, 16 Oct 2020 05:32:57 GMT
       expires:
       - '-1'
       pragma:
@@ -5375,7 +5572,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:37 GMT
+      - Fri, 16 Oct 2020 05:32:57 GMT
       expires:
       - '-1'
       pragma:
@@ -5431,7 +5628,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:38 GMT
+      - Fri, 16 Oct 2020 05:32:58 GMT
       expires:
       - '-1'
       pragma:
@@ -5475,7 +5672,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -5484,7 +5681,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:38 GMT
+      - Fri, 16 Oct 2020 05:32:58 GMT
       expires:
       - '-1'
       pragma:
@@ -5526,7 +5723,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2019-06-15
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -5535,7 +5732,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:40 GMT
+      - Fri, 16 Oct 2020 05:32:59 GMT
       expires:
       - '-1'
       pragma:
@@ -5577,7 +5774,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=policyName%20eq%20%27DefaultPolicy%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185870131275","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185001101385","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70368843776974","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70370462661815","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -5586,7 +5783,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:40 GMT
+      - Fri, 16 Oct 2020 05:32:59 GMT
       expires:
       - '-1'
       pragma:
@@ -5609,9 +5806,9 @@ interactions:
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
       "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy", "scheduleRunFrequency":
-      "Daily", "scheduleRunTimes": ["2020-10-15T22:00:00.000Z"], "scheduleWeeklyFrequency":
+      "Daily", "scheduleRunTimes": ["2020-10-16T15:00:00.000Z"], "scheduleWeeklyFrequency":
       0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy", "dailySchedule":
-      {"retentionTimes": ["2020-10-15T22:00:00.000Z"], "retentionDuration": {"count":
+      {"retentionTimes": ["2020-10-16T15:00:00.000Z"], "retentionDuration": {"count":
       30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 2, "timeZone":
       "UTC"}}'
     headers:
@@ -5638,7 +5835,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy5000010?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy5000010","name":"clitest-policy5000010","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy5000010","name":"clitest-policy5000010","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -5647,7 +5844,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:42 GMT
+      - Fri, 16 Oct 2020 05:33:01 GMT
       expires:
       - '-1'
       pragma:
@@ -5663,7 +5860,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -5700,7 +5897,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:05:43 GMT
+      - Fri, 16 Oct 2020 05:33:02 GMT
       expires:
       - '-1'
       pragma:
@@ -5720,9 +5917,9 @@ interactions:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
       "instantRPDetails": {"azureBackupRGNamePrefix": "RG_prefix", "azureBackupRGNameSuffix":
       "RG_suffix"}, "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-15T22:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-16T15:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2020-10-15T22:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2020-10-16T15:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 2,
       "timeZone": "UTC"}}'
     headers:
@@ -5749,7 +5946,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -5758,7 +5955,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:44 GMT
+      - Fri, 16 Oct 2020 05:33:03 GMT
       expires:
       - '-1'
       pragma:
@@ -5802,7 +5999,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2019-06-15
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -5811,7 +6008,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:44 GMT
+      - Fri, 16 Oct 2020 05:33:03 GMT
       expires:
       - '-1'
       pragma:
@@ -5862,7 +6059,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:05:45 GMT
+      - Fri, 16 Oct 2020 05:33:04 GMT
       expires:
       - '-1'
       pragma:
@@ -5872,7 +6069,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
+      - '14998'
       x-powered-by:
       - ASP.NET
     status:
@@ -5900,7 +6097,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2019-06-15
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -5909,7 +6106,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:45 GMT
+      - Fri, 16 Oct 2020 05:33:06 GMT
       expires:
       - '-1'
       pragma:
@@ -5951,7 +6148,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -5960,7 +6157,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:46 GMT
+      - Fri, 16 Oct 2020 05:33:07 GMT
       expires:
       - '-1'
       pragma:
@@ -6002,7 +6199,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2016-12-01&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20status%20eq%20%27Registered%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","friendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"Microsoft.Compute/virtualMachines","protectableObjectType":"Microsoft.Compute/virtualMachines"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","friendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"Microsoft.Compute/virtualMachines","protectableObjectType":"Microsoft.Compute/virtualMachines"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","friendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"Microsoft.Compute/virtualMachines","protectableObjectType":"Microsoft.Compute/virtualMachines"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","friendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"Microsoft.Compute/virtualMachines","protectableObjectType":"Microsoft.Compute/virtualMachines"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -6011,7 +6208,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:47 GMT
+      - Fri, 16 Oct 2020 05:33:07 GMT
       expires:
       - '-1'
       pragma:
@@ -6053,7 +6250,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185870131275","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185001101385","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70368843776974","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70370462661815","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -6062,7 +6259,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:48 GMT
+      - Fri, 16 Oct 2020 05:33:07 GMT
       expires:
       - '-1'
       pragma:
@@ -6105,7 +6302,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185870131275","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185001101385","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70368843776974","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70370462661815","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -6114,4844 +6311,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:05:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/protectedItems/VM%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005?api-version=2019-06-15
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2019-06-15
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Thu, 15 Oct 2020 12:05:49 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/969727af-520d-474e-91bd-407938a57a3a?api-version=2019-06-15
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:05:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:05:50 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:05:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:05:54 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:05:55 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:05:56 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:05:57 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:05:59 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:04 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:10 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:16 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:25 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:27 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:29 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:35 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:36 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:50 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:54 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:56 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:57 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:58 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:06:59 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:02 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:04 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:10 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:12 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:17 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:25 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:28 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:35 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:36 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '187'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"Succeeded","startTime":"2020-10-15T12:05:49.583263Z","endTime":"2020-10-15T12:05:49.583263Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"a9490290-8067-42fe-a879-b11b6b0b2f2b"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '302'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a9490290-8067-42fe-a879-b11b6b0b2f2b?api-version=2019-06-15
-  response:
-    body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a9490290-8067-42fe-a879-b11b6b0b2f2b","name":"a9490290-8067-42fe-a879-b11b6b0b2f2b","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M51.4961541S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000005","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-10-15T12:05:49.583263Z","endTime":"2020-10-15T12:07:41.0794171Z","activityId":"c31d94fb-0ede-11eb-8351-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '972'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup item list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c --query
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
-  response:
-    body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185001101385","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1963'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
-  response:
-    body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185001101385","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1963'
-      content-type:
-      - application/json
-      date:
-      - Thu, 15 Oct 2020 12:07:43 GMT
+      - Fri, 16 Oct 2020 05:33:08 GMT
       expires:
       - '-1'
       pragma:
@@ -10999,17 +6359,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2019-06-15
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:07:44 GMT
+      - Fri, 16 Oct 2020 05:33:09 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2019-06-15
       pragma:
       - no-cache
       strict-transport-security:
@@ -11017,7 +6377,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
+      - '14999'
       x-powered-by:
       - ASP.NET
     status:
@@ -11043,10 +6403,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11055,7 +6415,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:45 GMT
+      - Fri, 16 Oct 2020 05:33:09 GMT
       expires:
       - '-1'
       pragma:
@@ -11095,10 +6455,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11107,7 +6467,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:46 GMT
+      - Fri, 16 Oct 2020 05:33:10 GMT
       expires:
       - '-1'
       pragma:
@@ -11147,10 +6507,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11159,7 +6519,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:47 GMT
+      - Fri, 16 Oct 2020 05:33:11 GMT
       expires:
       - '-1'
       pragma:
@@ -11199,10 +6559,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11211,7 +6571,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:49 GMT
+      - Fri, 16 Oct 2020 05:33:13 GMT
       expires:
       - '-1'
       pragma:
@@ -11251,10 +6611,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11263,7 +6623,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:50 GMT
+      - Fri, 16 Oct 2020 05:33:14 GMT
       expires:
       - '-1'
       pragma:
@@ -11303,10 +6663,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11315,7 +6675,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:51 GMT
+      - Fri, 16 Oct 2020 05:33:16 GMT
       expires:
       - '-1'
       pragma:
@@ -11355,10 +6715,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11367,7 +6727,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:52 GMT
+      - Fri, 16 Oct 2020 05:33:17 GMT
       expires:
       - '-1'
       pragma:
@@ -11407,10 +6767,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11419,7 +6779,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:54 GMT
+      - Fri, 16 Oct 2020 05:33:18 GMT
       expires:
       - '-1'
       pragma:
@@ -11459,10 +6819,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11471,7 +6831,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:55 GMT
+      - Fri, 16 Oct 2020 05:33:19 GMT
       expires:
       - '-1'
       pragma:
@@ -11511,10 +6871,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11523,7 +6883,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:56 GMT
+      - Fri, 16 Oct 2020 05:33:21 GMT
       expires:
       - '-1'
       pragma:
@@ -11563,10 +6923,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11575,7 +6935,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:57 GMT
+      - Fri, 16 Oct 2020 05:33:22 GMT
       expires:
       - '-1'
       pragma:
@@ -11615,10 +6975,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11627,7 +6987,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:07:59 GMT
+      - Fri, 16 Oct 2020 05:33:23 GMT
       expires:
       - '-1'
       pragma:
@@ -11667,10 +7027,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11679,7 +7039,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:01 GMT
+      - Fri, 16 Oct 2020 05:33:24 GMT
       expires:
       - '-1'
       pragma:
@@ -11719,10 +7079,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11731,7 +7091,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:02 GMT
+      - Fri, 16 Oct 2020 05:33:26 GMT
       expires:
       - '-1'
       pragma:
@@ -11771,10 +7131,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11783,7 +7143,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:03 GMT
+      - Fri, 16 Oct 2020 05:33:27 GMT
       expires:
       - '-1'
       pragma:
@@ -11823,10 +7183,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11835,7 +7195,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:05 GMT
+      - Fri, 16 Oct 2020 05:33:28 GMT
       expires:
       - '-1'
       pragma:
@@ -11875,10 +7235,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11887,7 +7247,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:06 GMT
+      - Fri, 16 Oct 2020 05:33:29 GMT
       expires:
       - '-1'
       pragma:
@@ -11927,10 +7287,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11939,7 +7299,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:07 GMT
+      - Fri, 16 Oct 2020 05:33:30 GMT
       expires:
       - '-1'
       pragma:
@@ -11979,10 +7339,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11991,7 +7351,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:08 GMT
+      - Fri, 16 Oct 2020 05:33:32 GMT
       expires:
       - '-1'
       pragma:
@@ -12031,10 +7391,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12043,7 +7403,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:10 GMT
+      - Fri, 16 Oct 2020 05:33:33 GMT
       expires:
       - '-1'
       pragma:
@@ -12083,10 +7443,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12095,7 +7455,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:11 GMT
+      - Fri, 16 Oct 2020 05:33:34 GMT
       expires:
       - '-1'
       pragma:
@@ -12135,10 +7495,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12147,7 +7507,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:12 GMT
+      - Fri, 16 Oct 2020 05:33:35 GMT
       expires:
       - '-1'
       pragma:
@@ -12187,10 +7547,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12199,7 +7559,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:13 GMT
+      - Fri, 16 Oct 2020 05:33:36 GMT
       expires:
       - '-1'
       pragma:
@@ -12239,10 +7599,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12251,7 +7611,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:15 GMT
+      - Fri, 16 Oct 2020 05:33:38 GMT
       expires:
       - '-1'
       pragma:
@@ -12291,10 +7651,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12303,7 +7663,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:16 GMT
+      - Fri, 16 Oct 2020 05:33:39 GMT
       expires:
       - '-1'
       pragma:
@@ -12343,10 +7703,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12355,7 +7715,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:17 GMT
+      - Fri, 16 Oct 2020 05:33:40 GMT
       expires:
       - '-1'
       pragma:
@@ -12395,10 +7755,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12407,7 +7767,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:18 GMT
+      - Fri, 16 Oct 2020 05:33:41 GMT
       expires:
       - '-1'
       pragma:
@@ -12447,10 +7807,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12459,7 +7819,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:20 GMT
+      - Fri, 16 Oct 2020 05:33:43 GMT
       expires:
       - '-1'
       pragma:
@@ -12499,10 +7859,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12511,7 +7871,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:21 GMT
+      - Fri, 16 Oct 2020 05:33:45 GMT
       expires:
       - '-1'
       pragma:
@@ -12551,10 +7911,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12563,7 +7923,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:22 GMT
+      - Fri, 16 Oct 2020 05:33:46 GMT
       expires:
       - '-1'
       pragma:
@@ -12603,10 +7963,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12615,7 +7975,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:23 GMT
+      - Fri, 16 Oct 2020 05:33:47 GMT
       expires:
       - '-1'
       pragma:
@@ -12655,10 +8015,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12667,7 +8027,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:24 GMT
+      - Fri, 16 Oct 2020 05:33:48 GMT
       expires:
       - '-1'
       pragma:
@@ -12707,10 +8067,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12719,7 +8079,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:26 GMT
+      - Fri, 16 Oct 2020 05:33:49 GMT
       expires:
       - '-1'
       pragma:
@@ -12759,10 +8119,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12771,7 +8131,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:27 GMT
+      - Fri, 16 Oct 2020 05:33:51 GMT
       expires:
       - '-1'
       pragma:
@@ -12811,10 +8171,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12823,7 +8183,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:28 GMT
+      - Fri, 16 Oct 2020 05:33:52 GMT
       expires:
       - '-1'
       pragma:
@@ -12863,10 +8223,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12875,7 +8235,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:29 GMT
+      - Fri, 16 Oct 2020 05:33:53 GMT
       expires:
       - '-1'
       pragma:
@@ -12915,10 +8275,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12927,7 +8287,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:31 GMT
+      - Fri, 16 Oct 2020 05:33:54 GMT
       expires:
       - '-1'
       pragma:
@@ -12967,10 +8327,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12979,7 +8339,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:33 GMT
+      - Fri, 16 Oct 2020 05:33:56 GMT
       expires:
       - '-1'
       pragma:
@@ -13019,10 +8379,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13031,7 +8391,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:34 GMT
+      - Fri, 16 Oct 2020 05:33:57 GMT
       expires:
       - '-1'
       pragma:
@@ -13071,10 +8431,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13083,7 +8443,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:35 GMT
+      - Fri, 16 Oct 2020 05:33:58 GMT
       expires:
       - '-1'
       pragma:
@@ -13123,10 +8483,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13135,7 +8495,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:37 GMT
+      - Fri, 16 Oct 2020 05:33:59 GMT
       expires:
       - '-1'
       pragma:
@@ -13175,10 +8535,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13187,7 +8547,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:38 GMT
+      - Fri, 16 Oct 2020 05:34:00 GMT
       expires:
       - '-1'
       pragma:
@@ -13227,10 +8587,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13239,7 +8599,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:39 GMT
+      - Fri, 16 Oct 2020 05:34:02 GMT
       expires:
       - '-1'
       pragma:
@@ -13279,10 +8639,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13291,7 +8651,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:40 GMT
+      - Fri, 16 Oct 2020 05:34:03 GMT
       expires:
       - '-1'
       pragma:
@@ -13331,10 +8691,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13343,7 +8703,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:42 GMT
+      - Fri, 16 Oct 2020 05:34:04 GMT
       expires:
       - '-1'
       pragma:
@@ -13383,10 +8743,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13395,7 +8755,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:43 GMT
+      - Fri, 16 Oct 2020 05:34:05 GMT
       expires:
       - '-1'
       pragma:
@@ -13435,10 +8795,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13447,7 +8807,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:44 GMT
+      - Fri, 16 Oct 2020 05:34:07 GMT
       expires:
       - '-1'
       pragma:
@@ -13487,10 +8847,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13499,7 +8859,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:45 GMT
+      - Fri, 16 Oct 2020 05:34:08 GMT
       expires:
       - '-1'
       pragma:
@@ -13539,10 +8899,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13551,7 +8911,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:46 GMT
+      - Fri, 16 Oct 2020 05:34:09 GMT
       expires:
       - '-1'
       pragma:
@@ -13591,10 +8951,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13603,7 +8963,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:48 GMT
+      - Fri, 16 Oct 2020 05:34:10 GMT
       expires:
       - '-1'
       pragma:
@@ -13643,10 +9003,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13655,7 +9015,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:49 GMT
+      - Fri, 16 Oct 2020 05:34:11 GMT
       expires:
       - '-1'
       pragma:
@@ -13695,10 +9055,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13707,7 +9067,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:50 GMT
+      - Fri, 16 Oct 2020 05:34:13 GMT
       expires:
       - '-1'
       pragma:
@@ -13747,10 +9107,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13759,7 +9119,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:51 GMT
+      - Fri, 16 Oct 2020 05:34:14 GMT
       expires:
       - '-1'
       pragma:
@@ -13799,10 +9159,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13811,7 +9171,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:53 GMT
+      - Fri, 16 Oct 2020 05:34:15 GMT
       expires:
       - '-1'
       pragma:
@@ -13851,10 +9211,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13863,7 +9223,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:54 GMT
+      - Fri, 16 Oct 2020 05:34:16 GMT
       expires:
       - '-1'
       pragma:
@@ -13903,10 +9263,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13915,7 +9275,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:55 GMT
+      - Fri, 16 Oct 2020 05:34:19 GMT
       expires:
       - '-1'
       pragma:
@@ -13955,10 +9315,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13967,7 +9327,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:57 GMT
+      - Fri, 16 Oct 2020 05:34:20 GMT
       expires:
       - '-1'
       pragma:
@@ -14007,10 +9367,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14019,7 +9379,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:58 GMT
+      - Fri, 16 Oct 2020 05:34:21 GMT
       expires:
       - '-1'
       pragma:
@@ -14059,10 +9419,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14071,7 +9431,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:08:59 GMT
+      - Fri, 16 Oct 2020 05:34:22 GMT
       expires:
       - '-1'
       pragma:
@@ -14111,10 +9471,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14123,7 +9483,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:01 GMT
+      - Fri, 16 Oct 2020 05:34:23 GMT
       expires:
       - '-1'
       pragma:
@@ -14163,10 +9523,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14175,7 +9535,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:02 GMT
+      - Fri, 16 Oct 2020 05:34:25 GMT
       expires:
       - '-1'
       pragma:
@@ -14215,10 +9575,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14227,7 +9587,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:03 GMT
+      - Fri, 16 Oct 2020 05:34:26 GMT
       expires:
       - '-1'
       pragma:
@@ -14267,10 +9627,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14279,7 +9639,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:04 GMT
+      - Fri, 16 Oct 2020 05:34:27 GMT
       expires:
       - '-1'
       pragma:
@@ -14319,10 +9679,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14331,7 +9691,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:06 GMT
+      - Fri, 16 Oct 2020 05:34:28 GMT
       expires:
       - '-1'
       pragma:
@@ -14371,10 +9731,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14383,7 +9743,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:07 GMT
+      - Fri, 16 Oct 2020 05:34:29 GMT
       expires:
       - '-1'
       pragma:
@@ -14423,10 +9783,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14435,7 +9795,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:08 GMT
+      - Fri, 16 Oct 2020 05:34:31 GMT
       expires:
       - '-1'
       pragma:
@@ -14475,10 +9835,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14487,7 +9847,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:09 GMT
+      - Fri, 16 Oct 2020 05:34:32 GMT
       expires:
       - '-1'
       pragma:
@@ -14527,10 +9887,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14539,7 +9899,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:11 GMT
+      - Fri, 16 Oct 2020 05:34:33 GMT
       expires:
       - '-1'
       pragma:
@@ -14579,10 +9939,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14591,7 +9951,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:12 GMT
+      - Fri, 16 Oct 2020 05:34:34 GMT
       expires:
       - '-1'
       pragma:
@@ -14631,10 +9991,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14643,7 +10003,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:13 GMT
+      - Fri, 16 Oct 2020 05:34:36 GMT
       expires:
       - '-1'
       pragma:
@@ -14683,10 +10043,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14695,7 +10055,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:14 GMT
+      - Fri, 16 Oct 2020 05:34:37 GMT
       expires:
       - '-1'
       pragma:
@@ -14735,10 +10095,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14747,7 +10107,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:16 GMT
+      - Fri, 16 Oct 2020 05:34:39 GMT
       expires:
       - '-1'
       pragma:
@@ -14787,10 +10147,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14799,7 +10159,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:17 GMT
+      - Fri, 16 Oct 2020 05:34:40 GMT
       expires:
       - '-1'
       pragma:
@@ -14839,10 +10199,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14851,7 +10211,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:18 GMT
+      - Fri, 16 Oct 2020 05:34:41 GMT
       expires:
       - '-1'
       pragma:
@@ -14891,10 +10251,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14903,7 +10263,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:19 GMT
+      - Fri, 16 Oct 2020 05:34:42 GMT
       expires:
       - '-1'
       pragma:
@@ -14943,10 +10303,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14955,7 +10315,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:21 GMT
+      - Fri, 16 Oct 2020 05:34:43 GMT
       expires:
       - '-1'
       pragma:
@@ -14995,10 +10355,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15007,7 +10367,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:22 GMT
+      - Fri, 16 Oct 2020 05:34:45 GMT
       expires:
       - '-1'
       pragma:
@@ -15047,10 +10407,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15059,7 +10419,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:23 GMT
+      - Fri, 16 Oct 2020 05:34:46 GMT
       expires:
       - '-1'
       pragma:
@@ -15099,10 +10459,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15111,7 +10471,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:24 GMT
+      - Fri, 16 Oct 2020 05:34:47 GMT
       expires:
       - '-1'
       pragma:
@@ -15151,10 +10511,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15163,7 +10523,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:26 GMT
+      - Fri, 16 Oct 2020 05:34:48 GMT
       expires:
       - '-1'
       pragma:
@@ -15203,10 +10563,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15215,7 +10575,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:27 GMT
+      - Fri, 16 Oct 2020 05:34:50 GMT
       expires:
       - '-1'
       pragma:
@@ -15255,10 +10615,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15267,7 +10627,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:29 GMT
+      - Fri, 16 Oct 2020 05:34:51 GMT
       expires:
       - '-1'
       pragma:
@@ -15307,10 +10667,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15319,7 +10679,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:30 GMT
+      - Fri, 16 Oct 2020 05:34:52 GMT
       expires:
       - '-1'
       pragma:
@@ -15359,10 +10719,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15371,7 +10731,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:32 GMT
+      - Fri, 16 Oct 2020 05:34:53 GMT
       expires:
       - '-1'
       pragma:
@@ -15411,10 +10771,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15423,7 +10783,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:33 GMT
+      - Fri, 16 Oct 2020 05:34:54 GMT
       expires:
       - '-1'
       pragma:
@@ -15463,10 +10823,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15475,7 +10835,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:34 GMT
+      - Fri, 16 Oct 2020 05:34:56 GMT
       expires:
       - '-1'
       pragma:
@@ -15515,10 +10875,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15527,7 +10887,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:35 GMT
+      - Fri, 16 Oct 2020 05:34:57 GMT
       expires:
       - '-1'
       pragma:
@@ -15567,10 +10927,114 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"Succeeded","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"2020-10-15T12:07:44.8208913Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"187641e8-7ff7-4e09-a8e4-a3c720ffb31e"}}'
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:34:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"Succeeded","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"2020-10-16T05:33:09.2832611Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"d138a460-21ca-49cf-92a3-87bcf859f85d"}}'
     headers:
       cache-control:
       - no-cache
@@ -15579,7 +11043,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:37 GMT
+      - Fri, 16 Oct 2020 05:35:01 GMT
       expires:
       - '-1'
       pragma:
@@ -15619,11 +11083,11 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/187641e8-7ff7-4e09-a8e4-a3c720ffb31e?api-version=2019-06-15
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d138a460-21ca-49cf-92a3-87bcf859f85d?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/187641e8-7ff7-4e09-a8e4-a3c720ffb31e","name":"187641e8-7ff7-4e09-a8e4-a3c720ffb31e","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT1M51.4322738S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000006","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"2020-10-15T12:09:36.2531651Z","activityId":"079815da-0edf-11eb-8a70-c8f750f92764"}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d138a460-21ca-49cf-92a3-87bcf859f85d","name":"d138a460-21ca-49cf-92a3-87bcf859f85d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT1M51.8751354S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000006","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"2020-10-16T05:35:01.1583965Z","activityId":"12ad7f10-0f71-11eb-bd45-c8f750f92764"}}'
     headers:
       cache-control:
       - no-cache
@@ -15632,7 +11096,4792 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 15 Oct 2020 12:09:37 GMT
+      - Fri, 16 Oct 2020 05:35:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c --query
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70370462661815","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1963'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70370462661815","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1963'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/protectedItems/VM%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005?api-version=2019-06-15
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2019-06-15
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Fri, 16 Oct 2020 05:35:04 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/59680973-9993-46e0-a295-ec895881930f?api-version=2019-06-15
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:35:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"Succeeded","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"2020-10-16T05:35:05.1080419Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"be79e1a8-0969-448e-b103-522d831a2d6d"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/be79e1a8-0969-448e-b103-522d831a2d6d?api-version=2019-06-15
+  response:
+    body:
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/be79e1a8-0969-448e-b103-522d831a2d6d","name":"be79e1a8-0969-448e-b103-522d831a2d6d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M51.7041169S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000005","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"2020-10-16T05:36:56.8121588Z","activityId":"5759f3e8-0f71-11eb-aed8-c8f750f92764"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '973'
+      content-type:
+      - application/json
+      date:
+      - Fri, 16 Oct 2020 05:36:57 GMT
       expires:
       - '-1'
       pragma:
@@ -15684,7 +15933,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 15 Oct 2020 12:09:39 GMT
+      - Fri, 16 Oct 2020 05:37:08 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_policy.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_policy.yaml
@@ -25,16 +25,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2016-06-01
   response:
     body:
-      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-16T05%3A29%3A07.145647Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-16T07%3A19%3A17.3635384Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '538'
+      - '539'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:29:07 GMT
+      - Fri, 16 Oct 2020 07:19:17 GMT
       expires:
       - '-1'
       pragma:
@@ -72,7 +72,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -81,7 +81,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:29:08 GMT
+      - Fri, 16 Oct 2020 07:19:18 GMT
       expires:
       - '-1'
       pragma:
@@ -104,9 +104,9 @@ interactions:
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
       "instantRPDetails": {}, "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-16T15:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-16T17:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2020-10-16T15:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2020-10-16T17:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 2,
       "timeZone": "UTC"}}'
     headers:
@@ -133,7 +133,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -142,7 +142,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:29:10 GMT
+      - Fri, 16 Oct 2020 07:19:20 GMT
       expires:
       - '-1'
       pragma:
@@ -186,7 +186,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -195,7 +195,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:29:10 GMT
+      - Fri, 16 Oct 2020 07:19:20 GMT
       expires:
       - '-1'
       pragma:
@@ -218,9 +218,9 @@ interactions:
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
       "instantRPDetails": {}, "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-16T15:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-16T17:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2020-10-16T15:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2020-10-16T17:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 3,
       "timeZone": "UTC"}}'
     headers:
@@ -247,7 +247,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -256,7 +256,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:29:11 GMT
+      - Fri, 16 Oct 2020 07:19:23 GMT
       expires:
       - '-1'
       pragma:
@@ -300,7 +300,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-10-16T05:28:47Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-10-16T07:19:09Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -309,7 +309,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:29:13 GMT
+      - Fri, 16 Oct 2020 07:19:24 GMT
       expires:
       - '-1'
       pragma:
@@ -388,13 +388,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:29:13 GMT
+      - Fri, 16 Oct 2020 07:19:25 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Fri, 16 Oct 2020 05:34:13 GMT
+      - Fri, 16 Oct 2020 07:24:25 GMT
       source-age:
-      - '189'
+      - '259'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -402,21 +402,21 @@ interactions:
       via:
       - 1.1 varnish (Varnish/6.0), 1.1 varnish
       x-cache:
-      - HIT, HIT
+      - HFM, HIT
       x-cache-hits:
-      - 1, 1
+      - 0, 1
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 27fff518321187f8ee72e45b2aa60b340266aa97
+      - 9bfe9a20f9c5f22382a07f2c14d93fb000a61b6f
       x-frame-options:
       - deny
       x-github-request-id:
-      - DC7E:0B12:4A95DE:4DC35F:5F892705
+      - A148:0AED:4A9F9D:4DD599:5F89376E
       x-served-by:
-      - cache-sin18046-SIN
+      - cache-sin18041-SIN
       x-timer:
-      - S1602826153.489359,VS0,VE1
+      - S1602832765.162392,VS0,VE1
       x-xss-protection:
       - 1; mode=block
     status:
@@ -453,7 +453,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:29:13 GMT
+      - Fri, 16 Oct 2020 07:19:25 GMT
       expires:
       - '-1'
       pragma:
@@ -529,10 +529,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_LblmknQB0pWh5nHbaVtVBeLxN4R7JEDs","name":"vm_deploy_LblmknQB0pWh5nHbaVtVBeLxN4R7JEDs","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13015436836767274265","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-10-16T05:29:17.1406527Z","duration":"PT1.5470011S","correlationId":"d64bbe73-f954-4289-8752-600d85fa0a47","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_UTOoTZUBojTf3mA5elqNHjA6m4FMnxT1","name":"vm_deploy_UTOoTZUBojTf3mA5elqNHjA6m4FMnxT1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13050745456651796390","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-10-16T07:19:28.1936292Z","duration":"PT1.3159468S","correlationId":"90bb7f31-51bf-4d41-bdfc-5f8164059a05","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_LblmknQB0pWh5nHbaVtVBeLxN4R7JEDs/operationStatuses/08585987807298839815?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_UTOoTZUBojTf3mA5elqNHjA6m4FMnxT1/operationStatuses/08585987741185999704?api-version=2020-06-01
       cache-control:
       - no-cache
       content-length:
@@ -540,7 +540,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:29:17 GMT
+      - Fri, 16 Oct 2020 07:19:28 GMT
       expires:
       - '-1'
       pragma:
@@ -571,7 +571,7 @@ interactions:
       - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987807298839815?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987741185999704?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -583,7 +583,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:29:48 GMT
+      - Fri, 16 Oct 2020 07:19:58 GMT
       expires:
       - '-1'
       pragma:
@@ -614,7 +614,7 @@ interactions:
       - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987807298839815?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987741185999704?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -626,7 +626,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:30:18 GMT
+      - Fri, 16 Oct 2020 07:20:28 GMT
       expires:
       - '-1'
       pragma:
@@ -660,7 +660,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_LblmknQB0pWh5nHbaVtVBeLxN4R7JEDs","name":"vm_deploy_LblmknQB0pWh5nHbaVtVBeLxN4R7JEDs","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13015436836767274265","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-10-16T05:30:04.0652158Z","duration":"PT48.4715642S","correlationId":"d64bbe73-f954-4289-8752-600d85fa0a47","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_UTOoTZUBojTf3mA5elqNHjA6m4FMnxT1","name":"vm_deploy_UTOoTZUBojTf3mA5elqNHjA6m4FMnxT1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13050745456651796390","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-10-16T07:20:09.2602162Z","duration":"PT42.3825338S","correlationId":"90bb7f31-51bf-4d41-bdfc-5f8164059a05","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET"}]}}'
     headers:
       cache-control:
       - no-cache
@@ -669,7 +669,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:30:18 GMT
+      - Fri, 16 Oct 2020 07:20:28 GMT
       expires:
       - '-1'
       pragma:
@@ -709,16 +709,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"7ccc9165-6cd3-40d1-8bb6-4cb02b5a57e9\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"81ebcc78-6136-4a09-97b0-1d2613f2274e\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_02f440ce872d4de78211c272f3754297\",\r\n
+        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_b5b6ee53c07a4522a28c135fd04e26da\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGH7TBWBUWFRI37VDBUT7ZGGUBEXVPNMXE2H7UB6PMZXENT2OP74YSRLC44KJ4O6WIC/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_02f440ce872d4de78211c272f3754297\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGABAW3IMAAXAJOMCLNYBZXV57DSEP2ZXMWLJSUKBMCO3UHLF6UWGRL5L7GLJ25T4T5/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_b5b6ee53c07a4522a28c135fd04e26da\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000005\",\r\n
         \     \"adminUsername\": \"clitest-vm000005\",\r\n      \"windowsConfiguration\":
@@ -732,16 +732,16 @@ interactions:
         \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
         \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
         Ready\",\r\n            \"message\": \"VM status blob is found but not yet
-        populated.\",\r\n            \"time\": \"2020-10-16T05:30:19+00:00\"\r\n          }\r\n
+        populated.\",\r\n            \"time\": \"2020-10-16T07:20:30+00:00\"\r\n          }\r\n
         \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
-        \"clitest-vm000005_disk1_02f440ce872d4de78211c272f3754297\",\r\n          \"statuses\":
+        \"clitest-vm000005_disk1_b5b6ee53c07a4522a28c135fd04e26da\",\r\n          \"statuses\":
         [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-10-16T05:29:34.9533737+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-10-16T07:19:43.9996418+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded/osProvisioningInProgress\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"OS provisioning
-        in progress\",\r\n          \"time\": \"2020-10-16T05:30:01.5940158+00:00\"\r\n
+        in progress\",\r\n          \"time\": \"2020-10-16T07:20:08.1558982+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -753,7 +753,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:30:19 GMT
+      - Fri, 16 Oct 2020 07:20:29 GMT
       expires:
       - '-1'
       pragma:
@@ -797,14 +797,14 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000005VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic\",\r\n
-        \ \"etag\": \"W/\\\"69a41db6-02fa-4e3b-8598-49880f6f45c0\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"0a7f030c-81c1-498c-856e-062f1a88ce04\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"ed56204f-56d6-486e-8649-a1b69cf5834c\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"22fa7afe-9fe9-4e92-a6f8-0989f6b44361\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigclitest-vm000005\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic/ipConfigurations/ipconfigclitest-vm000005\",\r\n
-        \       \"etag\": \"W/\\\"69a41db6-02fa-4e3b-8598-49880f6f45c0\\\"\",\r\n
+        \       \"etag\": \"W/\\\"0a7f030c-81c1-498c-856e-062f1a88ce04\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
@@ -813,8 +813,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"qfhfmtfhhw0ulpubid53k3cyag.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-22-48-56-6F-8E\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"awbcdngeblqeborwzggljh5npa.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-22-48-56-B5-E9\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -828,9 +828,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:30:19 GMT
+      - Fri, 16 Oct 2020 07:20:30 GMT
       etag:
-      - W/"69a41db6-02fa-4e3b-8598-49880f6f45c0"
+      - W/"0a7f030c-81c1-498c-856e-062f1a88ce04"
       expires:
       - '-1'
       pragma:
@@ -847,7 +847,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 2f5968ca-2b44-4c41-8c21-d82672a6efef
+      - 9addeab1-b3f6-4200-b296-ef3c05ff175f
     status:
       code: 200
       message: OK
@@ -874,12 +874,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000005PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"622e5343-b043-4157-99a7-3ad197fa7651\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"b28f9b48-4cd1-4195-89aa-a46c1144eddc\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"5d3e6174-b570-44d7-b57d-13211634be82\",\r\n
-        \   \"ipAddress\": \"23.101.23.36\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"a48d94a0-e977-4f92-8366-e3e449f0246a\",\r\n
+        \   \"ipAddress\": \"40.65.135.38\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
         \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic/ipConfigurations/ipconfigclitest-vm000005\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
@@ -892,9 +892,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:30:19 GMT
+      - Fri, 16 Oct 2020 07:20:30 GMT
       etag:
-      - W/"622e5343-b043-4157-99a7-3ad197fa7651"
+      - W/"b28f9b48-4cd1-4195-89aa-a46c1144eddc"
       expires:
       - '-1'
       pragma:
@@ -911,7 +911,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - c597f71a-e246-426b-b2dc-3678bd396c79
+      - 9704518f-babb-46e6-acec-1d9c2dcc80a7
     status:
       code: 200
       message: OK
@@ -937,7 +937,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-10-16T05:28:47Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-10-16T07:19:09Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -946,7 +946,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:30:20 GMT
+      - Fri, 16 Oct 2020 07:20:30 GMT
       expires:
       - '-1'
       pragma:
@@ -1025,13 +1025,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:30:20 GMT
+      - Fri, 16 Oct 2020 07:20:31 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Fri, 16 Oct 2020 05:35:20 GMT
+      - Fri, 16 Oct 2020 07:25:31 GMT
       source-age:
-      - '256'
+      - '0'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -1040,21 +1040,21 @@ interactions:
       - 1.1 varnish (Varnish/6.0)
       - 1.1 varnish
       x-cache:
-      - HIT, HIT
+      - HFM, HIT
       x-cache-hits:
-      - 1, 2
+      - 0, 1
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 1631544cdcb3e6afb30adb55526925788dfe740a
+      - 2cc4596ab82304996799f2ee6ff29ad6f545f031
       x-frame-options:
       - deny
       x-github-request-id:
-      - DC7E:0B12:4A95DE:4DC35F:5F892705
+      - A148:0AED:4A9F9D:4DD599:5F89376E
       x-served-by:
-      - cache-sin18022-SIN
+      - cache-sin18047-SIN
       x-timer:
-      - S1602826221.794112,VS0,VE0
+      - S1602832831.310990,VS0,VE330
       x-xss-protection:
       - 1; mode=block
     status:
@@ -1084,17 +1084,17 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"clitest-vm000005VNET\",\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET\",\r\n
-        \     \"etag\": \"W/\\\"1fd8b62a-469d-4083-9ed3-1f8e140a97ee\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"3318cbed-dec8-4687-a39c-0e5902a44771\\\"\",\r\n      \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"southeastasia\",\r\n
         \     \"tags\": {\r\n        \"MabUsed\": \"Yes\",\r\n        \"Owner\": \"sisi\",\r\n
         \       \"Purpose\": \"CLITest\",\r\n        \"DeleteBy\": \"12-2099\",\r\n
         \       \"AutoShutdown\": \"No\"\r\n      },\r\n      \"properties\": {\r\n
         \       \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\":
-        \"4c564e81-3da7-45b5-be81-40ffd5745806\",\r\n        \"addressSpace\": {\r\n
+        \"b4218205-0ac4-40e0-ba36-c98cb49fed78\",\r\n        \"addressSpace\": {\r\n
         \         \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n          ]\r\n
         \       },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
         \"clitest-vm000005Subnet\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET/subnets/clitest-vm000005Subnet\",\r\n
-        \           \"etag\": \"W/\\\"1fd8b62a-469d-4083-9ed3-1f8e140a97ee\\\"\",\r\n
+        \           \"etag\": \"W/\\\"3318cbed-dec8-4687-a39c-0e5902a44771\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"ipConfigurations\":
         [\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic/ipConfigurations/ipconfigclitest-vm000005\"\r\n
@@ -1110,7 +1110,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:30:23 GMT
+      - Fri, 16 Oct 2020 07:20:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1127,7 +1127,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - a39796a1-74ee-40f5-bafd-012230962a6e
+      - 11ffa2d9-8bc4-4f7a-90ef-12a1e8d8edc4
     status:
       code: 200
       message: OK
@@ -1187,10 +1187,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_3Dd8TDm5Tc0ebfTdToVOovsazY3DUAlE","name":"vm_deploy_3Dd8TDm5Tc0ebfTdToVOovsazY3DUAlE","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5836018288145087110","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-10-16T05:30:26.4320979Z","duration":"PT1.4184497S","correlationId":"ac5092ff-5be8-44a0-8821-a00905c5d4a0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_4BgFDmoDQvF1Y1NE2iev2lOYRLOP7CKv","name":"vm_deploy_4BgFDmoDQvF1Y1NE2iev2lOYRLOP7CKv","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7920559732735901119","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-10-16T07:20:34.3619121Z","duration":"PT1.3879254S","correlationId":"9cc52429-eea0-485a-bc56-219c8cff6ae7","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_3Dd8TDm5Tc0ebfTdToVOovsazY3DUAlE/operationStatuses/08585987806604639877?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_4BgFDmoDQvF1Y1NE2iev2lOYRLOP7CKv/operationStatuses/08585987740525036679?api-version=2020-06-01
       cache-control:
       - no-cache
       content-length:
@@ -1198,7 +1198,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:30:26 GMT
+      - Fri, 16 Oct 2020 07:20:34 GMT
       expires:
       - '-1'
       pragma:
@@ -1229,7 +1229,7 @@ interactions:
       - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987806604639877?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987740525036679?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1241,7 +1241,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:30:56 GMT
+      - Fri, 16 Oct 2020 07:21:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1272,7 +1272,7 @@ interactions:
       - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987806604639877?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585987740525036679?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1284,7 +1284,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:31:27 GMT
+      - Fri, 16 Oct 2020 07:21:34 GMT
       expires:
       - '-1'
       pragma:
@@ -1318,16 +1318,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_3Dd8TDm5Tc0ebfTdToVOovsazY3DUAlE","name":"vm_deploy_3Dd8TDm5Tc0ebfTdToVOovsazY3DUAlE","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5836018288145087110","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-10-16T05:31:09.8314694Z","duration":"PT44.8178212S","correlationId":"ac5092ff-5be8-44a0-8821-a00905c5d4a0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_4BgFDmoDQvF1Y1NE2iev2lOYRLOP7CKv","name":"vm_deploy_4BgFDmoDQvF1Y1NE2iev2lOYRLOP7CKv","type":"Microsoft.Resources/deployments","properties":{"templateHash":"7920559732735901119","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-10-16T07:21:21.252409Z","duration":"PT48.2784223S","correlationId":"9cc52429-eea0-485a-bc56-219c8cff6ae7","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3500'
+      - '3499'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:31:27 GMT
+      - Fri, 16 Oct 2020 07:21:35 GMT
       expires:
       - '-1'
       pragma:
@@ -1367,16 +1367,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"b08e97ce-23a7-4cb7-91af-ee82db850472\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"5720f928-3833-476c-aeb5-83b22a0a5135\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000006_disk1_c23b4ada5ca448e5b8707480ec12111a\",\r\n
+        \"Windows\",\r\n        \"name\": \"clitest-vm000006_disk1_7276eaad4d034fde89acde2050e7c101\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGH7TBWBUWFRI37VDBUT7ZGGUBEXVPNMXE2H7UB6PMZXENT2OP74YSRLC44KJ4O6WIC/providers/Microsoft.Compute/disks/clitest-vm000006_disk1_c23b4ada5ca448e5b8707480ec12111a\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGABAW3IMAAXAJOMCLNYBZXV57DSEP2ZXMWLJSUKBMCO3UHLF6UWGRL5L7GLJ25T4T5/providers/Microsoft.Compute/disks/clitest-vm000006_disk1_7276eaad4d034fde89acde2050e7c101\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000006\",\r\n
         \     \"adminUsername\": \"clitest-vm000006\",\r\n      \"windowsConfiguration\":
@@ -1390,16 +1390,16 @@ interactions:
         \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
         \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
         Ready\",\r\n            \"message\": \"VM status blob is found but not yet
-        populated.\",\r\n            \"time\": \"2020-10-16T05:31:29+00:00\"\r\n          }\r\n
+        populated.\",\r\n            \"time\": \"2020-10-16T07:21:36+00:00\"\r\n          }\r\n
         \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
-        \"clitest-vm000006_disk1_c23b4ada5ca448e5b8707480ec12111a\",\r\n          \"statuses\":
+        \"clitest-vm000006_disk1_7276eaad4d034fde89acde2050e7c101\",\r\n          \"statuses\":
         [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-10-16T05:30:44.8439691+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-10-16T07:20:50.4527863+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded/osProvisioningInProgress\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"OS provisioning
-        in progress\",\r\n          \"time\": \"2020-10-16T05:31:07.5783444+00:00\"\r\n
+        in progress\",\r\n          \"time\": \"2020-10-16T07:21:19.9214987+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -1411,7 +1411,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:31:28 GMT
+      - Fri, 16 Oct 2020 07:21:35 GMT
       expires:
       - '-1'
       pragma:
@@ -1455,14 +1455,14 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000006VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic\",\r\n
-        \ \"etag\": \"W/\\\"52e241a6-c907-471a-956c-699d43fc6c5a\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"a4360995-81d8-49ce-8944-04d7bcab7272\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"e81fc5ae-de7e-493f-b8e9-677a0dd5f7ca\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"aba6b0d7-d42b-4b07-b257-d3eb637068ec\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigclitest-vm000006\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic/ipConfigurations/ipconfigclitest-vm000006\",\r\n
-        \       \"etag\": \"W/\\\"52e241a6-c907-471a-956c-699d43fc6c5a\\\"\",\r\n
+        \       \"etag\": \"W/\\\"a4360995-81d8-49ce-8944-04d7bcab7272\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
@@ -1471,8 +1471,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"qfhfmtfhhw0ulpubid53k3cyag.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-22-48-56-B8-06\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"awbcdngeblqeborwzggljh5npa.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-22-48-56-76-55\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -1486,9 +1486,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:31:29 GMT
+      - Fri, 16 Oct 2020 07:21:36 GMT
       etag:
-      - W/"52e241a6-c907-471a-956c-699d43fc6c5a"
+      - W/"a4360995-81d8-49ce-8944-04d7bcab7272"
       expires:
       - '-1'
       pragma:
@@ -1505,7 +1505,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 79f05fea-4ff1-4f27-91ca-43739dfc048e
+      - 2cbec329-9be1-4d0a-9254-2b257a953990
     status:
       code: 200
       message: OK
@@ -1532,12 +1532,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000006PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"f6cbab28-f2fe-4659-97c8-3013eb155cc2\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"e3e78ea8-9214-4df5-a9e1-59f0c435bfe3\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"9c554d46-f5b7-4e75-b35a-6ab1b192c36e\",\r\n
-        \   \"ipAddress\": \"23.101.28.116\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"246ae256-570d-454e-9e53-627ce9a9fd98\",\r\n
+        \   \"ipAddress\": \"52.139.199.67\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
         \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic/ipConfigurations/ipconfigclitest-vm000006\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
@@ -1550,9 +1550,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:31:29 GMT
+      - Fri, 16 Oct 2020 07:21:37 GMT
       etag:
-      - W/"f6cbab28-f2fe-4659-97c8-3013eb155cc2"
+      - W/"e3e78ea8-9214-4df5-a9e1-59f0c435bfe3"
       expires:
       - '-1'
       pragma:
@@ -1569,7 +1569,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - da9822dc-22bd-4482-8341-f19621914c0e
+      - ee7b8cc9-5389-4bcd-bdfb-8f4964bc7efd
     status:
       code: 200
       message: OK
@@ -1599,16 +1599,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"7ccc9165-6cd3-40d1-8bb6-4cb02b5a57e9\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"81ebcc78-6136-4a09-97b0-1d2613f2274e\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_02f440ce872d4de78211c272f3754297\",\r\n
+        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_b5b6ee53c07a4522a28c135fd04e26da\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGH7TBWBUWFRI37VDBUT7ZGGUBEXVPNMXE2H7UB6PMZXENT2OP74YSRLC44KJ4O6WIC/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_02f440ce872d4de78211c272f3754297\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGABAW3IMAAXAJOMCLNYBZXV57DSEP2ZXMWLJSUKBMCO3UHLF6UWGRL5L7GLJ25T4T5/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_b5b6ee53c07a4522a28c135fd04e26da\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000005\",\r\n
         \     \"adminUsername\": \"clitest-vm000005\",\r\n      \"windowsConfiguration\":
@@ -1626,7 +1626,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:31:29 GMT
+      - Fri, 16 Oct 2020 07:21:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1669,16 +1669,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2016-06-01
   response:
     body:
-      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-16T05%3A29%3A07.145647Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-16T07%3A19%3A17.3635384Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '538'
+      - '539'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:30 GMT
+      - Fri, 16 Oct 2020 07:21:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1718,7 +1718,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -1727,7 +1727,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:31 GMT
+      - Fri, 16 Oct 2020 07:21:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1778,7 +1778,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:32 GMT
+      - Fri, 16 Oct 2020 07:21:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1825,17 +1825,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2019-05-13-preview
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:31:33 GMT
+      - Fri, 16 Oct 2020 07:21:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -1868,7 +1868,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -1878,11 +1878,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:31:33 GMT
+      - Fri, 16 Oct 2020 07:21:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -1913,7 +1913,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -1923,11 +1923,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:31:34 GMT
+      - Fri, 16 Oct 2020 07:21:42 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -1958,7 +1958,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -1968,11 +1968,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:31:36 GMT
+      - Fri, 16 Oct 2020 07:21:44 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2003,7 +2003,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2013,11 +2013,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:31:37 GMT
+      - Fri, 16 Oct 2020 07:21:45 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2048,7 +2048,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2058,11 +2058,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:31:38 GMT
+      - Fri, 16 Oct 2020 07:21:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2093,7 +2093,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2103,11 +2103,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:31:39 GMT
+      - Fri, 16 Oct 2020 07:21:47 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2138,7 +2138,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2148,11 +2148,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:31:40 GMT
+      - Fri, 16 Oct 2020 07:21:48 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2183,7 +2183,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2193,11 +2193,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:31:42 GMT
+      - Fri, 16 Oct 2020 07:21:50 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -2228,52 +2228,7 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Fri, 16 Oct 2020 05:31:43 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-vm
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --vm -p
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/4e4f7fbc-77b5-476f-9c03-f261dda8d08a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/45e888a8-f530-4f4f-b17a-07e20d82df4a?api-version=2016-12-01
   response:
     body:
       string: ''
@@ -2281,7 +2236,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Fri, 16 Oct 2020 05:31:44 GMT
+      - Fri, 16 Oct 2020 07:21:51 GMT
       expires:
       - '-1'
       pragma:
@@ -2326,7 +2281,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:45 GMT
+      - Fri, 16 Oct 2020 07:21:52 GMT
       expires:
       - '-1'
       pragma:
@@ -2377,17 +2332,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationsStatus/55954780-b347-453a-b66e-3192a4cfb620?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationsStatus/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2019-06-15
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:31:46 GMT
+      - Fri, 16 Oct 2020 07:21:53 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationResults/55954780-b347-453a-b66e-3192a4cfb620?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationResults/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2019-06-15
       pragma:
       - no-cache
       strict-transport-security:
@@ -2395,7 +2350,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-powered-by:
       - ASP.NET
     status:
@@ -2420,19 +2375,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:47 GMT
+      - Fri, 16 Oct 2020 07:21:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2471,19 +2426,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:49 GMT
+      - Fri, 16 Oct 2020 07:21:54 GMT
       expires:
       - '-1'
       pragma:
@@ -2522,19 +2477,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:50 GMT
+      - Fri, 16 Oct 2020 07:21:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2573,19 +2528,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:51 GMT
+      - Fri, 16 Oct 2020 07:21:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2624,19 +2579,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:52 GMT
+      - Fri, 16 Oct 2020 07:21:58 GMT
       expires:
       - '-1'
       pragma:
@@ -2675,19 +2630,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:53 GMT
+      - Fri, 16 Oct 2020 07:21:59 GMT
       expires:
       - '-1'
       pragma:
@@ -2726,19 +2681,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:55 GMT
+      - Fri, 16 Oct 2020 07:22:00 GMT
       expires:
       - '-1'
       pragma:
@@ -2777,19 +2732,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:56 GMT
+      - Fri, 16 Oct 2020 07:22:01 GMT
       expires:
       - '-1'
       pragma:
@@ -2828,19 +2783,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:57 GMT
+      - Fri, 16 Oct 2020 07:22:04 GMT
       expires:
       - '-1'
       pragma:
@@ -2879,19 +2834,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:58 GMT
+      - Fri, 16 Oct 2020 07:22:05 GMT
       expires:
       - '-1'
       pragma:
@@ -2930,19 +2885,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:31:59 GMT
+      - Fri, 16 Oct 2020 07:22:06 GMT
       expires:
       - '-1'
       pragma:
@@ -2981,19 +2936,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:01 GMT
+      - Fri, 16 Oct 2020 07:22:07 GMT
       expires:
       - '-1'
       pragma:
@@ -3032,19 +2987,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:02 GMT
+      - Fri, 16 Oct 2020 07:22:08 GMT
       expires:
       - '-1'
       pragma:
@@ -3083,19 +3038,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:03 GMT
+      - Fri, 16 Oct 2020 07:22:10 GMT
       expires:
       - '-1'
       pragma:
@@ -3134,19 +3089,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:04 GMT
+      - Fri, 16 Oct 2020 07:22:11 GMT
       expires:
       - '-1'
       pragma:
@@ -3185,19 +3140,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:05 GMT
+      - Fri, 16 Oct 2020 07:22:12 GMT
       expires:
       - '-1'
       pragma:
@@ -3236,19 +3191,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:07 GMT
+      - Fri, 16 Oct 2020 07:22:13 GMT
       expires:
       - '-1'
       pragma:
@@ -3287,19 +3242,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:08 GMT
+      - Fri, 16 Oct 2020 07:22:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3338,19 +3293,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:09 GMT
+      - Fri, 16 Oct 2020 07:22:16 GMT
       expires:
       - '-1'
       pragma:
@@ -3389,19 +3344,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:10 GMT
+      - Fri, 16 Oct 2020 07:22:17 GMT
       expires:
       - '-1'
       pragma:
@@ -3440,19 +3395,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:11 GMT
+      - Fri, 16 Oct 2020 07:22:18 GMT
       expires:
       - '-1'
       pragma:
@@ -3491,19 +3446,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:13 GMT
+      - Fri, 16 Oct 2020 07:22:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3542,19 +3497,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:14 GMT
+      - Fri, 16 Oct 2020 07:22:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3593,19 +3548,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:15 GMT
+      - Fri, 16 Oct 2020 07:22:21 GMT
       expires:
       - '-1'
       pragma:
@@ -3644,19 +3599,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"InProgress","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '188'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:16 GMT
+      - Fri, 16 Oct 2020 07:22:23 GMT
       expires:
       - '-1'
       pragma:
@@ -3695,19 +3650,19 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/5b7f54e6-19e9-4ffd-9f90-ae4021e5d320?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"InProgress","startTime":"2020-10-16T05:31:47.348742Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","name":"5b7f54e6-19e9-4ffd-9f90-ae4021e5d320","status":"Succeeded","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"2020-10-16T07:21:53.5755805Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"d6642d14-00e6-4555-bf9b-e32dfbc30472"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '187'
+      - '304'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:18 GMT
+      - Fri, 16 Oct 2020 07:22:24 GMT
       expires:
       - '-1'
       pragma:
@@ -3746,71 +3701,20 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/55954780-b347-453a-b66e-3192a4cfb620?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d6642d14-00e6-4555-bf9b-e32dfbc30472?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"55954780-b347-453a-b66e-3192a4cfb620","name":"55954780-b347-453a-b66e-3192a4cfb620","status":"Succeeded","startTime":"2020-10-16T05:31:47.348742Z","endTime":"2020-10-16T05:31:47.348742Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"51dd6221-43ae-4c29-9334-9fe0cf4a2255"}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d6642d14-00e6-4555-bf9b-e32dfbc30472","name":"d6642d14-00e6-4555-bf9b-e32dfbc30472","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT31.0641986S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000005","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-10-16T07:21:53.5755805Z","endTime":"2020-10-16T07:22:24.6397791Z","activityId":"3a4117d9-0f80-11eb-8176-c8f750f92764"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '302'
+      - '968'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-vm
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --vm -p
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/51dd6221-43ae-4c29-9334-9fe0cf4a2255?api-version=2019-06-15
-  response:
-    body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/51dd6221-43ae-4c29-9334-9fe0cf4a2255","name":"51dd6221-43ae-4c29-9334-9fe0cf4a2255","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT31.0033595S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000005","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-10-16T05:31:47.348742Z","endTime":"2020-10-16T05:32:18.3521015Z","activityId":"d7dd48aa-0f70-11eb-bce6-c8f750f92764"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '967'
-      content-type:
-      - application/json
-      date:
-      - Fri, 16 Oct 2020 05:32:20 GMT
+      - Fri, 16 Oct 2020 07:22:26 GMT
       expires:
       - '-1'
       pragma:
@@ -3857,16 +3761,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"b08e97ce-23a7-4cb7-91af-ee82db850472\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"5720f928-3833-476c-aeb5-83b22a0a5135\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
         \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000006_disk1_c23b4ada5ca448e5b8707480ec12111a\",\r\n
+        \"Windows\",\r\n        \"name\": \"clitest-vm000006_disk1_7276eaad4d034fde89acde2050e7c101\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGH7TBWBUWFRI37VDBUT7ZGGUBEXVPNMXE2H7UB6PMZXENT2OP74YSRLC44KJ4O6WIC/providers/Microsoft.Compute/disks/clitest-vm000006_disk1_c23b4ada5ca448e5b8707480ec12111a\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGABAW3IMAAXAJOMCLNYBZXV57DSEP2ZXMWLJSUKBMCO3UHLF6UWGRL5L7GLJ25T4T5/providers/Microsoft.Compute/disks/clitest-vm000006_disk1_7276eaad4d034fde89acde2050e7c101\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000006\",\r\n
         \     \"adminUsername\": \"clitest-vm000006\",\r\n      \"windowsConfiguration\":
@@ -3884,7 +3788,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 16 Oct 2020 05:32:20 GMT
+      - Fri, 16 Oct 2020 07:22:26 GMT
       expires:
       - '-1'
       pragma:
@@ -3927,16 +3831,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2016-06-01
   response:
     body:
-      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-16T05%3A29%3A07.145647Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-16T07%3A19%3A17.3635384Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '538'
+      - '539'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:21 GMT
+      - Fri, 16 Oct 2020 07:22:27 GMT
       expires:
       - '-1'
       pragma:
@@ -3976,7 +3880,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":1}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":1}}'
     headers:
       cache-control:
       - no-cache
@@ -3985,7 +3889,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:21 GMT
+      - Fri, 16 Oct 2020 07:22:26 GMT
       expires:
       - '-1'
       pragma:
@@ -4036,7 +3940,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:21 GMT
+      - Fri, 16 Oct 2020 07:22:27 GMT
       expires:
       - '-1'
       pragma:
@@ -4087,7 +3991,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:22 GMT
+      - Fri, 16 Oct 2020 07:22:28 GMT
       expires:
       - '-1'
       pragma:
@@ -4138,17 +4042,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationsStatus/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationsStatus/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2019-06-15
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:32:23 GMT
+      - Fri, 16 Oct 2020 07:22:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationResults/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationResults/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2019-06-15
       pragma:
       - no-cache
       strict-transport-security:
@@ -4156,7 +4060,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -4181,10 +4085,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4193,7 +4097,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:25 GMT
+      - Fri, 16 Oct 2020 07:22:30 GMT
       expires:
       - '-1'
       pragma:
@@ -4232,10 +4136,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4244,7 +4148,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:26 GMT
+      - Fri, 16 Oct 2020 07:22:31 GMT
       expires:
       - '-1'
       pragma:
@@ -4283,10 +4187,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4295,7 +4199,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:27 GMT
+      - Fri, 16 Oct 2020 07:22:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4334,10 +4238,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4346,7 +4250,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:28 GMT
+      - Fri, 16 Oct 2020 07:22:34 GMT
       expires:
       - '-1'
       pragma:
@@ -4385,10 +4289,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4397,7 +4301,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:29 GMT
+      - Fri, 16 Oct 2020 07:22:35 GMT
       expires:
       - '-1'
       pragma:
@@ -4436,10 +4340,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4448,7 +4352,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:31 GMT
+      - Fri, 16 Oct 2020 07:22:36 GMT
       expires:
       - '-1'
       pragma:
@@ -4487,10 +4391,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4499,7 +4403,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:32 GMT
+      - Fri, 16 Oct 2020 07:22:37 GMT
       expires:
       - '-1'
       pragma:
@@ -4538,10 +4442,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4550,7 +4454,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:33 GMT
+      - Fri, 16 Oct 2020 07:22:39 GMT
       expires:
       - '-1'
       pragma:
@@ -4589,10 +4493,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4601,7 +4505,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:34 GMT
+      - Fri, 16 Oct 2020 07:22:40 GMT
       expires:
       - '-1'
       pragma:
@@ -4640,10 +4544,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4652,7 +4556,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:36 GMT
+      - Fri, 16 Oct 2020 07:22:41 GMT
       expires:
       - '-1'
       pragma:
@@ -4691,10 +4595,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4703,7 +4607,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:37 GMT
+      - Fri, 16 Oct 2020 07:22:42 GMT
       expires:
       - '-1'
       pragma:
@@ -4742,10 +4646,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4754,7 +4658,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:38 GMT
+      - Fri, 16 Oct 2020 07:22:43 GMT
       expires:
       - '-1'
       pragma:
@@ -4793,10 +4697,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4805,7 +4709,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:39 GMT
+      - Fri, 16 Oct 2020 07:22:45 GMT
       expires:
       - '-1'
       pragma:
@@ -4844,10 +4748,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4856,7 +4760,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:40 GMT
+      - Fri, 16 Oct 2020 07:22:46 GMT
       expires:
       - '-1'
       pragma:
@@ -4895,10 +4799,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4907,7 +4811,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:42 GMT
+      - Fri, 16 Oct 2020 07:22:47 GMT
       expires:
       - '-1'
       pragma:
@@ -4946,10 +4850,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4958,7 +4862,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:43 GMT
+      - Fri, 16 Oct 2020 07:22:49 GMT
       expires:
       - '-1'
       pragma:
@@ -4997,10 +4901,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5009,7 +4913,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:44 GMT
+      - Fri, 16 Oct 2020 07:22:50 GMT
       expires:
       - '-1'
       pragma:
@@ -5048,10 +4952,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5060,7 +4964,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:45 GMT
+      - Fri, 16 Oct 2020 07:22:51 GMT
       expires:
       - '-1'
       pragma:
@@ -5099,10 +5003,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5111,7 +5015,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:47 GMT
+      - Fri, 16 Oct 2020 07:22:52 GMT
       expires:
       - '-1'
       pragma:
@@ -5150,10 +5054,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5162,7 +5066,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:48 GMT
+      - Fri, 16 Oct 2020 07:22:53 GMT
       expires:
       - '-1'
       pragma:
@@ -5201,10 +5105,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5213,7 +5117,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:49 GMT
+      - Fri, 16 Oct 2020 07:22:55 GMT
       expires:
       - '-1'
       pragma:
@@ -5252,10 +5156,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5264,7 +5168,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:50 GMT
+      - Fri, 16 Oct 2020 07:22:56 GMT
       expires:
       - '-1'
       pragma:
@@ -5303,10 +5207,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5315,7 +5219,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:52 GMT
+      - Fri, 16 Oct 2020 07:22:58 GMT
       expires:
       - '-1'
       pragma:
@@ -5354,10 +5258,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5366,7 +5270,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:53 GMT
+      - Fri, 16 Oct 2020 07:22:59 GMT
       expires:
       - '-1'
       pragma:
@@ -5405,10 +5309,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"InProgress","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"InProgress","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -5417,7 +5321,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:54 GMT
+      - Fri, 16 Oct 2020 07:23:00 GMT
       expires:
       - '-1'
       pragma:
@@ -5456,10 +5360,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fe19ab75-f0df-4c94-80f4-6855c68410f5?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ab8350dd-e5d3-48a3-874b-ec2066f3aec1?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"fe19ab75-f0df-4c94-80f4-6855c68410f5","name":"fe19ab75-f0df-4c94-80f4-6855c68410f5","status":"Succeeded","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"2020-10-16T05:32:24.0288301Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"7ae5838e-e774-4f2d-98ce-8042698180f2"}}'
+      string: '{"id":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","name":"ab8350dd-e5d3-48a3-874b-ec2066f3aec1","status":"Succeeded","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"2020-10-16T07:22:30.1058422Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"af230348-f15d-454b-a1f5-84591ca9171c"}}'
     headers:
       cache-control:
       - no-cache
@@ -5468,7 +5372,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:55 GMT
+      - Fri, 16 Oct 2020 07:23:02 GMT
       expires:
       - '-1'
       pragma:
@@ -5507,20 +5411,20 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7ae5838e-e774-4f2d-98ce-8042698180f2?api-version=2019-06-15
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/af230348-f15d-454b-a1f5-84591ca9171c?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7ae5838e-e774-4f2d-98ce-8042698180f2","name":"7ae5838e-e774-4f2d-98ce-8042698180f2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT30.9870907S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000006","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-10-16T05:32:24.0288301Z","endTime":"2020-10-16T05:32:55.0159208Z","activityId":"f62a190a-0f70-11eb-82de-c8f750f92764"}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/af230348-f15d-454b-a1f5-84591ca9171c","name":"af230348-f15d-454b-a1f5-84591ca9171c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT30.866379S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000006","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-10-16T07:22:30.1058422Z","endTime":"2020-10-16T07:23:00.9722212Z","activityId":"57a1136e-0f80-11eb-b6c1-c8f750f92764"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '968'
+      - '967'
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:57 GMT
+      - Fri, 16 Oct 2020 07:23:01 GMT
       expires:
       - '-1'
       pragma:
@@ -5572,7 +5476,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:57 GMT
+      - Fri, 16 Oct 2020 07:23:02 GMT
       expires:
       - '-1'
       pragma:
@@ -5628,7 +5532,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:58 GMT
+      - Fri, 16 Oct 2020 07:23:03 GMT
       expires:
       - '-1'
       pragma:
@@ -5644,7 +5548,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-powered-by:
       - ASP.NET
     status:
@@ -5672,7 +5576,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -5681,7 +5585,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:58 GMT
+      - Fri, 16 Oct 2020 07:23:04 GMT
       expires:
       - '-1'
       pragma:
@@ -5723,7 +5627,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2019-06-15
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -5732,7 +5636,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:59 GMT
+      - Fri, 16 Oct 2020 07:23:04 GMT
       expires:
       - '-1'
       pragma:
@@ -5774,7 +5678,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=policyName%20eq%20%27DefaultPolicy%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70368843776974","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70370462661815","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593155383840","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593236760327","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -5783,7 +5687,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:32:59 GMT
+      - Fri, 16 Oct 2020 07:23:04 GMT
       expires:
       - '-1'
       pragma:
@@ -5806,9 +5710,9 @@ interactions:
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
       "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy", "scheduleRunFrequency":
-      "Daily", "scheduleRunTimes": ["2020-10-16T15:00:00.000Z"], "scheduleWeeklyFrequency":
+      "Daily", "scheduleRunTimes": ["2020-10-16T17:00:00.000Z"], "scheduleWeeklyFrequency":
       0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy", "dailySchedule":
-      {"retentionTimes": ["2020-10-16T15:00:00.000Z"], "retentionDuration": {"count":
+      {"retentionTimes": ["2020-10-16T17:00:00.000Z"], "retentionDuration": {"count":
       30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 2, "timeZone":
       "UTC"}}'
     headers:
@@ -5835,7 +5739,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy5000010?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy5000010","name":"clitest-policy5000010","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy5000010","name":"clitest-policy5000010","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -5844,7 +5748,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:01 GMT
+      - Fri, 16 Oct 2020 07:23:05 GMT
       expires:
       - '-1'
       pragma:
@@ -5897,7 +5801,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:33:02 GMT
+      - Fri, 16 Oct 2020 07:23:06 GMT
       expires:
       - '-1'
       pragma:
@@ -5917,9 +5821,9 @@ interactions:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
       "instantRPDetails": {"azureBackupRGNamePrefix": "RG_prefix", "azureBackupRGNameSuffix":
       "RG_suffix"}, "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-16T15:00:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-16T17:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2020-10-16T15:00:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2020-10-16T17:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 2,
       "timeZone": "UTC"}}'
     headers:
@@ -5946,7 +5850,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -5955,7 +5859,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:03 GMT
+      - Fri, 16 Oct 2020 07:23:07 GMT
       expires:
       - '-1'
       pragma:
@@ -5999,7 +5903,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2019-06-15
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -6008,7 +5912,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:03 GMT
+      - Fri, 16 Oct 2020 07:23:07 GMT
       expires:
       - '-1'
       pragma:
@@ -6059,7 +5963,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:33:04 GMT
+      - Fri, 16 Oct 2020 07:23:09 GMT
       expires:
       - '-1'
       pragma:
@@ -6069,7 +5973,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
+      - '14999'
       x-powered-by:
       - ASP.NET
     status:
@@ -6097,7 +6001,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2019-06-15
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -6106,7 +6010,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:06 GMT
+      - Fri, 16 Oct 2020 07:23:11 GMT
       expires:
       - '-1'
       pragma:
@@ -6148,7 +6052,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T15:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T15:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -6157,7 +6061,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:07 GMT
+      - Fri, 16 Oct 2020 07:23:11 GMT
       expires:
       - '-1'
       pragma:
@@ -6208,7 +6112,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:07 GMT
+      - Fri, 16 Oct 2020 07:23:11 GMT
       expires:
       - '-1'
       pragma:
@@ -6250,7 +6154,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70368843776974","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70370462661815","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593155383840","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593236760327","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -6259,7 +6163,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:07 GMT
+      - Fri, 16 Oct 2020 07:23:11 GMT
       expires:
       - '-1'
       pragma:
@@ -6302,7 +6206,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70368843776974","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70370462661815","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593155383840","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593236760327","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -6311,7 +6215,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:08 GMT
+      - Fri, 16 Oct 2020 07:23:12 GMT
       expires:
       - '-1'
       pragma:
@@ -6359,17 +6263,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2019-06-15
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:33:09 GMT
+      - Fri, 16 Oct 2020 07:23:14 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2019-06-15
       pragma:
       - no-cache
       strict-transport-security:
@@ -6403,10 +6307,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6415,7 +6319,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:09 GMT
+      - Fri, 16 Oct 2020 07:23:14 GMT
       expires:
       - '-1'
       pragma:
@@ -6455,10 +6359,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6467,7 +6371,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:10 GMT
+      - Fri, 16 Oct 2020 07:23:15 GMT
       expires:
       - '-1'
       pragma:
@@ -6507,10 +6411,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6519,7 +6423,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:11 GMT
+      - Fri, 16 Oct 2020 07:23:16 GMT
       expires:
       - '-1'
       pragma:
@@ -6559,10 +6463,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6571,7 +6475,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:13 GMT
+      - Fri, 16 Oct 2020 07:23:17 GMT
       expires:
       - '-1'
       pragma:
@@ -6611,10 +6515,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6623,7 +6527,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:14 GMT
+      - Fri, 16 Oct 2020 07:23:19 GMT
       expires:
       - '-1'
       pragma:
@@ -6663,10 +6567,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6675,7 +6579,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:16 GMT
+      - Fri, 16 Oct 2020 07:23:20 GMT
       expires:
       - '-1'
       pragma:
@@ -6715,10 +6619,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6727,7 +6631,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:17 GMT
+      - Fri, 16 Oct 2020 07:23:21 GMT
       expires:
       - '-1'
       pragma:
@@ -6767,10 +6671,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6779,7 +6683,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:18 GMT
+      - Fri, 16 Oct 2020 07:23:22 GMT
       expires:
       - '-1'
       pragma:
@@ -6819,10 +6723,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6831,7 +6735,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:19 GMT
+      - Fri, 16 Oct 2020 07:23:23 GMT
       expires:
       - '-1'
       pragma:
@@ -6871,10 +6775,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6883,7 +6787,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:21 GMT
+      - Fri, 16 Oct 2020 07:23:25 GMT
       expires:
       - '-1'
       pragma:
@@ -6923,10 +6827,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6935,7 +6839,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:22 GMT
+      - Fri, 16 Oct 2020 07:23:27 GMT
       expires:
       - '-1'
       pragma:
@@ -6975,10 +6879,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -6987,7 +6891,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:23 GMT
+      - Fri, 16 Oct 2020 07:23:28 GMT
       expires:
       - '-1'
       pragma:
@@ -7027,10 +6931,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7039,7 +6943,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:24 GMT
+      - Fri, 16 Oct 2020 07:23:29 GMT
       expires:
       - '-1'
       pragma:
@@ -7079,10 +6983,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7091,7 +6995,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:26 GMT
+      - Fri, 16 Oct 2020 07:23:31 GMT
       expires:
       - '-1'
       pragma:
@@ -7131,10 +7035,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7143,7 +7047,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:27 GMT
+      - Fri, 16 Oct 2020 07:23:32 GMT
       expires:
       - '-1'
       pragma:
@@ -7183,10 +7087,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7195,7 +7099,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:28 GMT
+      - Fri, 16 Oct 2020 07:23:33 GMT
       expires:
       - '-1'
       pragma:
@@ -7235,10 +7139,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7247,7 +7151,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:29 GMT
+      - Fri, 16 Oct 2020 07:23:34 GMT
       expires:
       - '-1'
       pragma:
@@ -7287,10 +7191,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7299,7 +7203,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:30 GMT
+      - Fri, 16 Oct 2020 07:23:36 GMT
       expires:
       - '-1'
       pragma:
@@ -7339,10 +7243,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7351,7 +7255,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:32 GMT
+      - Fri, 16 Oct 2020 07:23:37 GMT
       expires:
       - '-1'
       pragma:
@@ -7391,10 +7295,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7403,7 +7307,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:33 GMT
+      - Fri, 16 Oct 2020 07:23:38 GMT
       expires:
       - '-1'
       pragma:
@@ -7443,10 +7347,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7455,7 +7359,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:34 GMT
+      - Fri, 16 Oct 2020 07:23:39 GMT
       expires:
       - '-1'
       pragma:
@@ -7495,10 +7399,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7507,7 +7411,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:35 GMT
+      - Fri, 16 Oct 2020 07:23:40 GMT
       expires:
       - '-1'
       pragma:
@@ -7547,10 +7451,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7559,7 +7463,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:36 GMT
+      - Fri, 16 Oct 2020 07:23:42 GMT
       expires:
       - '-1'
       pragma:
@@ -7599,10 +7503,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7611,7 +7515,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:38 GMT
+      - Fri, 16 Oct 2020 07:23:43 GMT
       expires:
       - '-1'
       pragma:
@@ -7651,10 +7555,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7663,7 +7567,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:39 GMT
+      - Fri, 16 Oct 2020 07:23:44 GMT
       expires:
       - '-1'
       pragma:
@@ -7703,10 +7607,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7715,7 +7619,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:40 GMT
+      - Fri, 16 Oct 2020 07:23:45 GMT
       expires:
       - '-1'
       pragma:
@@ -7755,10 +7659,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7767,7 +7671,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:41 GMT
+      - Fri, 16 Oct 2020 07:23:47 GMT
       expires:
       - '-1'
       pragma:
@@ -7807,10 +7711,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7819,7 +7723,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:43 GMT
+      - Fri, 16 Oct 2020 07:23:48 GMT
       expires:
       - '-1'
       pragma:
@@ -7859,10 +7763,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7871,7 +7775,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:45 GMT
+      - Fri, 16 Oct 2020 07:23:49 GMT
       expires:
       - '-1'
       pragma:
@@ -7911,10 +7815,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7923,7 +7827,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:46 GMT
+      - Fri, 16 Oct 2020 07:23:50 GMT
       expires:
       - '-1'
       pragma:
@@ -7963,10 +7867,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -7975,7 +7879,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:47 GMT
+      - Fri, 16 Oct 2020 07:23:51 GMT
       expires:
       - '-1'
       pragma:
@@ -8015,10 +7919,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8027,7 +7931,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:48 GMT
+      - Fri, 16 Oct 2020 07:23:53 GMT
       expires:
       - '-1'
       pragma:
@@ -8067,10 +7971,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8079,7 +7983,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:49 GMT
+      - Fri, 16 Oct 2020 07:23:54 GMT
       expires:
       - '-1'
       pragma:
@@ -8119,10 +8023,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8131,7 +8035,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:51 GMT
+      - Fri, 16 Oct 2020 07:23:55 GMT
       expires:
       - '-1'
       pragma:
@@ -8171,10 +8075,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8183,7 +8087,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:52 GMT
+      - Fri, 16 Oct 2020 07:23:56 GMT
       expires:
       - '-1'
       pragma:
@@ -8223,10 +8127,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8235,7 +8139,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:53 GMT
+      - Fri, 16 Oct 2020 07:23:57 GMT
       expires:
       - '-1'
       pragma:
@@ -8275,10 +8179,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8287,7 +8191,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:54 GMT
+      - Fri, 16 Oct 2020 07:24:00 GMT
       expires:
       - '-1'
       pragma:
@@ -8327,10 +8231,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8339,7 +8243,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:56 GMT
+      - Fri, 16 Oct 2020 07:24:01 GMT
       expires:
       - '-1'
       pragma:
@@ -8379,10 +8283,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8391,7 +8295,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:57 GMT
+      - Fri, 16 Oct 2020 07:24:02 GMT
       expires:
       - '-1'
       pragma:
@@ -8431,10 +8335,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8443,7 +8347,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:58 GMT
+      - Fri, 16 Oct 2020 07:24:03 GMT
       expires:
       - '-1'
       pragma:
@@ -8483,10 +8387,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8495,7 +8399,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:33:59 GMT
+      - Fri, 16 Oct 2020 07:24:04 GMT
       expires:
       - '-1'
       pragma:
@@ -8535,10 +8439,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8547,7 +8451,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:00 GMT
+      - Fri, 16 Oct 2020 07:24:06 GMT
       expires:
       - '-1'
       pragma:
@@ -8587,10 +8491,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8599,7 +8503,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:02 GMT
+      - Fri, 16 Oct 2020 07:24:07 GMT
       expires:
       - '-1'
       pragma:
@@ -8639,10 +8543,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8651,7 +8555,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:03 GMT
+      - Fri, 16 Oct 2020 07:24:08 GMT
       expires:
       - '-1'
       pragma:
@@ -8691,10 +8595,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8703,7 +8607,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:04 GMT
+      - Fri, 16 Oct 2020 07:24:09 GMT
       expires:
       - '-1'
       pragma:
@@ -8743,10 +8647,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8755,7 +8659,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:05 GMT
+      - Fri, 16 Oct 2020 07:24:11 GMT
       expires:
       - '-1'
       pragma:
@@ -8795,10 +8699,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8807,7 +8711,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:07 GMT
+      - Fri, 16 Oct 2020 07:24:12 GMT
       expires:
       - '-1'
       pragma:
@@ -8847,10 +8751,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8859,7 +8763,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:08 GMT
+      - Fri, 16 Oct 2020 07:24:13 GMT
       expires:
       - '-1'
       pragma:
@@ -8899,10 +8803,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8911,7 +8815,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:09 GMT
+      - Fri, 16 Oct 2020 07:24:14 GMT
       expires:
       - '-1'
       pragma:
@@ -8951,10 +8855,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8963,7 +8867,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:10 GMT
+      - Fri, 16 Oct 2020 07:24:15 GMT
       expires:
       - '-1'
       pragma:
@@ -9003,10 +8907,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9015,7 +8919,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:11 GMT
+      - Fri, 16 Oct 2020 07:24:17 GMT
       expires:
       - '-1'
       pragma:
@@ -9055,10 +8959,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9067,7 +8971,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:13 GMT
+      - Fri, 16 Oct 2020 07:24:18 GMT
       expires:
       - '-1'
       pragma:
@@ -9107,10 +9011,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9119,7 +9023,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:14 GMT
+      - Fri, 16 Oct 2020 07:24:19 GMT
       expires:
       - '-1'
       pragma:
@@ -9159,10 +9063,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9171,7 +9075,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:15 GMT
+      - Fri, 16 Oct 2020 07:24:20 GMT
       expires:
       - '-1'
       pragma:
@@ -9211,10 +9115,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9223,7 +9127,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:16 GMT
+      - Fri, 16 Oct 2020 07:24:21 GMT
       expires:
       - '-1'
       pragma:
@@ -9263,10 +9167,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9275,7 +9179,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:19 GMT
+      - Fri, 16 Oct 2020 07:24:23 GMT
       expires:
       - '-1'
       pragma:
@@ -9315,10 +9219,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9327,7 +9231,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:20 GMT
+      - Fri, 16 Oct 2020 07:24:25 GMT
       expires:
       - '-1'
       pragma:
@@ -9367,10 +9271,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9379,7 +9283,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:21 GMT
+      - Fri, 16 Oct 2020 07:24:26 GMT
       expires:
       - '-1'
       pragma:
@@ -9419,10 +9323,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9431,7 +9335,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:22 GMT
+      - Fri, 16 Oct 2020 07:24:27 GMT
       expires:
       - '-1'
       pragma:
@@ -9471,10 +9375,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9483,7 +9387,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:23 GMT
+      - Fri, 16 Oct 2020 07:24:28 GMT
       expires:
       - '-1'
       pragma:
@@ -9523,10 +9427,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9535,7 +9439,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:25 GMT
+      - Fri, 16 Oct 2020 07:24:29 GMT
       expires:
       - '-1'
       pragma:
@@ -9575,10 +9479,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9587,7 +9491,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:26 GMT
+      - Fri, 16 Oct 2020 07:24:31 GMT
       expires:
       - '-1'
       pragma:
@@ -9627,10 +9531,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9639,7 +9543,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:27 GMT
+      - Fri, 16 Oct 2020 07:24:32 GMT
       expires:
       - '-1'
       pragma:
@@ -9679,10 +9583,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9691,7 +9595,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:28 GMT
+      - Fri, 16 Oct 2020 07:24:33 GMT
       expires:
       - '-1'
       pragma:
@@ -9731,10 +9635,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9743,7 +9647,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:29 GMT
+      - Fri, 16 Oct 2020 07:24:34 GMT
       expires:
       - '-1'
       pragma:
@@ -9783,10 +9687,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9795,7 +9699,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:31 GMT
+      - Fri, 16 Oct 2020 07:24:36 GMT
       expires:
       - '-1'
       pragma:
@@ -9835,10 +9739,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9847,7 +9751,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:32 GMT
+      - Fri, 16 Oct 2020 07:24:37 GMT
       expires:
       - '-1'
       pragma:
@@ -9887,10 +9791,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9899,7 +9803,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:33 GMT
+      - Fri, 16 Oct 2020 07:24:38 GMT
       expires:
       - '-1'
       pragma:
@@ -9939,10 +9843,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9951,7 +9855,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:34 GMT
+      - Fri, 16 Oct 2020 07:24:39 GMT
       expires:
       - '-1'
       pragma:
@@ -9991,10 +9895,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10003,7 +9907,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:36 GMT
+      - Fri, 16 Oct 2020 07:24:41 GMT
       expires:
       - '-1'
       pragma:
@@ -10043,10 +9947,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10055,7 +9959,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:37 GMT
+      - Fri, 16 Oct 2020 07:24:42 GMT
       expires:
       - '-1'
       pragma:
@@ -10095,10 +9999,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10107,7 +10011,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:39 GMT
+      - Fri, 16 Oct 2020 07:24:43 GMT
       expires:
       - '-1'
       pragma:
@@ -10147,10 +10051,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10159,7 +10063,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:40 GMT
+      - Fri, 16 Oct 2020 07:24:44 GMT
       expires:
       - '-1'
       pragma:
@@ -10199,10 +10103,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10211,7 +10115,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:41 GMT
+      - Fri, 16 Oct 2020 07:24:45 GMT
       expires:
       - '-1'
       pragma:
@@ -10251,10 +10155,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10263,7 +10167,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:42 GMT
+      - Fri, 16 Oct 2020 07:24:47 GMT
       expires:
       - '-1'
       pragma:
@@ -10303,10 +10207,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10315,7 +10219,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:43 GMT
+      - Fri, 16 Oct 2020 07:24:48 GMT
       expires:
       - '-1'
       pragma:
@@ -10355,10 +10259,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10367,7 +10271,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:45 GMT
+      - Fri, 16 Oct 2020 07:24:49 GMT
       expires:
       - '-1'
       pragma:
@@ -10407,10 +10311,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10419,7 +10323,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:46 GMT
+      - Fri, 16 Oct 2020 07:24:50 GMT
       expires:
       - '-1'
       pragma:
@@ -10459,10 +10363,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10471,7 +10375,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:47 GMT
+      - Fri, 16 Oct 2020 07:24:51 GMT
       expires:
       - '-1'
       pragma:
@@ -10511,10 +10415,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10523,7 +10427,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:48 GMT
+      - Fri, 16 Oct 2020 07:24:54 GMT
       expires:
       - '-1'
       pragma:
@@ -10563,10 +10467,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10575,7 +10479,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:50 GMT
+      - Fri, 16 Oct 2020 07:24:55 GMT
       expires:
       - '-1'
       pragma:
@@ -10615,10 +10519,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10627,7 +10531,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:51 GMT
+      - Fri, 16 Oct 2020 07:24:56 GMT
       expires:
       - '-1'
       pragma:
@@ -10667,10 +10571,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10679,7 +10583,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:52 GMT
+      - Fri, 16 Oct 2020 07:24:57 GMT
       expires:
       - '-1'
       pragma:
@@ -10719,10 +10623,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10731,7 +10635,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:53 GMT
+      - Fri, 16 Oct 2020 07:24:58 GMT
       expires:
       - '-1'
       pragma:
@@ -10771,10 +10675,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10783,7 +10687,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:54 GMT
+      - Fri, 16 Oct 2020 07:25:00 GMT
       expires:
       - '-1'
       pragma:
@@ -10823,10 +10727,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10835,7 +10739,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:56 GMT
+      - Fri, 16 Oct 2020 07:25:01 GMT
       expires:
       - '-1'
       pragma:
@@ -10875,10 +10779,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10887,7 +10791,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:57 GMT
+      - Fri, 16 Oct 2020 07:25:02 GMT
       expires:
       - '-1'
       pragma:
@@ -10927,10 +10831,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10939,7 +10843,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:34:58 GMT
+      - Fri, 16 Oct 2020 07:25:03 GMT
       expires:
       - '-1'
       pragma:
@@ -10979,10 +10883,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"InProgress","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"InProgress","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10991,7 +10895,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:00 GMT
+      - Fri, 16 Oct 2020 07:25:05 GMT
       expires:
       - '-1'
       pragma:
@@ -11031,10 +10935,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/8e50af1c-91e2-4248-b8a5-e88958ae9b42?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/64088854-a20d-4967-b18f-0f4d1a66e70a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","name":"8e50af1c-91e2-4248-b8a5-e88958ae9b42","status":"Succeeded","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"2020-10-16T05:33:09.2832611Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"d138a460-21ca-49cf-92a3-87bcf859f85d"}}'
+      string: '{"id":"64088854-a20d-4967-b18f-0f4d1a66e70a","name":"64088854-a20d-4967-b18f-0f4d1a66e70a","status":"Succeeded","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"2020-10-16T07:23:14.0730056Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"522e7ffe-a37f-40a3-b95c-a0f83252d7c2"}}'
     headers:
       cache-control:
       - no-cache
@@ -11043,7 +10947,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:01 GMT
+      - Fri, 16 Oct 2020 07:25:06 GMT
       expires:
       - '-1'
       pragma:
@@ -11083,11 +10987,11 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d138a460-21ca-49cf-92a3-87bcf859f85d?api-version=2019-06-15
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/522e7ffe-a37f-40a3-b95c-a0f83252d7c2?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d138a460-21ca-49cf-92a3-87bcf859f85d","name":"d138a460-21ca-49cf-92a3-87bcf859f85d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT1M51.8751354S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000006","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-10-16T05:33:09.2832611Z","endTime":"2020-10-16T05:35:01.1583965Z","activityId":"12ad7f10-0f71-11eb-bd45-c8f750f92764"}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/522e7ffe-a37f-40a3-b95c-a0f83252d7c2","name":"522e7ffe-a37f-40a3-b95c-a0f83252d7c2","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT1M51.5719883S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000006","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-10-16T07:23:14.0730056Z","endTime":"2020-10-16T07:25:05.6449939Z","activityId":"7321fad5-0f80-11eb-a232-c8f750f92764"}}'
     headers:
       cache-control:
       - no-cache
@@ -11096,7 +11000,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:02 GMT
+      - Fri, 16 Oct 2020 07:25:06 GMT
       expires:
       - '-1'
       pragma:
@@ -11139,7 +11043,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70370462661815","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593236760327","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -11148,7 +11052,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:02 GMT
+      - Fri, 16 Oct 2020 07:25:07 GMT
       expires:
       - '-1'
       pragma:
@@ -11191,7 +11095,7 @@ interactions:
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"70370462661815","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593236760327","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -11200,7 +11104,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:03 GMT
+      - Fri, 16 Oct 2020 07:25:07 GMT
       expires:
       - '-1'
       pragma:
@@ -11248,17 +11152,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2019-06-15
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:35:04 GMT
+      - Fri, 16 Oct 2020 07:25:09 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/59680973-9993-46e0-a295-ec895881930f?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2019-06-15
       pragma:
       - no-cache
       strict-transport-security:
@@ -11266,7 +11170,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
+      - '14998'
       x-powered-by:
       - ASP.NET
     status:
@@ -11292,10 +11196,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11304,7 +11208,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:04 GMT
+      - Fri, 16 Oct 2020 07:25:09 GMT
       expires:
       - '-1'
       pragma:
@@ -11344,10 +11248,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11356,7 +11260,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:07 GMT
+      - Fri, 16 Oct 2020 07:25:11 GMT
       expires:
       - '-1'
       pragma:
@@ -11396,10 +11300,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11408,7 +11312,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:08 GMT
+      - Fri, 16 Oct 2020 07:25:12 GMT
       expires:
       - '-1'
       pragma:
@@ -11448,10 +11352,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11460,7 +11364,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:09 GMT
+      - Fri, 16 Oct 2020 07:25:13 GMT
       expires:
       - '-1'
       pragma:
@@ -11500,10 +11404,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11512,7 +11416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:10 GMT
+      - Fri, 16 Oct 2020 07:25:14 GMT
       expires:
       - '-1'
       pragma:
@@ -11552,10 +11456,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11564,7 +11468,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:12 GMT
+      - Fri, 16 Oct 2020 07:25:16 GMT
       expires:
       - '-1'
       pragma:
@@ -11604,10 +11508,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11616,7 +11520,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:13 GMT
+      - Fri, 16 Oct 2020 07:25:17 GMT
       expires:
       - '-1'
       pragma:
@@ -11656,10 +11560,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11668,7 +11572,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:14 GMT
+      - Fri, 16 Oct 2020 07:25:18 GMT
       expires:
       - '-1'
       pragma:
@@ -11708,10 +11612,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11720,7 +11624,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:15 GMT
+      - Fri, 16 Oct 2020 07:25:19 GMT
       expires:
       - '-1'
       pragma:
@@ -11760,10 +11664,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11772,7 +11676,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:17 GMT
+      - Fri, 16 Oct 2020 07:25:21 GMT
       expires:
       - '-1'
       pragma:
@@ -11812,10 +11716,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11824,7 +11728,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:18 GMT
+      - Fri, 16 Oct 2020 07:25:22 GMT
       expires:
       - '-1'
       pragma:
@@ -11864,10 +11768,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11876,7 +11780,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:19 GMT
+      - Fri, 16 Oct 2020 07:25:25 GMT
       expires:
       - '-1'
       pragma:
@@ -11916,10 +11820,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11928,7 +11832,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:20 GMT
+      - Fri, 16 Oct 2020 07:25:26 GMT
       expires:
       - '-1'
       pragma:
@@ -11968,10 +11872,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -11980,7 +11884,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:22 GMT
+      - Fri, 16 Oct 2020 07:25:27 GMT
       expires:
       - '-1'
       pragma:
@@ -12020,10 +11924,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12032,7 +11936,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:23 GMT
+      - Fri, 16 Oct 2020 07:25:29 GMT
       expires:
       - '-1'
       pragma:
@@ -12072,10 +11976,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12084,7 +11988,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:24 GMT
+      - Fri, 16 Oct 2020 07:25:30 GMT
       expires:
       - '-1'
       pragma:
@@ -12124,10 +12028,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12136,7 +12040,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:25 GMT
+      - Fri, 16 Oct 2020 07:25:31 GMT
       expires:
       - '-1'
       pragma:
@@ -12176,10 +12080,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12188,7 +12092,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:27 GMT
+      - Fri, 16 Oct 2020 07:25:32 GMT
       expires:
       - '-1'
       pragma:
@@ -12228,10 +12132,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12240,7 +12144,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:28 GMT
+      - Fri, 16 Oct 2020 07:25:33 GMT
       expires:
       - '-1'
       pragma:
@@ -12280,10 +12184,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12292,7 +12196,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:29 GMT
+      - Fri, 16 Oct 2020 07:25:35 GMT
       expires:
       - '-1'
       pragma:
@@ -12332,10 +12236,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12344,7 +12248,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:30 GMT
+      - Fri, 16 Oct 2020 07:25:36 GMT
       expires:
       - '-1'
       pragma:
@@ -12384,10 +12288,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12396,7 +12300,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:32 GMT
+      - Fri, 16 Oct 2020 07:25:37 GMT
       expires:
       - '-1'
       pragma:
@@ -12436,10 +12340,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12448,7 +12352,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:33 GMT
+      - Fri, 16 Oct 2020 07:25:39 GMT
       expires:
       - '-1'
       pragma:
@@ -12488,10 +12392,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12500,7 +12404,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:34 GMT
+      - Fri, 16 Oct 2020 07:25:40 GMT
       expires:
       - '-1'
       pragma:
@@ -12540,10 +12444,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12552,7 +12456,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:35 GMT
+      - Fri, 16 Oct 2020 07:25:41 GMT
       expires:
       - '-1'
       pragma:
@@ -12592,10 +12496,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12604,7 +12508,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:37 GMT
+      - Fri, 16 Oct 2020 07:25:42 GMT
       expires:
       - '-1'
       pragma:
@@ -12644,10 +12548,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12656,7 +12560,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:38 GMT
+      - Fri, 16 Oct 2020 07:25:44 GMT
       expires:
       - '-1'
       pragma:
@@ -12696,10 +12600,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12708,7 +12612,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:39 GMT
+      - Fri, 16 Oct 2020 07:25:45 GMT
       expires:
       - '-1'
       pragma:
@@ -12748,10 +12652,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12760,7 +12664,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:40 GMT
+      - Fri, 16 Oct 2020 07:25:46 GMT
       expires:
       - '-1'
       pragma:
@@ -12800,10 +12704,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12812,7 +12716,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:42 GMT
+      - Fri, 16 Oct 2020 07:25:47 GMT
       expires:
       - '-1'
       pragma:
@@ -12852,10 +12756,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12864,7 +12768,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:43 GMT
+      - Fri, 16 Oct 2020 07:25:48 GMT
       expires:
       - '-1'
       pragma:
@@ -12904,10 +12808,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12916,7 +12820,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:44 GMT
+      - Fri, 16 Oct 2020 07:25:50 GMT
       expires:
       - '-1'
       pragma:
@@ -12956,10 +12860,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -12968,7 +12872,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:46 GMT
+      - Fri, 16 Oct 2020 07:25:51 GMT
       expires:
       - '-1'
       pragma:
@@ -13008,10 +12912,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13020,7 +12924,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:48 GMT
+      - Fri, 16 Oct 2020 07:25:52 GMT
       expires:
       - '-1'
       pragma:
@@ -13060,10 +12964,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13072,7 +12976,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:49 GMT
+      - Fri, 16 Oct 2020 07:25:53 GMT
       expires:
       - '-1'
       pragma:
@@ -13112,10 +13016,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13124,7 +13028,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:50 GMT
+      - Fri, 16 Oct 2020 07:25:56 GMT
       expires:
       - '-1'
       pragma:
@@ -13164,10 +13068,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13176,7 +13080,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:51 GMT
+      - Fri, 16 Oct 2020 07:25:57 GMT
       expires:
       - '-1'
       pragma:
@@ -13216,10 +13120,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13228,7 +13132,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:53 GMT
+      - Fri, 16 Oct 2020 07:25:58 GMT
       expires:
       - '-1'
       pragma:
@@ -13268,10 +13172,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13280,7 +13184,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:54 GMT
+      - Fri, 16 Oct 2020 07:25:59 GMT
       expires:
       - '-1'
       pragma:
@@ -13320,10 +13224,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13332,7 +13236,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:55 GMT
+      - Fri, 16 Oct 2020 07:26:00 GMT
       expires:
       - '-1'
       pragma:
@@ -13372,10 +13276,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13384,7 +13288,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:56 GMT
+      - Fri, 16 Oct 2020 07:26:02 GMT
       expires:
       - '-1'
       pragma:
@@ -13424,10 +13328,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13436,7 +13340,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:58 GMT
+      - Fri, 16 Oct 2020 07:26:03 GMT
       expires:
       - '-1'
       pragma:
@@ -13476,10 +13380,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13488,7 +13392,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:35:59 GMT
+      - Fri, 16 Oct 2020 07:26:05 GMT
       expires:
       - '-1'
       pragma:
@@ -13528,10 +13432,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13540,7 +13444,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:00 GMT
+      - Fri, 16 Oct 2020 07:26:06 GMT
       expires:
       - '-1'
       pragma:
@@ -13580,10 +13484,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13592,7 +13496,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:01 GMT
+      - Fri, 16 Oct 2020 07:26:07 GMT
       expires:
       - '-1'
       pragma:
@@ -13632,10 +13536,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13644,7 +13548,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:03 GMT
+      - Fri, 16 Oct 2020 07:26:08 GMT
       expires:
       - '-1'
       pragma:
@@ -13684,10 +13588,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13696,7 +13600,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:04 GMT
+      - Fri, 16 Oct 2020 07:26:09 GMT
       expires:
       - '-1'
       pragma:
@@ -13736,10 +13640,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13748,7 +13652,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:05 GMT
+      - Fri, 16 Oct 2020 07:26:12 GMT
       expires:
       - '-1'
       pragma:
@@ -13788,10 +13692,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13800,7 +13704,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:06 GMT
+      - Fri, 16 Oct 2020 07:26:13 GMT
       expires:
       - '-1'
       pragma:
@@ -13840,10 +13744,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13852,7 +13756,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:08 GMT
+      - Fri, 16 Oct 2020 07:26:14 GMT
       expires:
       - '-1'
       pragma:
@@ -13892,10 +13796,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13904,7 +13808,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:09 GMT
+      - Fri, 16 Oct 2020 07:26:15 GMT
       expires:
       - '-1'
       pragma:
@@ -13944,10 +13848,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -13956,7 +13860,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:10 GMT
+      - Fri, 16 Oct 2020 07:26:16 GMT
       expires:
       - '-1'
       pragma:
@@ -13996,10 +13900,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14008,7 +13912,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:11 GMT
+      - Fri, 16 Oct 2020 07:26:18 GMT
       expires:
       - '-1'
       pragma:
@@ -14048,10 +13952,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14060,7 +13964,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:13 GMT
+      - Fri, 16 Oct 2020 07:26:19 GMT
       expires:
       - '-1'
       pragma:
@@ -14100,10 +14004,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14112,7 +14016,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:14 GMT
+      - Fri, 16 Oct 2020 07:26:20 GMT
       expires:
       - '-1'
       pragma:
@@ -14152,10 +14056,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14164,7 +14068,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:15 GMT
+      - Fri, 16 Oct 2020 07:26:21 GMT
       expires:
       - '-1'
       pragma:
@@ -14204,10 +14108,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14216,7 +14120,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:16 GMT
+      - Fri, 16 Oct 2020 07:26:23 GMT
       expires:
       - '-1'
       pragma:
@@ -14256,10 +14160,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14268,7 +14172,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:19 GMT
+      - Fri, 16 Oct 2020 07:26:24 GMT
       expires:
       - '-1'
       pragma:
@@ -14308,10 +14212,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14320,7 +14224,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:20 GMT
+      - Fri, 16 Oct 2020 07:26:25 GMT
       expires:
       - '-1'
       pragma:
@@ -14360,10 +14264,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14372,7 +14276,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:21 GMT
+      - Fri, 16 Oct 2020 07:26:26 GMT
       expires:
       - '-1'
       pragma:
@@ -14412,10 +14316,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14424,7 +14328,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:22 GMT
+      - Fri, 16 Oct 2020 07:26:28 GMT
       expires:
       - '-1'
       pragma:
@@ -14464,10 +14368,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14476,7 +14380,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:23 GMT
+      - Fri, 16 Oct 2020 07:26:29 GMT
       expires:
       - '-1'
       pragma:
@@ -14516,10 +14420,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14528,7 +14432,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:25 GMT
+      - Fri, 16 Oct 2020 07:26:30 GMT
       expires:
       - '-1'
       pragma:
@@ -14568,10 +14472,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14580,7 +14484,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:26 GMT
+      - Fri, 16 Oct 2020 07:26:31 GMT
       expires:
       - '-1'
       pragma:
@@ -14620,10 +14524,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14632,7 +14536,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:27 GMT
+      - Fri, 16 Oct 2020 07:26:32 GMT
       expires:
       - '-1'
       pragma:
@@ -14672,10 +14576,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14684,7 +14588,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:29 GMT
+      - Fri, 16 Oct 2020 07:26:35 GMT
       expires:
       - '-1'
       pragma:
@@ -14724,10 +14628,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14736,7 +14640,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:30 GMT
+      - Fri, 16 Oct 2020 07:26:36 GMT
       expires:
       - '-1'
       pragma:
@@ -14776,10 +14680,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14788,7 +14692,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:31 GMT
+      - Fri, 16 Oct 2020 07:26:37 GMT
       expires:
       - '-1'
       pragma:
@@ -14828,10 +14732,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14840,7 +14744,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:32 GMT
+      - Fri, 16 Oct 2020 07:26:38 GMT
       expires:
       - '-1'
       pragma:
@@ -14880,10 +14784,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14892,7 +14796,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:33 GMT
+      - Fri, 16 Oct 2020 07:26:39 GMT
       expires:
       - '-1'
       pragma:
@@ -14932,10 +14836,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14944,7 +14848,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:35 GMT
+      - Fri, 16 Oct 2020 07:26:42 GMT
       expires:
       - '-1'
       pragma:
@@ -14984,10 +14888,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -14996,7 +14900,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:36 GMT
+      - Fri, 16 Oct 2020 07:26:43 GMT
       expires:
       - '-1'
       pragma:
@@ -15036,10 +14940,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15048,7 +14952,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:37 GMT
+      - Fri, 16 Oct 2020 07:26:44 GMT
       expires:
       - '-1'
       pragma:
@@ -15088,10 +14992,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15100,7 +15004,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:38 GMT
+      - Fri, 16 Oct 2020 07:26:45 GMT
       expires:
       - '-1'
       pragma:
@@ -15140,10 +15044,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15152,7 +15056,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:40 GMT
+      - Fri, 16 Oct 2020 07:26:47 GMT
       expires:
       - '-1'
       pragma:
@@ -15192,10 +15096,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15204,7 +15108,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:41 GMT
+      - Fri, 16 Oct 2020 07:26:48 GMT
       expires:
       - '-1'
       pragma:
@@ -15244,10 +15148,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15256,7 +15160,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:42 GMT
+      - Fri, 16 Oct 2020 07:26:49 GMT
       expires:
       - '-1'
       pragma:
@@ -15296,10 +15200,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15308,7 +15212,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:43 GMT
+      - Fri, 16 Oct 2020 07:26:50 GMT
       expires:
       - '-1'
       pragma:
@@ -15348,10 +15252,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15360,7 +15264,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:45 GMT
+      - Fri, 16 Oct 2020 07:26:52 GMT
       expires:
       - '-1'
       pragma:
@@ -15400,10 +15304,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15412,7 +15316,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:46 GMT
+      - Fri, 16 Oct 2020 07:26:53 GMT
       expires:
       - '-1'
       pragma:
@@ -15452,10 +15356,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15464,7 +15368,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:47 GMT
+      - Fri, 16 Oct 2020 07:26:54 GMT
       expires:
       - '-1'
       pragma:
@@ -15504,10 +15408,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15516,7 +15420,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:48 GMT
+      - Fri, 16 Oct 2020 07:26:55 GMT
       expires:
       - '-1'
       pragma:
@@ -15556,10 +15460,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15568,7 +15472,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:51 GMT
+      - Fri, 16 Oct 2020 07:26:57 GMT
       expires:
       - '-1'
       pragma:
@@ -15608,10 +15512,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15620,7 +15524,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:52 GMT
+      - Fri, 16 Oct 2020 07:26:58 GMT
       expires:
       - '-1'
       pragma:
@@ -15660,10 +15564,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15672,7 +15576,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:53 GMT
+      - Fri, 16 Oct 2020 07:26:59 GMT
       expires:
       - '-1'
       pragma:
@@ -15712,10 +15616,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"InProgress","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -15724,7 +15628,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:54 GMT
+      - Fri, 16 Oct 2020 07:27:00 GMT
       expires:
       - '-1'
       pragma:
@@ -15764,62 +15668,10 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/ea5ca0be-65a9-401b-9019-f49ba7baac35?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"InProgress","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"0001-01-01T00:00:00"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '188'
-      content-type:
-      - application/json
-      date:
-      - Fri, 16 Oct 2020 05:36:56 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection disable
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
-        --yes
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/59680973-9993-46e0-a295-ec895881930f?api-version=2016-12-01
-  response:
-    body:
-      string: '{"id":"59680973-9993-46e0-a295-ec895881930f","name":"59680973-9993-46e0-a295-ec895881930f","status":"Succeeded","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"2020-10-16T05:35:05.1080419Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"be79e1a8-0969-448e-b103-522d831a2d6d"}}'
+      string: '{"id":"ea5ca0be-65a9-401b-9019-f49ba7baac35","name":"ea5ca0be-65a9-401b-9019-f49ba7baac35","status":"Succeeded","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"2020-10-16T07:25:09.4377186Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"d4774b1b-1a55-4b31-917b-d38d81e440aa"}}'
     headers:
       cache-control:
       - no-cache
@@ -15828,7 +15680,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:57 GMT
+      - Fri, 16 Oct 2020 07:27:01 GMT
       expires:
       - '-1'
       pragma:
@@ -15868,11 +15720,11 @@ interactions:
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/be79e1a8-0969-448e-b103-522d831a2d6d?api-version=2019-06-15
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d4774b1b-1a55-4b31-917b-d38d81e440aa?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/be79e1a8-0969-448e-b103-522d831a2d6d","name":"be79e1a8-0969-448e-b103-522d831a2d6d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M51.7041169S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000005","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-10-16T05:35:05.1080419Z","endTime":"2020-10-16T05:36:56.8121588Z","activityId":"5759f3e8-0f71-11eb-aed8-c8f750f92764"}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/d4774b1b-1a55-4b31-917b-d38d81e440aa","name":"d4774b1b-1a55-4b31-917b-d38d81e440aa","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M52.1861139S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000005","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-10-16T07:25:09.4377186Z","endTime":"2020-10-16T07:27:01.6238325Z","activityId":"b7dcc77c-0f80-11eb-b8aa-c8f750f92764"}}'
     headers:
       cache-control:
       - no-cache
@@ -15881,7 +15733,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 16 Oct 2020 05:36:57 GMT
+      - Fri, 16 Oct 2020 07:27:02 GMT
       expires:
       - '-1'
       pragma:
@@ -15933,7 +15785,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 16 Oct 2020 05:37:08 GMT
+      - Fri, 16 Oct 2020 07:27:07 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_policy.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_policy.yaml
@@ -17,15 +17,15 @@ interactions:
       ParameterSetName:
       - -n -g --location
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservices/0.4.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservices/0.4.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2016-06-01
   response:
     body:
-      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-08-01T16%3A38%3A45.9794159Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-15T12%3A01%3A54.6287001Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -34,7 +34,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:38:48 GMT
+      - Thu, 15 Oct 2020 12:01:54 GMT
       expires:
       - '-1'
       pragma:
@@ -64,15 +64,15 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -81,7 +81,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:38:50 GMT
+      - Thu, 15 Oct 2020 12:01:55 GMT
       expires:
       - '-1'
       pragma:
@@ -104,9 +104,9 @@ interactions:
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
       "instantRPDetails": {}, "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-08-02T02:30:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-15T22:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2020-08-02T02:30:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2020-10-15T22:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 2,
       "timeZone": "UTC"}}'
     headers:
@@ -125,15 +125,15 @@ interactions:
       ParameterSetName:
       - -g -v --policy
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -142,7 +142,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:38:53 GMT
+      - Thu, 15 Oct 2020 12:01:57 GMT
       expires:
       - '-1'
       pragma:
@@ -178,15 +178,15 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -195,7 +195,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:38:55 GMT
+      - Thu, 15 Oct 2020 12:01:57 GMT
       expires:
       - '-1'
       pragma:
@@ -218,9 +218,9 @@ interactions:
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
       "instantRPDetails": {}, "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-08-02T02:30:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-15T22:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2020-08-02T02:30:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2020-10-15T22:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 3,
       "timeZone": "UTC"}}'
     headers:
@@ -239,15 +239,15 @@ interactions:
       ParameterSetName:
       - -g -v --policy
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -256,7 +256,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:38:57 GMT
+      - Thu, 15 Oct 2020 12:01:59 GMT
       expires:
       - '-1'
       pragma:
@@ -290,17 +290,17 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-08-01T16:38:15Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-10-15T12:01:49Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -309,7 +309,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:38:59 GMT
+      - Thu, 15 Oct 2020 12:02:01 GMT
       expires:
       - '-1'
       pragma:
@@ -333,7 +333,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.22.0
     method: GET
     uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
   response:
@@ -388,13 +388,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:39:00 GMT
+      - Thu, 15 Oct 2020 12:02:01 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Sat, 01 Aug 2020 16:44:00 GMT
+      - Thu, 15 Oct 2020 12:07:01 GMT
       source-age:
-      - '82'
+      - '226'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -403,21 +403,21 @@ interactions:
       - 1.1 varnish (Varnish/6.0)
       - 1.1 varnish
       x-cache:
-      - HIT, HIT
+      - MISS, HIT
       x-cache-hits:
-      - 1, 1
+      - 0, 1
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 640acdf317f99b4d329812754e4fb390c0ae80fa
+      - 45948d8154d08f12eb943ae2fbd3f04504256584
       x-frame-options:
       - deny
       x-github-request-id:
-      - 7708:070B:9EE30:AA746:5F259A6A
+      - 99C2:0B9D:34BC9F:36FDF4:5F88184D
       x-served-by:
-      - cache-sin18034-SIN
+      - cache-sin18040-SIN
       x-timer:
-      - S1596299940.245952,VS0,VE0
+      - S1602763321.493768,VS0,VE1
       x-xss-protection:
       - 1; mode=block
     status:
@@ -435,10 +435,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -454,7 +454,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:39:01 GMT
+      - Thu, 15 Oct 2020 12:02:01 GMT
       expires:
       - '-1'
       pragma:
@@ -480,10 +480,7 @@ interactions:
       "10.0.0.0/24"}}]}}, {"type": "Microsoft.Network/networkSecurityGroups", "name":
       "clitest-vm000005NSG", "apiVersion": "2015-06-15", "location": "southeastasia",
       "tags": {"MabUsed": "Yes", "Owner": "sisi", "Purpose": "CLITest", "DeleteBy":
-      "12-2099", "AutoShutdown": "No"}, "dependsOn": [], "properties": {"securityRules":
-      [{"name": "rdp", "properties": {"protocol": "Tcp", "sourcePortRange": "*", "destinationPortRange":
-      "3389", "sourceAddressPrefix": "*", "destinationAddressPrefix": "*", "access":
-      "Allow", "priority": 1000, "direction": "Inbound"}}]}}, {"apiVersion": "2018-01-01",
+      "12-2099", "AutoShutdown": "No"}, "dependsOn": []}, {"apiVersion": "2018-01-01",
       "type": "Microsoft.Network/publicIPAddresses", "name": "clitest-vm000005PublicIP",
       "location": "southeastasia", "tags": {"MabUsed": "Yes", "Owner": "sisi", "Purpose":
       "CLITest", "DeleteBy": "12-2099", "AutoShutdown": "No"}, "dependsOn": [], "properties":
@@ -519,32 +516,32 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '4072'
+      - '3807'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_8G8nogfv7BWhbW1bvF23boBWr3q1509T","name":"vm_deploy_8G8nogfv7BWhbW1bvF23boBWr3q1509T","type":"Microsoft.Resources/deployments","properties":{"templateHash":"9151094132925494406","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-08-01T16:39:07.76919Z","duration":"PT3.4695191S","correlationId":"59bb9dce-3cb6-42e7-b302-093dd4238aab","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_yXNE922pgsZ78v3R9zarZklQpGmyTjq6","name":"vm_deploy_yXNE922pgsZ78v3R9zarZklQpGmyTjq6","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3886864059066874618","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-10-15T12:02:04.1937028Z","duration":"PT1.1831765S","correlationId":"6fa68cb4-9388-4892-9b19-02542c4295d2","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_8G8nogfv7BWhbW1bvF23boBWr3q1509T/operationStatuses/08586053069411779593?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_yXNE922pgsZ78v3R9zarZklQpGmyTjq6/operationStatuses/08585988435624671102?api-version=2020-06-01
       cache-control:
       - no-cache
       content-length:
-      - '2958'
+      - '2960'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:39:08 GMT
+      - Thu, 15 Oct 2020 12:02:04 GMT
       expires:
       - '-1'
       pragma:
@@ -554,7 +551,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -570,12 +567,12 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586053069411779593?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585988435624671102?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -587,7 +584,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:39:41 GMT
+      - Thu, 15 Oct 2020 12:02:34 GMT
       expires:
       - '-1'
       pragma:
@@ -613,98 +610,12 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586053069411779593?api-version=2020-06-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sat, 01 Aug 2020 16:40:12 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
-      User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586053069411779593?api-version=2020-06-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sat, 01 Aug 2020 16:40:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
-      User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586053069411779593?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585988435624671102?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -716,7 +627,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:41:15 GMT
+      - Thu, 15 Oct 2020 12:03:04 GMT
       expires:
       - '-1'
       pragma:
@@ -742,24 +653,24 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_8G8nogfv7BWhbW1bvF23boBWr3q1509T","name":"vm_deploy_8G8nogfv7BWhbW1bvF23boBWr3q1509T","type":"Microsoft.Resources/deployments","properties":{"templateHash":"9151094132925494406","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-08-01T16:40:57.6239064Z","duration":"PT1M53.3242355S","correlationId":"59bb9dce-3cb6-42e7-b302-093dd4238aab","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_yXNE922pgsZ78v3R9zarZklQpGmyTjq6","name":"vm_deploy_yXNE922pgsZ78v3R9zarZklQpGmyTjq6","type":"Microsoft.Resources/deployments","properties":{"templateHash":"3886864059066874618","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-10-15T12:02:39.7969155Z","duration":"PT36.7863892S","correlationId":"6fa68cb4-9388-4892-9b19-02542c4295d2","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["southeastasia"]},{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4087'
+      - '4085'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:41:17 GMT
+      - Thu, 15 Oct 2020 12:03:05 GMT
       expires:
       - '-1'
       pragma:
@@ -785,10 +696,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-compute/13.0.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-compute/13.1.1 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -799,16 +710,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"0c9b7a2c-ad10-45b3-8ebf-83020f02f0e0\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"b31a8a63-848b-4851-8c82-9c996a0a2755\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"9600.19756.2007111612\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000005_OsDisk_1_24843958b0e9451baa505e0cb428221f\",\r\n
+        \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_16ed0e55accb490c962364721012bf88\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RG5SD72QUTVLST7ILEJLWWOCETK4BHOHRXUBKRHYFTLISN5IZV4OXGTASDF2LFLUXO7/providers/Microsoft.Compute/disks/clitest-vm000005_OsDisk_1_24843958b0e9451baa505e0cb428221f\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGSU6WBHXJEGODSHFZVKKKWBWBQWLTIRZRBG7F3Z2XQMLE7UD4WLFIHR4KHRVGU4NJV/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_16ed0e55accb490c962364721012bf88\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000005\",\r\n
         \     \"adminUsername\": \"clitest-vm000005\",\r\n      \"windowsConfiguration\":
@@ -822,16 +733,16 @@ interactions:
         \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
         \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
         Ready\",\r\n            \"message\": \"VM status blob is found but not yet
-        populated.\",\r\n            \"time\": \"2020-08-01T16:41:19+00:00\"\r\n          }\r\n
+        populated.\",\r\n            \"time\": \"2020-10-15T12:03:06+00:00\"\r\n          }\r\n
         \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
-        \"clitest-vm000005_OsDisk_1_24843958b0e9451baa505e0cb428221f\",\r\n          \"statuses\":
+        \"clitest-vm000005_disk1_16ed0e55accb490c962364721012bf88\",\r\n          \"statuses\":
         [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-08-01T16:39:35.0566585+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-10-15T12:02:12.9298726+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
-        \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2020-08-01T16:40:56.1514093+00:00\"\r\n
+        \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded/osProvisioningInProgress\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"OS provisioning
+        in progress\",\r\n          \"time\": \"2020-10-15T12:02:36.3360881+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -839,11 +750,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '3428'
+      - '3449'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:41:19 GMT
+      - Thu, 15 Oct 2020 12:03:06 GMT
       expires:
       - '-1'
       pragma:
@@ -860,7 +771,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3992,Microsoft.Compute/LowCostGet30Min;31989
+      - Microsoft.Compute/LowCostGet3Min;3992,Microsoft.Compute/LowCostGet30Min;31971
     status:
       code: 200
       message: OK
@@ -876,10 +787,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -887,14 +798,14 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000005VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic\",\r\n
-        \ \"etag\": \"W/\\\"c921f27c-f34f-4edc-be08-66f2c678d4b8\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"f05e66c0-751d-4704-bd74-022278576137\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"89ac7a6f-9187-4b87-ab54-1e3edc9c3717\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"9c549e30-3406-4d36-8521-d7cb01b6ec57\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigclitest-vm000005\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic/ipConfigurations/ipconfigclitest-vm000005\",\r\n
-        \       \"etag\": \"W/\\\"c921f27c-f34f-4edc-be08-66f2c678d4b8\\\"\",\r\n
+        \       \"etag\": \"W/\\\"f05e66c0-751d-4704-bd74-022278576137\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
@@ -903,8 +814,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"lff4utq2d5kerfulgtcxyhvlgf.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-C7-AB-8D\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"ylvaamdqdzwelpfmyxoaqemlob.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-C8-AD-E1\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -918,9 +829,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:41:22 GMT
+      - Thu, 15 Oct 2020 12:03:06 GMT
       etag:
-      - W/"c921f27c-f34f-4edc-be08-66f2c678d4b8"
+      - W/"f05e66c0-751d-4704-bd74-022278576137"
       expires:
       - '-1'
       pragma:
@@ -937,7 +848,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 13e142c4-9a3a-45b8-a6d9-a916060f11d1
+      - f4635dba-9e75-4c34-914f-c394b527b60d
     status:
       code: 200
       message: OK
@@ -953,10 +864,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -964,13 +875,13 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000005PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"a632fdb6-09c9-47d4-8684-67bbc80ca301\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"e4ef18d0-88a9-4985-b538-731a65587f08\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"685c6b8f-f464-40c6-9384-6dedd58164ef\",\r\n
-        \   \"ipAddress\": \"13.76.6.200\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
-        \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"b48999e5-a7ab-47df-a3ff-40c557cdb9a3\",\r\n
+        \   \"ipAddress\": \"52.237.127.139\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic/ipConfigurations/ipconfigclitest-vm000005\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
@@ -978,13 +889,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1180'
+      - '1183'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:41:23 GMT
+      - Thu, 15 Oct 2020 12:03:06 GMT
       etag:
-      - W/"a632fdb6-09c9-47d4-8684-67bbc80ca301"
+      - W/"e4ef18d0-88a9-4985-b538-731a65587f08"
       expires:
       - '-1'
       pragma:
@@ -1001,7 +912,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 6827ee80-8dfa-47ba-9bd9-aa239dca17bc
+      - 7e460074-7bc4-4c78-9428-696ec612420b
     status:
       code: 200
       message: OK
@@ -1017,17 +928,17 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-08-01T16:38:15Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"southeastasia","tags":{"product":"azurecli","cause":"automation","date":"2020-10-15T12:01:49Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1036,7 +947,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:41:25 GMT
+      - Thu, 15 Oct 2020 12:03:06 GMT
       expires:
       - '-1'
       pragma:
@@ -1060,7 +971,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.22.0
     method: GET
     uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
   response:
@@ -1115,13 +1026,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:41:25 GMT
+      - Thu, 15 Oct 2020 12:03:07 GMT
       etag:
       - W/"540044b4084c3c314537f1baa1770f248628b2bc9ba0328f1004c33862e049da"
       expires:
-      - Sat, 01 Aug 2020 16:46:25 GMT
+      - Thu, 15 Oct 2020 12:08:07 GMT
       source-age:
-      - '228'
+      - '292'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -1130,21 +1041,21 @@ interactions:
       - 1.1 varnish (Varnish/6.0)
       - 1.1 varnish
       x-cache:
-      - HIT, HIT
+      - MISS, HIT
       x-cache-hits:
-      - 1, 1
+      - 0, 1
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 0de51c70d8a5815f48c3f80971033fbbbd1659e3
+      - f63822bc17d8505b7f05a61d32b1d03a9b1bcc5a
       x-frame-options:
       - deny
       x-github-request-id:
-      - 7708:070B:9EE30:AA746:5F259A6A
+      - 99C2:0B9D:34BC9F:36FDF4:5F88184D
       x-served-by:
-      - cache-sin18042-SIN
+      - cache-sin18038-SIN
       x-timer:
-      - S1596300086.530193,VS0,VE1
+      - S1602763388.632259,VS0,VE1
       x-xss-protection:
       - 1; mode=block
     status:
@@ -1162,10 +1073,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -1174,33 +1085,33 @@ interactions:
     body:
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"clitest-vm000005VNET\",\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET\",\r\n
-        \     \"etag\": \"W/\\\"bf612435-59b6-4016-a794-35653d0743c8\\\"\",\r\n      \"type\":
+        \     \"etag\": \"W/\\\"0d432fb9-30e5-441d-8193-41b800b1b692\\\"\",\r\n      \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"southeastasia\",\r\n
         \     \"tags\": {\r\n        \"MabUsed\": \"Yes\",\r\n        \"Owner\": \"sisi\",\r\n
         \       \"Purpose\": \"CLITest\",\r\n        \"DeleteBy\": \"12-2099\",\r\n
         \       \"AutoShutdown\": \"No\"\r\n      },\r\n      \"properties\": {\r\n
         \       \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\":
-        \"4eea4b59-1f1c-48d4-968b-34c57c1eab35\",\r\n        \"addressSpace\": {\r\n
+        \"3000eac2-1e70-456c-bcac-c5dc08118b71\",\r\n        \"addressSpace\": {\r\n
         \         \"addressPrefixes\": [\r\n            \"10.0.0.0/16\"\r\n          ]\r\n
         \       },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
         \"clitest-vm000005Subnet\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET/subnets/clitest-vm000005Subnet\",\r\n
-        \           \"etag\": \"W/\\\"bf612435-59b6-4016-a794-35653d0743c8\\\"\",\r\n
+        \           \"etag\": \"W/\\\"0d432fb9-30e5-441d-8193-41b800b1b692\\\"\",\r\n
         \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"ipConfigurations\":
         [\r\n                {\r\n                  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic/ipConfigurations/ipconfigclitest-vm000005\"\r\n
-        \               }\r\n              ]\r\n            },\r\n            \"type\":
-        \"Microsoft.Network/virtualNetworks/subnets\"\r\n          }\r\n        ],\r\n
-        \       \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\":
+        \               }\r\n              ],\r\n              \"subnetID\": 0\r\n
+        \           },\r\n            \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \         }\r\n        ],\r\n        \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\":
         false,\r\n        \"enableVmProtection\": false\r\n      }\r\n    }\r\n  ]\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1995'
+      - '2025'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:41:28 GMT
+      - Thu, 15 Oct 2020 12:03:07 GMT
       expires:
       - '-1'
       pragma:
@@ -1217,7 +1128,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 9ceb4c6c-6414-49c6-b9a0-d7344ebc99ff
+      - e1523580-6d1d-4f42-9e42-2f23e45ac6ee
     status:
       code: 200
       message: OK
@@ -1228,17 +1139,13 @@ interactions:
       [{"type": "Microsoft.Network/networkSecurityGroups", "name": "clitest-vm000006NSG",
       "apiVersion": "2015-06-15", "location": "southeastasia", "tags": {"MabUsed":
       "Yes", "Owner": "sisi", "Purpose": "CLITest", "DeleteBy": "12-2099", "AutoShutdown":
-      "No"}, "dependsOn": [], "properties": {"securityRules": [{"name": "rdp", "properties":
-      {"protocol": "Tcp", "sourcePortRange": "*", "destinationPortRange": "3389",
-      "sourceAddressPrefix": "*", "destinationAddressPrefix": "*", "access": "Allow",
-      "priority": 1000, "direction": "Inbound"}}]}}, {"apiVersion": "2018-01-01",
-      "type": "Microsoft.Network/publicIPAddresses", "name": "clitest-vm000006PublicIP",
-      "location": "southeastasia", "tags": {"MabUsed": "Yes", "Owner": "sisi", "Purpose":
-      "CLITest", "DeleteBy": "12-2099", "AutoShutdown": "No"}, "dependsOn": [], "properties":
-      {"publicIPAllocationMethod": null}}, {"apiVersion": "2015-06-15", "type": "Microsoft.Network/networkInterfaces",
-      "name": "clitest-vm000006VMNic", "location": "southeastasia", "tags": {"MabUsed":
+      "No"}, "dependsOn": []}, {"apiVersion": "2018-01-01", "type": "Microsoft.Network/publicIPAddresses",
+      "name": "clitest-vm000006PublicIP", "location": "southeastasia", "tags": {"MabUsed":
       "Yes", "Owner": "sisi", "Purpose": "CLITest", "DeleteBy": "12-2099", "AutoShutdown":
-      "No"}, "dependsOn": ["Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG",
+      "No"}, "dependsOn": [], "properties": {"publicIPAllocationMethod": null}}, {"apiVersion":
+      "2015-06-15", "type": "Microsoft.Network/networkInterfaces", "name": "clitest-vm000006VMNic",
+      "location": "southeastasia", "tags": {"MabUsed": "Yes", "Owner": "sisi", "Purpose":
+      "CLITest", "DeleteBy": "12-2099", "AutoShutdown": "No"}, "dependsOn": ["Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG",
       "Microsoft.Network/publicIpAddresses/clitest-vm000006PublicIP"], "properties":
       {"ipConfigurations": [{"name": "ipconfigclitest-vm000006", "properties": {"privateIPAllocationMethod":
       "Dynamic", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET/subnets/clitest-vm000005Subnet"},
@@ -1267,24 +1174,24 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3585'
+      - '3320'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_L2S2wh59Txaqz56AmKhzo2RShan2oL9L","name":"vm_deploy_L2S2wh59Txaqz56AmKhzo2RShan2oL9L","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13155987910494993861","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-08-01T16:41:34.4316896Z","duration":"PT3.2461158S","correlationId":"7559074e-9d44-46a4-ab34-9dcc7b7d409c","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_pffzmSHD7GntALI1csEynkkKniM2L4v3","name":"vm_deploy_pffzmSHD7GntALI1csEynkkKniM2L4v3","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10583422459871746912","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2020-10-15T12:03:11.2607644Z","duration":"PT1.6667742S","correlationId":"bd228961-10cd-4aad-82ce-227c26a6b10f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_L2S2wh59Txaqz56AmKhzo2RShan2oL9L/operationStatuses/08586053067942920460?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_pffzmSHD7GntALI1csEynkkKniM2L4v3/operationStatuses/08585988434958836401?api-version=2020-06-01
       cache-control:
       - no-cache
       content-length:
@@ -1292,7 +1199,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:41:36 GMT
+      - Thu, 15 Oct 2020 12:03:11 GMT
       expires:
       - '-1'
       pragma:
@@ -1302,7 +1209,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -1318,12 +1225,12 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586053067942920460?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585988434958836401?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -1335,7 +1242,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:42:08 GMT
+      - Thu, 15 Oct 2020 12:03:41 GMT
       expires:
       - '-1'
       pragma:
@@ -1361,141 +1268,12 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586053067942920460?api-version=2020-06-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sat, 01 Aug 2020 16:42:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
-      User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586053067942920460?api-version=2020-06-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sat, 01 Aug 2020 16:43:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
-      User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586053067942920460?api-version=2020-06-01
-  response:
-    body:
-      string: '{"status":"Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '20'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Sat, 01 Aug 2020 16:43:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - vm create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
-      User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08586053067942920460?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585988434958836401?api-version=2020-06-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1507,7 +1285,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:44:13 GMT
+      - Thu, 15 Oct 2020 12:04:11 GMT
       expires:
       - '-1'
       pragma:
@@ -1533,24 +1311,24 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-resource/10.1.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_L2S2wh59Txaqz56AmKhzo2RShan2oL9L","name":"vm_deploy_L2S2wh59Txaqz56AmKhzo2RShan2oL9L","type":"Microsoft.Resources/deployments","properties":{"templateHash":"13155987910494993861","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-08-01T16:44:03.2691064Z","duration":"PT2M32.0835326S","correlationId":"7559074e-9d44-46a4-ab34-9dcc7b7d409c","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_pffzmSHD7GntALI1csEynkkKniM2L4v3","name":"vm_deploy_pffzmSHD7GntALI1csEynkkKniM2L4v3","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10583422459871746912","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2020-10-15T12:03:50.2682534Z","duration":"PT40.6742632S","correlationId":"bd228961-10cd-4aad-82ce-227c26a6b10f","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["southeastasia"]},{"resourceType":"publicIPAddresses","locations":["southeastasia"]},{"resourceType":"networkInterfaces","locations":["southeastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["southeastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000006PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000006VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000006"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3503'
+      - '3501'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:44:14 GMT
+      - Thu, 15 Oct 2020 12:04:12 GMT
       expires:
       - '-1'
       pragma:
@@ -1576,10 +1354,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-compute/13.0.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-compute/13.1.1 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -1590,16 +1368,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"530b621c-5bfa-4304-9c20-93bdce10869e\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"6d83da7c-a3ea-47e9-b895-556468c9079e\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"9600.19756.2007111612\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000006_OsDisk_1_4d0ef492f6314ecda1e02a7964bcf7d8\",\r\n
+        \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Windows\",\r\n        \"name\": \"clitest-vm000006_disk1_e2d41f81017c419894183e18226cde7c\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RG5SD72QUTVLST7ILEJLWWOCETK4BHOHRXUBKRHYFTLISN5IZV4OXGTASDF2LFLUXO7/providers/Microsoft.Compute/disks/clitest-vm000006_OsDisk_1_4d0ef492f6314ecda1e02a7964bcf7d8\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGSU6WBHXJEGODSHFZVKKKWBWBQWLTIRZRBG7F3Z2XQMLE7UD4WLFIHR4KHRVGU4NJV/providers/Microsoft.Compute/disks/clitest-vm000006_disk1_e2d41f81017c419894183e18226cde7c\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000006\",\r\n
         \     \"adminUsername\": \"clitest-vm000006\",\r\n      \"windowsConfiguration\":
@@ -1613,16 +1391,16 @@ interactions:
         \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
         \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
         Ready\",\r\n            \"message\": \"VM status blob is found but not yet
-        populated.\",\r\n            \"time\": \"2020-08-01T16:44:17+00:00\"\r\n          }\r\n
+        populated.\",\r\n            \"time\": \"2020-10-15T12:04:13+00:00\"\r\n          }\r\n
         \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
-        \"clitest-vm000006_OsDisk_1_4d0ef492f6314ecda1e02a7964bcf7d8\",\r\n          \"statuses\":
+        \"clitest-vm000006_disk1_e2d41f81017c419894183e18226cde7c\",\r\n          \"statuses\":
         [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2020-08-01T16:42:01.3865484+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2020-10-15T12:03:28.3674339+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2020-08-01T16:44:00.3249281+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2020-10-15T12:03:46.8830207+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
         \       }\r\n      ]\r\n    }\r\n  }\r\n}"
@@ -1630,11 +1408,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '3428'
+      - '3419'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:44:17 GMT
+      - Thu, 15 Oct 2020 12:04:13 GMT
       expires:
       - '-1'
       pragma:
@@ -1651,7 +1429,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3992,Microsoft.Compute/LowCostGet30Min;31981
+      - Microsoft.Compute/LowCostGet3Min;3990,Microsoft.Compute/LowCostGet30Min;31967
     status:
       code: 200
       message: OK
@@ -1667,10 +1445,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -1678,14 +1456,14 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000006VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic\",\r\n
-        \ \"etag\": \"W/\\\"97605fc1-1634-4e61-8cca-582859236871\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"362dac27-26ae-4f27-a3b5-0fd538cce1be\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"7bce7eff-1d06-4497-b839-c96364c582ff\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"c4b2f7c1-f8cb-4967-9e3f-b7c4ae541fa8\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigclitest-vm000006\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic/ipConfigurations/ipconfigclitest-vm000006\",\r\n
-        \       \"etag\": \"W/\\\"97605fc1-1634-4e61-8cca-582859236871\\\"\",\r\n
+        \       \"etag\": \"W/\\\"362dac27-26ae-4f27-a3b5-0fd538cce1be\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
@@ -1694,8 +1472,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"lff4utq2d5kerfulgtcxyhvlgf.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-22-48-55-7F-E3\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"ylvaamdqdzwelpfmyxoaqemlob.ix.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-C8-F6-4B\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000006NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -1709,9 +1487,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:44:20 GMT
+      - Thu, 15 Oct 2020 12:04:13 GMT
       etag:
-      - W/"97605fc1-1634-4e61-8cca-582859236871"
+      - W/"362dac27-26ae-4f27-a3b5-0fd538cce1be"
       expires:
       - '-1'
       pragma:
@@ -1728,7 +1506,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 1f3a800d-c2c5-4d30-b1c2-653b6fbdb2ac
+      - 46d1db21-a1ac-45d8-9540-72947b8cf0b2
     status:
       code: 200
       message: OK
@@ -1744,10 +1522,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --admin-username --admin-password --tags
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -1755,12 +1533,12 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"clitest-vm000006PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000006PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"f1214c7f-fc99-493b-8686-5c54e4672aaa\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"f1be6ddc-df0f-436d-846a-8293a5890aa8\\\"\",\r\n  \"location\":
         \"southeastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
         \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
         \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"bbe045a9-b6f7-4047-88f7-5027d79a1218\",\r\n
-        \   \"ipAddress\": \"104.43.20.137\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"b43585f8-f29d-4456-976a-1d7d96647ca5\",\r\n
+        \   \"ipAddress\": \"52.237.121.3\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
         \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000006VMNic/ipConfigurations/ipconfigclitest-vm000006\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
@@ -1769,13 +1547,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1182'
+      - '1181'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:44:20 GMT
+      - Thu, 15 Oct 2020 12:04:13 GMT
       etag:
-      - W/"f1214c7f-fc99-493b-8686-5c54e4672aaa"
+      - W/"f1be6ddc-df0f-436d-846a-8293a5890aa8"
       expires:
       - '-1'
       pragma:
@@ -1792,7 +1570,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - d9079144-aecb-47c8-a2ca-53e9401cb4ea
+      - a8fe9107-6392-401b-a274-d395872c3726
     status:
       code: 200
       message: OK
@@ -1810,8 +1588,8 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-compute/13.0.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-compute/13.1.1 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -1822,16 +1600,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"0c9b7a2c-ad10-45b3-8ebf-83020f02f0e0\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"b31a8a63-848b-4851-8c82-9c996a0a2755\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"9600.19756.2007111612\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000005_OsDisk_1_24843958b0e9451baa505e0cb428221f\",\r\n
+        \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_16ed0e55accb490c962364721012bf88\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RG5SD72QUTVLST7ILEJLWWOCETK4BHOHRXUBKRHYFTLISN5IZV4OXGTASDF2LFLUXO7/providers/Microsoft.Compute/disks/clitest-vm000005_OsDisk_1_24843958b0e9451baa505e0cb428221f\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGSU6WBHXJEGODSHFZVKKKWBWBQWLTIRZRBG7F3Z2XQMLE7UD4WLFIHR4KHRVGU4NJV/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_16ed0e55accb490c962364721012bf88\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000005\",\r\n
         \     \"adminUsername\": \"clitest-vm000005\",\r\n      \"windowsConfiguration\":
@@ -1845,11 +1623,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2210'
+      - '2204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:44:23 GMT
+      - Thu, 15 Oct 2020 12:04:13 GMT
       expires:
       - '-1'
       pragma:
@@ -1866,7 +1644,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3991,Microsoft.Compute/LowCostGet30Min;31980
+      - Microsoft.Compute/LowCostGet3Min;3989,Microsoft.Compute/LowCostGet30Min;31966
     status:
       code: 200
       message: OK
@@ -1884,15 +1662,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservices/0.4.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservices/0.4.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2016-06-01
   response:
     body:
-      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-08-01T16%3A38%3A45.9794159Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-15T12%3A01%3A54.6287001Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -1901,7 +1679,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:25 GMT
+      - Thu, 15 Oct 2020 12:04:14 GMT
       expires:
       - '-1'
       pragma:
@@ -1933,15 +1711,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -1950,7 +1728,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:28 GMT
+      - Thu, 15 Oct 2020 12:04:15 GMT
       expires:
       - '-1'
       pragma:
@@ -1984,24 +1762,24 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2016-12-01&$filter=backupManagementType%20eq%20%27AzureIaasVM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestorecant/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestorecant","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestorecant","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestorecant","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestorecant","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoregqqp","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoregqqp","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoregwou","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoregwou","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoreqhdt","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoreqhdt","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestorewkcw","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestorewkcw","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoreyvan","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoreyvan","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf/protectableItems/vm;iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf","name":"iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.vaults/providers/Microsoft.ClassicCompute/virtualMachines/fadfasdfsdf","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"fadfasdfsdf","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter/protectableItems/vm;iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter","name":"iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.vaults/providers/Microsoft.ClassicCompute/virtualMachines/testvmdeleter","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"testvmdeleter","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000005","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq;clitest-vm7dgm3/protectableItems/vm;iaasvmcontainerv2;clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq;clitest-vm7dgm3","name":"iaasvmcontainerv2;clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq;clitest-vm7dgm3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq/providers/Microsoft.Compute/virtualMachines/clitest-vm7dgm3","virtualMachineVersion":"Compute","resourceGroup":"clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm7dgm3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2/protectableItems/vm;iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2","name":"iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.encryptedvm/providers/Microsoft.Compute/virtualMachines/iaasenc-win-v2","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.encryptedvm","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasenc-win-v2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestorebbum","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestorebbum","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestorebdbr","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestorebdbr","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestoredxay","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestoredxay","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3","name":"iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing/providers/Microsoft.Compute/virtualMachines/iaas-win-ext3","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaas-win-ext3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing;iaasext-win-3/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing;iaasext-win-3","name":"iaasvmcontainerv2;iaasvm.existing;iaasext-win-3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing/providers/Microsoft.Compute/virtualMachines/iaasext-win-3","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasext-win-3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreciol","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreciol","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorecpkh","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorecpkh","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreegcg","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreegcg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreentn","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreentn","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorehbaz","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorehbaz","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreimgf","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreimgf","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorelzle","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorelzle","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoremrdb","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoremrdb","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoretylj","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoretylj","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm","name":"iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.vaults/providers/Microsoft.Compute/virtualMachines/jakavetEncVM","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"jakavetEncVM","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2/protectableItems/vm;iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2","name":"iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.vmbackup/providers/Microsoft.Compute/virtualMachines/iaasvbkp-win-v2","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.vmbackup","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasvbkp-win-v2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext/protectableItems/vm;iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext","name":"iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmhanaworkload.existing/providers/Microsoft.Compute/virtualMachines/iaashanaext","virtualMachineVersion":"Compute","resourceGroup":"iaasvmhanaworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaashanaext","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win/protectableItems/vm;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win","name":"iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmsqlworkload.existing/providers/Microsoft.Compute/virtualMachines/iaassqlext-win","virtualMachineVersion":"Compute","resourceGroup":"iaasvmsqlworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaassqlext-win","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win/protectableItems/vm;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win","name":"iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmsqlworkload.existing/providers/Microsoft.Compute/virtualMachines/iaassqlext2-win","virtualMachineVersion":"Compute","resourceGroup":"iaasvmsqlworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaassqlext2-win","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm/protectableItems/vm;iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm","name":"iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pscloudtestrg/providers/Microsoft.Compute/virtualMachines/psbvtsqlvm","virtualMachineVersion":"Compute","resourceGroup":"pscloudtestrg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"psbvtsqlvm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pstestrg8895;pstestvm/protectableItems/vm;iaasvmcontainerv2;pstestrg8895;pstestvm","name":"iaasvmcontainerv2;pstestrg8895;pstestvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pstestrg8895/providers/Microsoft.Compute/virtualMachines/pstestvm","virtualMachineVersion":"Compute","resourceGroup":"pstestrg8895","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"pstestvm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;riteshcrg;xcvsdsad/protectableItems/vm;iaasvmcontainerv2;riteshcrg;xcvsdsad","name":"iaasvmcontainerv2;riteshcrg;xcvsdsad","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/riteshcRG/providers/Microsoft.Compute/virtualMachines/xcvsdsad","virtualMachineVersion":"Compute","resourceGroup":"riteshcRG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"xcvsdsad","protectionState":"NotProtected"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;akneema;akneema-hana-vm/protectableItems/vm;iaasvmcontainerv2;akneema;akneema-hana-vm","name":"iaasvmcontainerv2;akneema;akneema-hana-vm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema/providers/Microsoft.Compute/virtualMachines/akneema-hana-vm","virtualMachineVersion":"Compute","resourceGroup":"akneema","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"akneema-hana-vm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;asebvtrg;asebvtseavm3/protectableItems/vm;iaasvmcontainerv2;asebvtrg;asebvtseavm3","name":"iaasvmcontainerv2;asebvtrg;asebvtseavm3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ASEBVTRG/providers/Microsoft.Compute/virtualMachines/asebvtseavm3","virtualMachineVersion":"Compute","resourceGroup":"ASEBVTRG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"asebvtseavm3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testcanarygeetasql/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testcanarygeetasql","name":"iaasvmcontainerv2;chandrikarg;testcanarygeetasql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testcanarygeetasql","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testcanarygeetasql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchg","name":"iaasvmcontainerv2;chandrikarg;testvmchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchgsql3/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchgsql3","name":"iaasvmcontainerv2;chandrikarg;testvmchgsql3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchgsql3","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchgsql3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmsqlchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmsqlchg","name":"iaasvmcontainerv2;chandrikarg;testvmsqlchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmsqlchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmsqlchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2014/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2014","name":"iaasvmcontainerv2;containerautoprotection;shrja-2014","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2014","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2014","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2019/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2019","name":"iaasvmcontainerv2;containerautoprotection;shrja-2019","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2019","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2019","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja2012r2/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja2012r2","name":"iaasvmcontainerv2;containerautoprotection;shrja2012r2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja2012R2","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2012R2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","name":"iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetasqlvmbanner14","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetasqlvmbanner14","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","name":"iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetsqlvmbanner1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetsqlvmbanner1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner10/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner10","name":"iaasvmcontainerv2;gesahoo;gesahoobanner10","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner10","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner10","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner11/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner11","name":"iaasvmcontainerv2;gesahoo;gesahoobanner11","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner11","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner11","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner12/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner12","name":"iaasvmcontainerv2;gesahoo;gesahoobanner12","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner12","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner12","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner5","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner5","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner6","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner6","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner7","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner7","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner8","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner9","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner9","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbannervm4","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbannervm4","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress2","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","name":"iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlvminprogress3","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlvminprogress3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","name":"iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlautobackupgeeta","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlautobackupgeeta","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","name":"iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlbannergeetacanary","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlbannergeetacanary","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testgesahoosql/protectableItems/vm;iaasvmcontainerv2;gesahoo;testgesahoosql","name":"iaasvmcontainerv2;gesahoo;testgesahoosql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testgesahoosql","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testgesahoosql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testprodgesahoo/protectableItems/vm;iaasvmcontainerv2;gesahoo;testprodgesahoo","name":"iaasvmcontainerv2;gesahoo;testprodgesahoo","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testProdGesahoo","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testProdGesahoo","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;nilay-rg;nilsha-test/protectableItems/vm;iaasvmcontainerv2;nilay-rg;nilsha-test","name":"iaasvmcontainerv2;nilay-rg;nilsha-test","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Nilay-RG/providers/Microsoft.Compute/virtualMachines/nilsha-test","virtualMachineVersion":"Compute","resourceGroup":"Nilay-RG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"nilsha-test","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8/protectableItems/vm;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","name":"iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pstestwlRG1bca8/providers/Microsoft.Compute/virtualMachines/pstestwlvm1bca8","virtualMachineVersion":"Compute","resourceGroup":"pstestwlRG1bca8","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"pstestwlvm1bca8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sarath-rg;sarathpstest001/protectableItems/vm;iaasvmcontainerv2;sarath-rg;sarathpstest001","name":"iaasvmcontainerv2;sarath-rg;sarathpstest001","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Compute/virtualMachines/sarathPSTest001","virtualMachineVersion":"Compute","resourceGroup":"sarath-rg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sarathPSTest001","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shrja2008_group;shrja2008/protectableItems/vm;iaasvmcontainerv2;shrja2008_group;shrja2008","name":"iaasvmcontainerv2;shrja2008_group;shrja2008","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shrja2008_group/providers/Microsoft.Compute/virtualMachines/shrja2008","virtualMachineVersion":"Compute","resourceGroup":"shrja2008_group","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2008","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","name":"iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/dsadsa","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"dsadsa","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;sddsds/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;sddsds","name":"iaasvmcontainerv2;shswain-rg-restoredata;sddsds","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/sddsds","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sddsds","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sisi-rsv;sisi-mercury/protectableItems/vm;iaasvmcontainerv2;sisi-rsv;sisi-mercury","name":"iaasvmcontainerv2;sisi-rsv;sisi-mercury","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sisi-RSV/providers/Microsoft.Compute/virtualMachines/sisi-mercury","virtualMachineVersion":"Compute","resourceGroup":"sisi-RSV","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sisi-mercury","protectionState":"NotProtected"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '32836'
+      - '31811'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:31 GMT
+      - Thu, 15 Oct 2020 12:04:16 GMT
       expires:
       - '-1'
       pragma:
@@ -2032,27 +1810,479 @@ interactions:
       - backup protection enable-for-vm
       Connection:
       - keep-alive
+      Content-Length:
+      - '0'
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/refreshContainers?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Oct 2020 12:04:17 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Oct 2020 12:04:18 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Oct 2020 12:04:20 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Oct 2020 12:04:21 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Oct 2020 12:04:22 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Oct 2020 12:04:23 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Oct 2020 12:04:24 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Oct 2020 12:04:26 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Oct 2020 12:04:27 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/6323cf68-ff63-41d9-bb1b-2c4be040d440?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      date:
+      - Thu, 15 Oct 2020 12:04:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2016-12-01&$filter=backupManagementType%20eq%20%27AzureIaasVM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestorecant/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestorecant","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestorecant","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestorecant","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestorecant","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoregqqp","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoregqqp","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoregwou","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoregwou","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoreqhdt","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoreqhdt","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestorewkcw","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestorewkcw","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoreyvan","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoreyvan","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf/protectableItems/vm;iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf","name":"iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.vaults/providers/Microsoft.ClassicCompute/virtualMachines/fadfasdfsdf","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"fadfasdfsdf","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter/protectableItems/vm;iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter","name":"iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.vaults/providers/Microsoft.ClassicCompute/virtualMachines/testvmdeleter","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"testvmdeleter","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000005","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq;clitest-vm7dgm3/protectableItems/vm;iaasvmcontainerv2;clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq;clitest-vm7dgm3","name":"iaasvmcontainerv2;clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq;clitest-vm7dgm3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq/providers/Microsoft.Compute/virtualMachines/clitest-vm7dgm3","virtualMachineVersion":"Compute","resourceGroup":"clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm7dgm3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2/protectableItems/vm;iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2","name":"iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.encryptedvm/providers/Microsoft.Compute/virtualMachines/iaasenc-win-v2","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.encryptedvm","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasenc-win-v2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestorebbum","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestorebbum","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestorebdbr","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestorebdbr","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestoredxay","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestoredxay","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3","name":"iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing/providers/Microsoft.Compute/virtualMachines/iaas-win-ext3","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaas-win-ext3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing;iaasext-win-3/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing;iaasext-win-3","name":"iaasvmcontainerv2;iaasvm.existing;iaasext-win-3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing/providers/Microsoft.Compute/virtualMachines/iaasext-win-3","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasext-win-3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreciol","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreciol","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorecpkh","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorecpkh","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreegcg","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreegcg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreentn","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreentn","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorehbaz","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorehbaz","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreimgf","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreimgf","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorelzle","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorelzle","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoremrdb","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoremrdb","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoretylj","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoretylj","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm","name":"iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.vaults/providers/Microsoft.Compute/virtualMachines/jakavetEncVM","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"jakavetEncVM","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2/protectableItems/vm;iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2","name":"iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.vmbackup/providers/Microsoft.Compute/virtualMachines/iaasvbkp-win-v2","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.vmbackup","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasvbkp-win-v2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext/protectableItems/vm;iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext","name":"iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmhanaworkload.existing/providers/Microsoft.Compute/virtualMachines/iaashanaext","virtualMachineVersion":"Compute","resourceGroup":"iaasvmhanaworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaashanaext","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win/protectableItems/vm;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win","name":"iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmsqlworkload.existing/providers/Microsoft.Compute/virtualMachines/iaassqlext-win","virtualMachineVersion":"Compute","resourceGroup":"iaasvmsqlworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaassqlext-win","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win/protectableItems/vm;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win","name":"iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmsqlworkload.existing/providers/Microsoft.Compute/virtualMachines/iaassqlext2-win","virtualMachineVersion":"Compute","resourceGroup":"iaasvmsqlworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaassqlext2-win","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm/protectableItems/vm;iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm","name":"iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pscloudtestrg/providers/Microsoft.Compute/virtualMachines/psbvtsqlvm","virtualMachineVersion":"Compute","resourceGroup":"pscloudtestrg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"psbvtsqlvm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pstestrg8895;pstestvm/protectableItems/vm;iaasvmcontainerv2;pstestrg8895;pstestvm","name":"iaasvmcontainerv2;pstestrg8895;pstestvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pstestrg8895/providers/Microsoft.Compute/virtualMachines/pstestvm","virtualMachineVersion":"Compute","resourceGroup":"pstestrg8895","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"pstestvm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;riteshcrg;xcvsdsad/protectableItems/vm;iaasvmcontainerv2;riteshcrg;xcvsdsad","name":"iaasvmcontainerv2;riteshcrg;xcvsdsad","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/riteshcRG/providers/Microsoft.Compute/virtualMachines/xcvsdsad","virtualMachineVersion":"Compute","resourceGroup":"riteshcRG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"xcvsdsad","protectionState":"NotProtected"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;akneema;akneema-hana-vm/protectableItems/vm;iaasvmcontainerv2;akneema;akneema-hana-vm","name":"iaasvmcontainerv2;akneema;akneema-hana-vm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema/providers/Microsoft.Compute/virtualMachines/akneema-hana-vm","virtualMachineVersion":"Compute","resourceGroup":"akneema","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"akneema-hana-vm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;asebvtrg;asebvtseavm3/protectableItems/vm;iaasvmcontainerv2;asebvtrg;asebvtseavm3","name":"iaasvmcontainerv2;asebvtrg;asebvtseavm3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ASEBVTRG/providers/Microsoft.Compute/virtualMachines/asebvtseavm3","virtualMachineVersion":"Compute","resourceGroup":"ASEBVTRG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"asebvtseavm3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testcanarygeetasql/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testcanarygeetasql","name":"iaasvmcontainerv2;chandrikarg;testcanarygeetasql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testcanarygeetasql","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testcanarygeetasql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchg","name":"iaasvmcontainerv2;chandrikarg;testvmchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchgsql3/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchgsql3","name":"iaasvmcontainerv2;chandrikarg;testvmchgsql3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchgsql3","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchgsql3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmsqlchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmsqlchg","name":"iaasvmcontainerv2;chandrikarg;testvmsqlchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmsqlchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmsqlchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000005","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000006","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2014/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2014","name":"iaasvmcontainerv2;containerautoprotection;shrja-2014","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2014","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2014","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2019/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2019","name":"iaasvmcontainerv2;containerautoprotection;shrja-2019","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2019","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2019","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja2012r2/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja2012r2","name":"iaasvmcontainerv2;containerautoprotection;shrja2012r2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja2012R2","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2012R2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","name":"iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetasqlvmbanner14","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetasqlvmbanner14","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","name":"iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetsqlvmbanner1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetsqlvmbanner1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner10/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner10","name":"iaasvmcontainerv2;gesahoo;gesahoobanner10","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner10","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner10","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner11/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner11","name":"iaasvmcontainerv2;gesahoo;gesahoobanner11","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner11","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner11","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner12/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner12","name":"iaasvmcontainerv2;gesahoo;gesahoobanner12","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner12","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner12","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner5","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner5","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner6","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner6","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner7","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner7","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner8","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner9","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner9","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbannervm4","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbannervm4","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress2","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","name":"iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlvminprogress3","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlvminprogress3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","name":"iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlautobackupgeeta","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlautobackupgeeta","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","name":"iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlbannergeetacanary","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlbannergeetacanary","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testgesahoosql/protectableItems/vm;iaasvmcontainerv2;gesahoo;testgesahoosql","name":"iaasvmcontainerv2;gesahoo;testgesahoosql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testgesahoosql","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testgesahoosql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testprodgesahoo/protectableItems/vm;iaasvmcontainerv2;gesahoo;testprodgesahoo","name":"iaasvmcontainerv2;gesahoo;testprodgesahoo","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testProdGesahoo","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testProdGesahoo","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;nilay-rg;nilsha-test/protectableItems/vm;iaasvmcontainerv2;nilay-rg;nilsha-test","name":"iaasvmcontainerv2;nilay-rg;nilsha-test","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Nilay-RG/providers/Microsoft.Compute/virtualMachines/nilsha-test","virtualMachineVersion":"Compute","resourceGroup":"Nilay-RG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"nilsha-test","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8/protectableItems/vm;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","name":"iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pstestwlRG1bca8/providers/Microsoft.Compute/virtualMachines/pstestwlvm1bca8","virtualMachineVersion":"Compute","resourceGroup":"pstestwlRG1bca8","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"pstestwlvm1bca8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sarath-rg;sarathpstest001/protectableItems/vm;iaasvmcontainerv2;sarath-rg;sarathpstest001","name":"iaasvmcontainerv2;sarath-rg;sarathpstest001","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Compute/virtualMachines/sarathPSTest001","virtualMachineVersion":"Compute","resourceGroup":"sarath-rg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sarathPSTest001","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shrja2008_group;shrja2008/protectableItems/vm;iaasvmcontainerv2;shrja2008_group;shrja2008","name":"iaasvmcontainerv2;shrja2008_group;shrja2008","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shrja2008_group/providers/Microsoft.Compute/virtualMachines/shrja2008","virtualMachineVersion":"Compute","resourceGroup":"shrja2008_group","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2008","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","name":"iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/dsadsa","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"dsadsa","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;sddsds/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;sddsds","name":"iaasvmcontainerv2;shswain-rg-restoredata;sddsds","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/sddsds","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sddsds","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sisi-rsv;sisi-mercury/protectableItems/vm;iaasvmcontainerv2;sisi-rsv;sisi-mercury","name":"iaasvmcontainerv2;sisi-rsv;sisi-mercury","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sisi-RSV/providers/Microsoft.Compute/virtualMachines/sisi-mercury","virtualMachineVersion":"Compute","resourceGroup":"sisi-RSV","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sisi-mercury","protectionState":"NotProtected"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '32836'
+      - '34331'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:34 GMT
+      - Thu, 15 Oct 2020 12:04:29 GMT
       expires:
       - '-1'
       pragma:
@@ -2092,8 +2322,8 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: PUT
@@ -2103,17 +2333,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationsStatus/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationsStatus/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2019-06-15
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Sat, 01 Aug 2020 16:44:36 GMT
+      - Thu, 15 Oct 2020 12:04:30 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationResults/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationResults/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2019-06-15
       pragma:
       - no-cache
       strict-transport-security:
@@ -2141,15 +2371,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2158,7 +2388,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:38 GMT
+      - Thu, 15 Oct 2020 12:04:31 GMT
       expires:
       - '-1'
       pragma:
@@ -2192,15 +2422,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2209,7 +2439,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:41 GMT
+      - Thu, 15 Oct 2020 12:04:32 GMT
       expires:
       - '-1'
       pragma:
@@ -2243,15 +2473,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2260,7 +2490,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:44 GMT
+      - Thu, 15 Oct 2020 12:04:33 GMT
       expires:
       - '-1'
       pragma:
@@ -2294,15 +2524,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2311,7 +2541,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:46 GMT
+      - Thu, 15 Oct 2020 12:04:35 GMT
       expires:
       - '-1'
       pragma:
@@ -2345,15 +2575,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2362,7 +2592,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:48 GMT
+      - Thu, 15 Oct 2020 12:04:36 GMT
       expires:
       - '-1'
       pragma:
@@ -2396,15 +2626,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2413,7 +2643,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:50 GMT
+      - Thu, 15 Oct 2020 12:04:37 GMT
       expires:
       - '-1'
       pragma:
@@ -2447,15 +2677,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2464,7 +2694,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:53 GMT
+      - Thu, 15 Oct 2020 12:04:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2498,15 +2728,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2515,7 +2745,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:54 GMT
+      - Thu, 15 Oct 2020 12:04:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2549,15 +2779,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2566,7 +2796,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:56 GMT
+      - Thu, 15 Oct 2020 12:04:41 GMT
       expires:
       - '-1'
       pragma:
@@ -2600,15 +2830,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2617,7 +2847,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:44:58 GMT
+      - Thu, 15 Oct 2020 12:04:42 GMT
       expires:
       - '-1'
       pragma:
@@ -2651,15 +2881,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2668,7 +2898,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:01 GMT
+      - Thu, 15 Oct 2020 12:04:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2702,15 +2932,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2719,7 +2949,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:02 GMT
+      - Thu, 15 Oct 2020 12:04:44 GMT
       expires:
       - '-1'
       pragma:
@@ -2753,15 +2983,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2770,7 +3000,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:05 GMT
+      - Thu, 15 Oct 2020 12:04:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2804,15 +3034,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"InProgress","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -2821,7 +3051,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:06 GMT
+      - Thu, 15 Oct 2020 12:04:47 GMT
       expires:
       - '-1'
       pragma:
@@ -2855,15 +3085,525 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e06b2e42-22f8-482c-abd4-f961a3cd949a?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e06b2e42-22f8-482c-abd4-f961a3cd949a","name":"e06b2e42-22f8-482c-abd4-f961a3cd949a","status":"Succeeded","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"2020-08-01T16:44:36.6619671Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"4e6870d4-470e-4d6b-b896-f6b22cd901b9"}}'
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:04:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:04:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:04:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:04:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:04:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:04:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:04:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:04:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:04:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"InProgress","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:05:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/c942db02-5d42-4a9d-903d-93f6609a80ab?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"c942db02-5d42-4a9d-903d-93f6609a80ab","name":"c942db02-5d42-4a9d-903d-93f6609a80ab","status":"Succeeded","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"2020-10-15T12:04:30.5360642Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"0fd4821d-5b23-4675-b805-953f4a6638ac"}}'
     headers:
       cache-control:
       - no-cache
@@ -2872,7 +3612,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:08 GMT
+      - Thu, 15 Oct 2020 12:05:01 GMT
       expires:
       - '-1'
       pragma:
@@ -2906,16 +3646,16 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/4e6870d4-470e-4d6b-b896-f6b22cd901b9?api-version=2019-06-15
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/0fd4821d-5b23-4675-b805-953f4a6638ac?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/4e6870d4-470e-4d6b-b896-f6b22cd901b9","name":"4e6870d4-470e-4d6b-b896-f6b22cd901b9","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT31.2390746S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000005","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-08-01T16:44:36.6619671Z","endTime":"2020-08-01T16:45:07.9010417Z","activityId":"3fe31ef4-d416-11ea-b339-186024943d4f"}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/0fd4821d-5b23-4675-b805-953f4a6638ac","name":"0fd4821d-5b23-4675-b805-953f4a6638ac","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT30.9612716S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000005","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-10-15T12:04:30.5360642Z","endTime":"2020-10-15T12:05:01.4973358Z","activityId":"8ad17eb0-0ede-11eb-9e60-c8f750f92764"}}'
     headers:
       cache-control:
       - no-cache
@@ -2924,7 +3664,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:11 GMT
+      - Thu, 15 Oct 2020 12:05:02 GMT
       expires:
       - '-1'
       pragma:
@@ -2959,8 +3699,8 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-compute/13.0.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-compute/13.1.1 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -2971,16 +3711,16 @@ interactions:
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"southeastasia\",\r\n
         \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
         \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
-        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"530b621c-5bfa-4304-9c20-93bdce10869e\",\r\n
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"6d83da7c-a3ea-47e9-b895-556468c9079e\",\r\n
         \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
         \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
         \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
         \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
-        \"9600.19756.2007111612\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Windows\",\r\n        \"name\": \"clitest-vm000006_OsDisk_1_4d0ef492f6314ecda1e02a7964bcf7d8\",\r\n
+        \"9600.19817.2009040500\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Windows\",\r\n        \"name\": \"clitest-vm000006_disk1_e2d41f81017c419894183e18226cde7c\",\r\n
         \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
         \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
-        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RG5SD72QUTVLST7ILEJLWWOCETK4BHOHRXUBKRHYFTLISN5IZV4OXGTASDF2LFLUXO7/providers/Microsoft.Compute/disks/clitest-vm000006_OsDisk_1_4d0ef492f6314ecda1e02a7964bcf7d8\"\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLITEST.RGSU6WBHXJEGODSHFZVKKKWBWBQWLTIRZRBG7F3Z2XQMLE7UD4WLFIHR4KHRVGU4NJV/providers/Microsoft.Compute/disks/clitest-vm000006_disk1_e2d41f81017c419894183e18226cde7c\"\r\n
         \       },\r\n        \"diskSizeGB\": 127\r\n      },\r\n      \"dataDisks\":
         []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"clitest-vm000006\",\r\n
         \     \"adminUsername\": \"clitest-vm000006\",\r\n      \"windowsConfiguration\":
@@ -2994,11 +3734,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2210'
+      - '2204'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Sat, 01 Aug 2020 16:45:13 GMT
+      - Thu, 15 Oct 2020 12:05:02 GMT
       expires:
       - '-1'
       pragma:
@@ -3015,7 +3755,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3988,Microsoft.Compute/LowCostGet30Min;31977
+      - Microsoft.Compute/LowCostGet3Min;3987,Microsoft.Compute/LowCostGet30Min;31963
     status:
       code: 200
       message: OK
@@ -3033,15 +3773,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservices/0.4.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservices/0.4.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2016-06-01
   response:
     body:
-      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-08-01T16%3A38%3A45.9794159Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+      string: '{"location":"southeastasia","name":"clitest-vault000002","etag":"W/\"datetime''2020-10-15T12%3A01%3A54.6287001Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
     headers:
       cache-control:
       - no-cache
@@ -3050,7 +3790,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:15 GMT
+      - Thu, 15 Oct 2020 12:05:02 GMT
       expires:
       - '-1'
       pragma:
@@ -3082,15 +3822,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":1}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":1}}'
     headers:
       cache-control:
       - no-cache
@@ -3099,7 +3839,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:17 GMT
+      - Thu, 15 Oct 2020 12:05:03 GMT
       expires:
       - '-1'
       pragma:
@@ -3133,24 +3873,24 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2016-12-01&$filter=backupManagementType%20eq%20%27AzureIaasVM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestorecant/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestorecant","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestorecant","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestorecant","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestorecant","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoregqqp","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoregqqp","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoregwou","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoregwou","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoreqhdt","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoreqhdt","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestorewkcw","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestorewkcw","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoreyvan","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoreyvan","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf/protectableItems/vm;iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf","name":"iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.vaults/providers/Microsoft.ClassicCompute/virtualMachines/fadfasdfsdf","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"fadfasdfsdf","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter/protectableItems/vm;iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter","name":"iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.vaults/providers/Microsoft.ClassicCompute/virtualMachines/testvmdeleter","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"testvmdeleter","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq;clitest-vm7dgm3/protectableItems/vm;iaasvmcontainerv2;clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq;clitest-vm7dgm3","name":"iaasvmcontainerv2;clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq;clitest-vm7dgm3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq/providers/Microsoft.Compute/virtualMachines/clitest-vm7dgm3","virtualMachineVersion":"Compute","resourceGroup":"clitest.rgzutcaglaonhk3cdqbelm2v2sreeashaw3zl5io67gq54t7uhparhcayl6t6livdcq","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm7dgm3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2/protectableItems/vm;iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2","name":"iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.encryptedvm/providers/Microsoft.Compute/virtualMachines/iaasenc-win-v2","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.encryptedvm","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasenc-win-v2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestorebbum","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestorebbum","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestorebdbr","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestorebdbr","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestoredxay","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestoredxay","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3","name":"iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing/providers/Microsoft.Compute/virtualMachines/iaas-win-ext3","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaas-win-ext3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing;iaasext-win-3/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing;iaasext-win-3","name":"iaasvmcontainerv2;iaasvm.existing;iaasext-win-3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing/providers/Microsoft.Compute/virtualMachines/iaasext-win-3","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasext-win-3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreciol","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreciol","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorecpkh","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorecpkh","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreegcg","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreegcg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreentn","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreentn","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorehbaz","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorehbaz","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreimgf","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreimgf","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorelzle","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorelzle","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoremrdb","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoremrdb","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoretylj","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoretylj","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm","name":"iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.vaults/providers/Microsoft.Compute/virtualMachines/jakavetEncVM","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"jakavetEncVM","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2/protectableItems/vm;iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2","name":"iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.vmbackup/providers/Microsoft.Compute/virtualMachines/iaasvbkp-win-v2","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.vmbackup","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasvbkp-win-v2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext/protectableItems/vm;iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext","name":"iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmhanaworkload.existing/providers/Microsoft.Compute/virtualMachines/iaashanaext","virtualMachineVersion":"Compute","resourceGroup":"iaasvmhanaworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaashanaext","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win/protectableItems/vm;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win","name":"iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmsqlworkload.existing/providers/Microsoft.Compute/virtualMachines/iaassqlext-win","virtualMachineVersion":"Compute","resourceGroup":"iaasvmsqlworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaassqlext-win","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win/protectableItems/vm;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win","name":"iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmsqlworkload.existing/providers/Microsoft.Compute/virtualMachines/iaassqlext2-win","virtualMachineVersion":"Compute","resourceGroup":"iaasvmsqlworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaassqlext2-win","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm/protectableItems/vm;iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm","name":"iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pscloudtestrg/providers/Microsoft.Compute/virtualMachines/psbvtsqlvm","virtualMachineVersion":"Compute","resourceGroup":"pscloudtestrg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"psbvtsqlvm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pstestrg8895;pstestvm/protectableItems/vm;iaasvmcontainerv2;pstestrg8895;pstestvm","name":"iaasvmcontainerv2;pstestrg8895;pstestvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pstestrg8895/providers/Microsoft.Compute/virtualMachines/pstestvm","virtualMachineVersion":"Compute","resourceGroup":"pstestrg8895","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"pstestvm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;riteshcrg;xcvsdsad/protectableItems/vm;iaasvmcontainerv2;riteshcrg;xcvsdsad","name":"iaasvmcontainerv2;riteshcrg;xcvsdsad","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/riteshcRG/providers/Microsoft.Compute/virtualMachines/xcvsdsad","virtualMachineVersion":"Compute","resourceGroup":"riteshcRG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"xcvsdsad","protectionState":"NotProtected"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;akneema;akneema-hana-vm/protectableItems/vm;iaasvmcontainerv2;akneema;akneema-hana-vm","name":"iaasvmcontainerv2;akneema;akneema-hana-vm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema/providers/Microsoft.Compute/virtualMachines/akneema-hana-vm","virtualMachineVersion":"Compute","resourceGroup":"akneema","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"akneema-hana-vm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;asebvtrg;asebvtseavm3/protectableItems/vm;iaasvmcontainerv2;asebvtrg;asebvtseavm3","name":"iaasvmcontainerv2;asebvtrg;asebvtseavm3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ASEBVTRG/providers/Microsoft.Compute/virtualMachines/asebvtseavm3","virtualMachineVersion":"Compute","resourceGroup":"ASEBVTRG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"asebvtseavm3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testcanarygeetasql/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testcanarygeetasql","name":"iaasvmcontainerv2;chandrikarg;testcanarygeetasql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testcanarygeetasql","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testcanarygeetasql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchg","name":"iaasvmcontainerv2;chandrikarg;testvmchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchgsql3/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchgsql3","name":"iaasvmcontainerv2;chandrikarg;testvmchgsql3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchgsql3","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchgsql3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmsqlchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmsqlchg","name":"iaasvmcontainerv2;chandrikarg;testvmsqlchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmsqlchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmsqlchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000006","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2014/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2014","name":"iaasvmcontainerv2;containerautoprotection;shrja-2014","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2014","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2014","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2019/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2019","name":"iaasvmcontainerv2;containerautoprotection;shrja-2019","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2019","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2019","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja2012r2/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja2012r2","name":"iaasvmcontainerv2;containerautoprotection;shrja2012r2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja2012R2","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2012R2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","name":"iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetasqlvmbanner14","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetasqlvmbanner14","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","name":"iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetsqlvmbanner1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetsqlvmbanner1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner10/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner10","name":"iaasvmcontainerv2;gesahoo;gesahoobanner10","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner10","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner10","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner11/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner11","name":"iaasvmcontainerv2;gesahoo;gesahoobanner11","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner11","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner11","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner12/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner12","name":"iaasvmcontainerv2;gesahoo;gesahoobanner12","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner12","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner12","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner5","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner5","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner6","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner6","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner7","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner7","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner8","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner9","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner9","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbannervm4","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbannervm4","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress2","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","name":"iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlvminprogress3","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlvminprogress3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","name":"iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlautobackupgeeta","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlautobackupgeeta","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","name":"iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlbannergeetacanary","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlbannergeetacanary","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testgesahoosql/protectableItems/vm;iaasvmcontainerv2;gesahoo;testgesahoosql","name":"iaasvmcontainerv2;gesahoo;testgesahoosql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testgesahoosql","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testgesahoosql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testprodgesahoo/protectableItems/vm;iaasvmcontainerv2;gesahoo;testprodgesahoo","name":"iaasvmcontainerv2;gesahoo;testprodgesahoo","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testProdGesahoo","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testProdGesahoo","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;nilay-rg;nilsha-test/protectableItems/vm;iaasvmcontainerv2;nilay-rg;nilsha-test","name":"iaasvmcontainerv2;nilay-rg;nilsha-test","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Nilay-RG/providers/Microsoft.Compute/virtualMachines/nilsha-test","virtualMachineVersion":"Compute","resourceGroup":"Nilay-RG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"nilsha-test","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8/protectableItems/vm;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","name":"iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pstestwlRG1bca8/providers/Microsoft.Compute/virtualMachines/pstestwlvm1bca8","virtualMachineVersion":"Compute","resourceGroup":"pstestwlRG1bca8","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"pstestwlvm1bca8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sarath-rg;sarathpstest001/protectableItems/vm;iaasvmcontainerv2;sarath-rg;sarathpstest001","name":"iaasvmcontainerv2;sarath-rg;sarathpstest001","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Compute/virtualMachines/sarathPSTest001","virtualMachineVersion":"Compute","resourceGroup":"sarath-rg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sarathPSTest001","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shrja2008_group;shrja2008/protectableItems/vm;iaasvmcontainerv2;shrja2008_group;shrja2008","name":"iaasvmcontainerv2;shrja2008_group;shrja2008","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shrja2008_group/providers/Microsoft.Compute/virtualMachines/shrja2008","virtualMachineVersion":"Compute","resourceGroup":"shrja2008_group","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2008","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","name":"iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/dsadsa","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"dsadsa","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;sddsds/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;sddsds","name":"iaasvmcontainerv2;shswain-rg-restoredata;sddsds","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/sddsds","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sddsds","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sisi-rsv;sisi-mercury/protectableItems/vm;iaasvmcontainerv2;sisi-rsv;sisi-mercury","name":"iaasvmcontainerv2;sisi-rsv;sisi-mercury","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sisi-RSV/providers/Microsoft.Compute/virtualMachines/sisi-mercury","virtualMachineVersion":"Compute","resourceGroup":"sisi-RSV","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sisi-mercury","protectionState":"NotProtected"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '31576'
+      - '33071'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:18 GMT
+      - Thu, 15 Oct 2020 12:05:04 GMT
       expires:
       - '-1'
       pragma:
@@ -3181,299 +3921,27 @@ interactions:
       - backup protection enable-for-vm
       Connection:
       - keep-alive
-      Content-Length:
-      - '0'
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
-      accept-language:
-      - en-US
-    method: POST
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/refreshContainers?api-version=2016-12-01
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/f68bb671-98a7-49be-82ed-738137864338?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Sat, 01 Aug 2020 16:45:20 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f68bb671-98a7-49be-82ed-738137864338?api-version=2016-12-01
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-vm
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --vm -p
-      User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f68bb671-98a7-49be-82ed-738137864338?api-version=2016-12-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Sat, 01 Aug 2020 16:45:23 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f68bb671-98a7-49be-82ed-738137864338?api-version=2016-12-01
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-vm
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --vm -p
-      User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f68bb671-98a7-49be-82ed-738137864338?api-version=2016-12-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Sat, 01 Aug 2020 16:45:26 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f68bb671-98a7-49be-82ed-738137864338?api-version=2016-12-01
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-vm
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --vm -p
-      User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f68bb671-98a7-49be-82ed-738137864338?api-version=2016-12-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Sat, 01 Aug 2020 16:45:28 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f68bb671-98a7-49be-82ed-738137864338?api-version=2016-12-01
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-vm
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --vm -p
-      User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f68bb671-98a7-49be-82ed-738137864338?api-version=2016-12-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Sat, 01 Aug 2020 16:45:29 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f68bb671-98a7-49be-82ed-738137864338?api-version=2016-12-01
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-vm
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --vm -p
-      User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/f68bb671-98a7-49be-82ed-738137864338?api-version=2016-12-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      date:
-      - Sat, 01 Aug 2020 16:45:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup protection enable-for-vm
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -v --vm -p
-      User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2016-12-01&$filter=backupManagementType%20eq%20%27AzureIaasVM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestorecant/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestorecant","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestorecant","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestorecant","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestorecant","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoregqqp","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoregqqp","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoregqqp","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoregwou","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoregwou","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoregwou","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoreqhdt","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoreqhdt","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoreqhdt","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestorewkcw","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestorewkcw","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestorewkcw","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan/protectableItems/vm;iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan","name":"iaasvmcontainer;iaasvm.existing.restore;vmerestoreyvan","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.ClassicCompute/virtualMachines/vmerestoreyvan","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"vmerestoreyvan","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf/protectableItems/vm;iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf","name":"iaasvmcontainer;iaasvm.existing.vaults;fadfasdfsdf","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.vaults/providers/Microsoft.ClassicCompute/virtualMachines/fadfasdfsdf","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"fadfasdfsdf","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter/protectableItems/vm;iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter","name":"iaasvmcontainer;iaasvm.existing.vaults;testvmdeleter","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.vaults/providers/Microsoft.ClassicCompute/virtualMachines/testvmdeleter","virtualMachineVersion":"ClassicCompute","resourceGroup":"iaasvm.existing.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.ClassicCompute/virtualMachines","friendlyName":"testvmdeleter","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000006","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rgp6qm66rqcubeehdj2uykdkhilp3275txglxu6mzpfiuptjpv3dce3qdtoijgzkwb6;clitest-vmbfrpo/protectableItems/vm;iaasvmcontainerv2;clitest.rgp6qm66rqcubeehdj2uykdkhilp3275txglxu6mzpfiuptjpv3dce3qdtoijgzkwb6;clitest-vmbfrpo","name":"iaasvmcontainerv2;clitest.rgp6qm66rqcubeehdj2uykdkhilp3275txglxu6mzpfiuptjpv3dce3qdtoijgzkwb6;clitest-vmbfrpo","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgp6qm66rqcubeehdj2uykdkhilp3275txglxu6mzpfiuptjpv3dce3qdtoijgzkwb6/providers/Microsoft.Compute/virtualMachines/clitest-vmbfrpo","virtualMachineVersion":"Compute","resourceGroup":"clitest.rgp6qm66rqcubeehdj2uykdkhilp3275txglxu6mzpfiuptjpv3dce3qdtoijgzkwb6","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vmbfrpo","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rgp6qm66rqcubeehdj2uykdkhilp3275txglxu6mzpfiuptjpv3dce3qdtoijgzkwb6;clitest-vmvxrn6/protectableItems/vm;iaasvmcontainerv2;clitest.rgp6qm66rqcubeehdj2uykdkhilp3275txglxu6mzpfiuptjpv3dce3qdtoijgzkwb6;clitest-vmvxrn6","name":"iaasvmcontainerv2;clitest.rgp6qm66rqcubeehdj2uykdkhilp3275txglxu6mzpfiuptjpv3dce3qdtoijgzkwb6;clitest-vmvxrn6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgp6qm66rqcubeehdj2uykdkhilp3275txglxu6mzpfiuptjpv3dce3qdtoijgzkwb6/providers/Microsoft.Compute/virtualMachines/clitest-vmvxrn6","virtualMachineVersion":"Compute","resourceGroup":"clitest.rgp6qm66rqcubeehdj2uykdkhilp3275txglxu6mzpfiuptjpv3dce3qdtoijgzkwb6","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vmvxrn6","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2/protectableItems/vm;iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2","name":"iaasvmcontainerv2;iaasvm.encryptedvm;iaasenc-win-v2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.encryptedvm/providers/Microsoft.Compute/virtualMachines/iaasenc-win-v2","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.encryptedvm","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasenc-win-v2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebbum","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestorebbum","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestorebbum","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestorebdbr","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestorebdbr","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestorebdbr","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay","name":"iaasvmcontainerv2;iaasvm.existing.restore;vmerestoredxay","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.restore/providers/Microsoft.Compute/virtualMachines/vmerestoredxay","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmerestoredxay","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3","name":"iaasvmcontainerv2;iaasvm.existing;iaas-win-ext3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing/providers/Microsoft.Compute/virtualMachines/iaas-win-ext3","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaas-win-ext3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.existing;iaasext-win-3/protectableItems/vm;iaasvmcontainerv2;iaasvm.existing;iaasext-win-3","name":"iaasvmcontainerv2;iaasvm.existing;iaasext-win-3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing/providers/Microsoft.Compute/virtualMachines/iaasext-win-3","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasext-win-3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreciol","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreciol","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreciol","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorecpkh","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorecpkh","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorecpkh","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreegcg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreegcg","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreegcg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreentn","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreentn","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreentn","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorehbaz","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorehbaz","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorehbaz","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoreimgf","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoreimgf","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoreimgf","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestorelzle","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestorelzle","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestorelzle","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoremrdb","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoremrdb","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoremrdb","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj","name":"iaasvmcontainerv2;iaasvm.new.restore;vmnrestoretylj","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.restore/providers/Microsoft.Compute/virtualMachines/vmnrestoretylj","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.restore","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"vmnrestoretylj","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm/protectableItems/vm;iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm","name":"iaasvmcontainerv2;iaasvm.new.vaults;jakavetencvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.new.vaults/providers/Microsoft.Compute/virtualMachines/jakavetEncVM","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.new.vaults","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"jakavetEncVM","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2/protectableItems/vm;iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2","name":"iaasvmcontainerv2;iaasvm.vmbackup;iaasvbkp-win-v2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.vmbackup/providers/Microsoft.Compute/virtualMachines/iaasvbkp-win-v2","virtualMachineVersion":"Compute","resourceGroup":"iaasvm.vmbackup","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaasvbkp-win-v2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext/protectableItems/vm;iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext","name":"iaasvmcontainerv2;iaasvmhanaworkload.existing;iaashanaext","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmhanaworkload.existing/providers/Microsoft.Compute/virtualMachines/iaashanaext","virtualMachineVersion":"Compute","resourceGroup":"iaasvmhanaworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaashanaext","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win/protectableItems/vm;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win","name":"iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext-win","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmsqlworkload.existing/providers/Microsoft.Compute/virtualMachines/iaassqlext-win","virtualMachineVersion":"Compute","resourceGroup":"iaasvmsqlworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaassqlext-win","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win/protectableItems/vm;iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win","name":"iaasvmcontainerv2;iaasvmsqlworkload.existing;iaassqlext2-win","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvmsqlworkload.existing/providers/Microsoft.Compute/virtualMachines/iaassqlext2-win","virtualMachineVersion":"Compute","resourceGroup":"iaasvmsqlworkload.existing","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"iaassqlext2-win","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm/protectableItems/vm;iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm","name":"iaasvmcontainerv2;pscloudtestrg;psbvtsqlvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pscloudtestrg/providers/Microsoft.Compute/virtualMachines/psbvtsqlvm","virtualMachineVersion":"Compute","resourceGroup":"pscloudtestrg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"psbvtsqlvm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pstestrg8895;pstestvm/protectableItems/vm;iaasvmcontainerv2;pstestrg8895;pstestvm","name":"iaasvmcontainerv2;pstestrg8895;pstestvm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pstestrg8895/providers/Microsoft.Compute/virtualMachines/pstestvm","virtualMachineVersion":"Compute","resourceGroup":"pstestrg8895","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"pstestvm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;riteshcrg;xcvsdsad/protectableItems/vm;iaasvmcontainerv2;riteshcrg;xcvsdsad","name":"iaasvmcontainerv2;riteshcrg;xcvsdsad","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/riteshcRG/providers/Microsoft.Compute/virtualMachines/xcvsdsad","virtualMachineVersion":"Compute","resourceGroup":"riteshcRG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"xcvsdsad","protectionState":"NotProtected"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;akneema;akneema-hana-vm/protectableItems/vm;iaasvmcontainerv2;akneema;akneema-hana-vm","name":"iaasvmcontainerv2;akneema;akneema-hana-vm","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema/providers/Microsoft.Compute/virtualMachines/akneema-hana-vm","virtualMachineVersion":"Compute","resourceGroup":"akneema","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"akneema-hana-vm","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;asebvtrg;asebvtseavm3/protectableItems/vm;iaasvmcontainerv2;asebvtrg;asebvtseavm3","name":"iaasvmcontainerv2;asebvtrg;asebvtseavm3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ASEBVTRG/providers/Microsoft.Compute/virtualMachines/asebvtseavm3","virtualMachineVersion":"Compute","resourceGroup":"ASEBVTRG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"asebvtseavm3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testcanarygeetasql/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testcanarygeetasql","name":"iaasvmcontainerv2;chandrikarg;testcanarygeetasql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testcanarygeetasql","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testcanarygeetasql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchg","name":"iaasvmcontainerv2;chandrikarg;testvmchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmchgsql3/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmchgsql3","name":"iaasvmcontainerv2;chandrikarg;testvmchgsql3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmchgsql3","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmchgsql3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;chandrikarg;testvmsqlchg/protectableItems/vm;iaasvmcontainerv2;chandrikarg;testvmsqlchg","name":"iaasvmcontainerv2;chandrikarg;testvmsqlchg","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chandrikarg/providers/Microsoft.Compute/virtualMachines/testvmsqlchg","virtualMachineVersion":"Compute","resourceGroup":"chandrikarg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testvmsqlchg","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000006","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2014/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2014","name":"iaasvmcontainerv2;containerautoprotection;shrja-2014","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2014","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2014","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja-2019/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja-2019","name":"iaasvmcontainerv2;containerautoprotection;shrja-2019","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja-2019","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja-2019","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;containerautoprotection;shrja2012r2/protectableItems/vm;iaasvmcontainerv2;containerautoprotection;shrja2012r2","name":"iaasvmcontainerv2;containerautoprotection;shrja2012r2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ContainerAutoProtection/providers/Microsoft.Compute/virtualMachines/shrja2012R2","virtualMachineVersion":"Compute","resourceGroup":"ContainerAutoProtection","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2012R2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","name":"iaasvmcontainerv2;gesahoo;geetasqlvmbanner14","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetasqlvmbanner14","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetasqlvmbanner14","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1/protectableItems/vm;iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","name":"iaasvmcontainerv2;gesahoo;geetsqlvmbanner1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/geetsqlvmbanner1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"geetsqlvmbanner1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner10/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner10","name":"iaasvmcontainerv2;gesahoo;gesahoobanner10","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner10","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner10","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner11/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner11","name":"iaasvmcontainerv2;gesahoo;gesahoobanner11","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner11","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner11","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoobanner12/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoobanner12","name":"iaasvmcontainerv2;gesahoo;gesahoobanner12","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoobanner12","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoobanner12","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner5","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner5","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner5","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner6","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner6","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner6","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner7","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner7","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner7","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner8","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbanner9","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbanner9","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbanner9","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","name":"iaasvmcontainerv2;gesahoo;gesahoosqlbannervm4","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlbannervm4","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlbannervm4","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress1","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress1","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","name":"iaasvmcontainerv2;gesahoo;gesahoosqlinprogress2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlinprogress2","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlinprogress2","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3/protectableItems/vm;iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","name":"iaasvmcontainerv2;gesahoo;gesahoosqlvminprogress3","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/gesahoosqlvminprogress3","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"gesahoosqlvminprogress3","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","name":"iaasvmcontainerv2;gesahoo;sqlautobackupgeeta","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlautobackupgeeta","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlautobackupgeeta","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary/protectableItems/vm;iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","name":"iaasvmcontainerv2;gesahoo;sqlbannergeetacanary","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/sqlbannergeetacanary","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sqlbannergeetacanary","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testgesahoosql/protectableItems/vm;iaasvmcontainerv2;gesahoo;testgesahoosql","name":"iaasvmcontainerv2;gesahoo;testgesahoosql","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testgesahoosql","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testgesahoosql","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;gesahoo;testprodgesahoo/protectableItems/vm;iaasvmcontainerv2;gesahoo;testprodgesahoo","name":"iaasvmcontainerv2;gesahoo;testprodgesahoo","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gesahoo/providers/Microsoft.Compute/virtualMachines/testProdGesahoo","virtualMachineVersion":"Compute","resourceGroup":"gesahoo","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"testProdGesahoo","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;nilay-rg;nilsha-test/protectableItems/vm;iaasvmcontainerv2;nilay-rg;nilsha-test","name":"iaasvmcontainerv2;nilay-rg;nilsha-test","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Nilay-RG/providers/Microsoft.Compute/virtualMachines/nilsha-test","virtualMachineVersion":"Compute","resourceGroup":"Nilay-RG","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"nilsha-test","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8/protectableItems/vm;iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","name":"iaasvmcontainerv2;pstestwlrg1bca8;pstestwlvm1bca8","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pstestwlRG1bca8/providers/Microsoft.Compute/virtualMachines/pstestwlvm1bca8","virtualMachineVersion":"Compute","resourceGroup":"pstestwlRG1bca8","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"pstestwlvm1bca8","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sarath-rg;sarathpstest001/protectableItems/vm;iaasvmcontainerv2;sarath-rg;sarathpstest001","name":"iaasvmcontainerv2;sarath-rg;sarathpstest001","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Compute/virtualMachines/sarathPSTest001","virtualMachineVersion":"Compute","resourceGroup":"sarath-rg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sarathPSTest001","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shrja2008_group;shrja2008/protectableItems/vm;iaasvmcontainerv2;shrja2008_group;shrja2008","name":"iaasvmcontainerv2;shrja2008_group;shrja2008","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shrja2008_group/providers/Microsoft.Compute/virtualMachines/shrja2008","virtualMachineVersion":"Compute","resourceGroup":"shrja2008_group","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"shrja2008","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","name":"iaasvmcontainerv2;shswain-rg-restoredata;dsadsa","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/dsadsa","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"dsadsa","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;shswain-rg-restoredata;sddsds/protectableItems/vm;iaasvmcontainerv2;shswain-rg-restoredata;sddsds","name":"iaasvmcontainerv2;shswain-rg-restoredata;sddsds","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/shswain-rg-restoredata/providers/Microsoft.Compute/virtualMachines/sddsds","virtualMachineVersion":"Compute","resourceGroup":"shswain-rg-restoredata","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sddsds","protectionState":"NotProtected"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;sisi-rsv;sisi-mercury/protectableItems/vm;iaasvmcontainerv2;sisi-rsv;sisi-mercury","name":"iaasvmcontainerv2;sisi-rsv;sisi-mercury","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sisi-RSV/providers/Microsoft.Compute/virtualMachines/sisi-mercury","virtualMachineVersion":"Compute","resourceGroup":"sisi-RSV","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"sisi-mercury","protectionState":"NotProtected"}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '34096'
+      - '33071'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:34 GMT
+      - Thu, 15 Oct 2020 12:05:04 GMT
       expires:
       - '-1'
       pragma:
@@ -3513,8 +3981,8 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: PUT
@@ -3524,17 +3992,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationsStatus/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationsStatus/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2019-06-15
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Sat, 01 Aug 2020 16:45:37 GMT
+      - Thu, 15 Oct 2020 12:05:05 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationResults/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/operationResults/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2019-06-15
       pragma:
       - no-cache
       strict-transport-security:
@@ -3542,7 +4010,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -3562,15 +4030,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3579,7 +4047,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:38 GMT
+      - Thu, 15 Oct 2020 12:05:06 GMT
       expires:
       - '-1'
       pragma:
@@ -3613,15 +4081,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3630,7 +4098,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:40 GMT
+      - Thu, 15 Oct 2020 12:05:07 GMT
       expires:
       - '-1'
       pragma:
@@ -3664,15 +4132,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3681,7 +4149,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:43 GMT
+      - Thu, 15 Oct 2020 12:05:09 GMT
       expires:
       - '-1'
       pragma:
@@ -3715,15 +4183,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3732,7 +4200,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:45 GMT
+      - Thu, 15 Oct 2020 12:05:10 GMT
       expires:
       - '-1'
       pragma:
@@ -3766,15 +4234,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3783,7 +4251,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:46 GMT
+      - Thu, 15 Oct 2020 12:05:11 GMT
       expires:
       - '-1'
       pragma:
@@ -3817,15 +4285,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3834,7 +4302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:48 GMT
+      - Thu, 15 Oct 2020 12:05:12 GMT
       expires:
       - '-1'
       pragma:
@@ -3868,15 +4336,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3885,7 +4353,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:51 GMT
+      - Thu, 15 Oct 2020 12:05:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3919,15 +4387,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3936,7 +4404,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:53 GMT
+      - Thu, 15 Oct 2020 12:05:15 GMT
       expires:
       - '-1'
       pragma:
@@ -3970,15 +4438,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -3987,7 +4455,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:55 GMT
+      - Thu, 15 Oct 2020 12:05:16 GMT
       expires:
       - '-1'
       pragma:
@@ -4021,15 +4489,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4038,7 +4506,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:57 GMT
+      - Thu, 15 Oct 2020 12:05:17 GMT
       expires:
       - '-1'
       pragma:
@@ -4072,15 +4540,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4089,7 +4557,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:45:59 GMT
+      - Thu, 15 Oct 2020 12:05:18 GMT
       expires:
       - '-1'
       pragma:
@@ -4123,15 +4591,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4140,7 +4608,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:00 GMT
+      - Thu, 15 Oct 2020 12:05:20 GMT
       expires:
       - '-1'
       pragma:
@@ -4174,15 +4642,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4191,7 +4659,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:03 GMT
+      - Thu, 15 Oct 2020 12:05:21 GMT
       expires:
       - '-1'
       pragma:
@@ -4225,15 +4693,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4242,7 +4710,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:05 GMT
+      - Thu, 15 Oct 2020 12:05:22 GMT
       expires:
       - '-1'
       pragma:
@@ -4276,15 +4744,15 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"InProgress","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -4293,7 +4761,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:07 GMT
+      - Thu, 15 Oct 2020 12:05:23 GMT
       expires:
       - '-1'
       pragma:
@@ -4327,15 +4795,474 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7dc18614-5343-476b-b41a-4c7a413cdf97?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"7dc18614-5343-476b-b41a-4c7a413cdf97","name":"7dc18614-5343-476b-b41a-4c7a413cdf97","status":"Succeeded","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"2020-08-01T16:45:36.9624055Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"e0880132-a81b-4895-89a7-8da00b7d6a7b"}}'
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:05:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:05:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:05:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:05:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:05:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:05:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:05:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:05:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"InProgress","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:05:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/b3d90262-51b4-411b-91b3-a474857f5790?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"b3d90262-51b4-411b-91b3-a474857f5790","name":"b3d90262-51b4-411b-91b3-a474857f5790","status":"Succeeded","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"2020-10-15T12:05:06.1164156Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"7c3071ac-ba83-4a23-8d57-3b1adaac672c"}}'
     headers:
       cache-control:
       - no-cache
@@ -4344,7 +5271,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:10 GMT
+      - Thu, 15 Oct 2020 12:05:36 GMT
       expires:
       - '-1'
       pragma:
@@ -4378,16 +5305,16 @@ interactions:
       ParameterSetName:
       - -g -v --vm -p
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/e0880132-a81b-4895-89a7-8da00b7d6a7b?api-version=2019-06-15
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7c3071ac-ba83-4a23-8d57-3b1adaac672c?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/e0880132-a81b-4895-89a7-8da00b7d6a7b","name":"e0880132-a81b-4895-89a7-8da00b7d6a7b","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT30.9898318S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000006","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-08-01T16:45:36.9624055Z","endTime":"2020-08-01T16:46:07.9522373Z","activityId":"5db12036-d416-11ea-9f94-186024943d4f"}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7c3071ac-ba83-4a23-8d57-3b1adaac672c","name":"7c3071ac-ba83-4a23-8d57-3b1adaac672c","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT30.8145486S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000006","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2020-10-15T12:05:06.1164156Z","endTime":"2020-10-15T12:05:36.9309642Z","activityId":"a7e36bb3-0ede-11eb-b2fa-c8f750f92764"}}'
     headers:
       cache-control:
       - no-cache
@@ -4396,7 +5323,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:11 GMT
+      - Thu, 15 Oct 2020 12:05:37 GMT
       expires:
       - '-1'
       pragma:
@@ -4431,8 +5358,8 @@ interactions:
       ParameterSetName:
       - -g -n --soft-delete-feature-state
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -4448,7 +5375,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:13 GMT
+      - Thu, 15 Oct 2020 12:05:37 GMT
       expires:
       - '-1'
       pragma:
@@ -4487,8 +5414,8 @@ interactions:
       ParameterSetName:
       - -g -n --soft-delete-feature-state
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: PATCH
@@ -4504,7 +5431,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:15 GMT
+      - Thu, 15 Oct 2020 12:05:38 GMT
       expires:
       - '-1'
       pragma:
@@ -4520,7 +5447,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -4540,15 +5467,15 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -4557,7 +5484,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:17 GMT
+      - Thu, 15 Oct 2020 12:05:38 GMT
       expires:
       - '-1'
       pragma:
@@ -4591,15 +5518,15 @@ interactions:
       ParameterSetName:
       - -g -v
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2019-06-15
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -4608,7 +5535,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:19 GMT
+      - Thu, 15 Oct 2020 12:05:40 GMT
       expires:
       - '-1'
       pragma:
@@ -4642,15 +5569,15 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=policyName%20eq%20%27DefaultPolicy%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17594319320070","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593109254903","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185870131275","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185001101385","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -4659,7 +5586,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:21 GMT
+      - Thu, 15 Oct 2020 12:05:40 GMT
       expires:
       - '-1'
       pragma:
@@ -4681,11 +5608,121 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
+      "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy", "scheduleRunFrequency":
+      "Daily", "scheduleRunTimes": ["2020-10-15T22:00:00.000Z"], "scheduleWeeklyFrequency":
+      0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy", "dailySchedule":
+      {"retentionTimes": ["2020-10-15T22:00:00.000Z"], "retentionDuration": {"count":
+      30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 2, "timeZone":
+      "UTC"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '513'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - --backup-management-type -g -v -n --policy
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy5000010?api-version=2019-06-15
+  response:
+    body:
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy5000010","name":"clitest-policy5000010","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '850'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:05:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup policy delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy5000010?api-version=2016-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 15 Oct 2020 12:05:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemsCount": 0, "backupManagementType": "AzureIaasVM",
       "instantRPDetails": {"azureBackupRGNamePrefix": "RG_prefix", "azureBackupRGNameSuffix":
       "RG_suffix"}, "schedulePolicy": {"schedulePolicyType": "SimpleSchedulePolicy",
-      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-08-02T02:30:00.000Z"],
+      "scheduleRunFrequency": "Daily", "scheduleRunTimes": ["2020-10-15T22:00:00.000Z"],
       "scheduleWeeklyFrequency": 0}, "retentionPolicy": {"retentionPolicyType": "LongTermRetentionPolicy",
-      "dailySchedule": {"retentionTimes": ["2020-08-02T02:30:00.000Z"], "retentionDuration":
+      "dailySchedule": {"retentionTimes": ["2020-10-15T22:00:00.000Z"], "retentionDuration":
       {"count": 30, "durationType": "Days"}}}, "instantRpRetentionRangeInDays": 2,
       "timeZone": "UTC"}}'
     headers:
@@ -4704,15 +5741,15 @@ interactions:
       ParameterSetName:
       - -g -v --policy
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -4721,7 +5758,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:23 GMT
+      - Thu, 15 Oct 2020 12:05:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4737,7 +5774,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -4757,15 +5794,15 @@ interactions:
       ParameterSetName:
       - -g -v
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2019-06-15
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-policy000009","name":"clitest-policy000009","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{"azureBackupRGNamePrefix":"RG_prefix","azureBackupRGNameSuffix":"RG_suffix"},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -4774,7 +5811,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:25 GMT
+      - Thu, 15 Oct 2020 12:05:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4810,8 +5847,8 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: DELETE
@@ -4825,7 +5862,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Sat, 01 Aug 2020 16:46:27 GMT
+      - Thu, 15 Oct 2020 12:05:45 GMT
       expires:
       - '-1'
       pragma:
@@ -4835,7 +5872,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
+      - '14999'
       x-powered-by:
       - ASP.NET
     status:
@@ -4855,15 +5892,15 @@ interactions:
       ParameterSetName:
       - -g -v
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies?api-version=2019-06-15
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000003","name":"clitest-item000003","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -4872,7 +5909,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:29 GMT
+      - Thu, 15 Oct 2020 12:05:45 GMT
       expires:
       - '-1'
       pragma:
@@ -4906,15 +5943,15 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-08-02T02:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-08-02T02:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/clitest-item000004","name":"clitest-item000004","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-10-15T22:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-10-15T22:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":3,"timeZone":"UTC","protectedItemsCount":0}}'
     headers:
       cache-control:
       - no-cache
@@ -4923,7 +5960,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:31 GMT
+      - Thu, 15 Oct 2020 12:05:46 GMT
       expires:
       - '-1'
       pragma:
@@ -4957,8 +5994,8 @@ interactions:
       ParameterSetName:
       - --backup-management-type -v -g --query
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
@@ -4974,7 +6011,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:33 GMT
+      - Thu, 15 Oct 2020 12:05:47 GMT
       expires:
       - '-1'
       pragma:
@@ -5008,15 +6045,15 @@ interactions:
       ParameterSetName:
       - --backup-management-type --workload-type -g -v -c --query
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17594319320070","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593109254903","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185870131275","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185001101385","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -5025,7 +6062,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:34 GMT
+      - Thu, 15 Oct 2020 12:05:48 GMT
       expires:
       - '-1'
       pragma:
@@ -5060,15 +6097,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17594319320070","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593109254903","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185870131275","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}},{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185001101385","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -5077,7 +6114,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:36 GMT
+      - Thu, 15 Oct 2020 12:05:48 GMT
       expires:
       - '-1'
       pragma:
@@ -5114,8 +6151,8 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: DELETE
@@ -5125,17 +6162,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2019-06-15
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Sat, 01 Aug 2020 16:46:39 GMT
+      - Thu, 15 Oct 2020 12:05:49 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/969727af-520d-474e-91bd-407938a57a3a?api-version=2019-06-15
       pragma:
       - no-cache
       strict-transport-security:
@@ -5164,24 +6201,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:41 GMT
+      - Thu, 15 Oct 2020 12:05:49 GMT
       expires:
       - '-1'
       pragma:
@@ -5216,24 +6253,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:43 GMT
+      - Thu, 15 Oct 2020 12:05:50 GMT
       expires:
       - '-1'
       pragma:
@@ -5268,24 +6305,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:45 GMT
+      - Thu, 15 Oct 2020 12:05:53 GMT
       expires:
       - '-1'
       pragma:
@@ -5320,24 +6357,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:47 GMT
+      - Thu, 15 Oct 2020 12:05:54 GMT
       expires:
       - '-1'
       pragma:
@@ -5372,24 +6409,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:49 GMT
+      - Thu, 15 Oct 2020 12:05:55 GMT
       expires:
       - '-1'
       pragma:
@@ -5424,24 +6461,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:52 GMT
+      - Thu, 15 Oct 2020 12:05:56 GMT
       expires:
       - '-1'
       pragma:
@@ -5476,24 +6513,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:54 GMT
+      - Thu, 15 Oct 2020 12:05:57 GMT
       expires:
       - '-1'
       pragma:
@@ -5528,24 +6565,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:56 GMT
+      - Thu, 15 Oct 2020 12:05:59 GMT
       expires:
       - '-1'
       pragma:
@@ -5580,24 +6617,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:46:59 GMT
+      - Thu, 15 Oct 2020 12:06:00 GMT
       expires:
       - '-1'
       pragma:
@@ -5632,24 +6669,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:01 GMT
+      - Thu, 15 Oct 2020 12:06:01 GMT
       expires:
       - '-1'
       pragma:
@@ -5684,24 +6721,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:03 GMT
+      - Thu, 15 Oct 2020 12:06:03 GMT
       expires:
       - '-1'
       pragma:
@@ -5736,24 +6773,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:05 GMT
+      - Thu, 15 Oct 2020 12:06:04 GMT
       expires:
       - '-1'
       pragma:
@@ -5788,24 +6825,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:07 GMT
+      - Thu, 15 Oct 2020 12:06:05 GMT
       expires:
       - '-1'
       pragma:
@@ -5840,24 +6877,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:09 GMT
+      - Thu, 15 Oct 2020 12:06:06 GMT
       expires:
       - '-1'
       pragma:
@@ -5892,24 +6929,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:11 GMT
+      - Thu, 15 Oct 2020 12:06:08 GMT
       expires:
       - '-1'
       pragma:
@@ -5944,24 +6981,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:13 GMT
+      - Thu, 15 Oct 2020 12:06:09 GMT
       expires:
       - '-1'
       pragma:
@@ -5996,24 +7033,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:16 GMT
+      - Thu, 15 Oct 2020 12:06:10 GMT
       expires:
       - '-1'
       pragma:
@@ -6048,24 +7085,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:18 GMT
+      - Thu, 15 Oct 2020 12:06:11 GMT
       expires:
       - '-1'
       pragma:
@@ -6100,24 +7137,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:21 GMT
+      - Thu, 15 Oct 2020 12:06:13 GMT
       expires:
       - '-1'
       pragma:
@@ -6152,24 +7189,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:23 GMT
+      - Thu, 15 Oct 2020 12:06:14 GMT
       expires:
       - '-1'
       pragma:
@@ -6204,24 +7241,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:25 GMT
+      - Thu, 15 Oct 2020 12:06:15 GMT
       expires:
       - '-1'
       pragma:
@@ -6256,24 +7293,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:27 GMT
+      - Thu, 15 Oct 2020 12:06:16 GMT
       expires:
       - '-1'
       pragma:
@@ -6308,24 +7345,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:29 GMT
+      - Thu, 15 Oct 2020 12:06:18 GMT
       expires:
       - '-1'
       pragma:
@@ -6360,24 +7397,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:31 GMT
+      - Thu, 15 Oct 2020 12:06:19 GMT
       expires:
       - '-1'
       pragma:
@@ -6412,24 +7449,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:33 GMT
+      - Thu, 15 Oct 2020 12:06:20 GMT
       expires:
       - '-1'
       pragma:
@@ -6464,24 +7501,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:35 GMT
+      - Thu, 15 Oct 2020 12:06:21 GMT
       expires:
       - '-1'
       pragma:
@@ -6516,24 +7553,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:38 GMT
+      - Thu, 15 Oct 2020 12:06:23 GMT
       expires:
       - '-1'
       pragma:
@@ -6568,24 +7605,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:40 GMT
+      - Thu, 15 Oct 2020 12:06:24 GMT
       expires:
       - '-1'
       pragma:
@@ -6620,24 +7657,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:41 GMT
+      - Thu, 15 Oct 2020 12:06:25 GMT
       expires:
       - '-1'
       pragma:
@@ -6672,24 +7709,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:43 GMT
+      - Thu, 15 Oct 2020 12:06:26 GMT
       expires:
       - '-1'
       pragma:
@@ -6724,24 +7761,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:46 GMT
+      - Thu, 15 Oct 2020 12:06:27 GMT
       expires:
       - '-1'
       pragma:
@@ -6776,24 +7813,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:48 GMT
+      - Thu, 15 Oct 2020 12:06:29 GMT
       expires:
       - '-1'
       pragma:
@@ -6828,24 +7865,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:50 GMT
+      - Thu, 15 Oct 2020 12:06:30 GMT
       expires:
       - '-1'
       pragma:
@@ -6880,24 +7917,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:53 GMT
+      - Thu, 15 Oct 2020 12:06:31 GMT
       expires:
       - '-1'
       pragma:
@@ -6932,24 +7969,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:54 GMT
+      - Thu, 15 Oct 2020 12:06:32 GMT
       expires:
       - '-1'
       pragma:
@@ -6984,24 +8021,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:57 GMT
+      - Thu, 15 Oct 2020 12:06:34 GMT
       expires:
       - '-1'
       pragma:
@@ -7036,24 +8073,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:47:59 GMT
+      - Thu, 15 Oct 2020 12:06:35 GMT
       expires:
       - '-1'
       pragma:
@@ -7088,24 +8125,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:01 GMT
+      - Thu, 15 Oct 2020 12:06:36 GMT
       expires:
       - '-1'
       pragma:
@@ -7140,24 +8177,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:03 GMT
+      - Thu, 15 Oct 2020 12:06:37 GMT
       expires:
       - '-1'
       pragma:
@@ -7192,24 +8229,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:06 GMT
+      - Thu, 15 Oct 2020 12:06:39 GMT
       expires:
       - '-1'
       pragma:
@@ -7244,24 +8281,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:08 GMT
+      - Thu, 15 Oct 2020 12:06:40 GMT
       expires:
       - '-1'
       pragma:
@@ -7296,24 +8333,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:10 GMT
+      - Thu, 15 Oct 2020 12:06:41 GMT
       expires:
       - '-1'
       pragma:
@@ -7348,24 +8385,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:12 GMT
+      - Thu, 15 Oct 2020 12:06:42 GMT
       expires:
       - '-1'
       pragma:
@@ -7400,24 +8437,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:14 GMT
+      - Thu, 15 Oct 2020 12:06:43 GMT
       expires:
       - '-1'
       pragma:
@@ -7452,24 +8489,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:15 GMT
+      - Thu, 15 Oct 2020 12:06:45 GMT
       expires:
       - '-1'
       pragma:
@@ -7504,24 +8541,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:17 GMT
+      - Thu, 15 Oct 2020 12:06:46 GMT
       expires:
       - '-1'
       pragma:
@@ -7556,24 +8593,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:20 GMT
+      - Thu, 15 Oct 2020 12:06:47 GMT
       expires:
       - '-1'
       pragma:
@@ -7608,24 +8645,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:21 GMT
+      - Thu, 15 Oct 2020 12:06:48 GMT
       expires:
       - '-1'
       pragma:
@@ -7660,24 +8697,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:24 GMT
+      - Thu, 15 Oct 2020 12:06:50 GMT
       expires:
       - '-1'
       pragma:
@@ -7712,24 +8749,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:26 GMT
+      - Thu, 15 Oct 2020 12:06:51 GMT
       expires:
       - '-1'
       pragma:
@@ -7764,24 +8801,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:29 GMT
+      - Thu, 15 Oct 2020 12:06:53 GMT
       expires:
       - '-1'
       pragma:
@@ -7816,24 +8853,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"InProgress","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '188'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:31 GMT
+      - Thu, 15 Oct 2020 12:06:54 GMT
       expires:
       - '-1'
       pragma:
@@ -7868,24 +8905,24 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/53f683d6-c174-47d4-ae8a-cadaa1efc155?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"53f683d6-c174-47d4-ae8a-cadaa1efc155","name":"53f683d6-c174-47d4-ae8a-cadaa1efc155","status":"Succeeded","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"2020-08-01T16:46:39.6107915Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"6dfafbaf-c1af-4e87-aa0d-c3855f272017"}}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:33 GMT
+      - Thu, 15 Oct 2020 12:06:56 GMT
       expires:
       - '-1'
       pragma:
@@ -7920,25 +8957,1897 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/6dfafbaf-c1af-4e87-aa0d-c3855f272017?api-version=2019-06-15
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/6dfafbaf-c1af-4e87-aa0d-c3855f272017","name":"6dfafbaf-c1af-4e87-aa0d-c3855f272017","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M52.1178498S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000005","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-08-01T16:46:39.6107915Z","endTime":"2020-08-01T16:48:31.7286413Z","activityId":"8fa0a06c-d416-11ea-9e92-186024943d4f"}}'
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '973'
+      - '187'
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:34 GMT
+      - Thu, 15 Oct 2020 12:06:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:06:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:06:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"InProgress","startTime":"2020-10-15T12:05:49.583263Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/969727af-520d-474e-91bd-407938a57a3a?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"969727af-520d-474e-91bd-407938a57a3a","name":"969727af-520d-474e-91bd-407938a57a3a","status":"Succeeded","startTime":"2020-10-15T12:05:49.583263Z","endTime":"2020-10-15T12:05:49.583263Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"a9490290-8067-42fe-a879-b11b6b0b2f2b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '302'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a9490290-8067-42fe-a879-b11b6b0b2f2b?api-version=2019-06-15
+  response:
+    body:
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/a9490290-8067-42fe-a879-b11b6b0b2f2b","name":"a9490290-8067-42fe-a879-b11b6b0b2f2b","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M51.4961541S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000005","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-10-15T12:05:49.583263Z","endTime":"2020-10-15T12:07:41.0794171Z","activityId":"c31d94fb-0ede-11eb-8351-c8f750f92764"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '972'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:07:41 GMT
       expires:
       - '-1'
       pragma:
@@ -7973,15 +10882,15 @@ interactions:
       ParameterSetName:
       - --backup-management-type --workload-type -g -v -c --query
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593109254903","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185001101385","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -7990,7 +10899,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:36 GMT
+      - Thu, 15 Oct 2020 12:07:42 GMT
       expires:
       - '-1'
       pragma:
@@ -8025,15 +10934,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2019-06-15&$filter=backupManagementType%20eq%20%27AzureIaasVM%27%20and%20itemType%20eq%20%27VM%27
   response:
     body:
-      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"17593109254903","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
+      string: '{"value":[{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000006","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"35185001101385","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000006","policyId":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy"}}]}'
     headers:
       cache-control:
       - no-cache
@@ -8042,7 +10951,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:38 GMT
+      - Thu, 15 Oct 2020 12:07:43 GMT
       expires:
       - '-1'
       pragma:
@@ -8079,8 +10988,8 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: DELETE
@@ -8090,17 +10999,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2019-06-15
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Sat, 01 Aug 2020 16:48:40 GMT
+      - Thu, 15 Oct 2020 12:07:44 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2019-06-15
+      - https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2019-06-15
       pragma:
       - no-cache
       strict-transport-security:
@@ -8108,7 +11017,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14997'
+      - '14998'
       x-powered-by:
       - ASP.NET
     status:
@@ -8129,15 +11038,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8146,7 +11055,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:42 GMT
+      - Thu, 15 Oct 2020 12:07:45 GMT
       expires:
       - '-1'
       pragma:
@@ -8181,15 +11090,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8198,7 +11107,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:44 GMT
+      - Thu, 15 Oct 2020 12:07:46 GMT
       expires:
       - '-1'
       pragma:
@@ -8233,15 +11142,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8250,7 +11159,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:46 GMT
+      - Thu, 15 Oct 2020 12:07:47 GMT
       expires:
       - '-1'
       pragma:
@@ -8285,15 +11194,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8302,7 +11211,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:48 GMT
+      - Thu, 15 Oct 2020 12:07:49 GMT
       expires:
       - '-1'
       pragma:
@@ -8337,15 +11246,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8354,7 +11263,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:50 GMT
+      - Thu, 15 Oct 2020 12:07:50 GMT
       expires:
       - '-1'
       pragma:
@@ -8389,15 +11298,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8406,7 +11315,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:52 GMT
+      - Thu, 15 Oct 2020 12:07:51 GMT
       expires:
       - '-1'
       pragma:
@@ -8441,15 +11350,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8458,7 +11367,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:54 GMT
+      - Thu, 15 Oct 2020 12:07:52 GMT
       expires:
       - '-1'
       pragma:
@@ -8493,15 +11402,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8510,7 +11419,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:57 GMT
+      - Thu, 15 Oct 2020 12:07:54 GMT
       expires:
       - '-1'
       pragma:
@@ -8545,15 +11454,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8562,7 +11471,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:48:59 GMT
+      - Thu, 15 Oct 2020 12:07:55 GMT
       expires:
       - '-1'
       pragma:
@@ -8597,15 +11506,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8614,7 +11523,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:01 GMT
+      - Thu, 15 Oct 2020 12:07:56 GMT
       expires:
       - '-1'
       pragma:
@@ -8649,15 +11558,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8666,7 +11575,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:03 GMT
+      - Thu, 15 Oct 2020 12:07:57 GMT
       expires:
       - '-1'
       pragma:
@@ -8701,15 +11610,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8718,7 +11627,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:04 GMT
+      - Thu, 15 Oct 2020 12:07:59 GMT
       expires:
       - '-1'
       pragma:
@@ -8753,15 +11662,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8770,7 +11679,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:07 GMT
+      - Thu, 15 Oct 2020 12:08:01 GMT
       expires:
       - '-1'
       pragma:
@@ -8805,15 +11714,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8822,7 +11731,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:09 GMT
+      - Thu, 15 Oct 2020 12:08:02 GMT
       expires:
       - '-1'
       pragma:
@@ -8857,15 +11766,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8874,7 +11783,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:11 GMT
+      - Thu, 15 Oct 2020 12:08:03 GMT
       expires:
       - '-1'
       pragma:
@@ -8909,15 +11818,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8926,7 +11835,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:13 GMT
+      - Thu, 15 Oct 2020 12:08:05 GMT
       expires:
       - '-1'
       pragma:
@@ -8961,15 +11870,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -8978,7 +11887,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:15 GMT
+      - Thu, 15 Oct 2020 12:08:06 GMT
       expires:
       - '-1'
       pragma:
@@ -9013,15 +11922,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9030,7 +11939,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:17 GMT
+      - Thu, 15 Oct 2020 12:08:07 GMT
       expires:
       - '-1'
       pragma:
@@ -9065,15 +11974,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9082,7 +11991,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:19 GMT
+      - Thu, 15 Oct 2020 12:08:08 GMT
       expires:
       - '-1'
       pragma:
@@ -9117,15 +12026,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9134,7 +12043,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:22 GMT
+      - Thu, 15 Oct 2020 12:08:10 GMT
       expires:
       - '-1'
       pragma:
@@ -9169,15 +12078,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9186,7 +12095,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:24 GMT
+      - Thu, 15 Oct 2020 12:08:11 GMT
       expires:
       - '-1'
       pragma:
@@ -9221,15 +12130,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9238,7 +12147,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:25 GMT
+      - Thu, 15 Oct 2020 12:08:12 GMT
       expires:
       - '-1'
       pragma:
@@ -9273,15 +12182,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9290,7 +12199,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:28 GMT
+      - Thu, 15 Oct 2020 12:08:13 GMT
       expires:
       - '-1'
       pragma:
@@ -9325,15 +12234,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9342,7 +12251,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:31 GMT
+      - Thu, 15 Oct 2020 12:08:15 GMT
       expires:
       - '-1'
       pragma:
@@ -9377,15 +12286,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9394,7 +12303,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:32 GMT
+      - Thu, 15 Oct 2020 12:08:16 GMT
       expires:
       - '-1'
       pragma:
@@ -9429,15 +12338,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9446,7 +12355,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:34 GMT
+      - Thu, 15 Oct 2020 12:08:17 GMT
       expires:
       - '-1'
       pragma:
@@ -9481,15 +12390,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9498,7 +12407,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:37 GMT
+      - Thu, 15 Oct 2020 12:08:18 GMT
       expires:
       - '-1'
       pragma:
@@ -9533,15 +12442,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9550,7 +12459,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:39 GMT
+      - Thu, 15 Oct 2020 12:08:20 GMT
       expires:
       - '-1'
       pragma:
@@ -9585,15 +12494,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9602,7 +12511,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:41 GMT
+      - Thu, 15 Oct 2020 12:08:21 GMT
       expires:
       - '-1'
       pragma:
@@ -9637,15 +12546,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9654,7 +12563,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:43 GMT
+      - Thu, 15 Oct 2020 12:08:22 GMT
       expires:
       - '-1'
       pragma:
@@ -9689,15 +12598,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9706,7 +12615,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:45 GMT
+      - Thu, 15 Oct 2020 12:08:23 GMT
       expires:
       - '-1'
       pragma:
@@ -9741,15 +12650,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9758,7 +12667,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:47 GMT
+      - Thu, 15 Oct 2020 12:08:24 GMT
       expires:
       - '-1'
       pragma:
@@ -9793,15 +12702,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9810,7 +12719,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:48 GMT
+      - Thu, 15 Oct 2020 12:08:26 GMT
       expires:
       - '-1'
       pragma:
@@ -9845,15 +12754,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9862,7 +12771,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:52 GMT
+      - Thu, 15 Oct 2020 12:08:27 GMT
       expires:
       - '-1'
       pragma:
@@ -9897,15 +12806,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9914,7 +12823,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:53 GMT
+      - Thu, 15 Oct 2020 12:08:28 GMT
       expires:
       - '-1'
       pragma:
@@ -9949,15 +12858,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -9966,7 +12875,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:56 GMT
+      - Thu, 15 Oct 2020 12:08:29 GMT
       expires:
       - '-1'
       pragma:
@@ -10001,15 +12910,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10018,7 +12927,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:58 GMT
+      - Thu, 15 Oct 2020 12:08:31 GMT
       expires:
       - '-1'
       pragma:
@@ -10053,15 +12962,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10070,7 +12979,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:49:59 GMT
+      - Thu, 15 Oct 2020 12:08:33 GMT
       expires:
       - '-1'
       pragma:
@@ -10105,15 +13014,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10122,7 +13031,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:02 GMT
+      - Thu, 15 Oct 2020 12:08:34 GMT
       expires:
       - '-1'
       pragma:
@@ -10157,15 +13066,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10174,7 +13083,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:04 GMT
+      - Thu, 15 Oct 2020 12:08:35 GMT
       expires:
       - '-1'
       pragma:
@@ -10209,15 +13118,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10226,7 +13135,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:06 GMT
+      - Thu, 15 Oct 2020 12:08:37 GMT
       expires:
       - '-1'
       pragma:
@@ -10261,15 +13170,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10278,7 +13187,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:08 GMT
+      - Thu, 15 Oct 2020 12:08:38 GMT
       expires:
       - '-1'
       pragma:
@@ -10313,15 +13222,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10330,7 +13239,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:10 GMT
+      - Thu, 15 Oct 2020 12:08:39 GMT
       expires:
       - '-1'
       pragma:
@@ -10365,15 +13274,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10382,7 +13291,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:12 GMT
+      - Thu, 15 Oct 2020 12:08:40 GMT
       expires:
       - '-1'
       pragma:
@@ -10417,15 +13326,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10434,7 +13343,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:14 GMT
+      - Thu, 15 Oct 2020 12:08:42 GMT
       expires:
       - '-1'
       pragma:
@@ -10469,15 +13378,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10486,7 +13395,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:16 GMT
+      - Thu, 15 Oct 2020 12:08:43 GMT
       expires:
       - '-1'
       pragma:
@@ -10521,15 +13430,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10538,7 +13447,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:18 GMT
+      - Thu, 15 Oct 2020 12:08:44 GMT
       expires:
       - '-1'
       pragma:
@@ -10573,15 +13482,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10590,7 +13499,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:20 GMT
+      - Thu, 15 Oct 2020 12:08:45 GMT
       expires:
       - '-1'
       pragma:
@@ -10625,15 +13534,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10642,7 +13551,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:21 GMT
+      - Thu, 15 Oct 2020 12:08:46 GMT
       expires:
       - '-1'
       pragma:
@@ -10677,15 +13586,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10694,7 +13603,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:24 GMT
+      - Thu, 15 Oct 2020 12:08:48 GMT
       expires:
       - '-1'
       pragma:
@@ -10729,15 +13638,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10746,7 +13655,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:25 GMT
+      - Thu, 15 Oct 2020 12:08:49 GMT
       expires:
       - '-1'
       pragma:
@@ -10781,15 +13690,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10798,7 +13707,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:28 GMT
+      - Thu, 15 Oct 2020 12:08:50 GMT
       expires:
       - '-1'
       pragma:
@@ -10833,15 +13742,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10850,7 +13759,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:29 GMT
+      - Thu, 15 Oct 2020 12:08:51 GMT
       expires:
       - '-1'
       pragma:
@@ -10885,15 +13794,15 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"InProgress","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"0001-01-01T00:00:00"}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
     headers:
       cache-control:
       - no-cache
@@ -10902,7 +13811,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:31 GMT
+      - Thu, 15 Oct 2020 12:08:53 GMT
       expires:
       - '-1'
       pragma:
@@ -10937,15 +13846,1731 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e731ebc8-b04a-49a3-ae5a-995bc41f8d1c?api-version=2016-12-01
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
   response:
     body:
-      string: '{"id":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","name":"e731ebc8-b04a-49a3-ae5a-995bc41f8d1c","status":"Succeeded","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"2020-08-01T16:48:40.7089172Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"7cb8b010-692a-4fa4-bf22-4c60599c9036"}}'
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:08:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:08:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:08:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:08:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:08:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"InProgress","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 15 Oct 2020 12:09:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/fd74c4b2-23c2-44f0-b2ab-9b04fab77369?api-version=2016-12-01
+  response:
+    body:
+      string: '{"id":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","name":"fd74c4b2-23c2-44f0-b2ab-9b04fab77369","status":"Succeeded","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"2020-10-15T12:07:44.8208913Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"187641e8-7ff7-4e09-a8e4-a3c720ffb31e"}}'
     headers:
       cache-control:
       - no-cache
@@ -10954,7 +15579,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:33 GMT
+      - Thu, 15 Oct 2020 12:09:37 GMT
       expires:
       - '-1'
       pragma:
@@ -10989,16 +15614,16 @@ interactions:
       - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
         --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservicesbackup/0.6.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: GET
-    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7cb8b010-692a-4fa4-bf22-4c60599c9036?api-version=2019-06-15
+    uri: https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/187641e8-7ff7-4e09-a8e4-a3c720ffb31e?api-version=2019-06-15
   response:
     body:
-      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/7cb8b010-692a-4fa4-bf22-4c60599c9036","name":"7cb8b010-692a-4fa4-bf22-4c60599c9036","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT1M51.8737661S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
-        Name":"clitest-vm000006","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-08-01T16:48:40.7089172Z","endTime":"2020-08-01T16:50:32.5826833Z","activityId":"d84d4880-d416-11ea-b024-186024943d4f"}}'
+      string: '{"id":"/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/187641e8-7ff7-4e09-a8e4-a3c720ffb31e","name":"187641e8-7ff7-4e09-a8e4-a3c720ffb31e","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000006","duration":"PT1M51.4322738S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000006","Number of Recovery Points":"0"}},"entityFriendlyName":"clitest-vm000006","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2020-10-15T12:07:44.8208913Z","endTime":"2020-10-15T12:09:36.2531651Z","activityId":"079815da-0edf-11eb-8a70-c8f750f92764"}}'
     headers:
       cache-control:
       - no-cache
@@ -11007,7 +15632,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Sat, 01 Aug 2020 16:50:36 GMT
+      - Thu, 15 Oct 2020 12:09:37 GMT
       expires:
       - '-1'
       pragma:
@@ -11044,8 +15669,8 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - python/3.7.4 (Windows-10-10.0.18362-SP0) msrest/0.6.13 msrest_azure/0.6.3
-        azure-mgmt-recoveryservices/0.4.0 Azure-SDK-For-Python AZURECLI/2.10.0
+      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-recoveryservices/0.4.0 Azure-SDK-For-Python AZURECLI/2.13.0
       accept-language:
       - en-US
     method: DELETE
@@ -11059,7 +15684,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Sat, 01 Aug 2020 16:50:44 GMT
+      - Thu, 15 Oct 2020 12:09:39 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py
@@ -194,7 +194,8 @@ class BackupTests(ScenarioTest, unittest.TestCase):
             'default': 'DefaultPolicy',
             'vault': vault_name,
             'vm1': vm1,
-            'vm2': vm2
+            'vm2': vm2,
+            'policy5': self.create_random_name('clitest-policy5', 24),
         })
 
         self.cmd('backup vault backup-properties set -g {rg} -n {vault} --soft-delete-feature-state Disable')
@@ -216,6 +217,13 @@ class BackupTests(ScenarioTest, unittest.TestCase):
             self.check("length([?properties.friendlyName == '{}'])".format(vm1), 1),
             self.check("length([?properties.friendlyName == '{}'])".format(vm2), 1)
         ])
+
+        self.kwargs['policy1_json']['name'] = self.kwargs['policy5']
+        self.kwargs['backup-management-type'] = self.kwargs['policy1_json']['properties']['backupManagementType']
+        self.kwargs['policy5_json'] = json.dumps(self.kwargs['policy1_json'])
+        self.cmd("backup policy create --backup-management-type {backup-management-type} -g {rg} -v {vault} -n {policy5} --policy '{policy5_json}'")
+
+        self.cmd('backup policy delete -g {rg} -v {vault} -n {policy5}')
 
         self.kwargs['policy1_json']['name'] = self.kwargs['policy3']
         if 'instantRpDetails' in self.kwargs['policy1_json']['properties']:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Added command to create policy for IaaSVM from CLI.

**Testing Guide**  
az backup policy create --backup-management-type AzureIaasVM -g {rg} -v {vault} -n {policy_name} --policy {policy_json}

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
