### PR TITLE
[ARM] Fix an issue where What-If shows two resource group scopes with different casing

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -540,9 +540,9 @@ def _get_max_path_length_from_object(value):
 
 def _is_leaf(value):
     return (
-        isinstance(value, (type(None), bool, int, float, str))
-        or (isinstance(value, list) and not value)
-        or (isinstance(value, dict) and not value)
+        isinstance(value, (type(None), bool, int, float, str)) or
+        (isinstance(value, list) and not value) or
+        (isinstance(value, dict) and not value)
     )
 
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -148,14 +148,16 @@ def _format_resource_changes(builder, resource_changes):
     if not resource_changes:
         return
 
-    num_scopes = len(set(map(_get_scope, resource_changes)))
-    resource_changes_by_scope = groupby(sorted(resource_changes, key=_get_scope), _get_scope)
+    num_scopes = len(set(map(_get_scope_uppercase, resource_changes)))
+    resource_changes_by_scope = groupby(sorted(resource_changes, key=_get_scope_uppercase), _get_scope_uppercase)
 
     builder.append_line()
     builder.append_line(f"The deployment will update the following {'scope:' if num_scopes == 1 else 'scopes'}")
 
-    for scope, resource_changes_in_scope in resource_changes_by_scope:
-        _format_resource_changes_in_scope(builder, scope, resource_changes_in_scope)
+    for _, resource_changes_in_scope in resource_changes_by_scope:
+        resource_changes_in_scope_list = list(resource_changes_in_scope)
+        scope = _get_scope(resource_changes_in_scope_list[0])
+        _format_resource_changes_in_scope(builder, scope, resource_changes_in_scope_list)
 
 
 def _format_resource_changes_in_scope(builder, scope, resource_changes_in_scope):
@@ -361,6 +363,10 @@ def _get_scope(resource_change):
     return scope
 
 
+def _get_scope_uppercase(resource_change):
+    return _get_scope(resource_change).upper()
+
+
 def _get_relative_resource_id(resource_change):
     _, relative_resource_id = split_resource_id(resource_change.resource_id)
     return relative_resource_id
@@ -534,9 +540,9 @@ def _get_max_path_length_from_object(value):
 
 def _is_leaf(value):
     return (
-        isinstance(value, (type(None), bool, int, float, str)) or
-        (isinstance(value, list) and not value) or
-        (isinstance(value, dict) and not value)
+        isinstance(value, (type(None), bool, int, float, str))
+        or (isinstance(value, list) and not value)
+        or (isinstance(value, dict) and not value)
     )
 
 

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
@@ -188,7 +188,7 @@ class TestFormatWhatIfOperationResult(unittest.TestCase):
     def test_group_resources_changes_by_sorted_scope(self):
         changes = [
             WhatIfChange(
-                resource_id="/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1/providers/p1/foo1",
+                resource_id="/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/RG1/providers/p1/foo1",
                 change_type=ChangeType.create,
             ),
             WhatIfChange(
@@ -214,7 +214,7 @@ class TestFormatWhatIfOperationResult(unittest.TestCase):
         ]
 
         expected = f"""
-Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
+Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/RG1
 {Color.GREEN}
   + p1/foo1
   + p2/bar


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

The PR contains a simple fix for the user reported issue: Azure/arm-template-whatif#126.

**Testing Guide**  
<!--Example commands with explanations.-->
az deployment group/sub/mg/tenant what-if ...

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
