### PR TITLE
{Core} Show custom headers in --debug log

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -95,19 +95,25 @@ def configure_common_settings(cli_ctx, client):
     except KeyError:
         pass
 
+    # Prepare CommandName header
+    command_name_suffix = ';completer-request' if cli_ctx.data['completer_active'] else ''
+    cli_ctx.data['headers']['CommandName'] = "{}{}".format(cli_ctx.data['command'], command_name_suffix)
+
+    # Prepare ParameterSetName header
+    if cli_ctx.data.get('safe_params'):
+        cli_ctx.data['headers']['ParameterSetName'] = ' '.join(cli_ctx.data['safe_params'])
+
+    # Prepare x-ms-client-request-id header
+    client.config.generate_client_request_id = 'x-ms-client-request-id' not in cli_ctx.data['headers']
+
+    logger.debug("Adding custom headers to the client:")
+
     for header, value in cli_ctx.data['headers'].items():
+        # msrest doesn't print custom headers in debug log, so CLI should do that
+        logger.debug("    '%s': '%s'", header, value)
         # We are working with the autorest team to expose the add_header functionality of the generated client to avoid
         # having to access private members
         client._client.add_header(header, value)  # pylint: disable=protected-access
-
-    command_name_suffix = ';completer-request' if cli_ctx.data['completer_active'] else ''
-    # pylint: disable=protected-access
-    client._client.add_header('CommandName',
-                              "{}{}".format(cli_ctx.data['command'], command_name_suffix))
-    if cli_ctx.data.get('safe_params'):
-        client._client.add_header('ParameterSetName',
-                                  ' '.join(cli_ctx.data['safe_params']))
-    client.config.generate_client_request_id = 'x-ms-client-request-id' not in cli_ctx.data['headers']
 
 
 def configure_common_settings_track2(cli_ctx):


### PR DESCRIPTION
When making any HTTP request, CLI will add some custom headers
- `x-ms-client-request-id` 
- `CommandName`
- `ParameterSetName`

to the request via the SDK client. But `msrest` doesn't print custom headers in the debug log. 

This PR makes CLI print custom headers so that users can know what information is sent to the server and logged in the server-side telemetry. This can also help code-gen team gather more information without checking the server-side telemetry.

```powershell
> az group show -n fy --debug

Adding custom headers to the client:
    'x-ms-client-request-id': '220893a8-14e0-11eb-ae06-84a93e63aa78'
    'CommandName': 'group show'
    'ParameterSetName': '-n --debug'
...
msrest.http_logger : Request URL: 'https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/fy?api-version=2020-06-01'
msrest.http_logger : Request method: 'GET'
msrest.http_logger : Request headers:
msrest.http_logger :     'Accept': 'application/json'
msrest.http_logger :     'accept-language': 'en-US'
msrest.http_logger :     'User-Agent': 'python/3.8.6 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0 (PIP)'
```

ℹ Track 2 SDK can print custom headers correctly, so there is no need to do this in `configure_common_settings_track2`. 

See email: _Show 'CommandName' and 'ParameterSetName' in --debug log_