### PR TITLE
[Compute] az vm update / az sig image-version update: Support update vm/image-version even it uses a cross tenant image

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/commands.py
@@ -286,7 +286,7 @@ def load_command_table(self, _):
         g.command('start', 'start', supports_no_wait=True)
         g.command('stop', 'power_off', supports_no_wait=True, validator=process_vm_vmss_stop)
         g.command('reapply', 'reapply', supports_no_wait=True, min_api='2019-07-01')
-        g.generic_update_command('update', setter_name='update_vm', setter_type=compute_custom, supports_no_wait=True)
+        g.generic_update_command('update', getter_name='get_vm_for_generic_update', setter_name='update_vm', setter_type=compute_custom, command_type=compute_custom, supports_no_wait=True)
         g.wait_command('wait', getter_name='get_instance_view', getter_type=compute_custom)
         g.custom_command('auto-shutdown', 'auto_shutdown_vm')
         g.command('assess-patches', 'assess_patches', min_api='2020-06-01')
@@ -480,7 +480,7 @@ def load_command_table(self, _):
         g.show_command('show', 'get', table_transformer='{Name:name, ResourceGroup:resourceGroup, ProvisioningState:provisioningState, TargetRegions: publishingProfile.targetRegions && join(`, `, publishingProfile.targetRegions[*].name), ReplicationState:replicationStatus.aggregatedState}')
         g.command('list', 'list_by_gallery_image')
         g.custom_command('create', 'create_image_version', supports_no_wait=True)
-        g.generic_update_command('update', setter_arg_name='gallery_image_version', setter_name='update_image_version', setter_type=compute_custom, supports_no_wait=True)
+        g.generic_update_command('update', getter_name='get_image_version_for_generic_update', setter_arg_name='gallery_image_version', setter_name='update_image_version', setter_type=compute_custom, command_type=compute_custom, supports_no_wait=True)
         g.wait_command('wait')
 
     with self.command_group('ppg', compute_proximity_placement_groups_sdk, min_api='2018-04-01', client_factory=cf_proximity_placement_groups) as g:

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -1239,6 +1239,7 @@ def show_vm(cmd, resource_group_name, vm_name, show_details=False):
 def get_vm_for_generic_update(cmd, resource_group_name, vm_name):
     client = _compute_client_factory(cmd.cli_ctx)
     vm = client.virtual_machines.get(resource_group_name, vm_name)
+    # To avoid unnecessary permission check of image
     vm.storage_profile.image_reference = None
     return vm
 
@@ -3291,9 +3292,11 @@ def fix_gallery_image_date_info(date_info):
     return date_info
 
 
+# pylint: disable=line-too-long
 def get_image_version_for_generic_update(cmd, resource_group_name, gallery_name, gallery_image_name, gallery_image_version_name):
     client = _compute_client_factory(cmd.cli_ctx)
     version = client.gallery_image_versions.get(resource_group_name, gallery_name, gallery_image_name, gallery_image_version_name)
+    # To avoid unnecessary permission check of image
     version.storage_profile.source = None
     return version
 

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -1236,6 +1236,13 @@ def show_vm(cmd, resource_group_name, vm_name, show_details=False):
         else get_vm(cmd, resource_group_name, vm_name)
 
 
+def get_vm_for_generic_update(cmd, resource_group_name, vm_name):
+    client = _compute_client_factory(cmd.cli_ctx)
+    vm = client.virtual_machines.get(resource_group_name, vm_name)
+    vm.storage_profile.image_reference = None
+    return vm
+
+
 def update_vm(cmd, resource_group_name, vm_name, os_disk=None, disk_caching=None,
               write_accelerator=None, license_type=None, no_wait=False, ultra_ssd_enabled=None,
               priority=None, max_price=None, proximity_placement_group=None, workspace=None, **kwargs):
@@ -1294,8 +1301,8 @@ def update_vm(cmd, resource_group_name, vm_name, os_disk=None, disk_caching=None
         _set_data_source_for_workspace(cmd, os_type, resource_group_name, workspace_name)
 
     aux_subscriptions = None
-    if vm and vm.storage_profile and vm.storage_profile.image_reference and vm.storage_profile.image_reference.id:
-        aux_subscriptions = _parse_aux_subscriptions(vm.storage_profile.image_reference.id)
+    if vm and vm.storage_profile and vm.storage_profile.image_reference and 'id' in vm.storage_profile.image_reference:
+        aux_subscriptions = _parse_aux_subscriptions(vm.storage_profile.image_reference['id'])
     client = _compute_client_factory(cmd.cli_ctx, aux_subscriptions=aux_subscriptions)
     return sdk_no_wait(no_wait, client.virtual_machines.create_or_update, resource_group_name, vm_name, **kwargs)
 # endregion
@@ -3284,6 +3291,13 @@ def fix_gallery_image_date_info(date_info):
     return date_info
 
 
+def get_image_version_for_generic_update(cmd, resource_group_name, gallery_name, gallery_image_name, gallery_image_version_name):
+    client = _compute_client_factory(cmd.cli_ctx)
+    version = client.gallery_image_versions.get(resource_group_name, gallery_name, gallery_image_name, gallery_image_version_name)
+    version.storage_profile.source = None
+    return version
+
+
 def update_image_version(cmd, resource_group_name, gallery_name, gallery_image_name, gallery_image_version_name,
                          target_regions=None, replica_count=None, no_wait=False, **kwargs):
     image_version = kwargs['gallery_image_version']
@@ -3297,8 +3311,8 @@ def update_image_version(cmd, resource_group_name, gallery_name, gallery_image_n
 
     aux_subscriptions = None
     if image_version.storage_profile and image_version.storage_profile.source and \
-            image_version.storage_profile.source.id:
-        aux_subscriptions = _parse_aux_subscriptions(image_version.storage_profile.source.id)
+            'id' in image_version.storage_profile.source:
+        aux_subscriptions = _parse_aux_subscriptions(image_version.storage_profile.source['id'])
     client = _compute_client_factory(cmd.cli_ctx, aux_subscriptions=aux_subscriptions)
 
     return sdk_no_wait(no_wait, client.gallery_image_versions.create_or_update, resource_group_name, gallery_name,


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR is to fix #15536 

Previously, the user can't update a vm/image-version if the vm/image-version uses a cross tenant image which he/she has no permission to access.

The root cause is that CLI use the create_or_update API to in `update` command to support generic update. The service will check all the properties in the request body even the property value is not changed.

To fix this, we need to set the `storage_profile.image_reference` / `storage_profile.source` to None in the request body if the user is not updating the image property itself.

There is a similar PR #14992 which created by @qwordy .

**Testing Guide**  
Prepare a image, assume its id is <IMGAGE_ID>, and in <subscription_1>

update vm
`az account set -s <subscription_2>`
`az vm create -g <rg> -n <vm_name> --image <IMAGE_ID>`
> login with another user account who doesn't as <subscription_1> permission.

`az vm update -g <rg> -n <vm_name> hardwareProfile.vmSize=Standard_B2`



**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
