### PR TITLE
{Auto Complete} Fix default completer

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -223,7 +223,7 @@ class AzCliCommandParser(CLICommandParser):
     def enable_autocomplete(self):
         argcomplete.autocomplete = AzCompletionFinder()
         argcomplete.autocomplete(self, validator=lambda c, p: c.lower().startswith(p.lower()),
-                                 default_completer=lambda _: ())
+                                 default_completer=lambda *args, **kw: ())
 
     def _get_failure_recovery_arguments(self, action=None):
         # Strip the leading "az " and any extraneous whitespace.

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -223,7 +223,7 @@ class AzCliCommandParser(CLICommandParser):
     def enable_autocomplete(self):
         argcomplete.autocomplete = AzCompletionFinder()
         argcomplete.autocomplete(self, validator=lambda c, p: c.lower().startswith(p.lower()),
-                                 default_completer=lambda *args, **kw: ())
+                                 default_completer=lambda *args, **kwargs: ())
 
     def _get_failure_recovery_arguments(self, action=None):
         # Strip the leading "az " and any extraneous whitespace.


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #3807

The current default completer only takes one positional argument and will throw an error when invoked in `argcomplete` with keyword argument:
https://github.com/kislyuk/argcomplete/blob/a93a4f4dc785373f320d168d2d5a1a11bdc50315/argcomplete/__init__.py#L452-L454
`completer(prefix=cword_prefix, action=active_action, parser=parser, parsed_args=parsed_args)`

This PR makes the default completer take any number of positional or keyword arguments.

**Testing Guide**  
<!--Example commands with explanations.-->
On Ubuntu, turn on argcomplete debug with:
`export _ARC_DEBUG=1`

Type the following command and press tab key.
`az vm show --ids /sub`

You can see the error: `TypeError: <lambda>() got an unexpected keyword argument 'prefix'`

Apply the change in this PR to argcomplete by running:
`eval "$(register-python-argcomplete az)"`

Repeat the step for tab completion and the error is gone.


**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
