### PR TITLE
{Compute} Apply UsageError to replace CLIError prefixed with 'Usage error'

### DIFF
--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -131,6 +131,13 @@ class ArgumentParseError(UserFault):
     pass
 
 
+class UsageError(UserFault):
+    """ Fallback of the argument usage related errors.
+    Avoid using this class unless the error can not be classified
+    into the above Argument related error types. """
+    pass
+
+
 # Response related error types
 class BadRequestError(UserFault):
     """ Bad request from client: 400 error """

--- a/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
@@ -24,6 +24,7 @@ from knack.log import get_logger
 from msrestazure.azure_exceptions import CloudError
 from msrestazure.tools import is_valid_resource_id, resource_id, parse_resource_id
 
+from azure.cli.core.azclierror import UsageError
 from azure.cli.core.commands import cached_get, cached_put
 from azure.cli.core.commands.client_factory import get_subscription_id
 from azure.cli.core.commands.validators import get_default_location_from_resource_group, validate_tags
@@ -326,7 +327,7 @@ def process_img_tmpl_output_add_namespace(cmd, namespace):
     if len(outputs) != 1:
         err = "Supplied outputs: {}".format(outputs)
         logger.debug(err)
-        raise CLIError("Usage error: must supply exactly one destination type to add. Supplied {}".format(len(outputs)))
+        raise UsageError("must supply exactly one destination type to add. Supplied {}".format(len(outputs)))
 
     if namespace.managed_image:
         if not is_valid_resource_id(namespace.managed_image):
@@ -340,7 +341,7 @@ def process_img_tmpl_output_add_namespace(cmd, namespace):
     if namespace.gallery_image_definition:
         if not is_valid_resource_id(namespace.gallery_image_definition):
             if not namespace.gallery_name:
-                raise CLIError("Usage error: gallery image definition is a name and not an ID.")
+                raise UsageError("gallery image definition is a name and not an ID.")
 
             namespace.gallery_image_definition = resource_id(
                 subscription=get_subscription_id(cmd.cli_ctx), resource_group=namespace.resource_group_name,
@@ -350,7 +351,7 @@ def process_img_tmpl_output_add_namespace(cmd, namespace):
             )
 
     if namespace.is_vhd and not namespace.output_name:
-        raise CLIError("Usage error: If --is-vhd is used, a run output name must be provided via --output-name.")
+        raise UsageError("If --is-vhd is used, a run output name must be provided via --output-name.")
 
     subscription_locations = get_subscription_locations(cmd.cli_ctx)
     location_names = [location.name for location in subscription_locations]
@@ -432,7 +433,7 @@ def create_image_template(  # pylint: disable=too-many-locals, too-many-branches
         template_source = ImageTemplatePlatformImageSource(**source_dict)
     elif source_dict['type'] == _SourceType.ISO_URI:
         # It was supported before but is removed in the current service version.
-        raise CLIError('usage error: Source type ISO URI is not supported.')
+        raise UsageError('Source type ISO URI is not supported.')
     elif source_dict['type'] == _SourceType.MANAGED_IMAGE:
         template_source = ImageTemplateManagedImageSource(**source_dict)
     elif source_dict['type'] == _SourceType.SIG_VERSION:

--- a/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
@@ -327,7 +327,7 @@ def process_img_tmpl_output_add_namespace(cmd, namespace):
     if len(outputs) != 1:
         err = "Supplied outputs: {}".format(outputs)
         logger.debug(err)
-        raise UsageError("must supply exactly one destination type to add. Supplied {}".format(len(outputs)))
+        raise UsageError("Must supply exactly one destination type to add. Supplied {}".format(len(outputs)))
 
     if namespace.managed_image:
         if not is_valid_resource_id(namespace.managed_image):
@@ -341,7 +341,7 @@ def process_img_tmpl_output_add_namespace(cmd, namespace):
     if namespace.gallery_image_definition:
         if not is_valid_resource_id(namespace.gallery_image_definition):
             if not namespace.gallery_name:
-                raise UsageError("gallery image definition is a name and not an ID.")
+                raise UsageError("Gallery image definition is a name and not an ID.")
 
             namespace.gallery_image_definition = resource_id(
                 subscription=get_subscription_id(cmd.cli_ctx), resource_group=namespace.resource_group_name,

--- a/src/azure-cli/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_template_builder.py
@@ -8,6 +8,7 @@ from enum import Enum
 
 from knack.util import CLIError
 
+from azure.cli.core.azclierror import UsageError
 from azure.cli.core.util import b64encode
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.commands.arm import ArmTemplateBuilder
@@ -399,8 +400,8 @@ def build_vm_resource(  # pylint: disable=too-many-locals, too-many-statements
         data_disks = [v for k, v in disk_info.items() if k != 'os']
         if data_disk_encryption_sets:
             if len(data_disk_encryption_sets) != len(data_disks):
-                raise CLIError(
-                    'usage error: Number of --data-disk-encryption-sets mismatches with number of data disks.')
+                raise UsageError(
+                    'Number of --data-disk-encryption-sets mismatches with number of data disks.')
             for i, data_disk in enumerate(data_disks):
                 data_disk['managedDisk']['diskEncryptionSet'] = {'id': data_disk_encryption_sets[i]}
         if data_disks:
@@ -781,18 +782,18 @@ def build_vmss_resource(cmd, name, naming_prefix, location, tags, overprovision,
     data_disks = [v for k, v in disk_info.items() if k != 'os']
     if data_disk_encryption_sets:
         if len(data_disk_encryption_sets) != len(data_disks):
-            raise CLIError(
-                'usage error: Number of --data-disk-encryption-sets mismatches with number of data disks.')
+            raise UsageError(
+                'Number of --data-disk-encryption-sets mismatches with number of data disks.')
         for i, data_disk in enumerate(data_disks):
             data_disk['managedDisk']['diskEncryptionSet'] = {'id': data_disk_encryption_sets[i]}
     if data_disk_iops:
         if len(data_disk_iops) != len(data_disks):
-            raise CLIError('usage error: Number of --data-disk-iops mismatches with number of data disks.')
+            raise UsageError('Number of --data-disk-iops mismatches with number of data disks.')
         for i, data_disk in enumerate(data_disks):
             data_disk['diskIOPSReadWrite'] = data_disk_iops[i]
     if data_disk_mbps:
         if len(data_disk_mbps) != len(data_disks):
-            raise CLIError('usage error: Number of --data-disk-mbps mismatches with number of data disks.')
+            raise UsageError('Number of --data-disk-mbps mismatches with number of data disks.')
         for i, data_disk in enumerate(data_disks):
             data_disk['diskMBpsReadWrite'] = data_disk_mbps[i]
     if data_disks:

--- a/src/azure-cli/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_template_builder.py
@@ -6,8 +6,6 @@
 
 from enum import Enum
 
-from knack.util import CLIError
-
 from azure.cli.core.azclierror import UsageError
 from azure.cli.core.util import b64encode
 from azure.cli.core.profiles import ResourceType

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -1107,7 +1107,7 @@ def _validate_vm_vmss_msi(cmd, namespace, from_set_command=False):
         user_assigned_identities = [x for x in identities if x != MSI_LOCAL_ID]
         if user_assigned_identities and not cmd.supported_api_version(min_api='2017-12-01'):
             raise UsageError('user assigned identity is only available under profile '
-                           'with minimum Compute API version of 2017-12-01')
+                             'with minimum Compute API version of 2017-12-01')
         if namespace.identity_scope:
             if identities and MSI_LOCAL_ID not in identities:
                 raise UsageError("'--scope'/'--role' is only applicable when assign system identity")
@@ -1402,7 +1402,7 @@ def process_vmss_create_namespace(cmd, namespace):
         ]
         if any(param is not None for param in banned_params):
             raise UsageError('In VM mode, only name, resource-group, location, '
-                           'tags, zones, platform-fault-domain-count, single-placement-group and ppg are allowed')
+                             'tags, zones, platform-fault-domain-count, single-placement-group and ppg are allowed')
         return
     validate_tags(namespace)
     if namespace.vm_sku is None:
@@ -1446,7 +1446,7 @@ def validate_vmss_update_namespace(cmd, namespace):  # pylint: disable=unused-ar
     if not namespace.instance_id:
         if namespace.protect_from_scale_in is not None or namespace.protect_from_scale_set_actions is not None:
             raise UsageError("protection policies can only be applied to VM instances within a VMSS."
-                           " Please use --instance-id to specify a VM instance")
+                             " Please use --instance-id to specify a VM instance")
     _validate_vmss_update_terminate_notification_related(cmd, namespace)
     _validate_vmss_update_automatic_repairs(cmd, namespace)
 # endregion
@@ -1523,7 +1523,7 @@ def process_image_create_namespace(cmd, namespace):
                     namespace.data_snapshots.append(source_snapshot)
         if not namespace.os_type:
             raise UsageError("os type is required to create the image, "
-                           "please specify '--os-type OS_TYPE'")
+                             "please specify '--os-type OS_TYPE'")
 
 
 def _figure_out_storage_source(cli_ctx, resource_group_name, source):
@@ -1604,9 +1604,9 @@ def process_gallery_image_version_namespace(cmd, namespace):
                     storage_account_type = parts[1]
                     if parts[1].lower() not in storage_account_types_list:
                         raise UsageError("{} is an invalid target region argument. The second part is "
-                                       "neither an integer replica count or a valid storage account type. "
-                                       "Storage account types must be one of {}."
-                                       .format(t, storage_account_types_str))
+                                         "neither an integer replica count or a valid storage account type. "
+                                         "Storage account types must be one of {}."
+                                         .format(t, storage_account_types_str))
 
             # Region specified, but also replica count and storage account type
             elif len(parts) == 3:
@@ -1615,11 +1615,11 @@ def process_gallery_image_version_namespace(cmd, namespace):
                     storage_account_type = parts[2]
                     if storage_account_type not in storage_account_types_list:
                         raise UsageError("{} is an invalid target region argument. The third part is "
-                                       "not a valid storage account type. Storage account types must be one of {}."
-                                       .format(t, storage_account_types_str))
+                                         "not a valid storage account type. Storage account types must be one of {}."
+                                         .format(t, storage_account_types_str))
                 except ValueError:
                     raise UsageError("{} is an invalid target region argument. "
-                                   "The second part must be a valid integer replica count.".format(t))
+                                     "The second part must be a valid integer replica count.".format(t))
 
             # Parse target region encryption, example: ['des1,0,des2,1,des3', 'null', 'des4']
             encryption = None
@@ -1638,7 +1638,7 @@ def process_gallery_image_version_namespace(cmd, namespace):
                     data_disk_images_len = len(data_disk_images)
                     if data_disk_images_len % 2 != 0:
                         raise UsageError('LUN and disk encryption set for data disk should appear '
-                                       'in pair in --target-region-encryption. Example: osdes,0,datades0,1,datades1')
+                                         'in pair in --target-region-encryption. Example: osdes,0,datades0,1,datades1')
                     data_disk_image_encryption_list = []
                     for j in range(int(data_disk_images_len / 2)):
                         lun = data_disk_images[j * 2]
@@ -1710,7 +1710,7 @@ def _validate_vmss_create_automatic_repairs(cmd, namespace):  # pylint: disable=
     if namespace.automatic_repairs_grace_period is not None:
         if namespace.load_balancer is None or namespace.health_probe is None:
             raise UsageError("--load-balancer and --health-probe are required "
-                           "when creating vmss with automatic repairs")
+                             "when creating vmss with automatic repairs")
     _validate_vmss_automatic_repairs(cmd, namespace)
 
 

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -489,7 +489,7 @@ def _validate_vm_create_storage_profile(cmd, namespace, for_scale_set=False):
             image_data_disks = [{'lun': disk.lun} for disk in image_data_disks]
 
         else:
-            raise UsageError('unrecognized image information "{}"'.format(namespace.image))
+            raise UsageError('Unrecognized image information "{}"'.format(namespace.image))
 
         # pylint: disable=no-member
 
@@ -1106,7 +1106,7 @@ def _validate_vm_vmss_msi(cmd, namespace, from_set_command=False):
                 namespace.identity_role))
         user_assigned_identities = [x for x in identities if x != MSI_LOCAL_ID]
         if user_assigned_identities and not cmd.supported_api_version(min_api='2017-12-01'):
-            raise UsageError('user assigned identity is only available under profile '
+            raise UsageError('User assigned identity is only available under profile '
                              'with minimum Compute API version of 2017-12-01')
         if namespace.identity_scope:
             if identities and MSI_LOCAL_ID not in identities:
@@ -1445,7 +1445,7 @@ def process_vmss_create_namespace(cmd, namespace):
 def validate_vmss_update_namespace(cmd, namespace):  # pylint: disable=unused-argument
     if not namespace.instance_id:
         if namespace.protect_from_scale_in is not None or namespace.protect_from_scale_set_actions is not None:
-            raise UsageError("protection policies can only be applied to VM instances within a VMSS."
+            raise UsageError("Protection policies can only be applied to VM instances within a VMSS."
                              " Please use --instance-id to specify a VM instance")
     _validate_vmss_update_terminate_notification_related(cmd, namespace)
     _validate_vmss_update_automatic_repairs(cmd, namespace)
@@ -1522,7 +1522,7 @@ def process_image_create_namespace(cmd, namespace):
                 if source_snapshot:
                     namespace.data_snapshots.append(source_snapshot)
         if not namespace.os_type:
-            raise UsageError("os type is required to create the image, "
+            raise UsageError("OS type is required to create the image, "
                              "please specify '--os-type OS_TYPE'")
 
 
@@ -1692,9 +1692,9 @@ def _validate_vmss_update_terminate_notification_related(cmd, namespace):  # pyl
     If enable_terminate_notification is true, must specify terminate_notification_time
     """
     if namespace.enable_terminate_notification is False and namespace.terminate_notification_time is not None:
-        raise UsageError("please enable --enable-terminate-notification")
+        raise UsageError("Please enable --enable-terminate-notification")
     if namespace.enable_terminate_notification is True and namespace.terminate_notification_time is None:
-        raise UsageError("please set --terminate-notification-time")
+        raise UsageError("Please set --terminate-notification-time")
     _validate_vmss_terminate_notification(cmd, namespace)
 
 
@@ -1716,9 +1716,9 @@ def _validate_vmss_create_automatic_repairs(cmd, namespace):  # pylint: disable=
 
 def _validate_vmss_update_automatic_repairs(cmd, namespace):  # pylint: disable=unused-argument
     if namespace.enable_automatic_repairs is False and namespace.automatic_repairs_grace_period is not None:
-        raise UsageError("please enable --enable-automatic-repairs")
+        raise UsageError("Please enable --enable-automatic-repairs")
     if namespace.enable_automatic_repairs is True and namespace.automatic_repairs_grace_period is None:
-        raise UsageError("please set --automatic-repairs-grace-period")
+        raise UsageError("Please set --automatic-repairs-grace-period")
     _validate_vmss_automatic_repairs(cmd, namespace)
 
 

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -14,6 +14,8 @@ except ImportError:
 from knack.log import get_logger
 from knack.util import CLIError
 
+from azure.cli.core.azclierror import UsageError
+
 logger = get_logger(__name__)
 
 
@@ -227,7 +229,7 @@ def normalize_disk_info(image_data_disks=None,
     if is_lv_size:
         for v in info.values():
             if v.get('caching', 'None').lower() != 'none':
-                raise CLIError('usage error: for Lv series of machines, "None" is the only supported caching mode')
+                raise UsageError('for Lv series of machines, "None" is the only supported caching mode')
 
     result_info = {'os': info['os']}
 
@@ -266,7 +268,7 @@ def update_disk_caching(model, caching_settings):
     else:
         for x in caching_settings:
             if '=' not in x:
-                raise CLIError("usage error: please use 'LUN=VALUE' to configure caching on individual disk")
+                raise UsageError("please use 'LUN=VALUE' to configure caching on individual disk")
             lun, value = x.split('=', 1)
             lun = lun.lower()
             lun = int(lun) if lun != 'os' else lun
@@ -300,7 +302,7 @@ def update_write_accelerator_settings(model, write_accelerator_settings):
     else:
         for x in write_accelerator_settings:
             if '=' not in x:
-                raise CLIError("usage error: please use 'LUN=VALUE' to configure write accelerator"
+                raise UsageError("please use 'LUN=VALUE' to configure write accelerator"
                                " on individual disk")
             lun, value = x.split('=', 1)
             lun = lun.lower()

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -303,7 +303,7 @@ def update_write_accelerator_settings(model, write_accelerator_settings):
         for x in write_accelerator_settings:
             if '=' not in x:
                 raise UsageError("please use 'LUN=VALUE' to configure write accelerator"
-                               " on individual disk")
+                                 " on individual disk")
             lun, value = x.split('=', 1)
             lun = lun.lower()
             lun = int(lun) if lun != 'os' else lun

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -229,7 +229,7 @@ def normalize_disk_info(image_data_disks=None,
     if is_lv_size:
         for v in info.values():
             if v.get('caching', 'None').lower() != 'none':
-                raise UsageError('for Lv series of machines, "None" is the only supported caching mode')
+                raise UsageError('For Lv series of machines, "None" is the only supported caching mode')
 
     result_info = {'os': info['os']}
 
@@ -268,7 +268,7 @@ def update_disk_caching(model, caching_settings):
     else:
         for x in caching_settings:
             if '=' not in x:
-                raise UsageError("please use 'LUN=VALUE' to configure caching on individual disk")
+                raise UsageError("Please use 'LUN=VALUE' to configure caching on individual disk")
             lun, value = x.split('=', 1)
             lun = lun.lower()
             lun = int(lun) if lun != 'os' else lun
@@ -302,7 +302,7 @@ def update_write_accelerator_settings(model, write_accelerator_settings):
     else:
         for x in write_accelerator_settings:
             if '=' not in x:
-                raise UsageError("please use 'LUN=VALUE' to configure write accelerator"
+                raise UsageError("Please use 'LUN=VALUE' to configure write accelerator"
                                  " on individual disk")
             lun, value = x.split('=', 1)
             lun = lun.lower()

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -1781,7 +1781,7 @@ def _terms_prepare(cmd, urn, publisher, offer, plan):
             raise UsageError('If using --urn, do not use any of --plan, --offer, --publisher.')
         terms = urn.split(':')
         if len(terms) != 4:
-            raise UsageError('urn should be in the format of publisher:offer:sku:version.')
+            raise UsageError('--urn should be in the format of publisher:offer:sku:version.')
         publisher, offer = terms[0], terms[1]
         image = show_vm_image(cmd, urn)
         if not image.plan:
@@ -3329,7 +3329,7 @@ def create_proximity_placement_group(cmd, client, proximity_placement_group_name
 
     if ppg_type and ppg_type not in choices:
         logger.info("Valid choices: %s", str(choices))
-        raise UsageError("invalid value for --type/-t")
+        raise UsageError("Invalid value for --type/-t")
 
     ppg_params = ProximityPlacementGroup(name=proximity_placement_group_name, proximity_placement_group_type=ppg_type,
                                          location=location, tags=(tags or {}))

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_actions.py
@@ -290,7 +290,7 @@ class TestActions(unittest.TestCase):
 
         with self.assertRaises(CLIError) as err:
             _validate_vm_vmss_msi(cmd, np_mock)
-        self.assertTrue("usage error: '--role reader' is not applicable as the '--scope' is "
+        self.assertTrue("'--role reader' is not applicable as the '--scope' is "
                         "not provided" in str(err.exception))
 
         # check throw on : az vm/vmss create --scope "some scope"
@@ -299,7 +299,7 @@ class TestActions(unittest.TestCase):
         np_mock.identity_scope = 'foo-scope'
         with self.assertRaises(CLIError) as err:
             _validate_vm_vmss_msi(cmd, np_mock)
-        self.assertTrue('usage error: --assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
+        self.assertTrue('--assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
 
         # check throw on : az vm/vmss create --role "reader"
         np_mock = mock.MagicMock()
@@ -307,7 +307,7 @@ class TestActions(unittest.TestCase):
         np_mock.identity_role = 'reader'
         with self.assertRaises(CLIError) as err:
             _validate_vm_vmss_msi(cmd, np_mock)
-        self.assertTrue('usage error: --assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
+        self.assertTrue('--assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
 
         # check we set right role id
         np_mock = mock.MagicMock()

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_actions.py
@@ -292,7 +292,7 @@ class TestActions(unittest.TestCase):
 
         with self.assertRaises(CLIError) as err:
             _validate_vm_vmss_msi(cmd, np_mock)
-        self.assertTrue("usage error: '--role reader' is not applicable as the '--scope' is "
+        self.assertTrue("'--role reader' is not applicable as the '--scope' is "
                         "not provided" in str(err.exception))
 
         # check throw on : az vm/vmss create --scope "some scope"
@@ -301,7 +301,7 @@ class TestActions(unittest.TestCase):
         np_mock.identity_scope = 'foo-scope'
         with self.assertRaises(CLIError) as err:
             _validate_vm_vmss_msi(cmd, np_mock)
-        self.assertTrue('usage error: --assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
+        self.assertTrue('--assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
 
         # check throw on : az vm/vmss create --role "reader"
         np_mock = mock.MagicMock()
@@ -309,7 +309,7 @@ class TestActions(unittest.TestCase):
         np_mock.identity_role = 'reader'
         with self.assertRaises(CLIError) as err:
             _validate_vm_vmss_msi(cmd, np_mock)
-        self.assertTrue('usage error: --assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
+        self.assertTrue('--assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
 
         # check we set right role id
         np_mock = mock.MagicMock()

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_actions.py
@@ -396,7 +396,7 @@ class TestActions(unittest.TestCase):
         # error on lv/lv2 machines with caching mode other than "None"
         with self.assertRaises(CLIError) as err:
             normalize_disk_info(data_disk_cachings=['ReadWrite'], data_disk_sizes_gb=[1, 2], size='standard_L16s_v2')
-        self.assertTrue('for Lv series of machines, "None" is the only supported caching mode' in str(err.exception))
+        self.assertTrue('For Lv series of machines, "None" is the only supported caching mode' in str(err.exception))
 
     @mock.patch('azure.cli.command_modules.vm._validators._compute_client_factory', autospec=True)
     def test_validate_vm_vmss_accelerated_networking(self, client_factory_mock):

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -305,7 +305,7 @@ class TestActions(unittest.TestCase):
 
         with self.assertRaises(CLIError) as err:
             _validate_vm_vmss_msi(cmd, np_mock)
-        self.assertTrue("usage error: '--role reader' is not applicable as the '--scope' is "
+        self.assertTrue("'--role reader' is not applicable as the '--scope' is "
                         "not provided" in str(err.exception))
 
         # check throw on : az vm/vmss create --scope "some scope"
@@ -314,7 +314,7 @@ class TestActions(unittest.TestCase):
         np_mock.identity_scope = 'foo-scope'
         with self.assertRaises(CLIError) as err:
             _validate_vm_vmss_msi(cmd, np_mock)
-        self.assertTrue('usage error: --assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
+        self.assertTrue('--assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
 
         # check throw on : az vm/vmss create --role "reader"
         np_mock = mock.MagicMock()
@@ -322,7 +322,7 @@ class TestActions(unittest.TestCase):
         np_mock.identity_role = 'reader'
         with self.assertRaises(CLIError) as err:
             _validate_vm_vmss_msi(cmd, np_mock)
-        self.assertTrue('usage error: --assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
+        self.assertTrue('--assign-identity [--scope SCOPE] [--role ROLE]' in str(err.exception))
 
         # check we set right role id
         np_mock = mock.MagicMock()

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -409,7 +409,7 @@ class TestActions(unittest.TestCase):
         # error on lv/lv2 machines with caching mode other than "None"
         with self.assertRaises(CLIError) as err:
             normalize_disk_info(data_disk_cachings=['ReadWrite'], data_disk_sizes_gb=[1, 2], size='standard_L16s_v2')
-        self.assertTrue('for Lv series of machines, "None" is the only supported caching mode' in str(err.exception))
+        self.assertTrue('For Lv series of machines, "None" is the only supported caching mode' in str(err.exception))
 
     def test_normalize_disk_info_from_images(self):
         # test create from data disk image


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR uses the UsageError to replace the all the CLIErrors prefixed by 'Usage error: ' in vm command group, so that
1. the errors can be classified into userfaults
2. we can control whether to print error types in CLI Core instead of in each of the error messages

**Testing Guide**  
<!--Example commands with explanations.-->
No difference from users' experience.
