### PR TITLE
{Telemetry} Add platform information and some config values

### DIFF
--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -22,6 +22,10 @@ TELEMETRY_VERSION = '0.0.1.4'
 AZURE_CLI_PREFIX = 'Context.Default.AzureCLI.'
 DEFAULT_INSTRUMENTATION_KEY = 'c4395b75-49cc-422c-bc95-c7d51aef5d46'
 CORRELATION_ID_PROP_NAME = 'Reserved.DataModel.CorrelationId'
+# Put a config section or key (section.name) in the allowed set to allow recording the config
+# values in the section or for the key with 'az config set'
+ALLOWED_CONFIG_SECTIONS_OR_KEYS = {'auto-upgrade', 'extension', 'core', 'logging.enable_log_file',
+                                   'output.show_survey_link'}
 
 
 class TelemetrySession:  # pylint: disable=too-many-instance-attributes
@@ -344,8 +348,23 @@ def set_user_fault(summary=None):
 
 @decorators.suppress_all_exceptions()
 def set_debug_info(key, info):
+    if key == 'ConfigSet':
+        info = _process_config_set_debug_info(info)
+
     debug_info = '{}: {}'.format(key, info)
     _session.debug_info.append(debug_info)
+
+
+@decorators.suppress_all_exceptions()
+def _process_config_set_debug_info(info):
+    processed_info = []
+    # info is a list of tuples
+    for key, section, value in info:
+        if section in ALLOWED_CONFIG_SECTIONS_OR_KEYS or key in ALLOWED_CONFIG_SECTIONS_OR_KEYS:
+            processed_info.append('{}={}'.format(key, value))
+        else:
+            processed_info.append('{}={}'.format(key, '***' if value else value))
+    return ' '.join(processed_info)
 
 
 @decorators.suppress_all_exceptions()

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -136,6 +136,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
             'Context.Default.VS.Core.Machine.Id': _get_hash_machine_id(),
             'Context.Default.VS.Core.OS.Type': platform.system().lower(),  # eg. darwin, windows
             'Context.Default.VS.Core.OS.Version': platform.version().lower(),  # eg. 10.0.14942
+            'Context.Default.VS.Core.OS.Platform': platform.platform().lower(),  # eg. windows-10-10.0.19041-sp0
             'Context.Default.VS.Core.User.Id': _get_installation_id(),
             'Context.Default.VS.Core.User.IsMicrosoftInternal': 'False',
             'Context.Default.VS.Core.User.IsOptedIn': 'True',

--- a/src/azure-cli/azure/cli/command_modules/config/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/config/custom.py
@@ -44,12 +44,8 @@ def config_set(cmd, key_value=None, local=False):
                 name = parts[1]
 
                 cmd.cli_ctx.config.set_value(section, name, _normalize_config_value(value))
-                if section in telemetry_allowed_sections_or_keys or key in telemetry_allowed_sections_or_keys:
-                    telemetry_content.append('{}={}'.format(key, value))
-                else:
-                    telemetry_content.append('{}=***'.format(key))
-            if telemetry_content:
-                telemetry.set_debug_info('ConfigSet', ' '.join(telemetry_content))
+                telemetry_content.append((key, section, value))
+            telemetry.set_debug_info('ConfigSet', telemetry_content)
 
 
 def config_get(cmd, key=None, local=False):

--- a/src/azure-cli/azure/cli/command_modules/config/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/config/custom.py
@@ -12,11 +12,6 @@ import azure.cli.core.telemetry as telemetry
 
 logger = get_logger(__name__)
 
-# Put a section or key (section.name) in the set to allow recording the config
-# values in the section or for the key
-telemetry_allowed_sections_or_keys = {'auto-upgrade', 'extension', 'core', 'logging.enable_log_file',
-                                      'output.show_survey_link'}
-
 
 def _normalize_config_value(value):
     if value:
@@ -27,7 +22,7 @@ def _normalize_config_value(value):
 def config_set(cmd, key_value=None, local=False):
     if key_value:
         with ScopedConfig(cmd.cli_ctx.config, local):
-            telemetry_content = []
+            telemetry_contents = []
             for kv in key_value:
                 # core.no_color=true
                 parts = kv.split('=', 1)
@@ -44,8 +39,8 @@ def config_set(cmd, key_value=None, local=False):
                 name = parts[1]
 
                 cmd.cli_ctx.config.set_value(section, name, _normalize_config_value(value))
-                telemetry_content.append((key, section, value))
-            telemetry.set_debug_info('ConfigSet', telemetry_content)
+                telemetry_contents.append((key, section, value))
+            telemetry.set_debug_info('ConfigSet', telemetry_contents)
 
 
 def config_get(cmd, key=None, local=False):


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Currently, we only have platform system name in telemetry, i.e., `windows`, `linux`, `macos`. This PR adds more platform details in a new property in telemetry, e.g., `windows-10-10.0.19041-sp0`, `Linux-5.0.0-1027-azure-x86_64-with-Ubuntu-18.04-bionic`.

This PR also adds all keys in `az config set/unset` commands in telemetry. For `az config set`, if the section or key is in the allow list (mainly for switch type configs), values will also be recorded. We can better analyze users' preference with this data.


 
**Testing Guide**  
<!--Example commands with explanations.-->
1. Run the following command and config keys and values are recorded.
   `az config set auto-upgrade.enable=no extension.run_after_dynamic_install=no`

    > "Context.Default.AzureCLI.debug_info":"ConfigSet: auto-upgrade.enable=no extension.run_after_dynamic_install=no"

2. Run the following command and only config keys are recorded.
    `az config set defaults.group=myGroup storage.account=myAccount`

    > "Context.Default.AzureCLI.debug_info":"ConfigSet: defaults.group=*** storage.account=***"

3. Run the following command and keys are recorded.
    `az config unset auto-upgrade.enable defaults.group`

    > "Context.Default.AzureCLI.debug_info":"ConfigUnset: auto-upgrade.enable defaults.group"

4. A new property `Context.Default.VS.Core.OS.Platform` is recorded for all comamnds.


**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
