### PR TITLE
{Core} Skip positional arguments for failure recommendations

### DIFF
--- a/src/azure-cli-core/azure/cli/core/command_recommender.py
+++ b/src/azure-cli-core/azure/cli/core/command_recommender.py
@@ -251,7 +251,10 @@ class CommandRecommender():
             if parameter_table:
                 for argument in parameter_table.values():
                     options = argument.type.settings['options_list']
-                    options = (option for option in options if not isinstance(option, Deprecated))
+                    options = [option for option in options if not isinstance(option, Deprecated)]
+                    # skip the positional arguments
+                    if not options:
+                        continue
                     try:
                         sorted_options = sorted(options, key=len, reverse=True)
                         standard_form = sorted_options[0]


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix issue #15465，#15591

This PR fixes the positional arguments parsing issue in failure recommendations. The original logic ignored the positional arguments, which would make CLI crash when running a command with positional arguments if that command failed.

**Testing Guide**  
<!--Example commands with explanations.-->
Previously, CLI will crash when running `az acr build`
```
...
azure/cli/core/command_recommender.py, ln 162, in recommend_a_command
    normalized_parameters = self._normalize_parameters(parameters)
azure/cli/core/command_recommender.py, ln 244, in _normalize_parameters
    standard_form = sorted_options[0]
IndexError: list index out of range
```
Now, it prints the right error messages
```
RequiredArgumentMissingError: the following arguments are required: --registry/-r, <SOURCE_LOCATION>
Try this: 'az acr build -r MyRegistry .'
Still stuck? Run 'az acr build --help' to view all commands or go to 'https://docs.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest' to learn more
```

