### PR TITLE
{Core} Log command handler calls

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -781,6 +781,8 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
                 client_arg_name = resolve_client_arg_name(operation, kwargs)
                 if client_arg_name in op_args:
                     command_args[client_arg_name] = client
+            from azure.cli.core.util import log_command_handler_call
+            log_command_handler_call(op, **command_args)
             return op(**command_args)
 
         def default_arguments_loader():

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -26,7 +26,8 @@ from azure.cli.core.commands.constants import (
 from azure.cli.core.commands.parameters import (
     AzArgumentContext, patch_arg_make_required, patch_arg_make_optional)
 from azure.cli.core.extension import get_extension
-from azure.cli.core.util import get_command_type_kwarg, read_file_content, get_arg_list, poller_classes
+from azure.cli.core.util import (get_command_type_kwarg, read_file_content, get_arg_list, poller_classes,
+                                 log_command_handler_call)
 from azure.cli.core.local_context import LocalContextAction
 import azure.cli.core.telemetry as telemetry
 
@@ -396,8 +397,10 @@ def cached_get(cmd_obj, operation, *args, **kwargs):
     def _get_operation():
         result = None
         if args:
+            log_command_handler_call(operation, *args)
             result = operation(*args)
         elif kwargs is not None:
+            log_command_handler_call(operation, **kwargs)
             result = operation(**kwargs)
         return result
 
@@ -432,9 +435,11 @@ def cached_put(cmd_obj, operation, parameters, *args, setter_arg_name='parameter
         result = None
         if args:
             extended_args = args + (parameters,)
+            log_command_handler_call(operation, *extended_args)
             result = operation(*extended_args)
         elif kwargs is not None:
             kwargs[setter_arg_name] = parameters
+            log_command_handler_call(operation, **kwargs)
             result = operation(**kwargs)
             del kwargs[setter_arg_name]
         return result

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -18,7 +18,7 @@ from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.events import EVENT_INVOKER_PRE_LOAD_ARGUMENTS
 from azure.cli.core.commands.validators import IterateValue
 from azure.cli.core.util import (
-    shell_safe_json_parse, augment_no_wait_handler_args, get_command_type_kwarg, find_child_item)
+    shell_safe_json_parse, augment_no_wait_handler_args, get_command_type_kwarg, find_child_item, log_command_handler_call)
 from azure.cli.core.profiles import ResourceType, get_sdk
 
 from knack.arguments import CLICommandArgument, ignore_type
@@ -680,6 +680,7 @@ def _cli_wait_command(context, name, getter_op, custom_command=False, **kwargs):
         for _ in range(0, timeout, interval):
             try:
                 progress_indicator.add(message='Waiting')
+                log_command_handler_call(getter, **args)
                 instance = getter(**args)
                 if wait_for_exists:
                     progress_indicator.end()
@@ -751,6 +752,7 @@ def _cli_show_command(context, name, getter_op, custom_command=False, **kwargs):
 
         getter = context_copy.get_op_handler(getter_op, operation_group=kwargs.get('operation_group'))
         try:
+            log_command_handler_call(getter, **args)
             return getter(**args)
         except Exception as ex:  # pylint: disable=broad-except
             show_exception_handler(ex)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1165,3 +1165,8 @@ def handle_version_update():
             refresh_known_clouds()
     except Exception as ex:  # pylint: disable=broad-except
         logger.warning(ex)
+
+
+def log_command_handler_call(func, description=None, *args, **kwargs):
+    logger.debug("Calling command handler: module=%s, name=%s, args=%s, kwargs=%s",
+                 func.__module__, func.__qualname__, args, kwargs)


### PR DESCRIPTION
## Context

An SDK parameter can have multiple aliases when exposed via command line. For example, `resource_group_name` can map to

- `--name`
- `-n`
- `--resource-group` 
- `-g`

https://github.com/Azure/azure-cli/blob/f707487dd06651f7df64c7397e0ebad999db5722/src/azure-cli/azure/cli/command_modules/resource/_params.py#L223

It is impossible to identity the corresponding SDK parameter name just by looking at the name itself.

## Changes

This PR logs the call to the **command handlers** along with the parameters. The **command handlers** can be

- an SDK function
- a custom function

```powershell
# Custom function
> az group create -g rg1 -l westus --debug
Calling command handler: module=azure.cli.command_modules.resource.custom, name=create_resource_group, args=(), kwargs={'cmd': <azure.cli.core.commands.AzCliCommand object at 0x0000025BC768B490>, 'rg_name': 'rg1', 'location': 'westus', 'tags': None, 'managed_by': None}

# SDK function
> az group show -g rg1 --debug
Calling command handler: module=azure.mgmt.resource.resources.v2020_06_01.operations._resource_groups_operations, name=ResourceGroupsOperations.get, args=(), kwargs={'resource_group_name': 'rg1', 'self': <azure.mgmt.resource.resources.v2020_06_01.operations._resource_groups_operations.ResourceGroupsOperations object at 0x000001C45DC4E8E0>}

# Wait command by calling SDK function
> az group wait -g rg1 --created --debug
Calling command handler: module=azure.mgmt.resource.resources.v2020_06_01.operations._resource_groups_operations, name=ResourceGroupsOperations.get, args=(), kwargs={'resource_group_name': 'rg1', 'self': <azure.mgmt.resource.resources.v2020_06_01.operations._resource_groups_operations.ResourceGroupsOperations object at 0x0000024930F3BEB0>}

# Generic update command
> az group update -n rg1 --tags a=b --debug
Calling command handler: module=azure.mgmt.resource.resources.v2020_06_01.operations._resource_groups_operations, name=ResourceGroupsOperations.get, args=(), kwargs={'resource_group_name': 'rg1', 'self': <azure.mgmt.resource.resources.v2020_06_01.operations._resource_groups_operations.ResourceGroupsOperations object at 0x00000281D5852FA0>}
Calling command handler: module=azure.mgmt.resource.resources.v2020_06_01.operations._resource_groups_operations, name=ResourceGroupsOperations.create_or_update, args=(), kwargs={'resource_group_name': 'rg1', 'self': <azure.mgmt.resource.resources.v2020_06_01.operations._resource_groups_operations.ResourceGroupsOperations object at 0x000001C38CD95EB0>, 'parameters': <azure.mgmt.resource.resources.v2020_06_01.models._models_py3.ResourceGroup object at 0x000001C38CD6ECD0>}
```

## Benefits

- This gives more information on

    - the parameters with unified names (except for custom function handlers), like `resource_group_name` 
    - the full path of the SDK function called

- This helps the code-gen team to identity the mapping between **SDK parameters** and **CLI parameters** to provide a more consistent parameter naming.

Note: This won't cause any credential leak because all parameters are printed at the first-line of the debug log already:

```
Command arguments: ['group', 'update', '-n', 'rg1', '--tags', 'a=b', '--debug']
```
