### PR TITLE
{Error Improvement} Catch and categorize HttpError in core exception handler

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -61,7 +61,7 @@ def handle_exception(ex):  # pylint: disable=too-many-locals, too-many-statement
     from azure.cli.core.azlogging import CommandLoggerContext
     from azure.common import AzureException
     from azure.core.exceptions import AzureError
-    from requests.exceptions import SSLError
+    from requests.exceptions import SSLError, HTTPError
     import azure.cli.core.azclierror as azclierror
     import traceback
 
@@ -122,6 +122,13 @@ def handle_exception(ex):  # pylint: disable=too-many-locals, too-many-statement
             message, status_code = extract_http_operation_error(ex)
             if message:
                 error_msg = message
+            AzCLIErrorType = get_error_type_by_status_code(status_code)
+            az_error = AzCLIErrorType(error_msg)
+
+        elif isinstance(ex, HTTPError):
+            status_code = 'Unknown Code'
+            if ex.response and ex.response.status_code:
+                status_code = ex.response.status_code
             AzCLIErrorType = get_error_type_by_status_code(status_code)
             az_error = AzCLIErrorType(error_msg)
 
@@ -211,7 +218,7 @@ def get_error_type_by_status_code(status_code):
     if status_code.startswith('5'):
         return azclierror.AzureInternalError
 
-    return azclierror.AzureResponseError
+    return azclierror.UnknownError
 
 
 def is_azure_connection_error(error_msg):

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -126,9 +126,7 @@ def handle_exception(ex):  # pylint: disable=too-many-locals, too-many-statement
             az_error = AzCLIErrorType(error_msg)
 
         elif isinstance(ex, HTTPError):
-            status_code = 'Unknown Code'
-            if ex.response and ex.response.status_code:
-                status_code = ex.response.status_code
+            status_code = str(getattr(ex.response, 'status_code', 'Unknown Code'))
             AzCLIErrorType = get_error_type_by_status_code(status_code)
             az_error = AzCLIErrorType(error_msg)
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
HTTPErrors are widely raised in different command groups, while they are not caught in core exception handler. Previously, CLI would crash and users would get the raw traces when these error happen. 

This PR supports 
- catching the HTTPErrors in core exception handler.
- categorizing them into the new defined error types.

Here is a table showing the uncaught HTTPError count in AzureCLI@2.12.0 in last month.

CommandGroup | HTTPError Count
-- | --
NETWORK | 1392
DLS | 208
AD | 123
VM | 77
AKS | 51
LOGIN | 41
CONTAINER | 36
GROUP | 35
PROVIDER | 31
COSMOSDB | 27
DEPLOYMENT | 27
ROLE | 26
ACCOUNT | 20
RESOURCE | 11
STORAGE | 11
DT | 9
TAG | 9
KEYVAULT | 8
IMAGE | 7
ARO | 4
POLICY | 4
SQL | 4
VMSS | 4
BACKUP | 3
SIG | 3
WEBAPP | 3
DISK | 2
FUNCTIONAPP | 2
IOT | 2
ACR | 1
FUSION | 1



 

**Testing Guide**  
<!--Example commands with explanations.-->

You can test the case by raising an HTTPError manually in your codes, for example

Previously, when the HTTPError was not caught, CLI just crashed.
```
CLIInternalError: The command failed with an unexpected error. Here is the traceback:
Traceback (most recent call last):
  File "C:\Users\houk\Desktop\msws\env_new\lib\site-packages\knack\cli.py", line 215, in invoke
    cmd_result = self.invocation.execute(args)
  File "c:\users\houk\desktop\msws\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 654, in execute
    raise ex
  File "c:\users\houk\desktop\msws\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 718, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "c:\users\houk\desktop\msws\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 711, in _run_job
    six.reraise(*sys.exc_info())
  File "C:\Users\houk\Desktop\msws\env_new\lib\site-packages\six.py", line 703, in reraise
    raise value
  File "c:\users\houk\desktop\msws\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 688, in _run_job
    result = cmd_copy(params)
  File "c:\users\houk\desktop\msws\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 325, in __call__
    return self.handler(*args, **kwargs)
  File "c:\users\houk\desktop\msws\azure-cli\src\azure-cli-core\azure\cli\core\__init__.py", line 784, in default_command_handler
    return op(**command_args)
  File "c:\users\houk\desktop\msws\azure-cli\src\azure-cli\azure\cli\command_modules\vm\custom.py", line 581, in list_snapshots
    raise err
requests.exceptions.HTTPError: [Errno 400] test_url: 'test_err_message'
To open an issue, please run: 'az feedback'
```

Now,
```
BadRequestError: [Errno 400] test_url: 'test_err_message'
```