### PR TITLE
[Backup] increasing VM protection limit from 100 to 1000

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -207,6 +207,10 @@ def enable_protection_for_vm(cmd, client, resource_group_name, vault_name, vm, p
     vault = vaults_cf(cmd.cli_ctx).get(resource_group_name, vault_name)
     policy = show_policy(protection_policies_cf(cmd.cli_ctx), resource_group_name, vault_name, policy_name)
 
+    # throw error if policy has more than 1000 protected VMs.
+    if policy.properties.protected_items_count >= 1000:
+        raise CLIError("Cannot configure backup for more than 1000 VMs per policy")
+
     if vm.location.lower() != vault.location.lower():
         raise CLIError(
             """
@@ -344,9 +348,9 @@ def update_policy_for_item(cmd, client, resource_group_name, vault_name, item, p
             Use the relevant get-default policy command and use it to update the policy for the workload.
             """)
 
-    # throw error if policy has more than 100 protected VMs.
-    if policy.properties.protected_items_count >= 100:
-        raise CLIError("Cannot configure backup for more than 100 VMs per policy")
+    # throw error if policy has more than 1000 protected VMs.
+    if policy.properties.protected_items_count >= 1000:
+        raise CLIError("Cannot configure backup for more than 1000 VMs per policy")
 
     # Get container and item URIs
     container_uri = _get_protection_container_uri_from_id(item.id)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Relaxed the client side limit for AzureIaasVM protection from 100 to 1000
 
**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [Yes ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [Yes ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
