### PR TITLE
[KeyVault] Refine error messages for HSM `list-deleted` and `purge`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -16,7 +16,7 @@ from knack.util import CLIError
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.validators import validate_tags
-from azure.cli.core.azclierror import RequiredArgumentMissingError
+from azure.cli.core.azclierror import InvalidArgumentValueError, RequiredArgumentMissingError
 
 
 secret_text_encoding_values = ['utf-8', 'utf-16le', 'utf-16be', 'ascii']
@@ -295,6 +295,9 @@ def validate_deleted_vault_or_hsm_name(cmd, ns):
 
     vault_name = getattr(ns, 'vault_name', None)
     hsm_name = getattr(ns, 'hsm_name', None)
+
+    if hsm_name:
+        raise InvalidArgumentValueError('Operation "purge" has not been supported for HSM.')
 
     if not vault_name and not hsm_name:
         raise CLIError('Please specify --vault-name or --hsm-name.')

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -218,7 +218,8 @@ def delete_vault_or_hsm(cmd, client, resource_group_name=None, vault_name=None, 
     )
 
 
-def purge_vault_or_hsm(cmd, client, location=None, vault_name=None, hsm_name=None, no_wait=False):
+def purge_vault_or_hsm(cmd, client, location=None, vault_name=None, hsm_name=None,  # pylint: disable=unused-argument
+                       no_wait=False):
     if is_azure_stack_profile(cmd) or vault_name:
         return sdk_no_wait(
             no_wait,
@@ -226,9 +227,7 @@ def purge_vault_or_hsm(cmd, client, location=None, vault_name=None, hsm_name=Non
             location=location,
             vault_name=vault_name
         )
-
-    if hsm_name:
-        raise InvalidArgumentValueError('Operation "purge" has not been supported for HSM.')
+    return None
 
 
 def list_deleted_vault_or_hsm(cmd, client, resource_type=None):


### PR DESCRIPTION
Fix #15632 

Old messages:
```
'ManagedHsmsOperations' object has no attribute 'list_deleted'
Traceback (most recent call last):
python3.6/site-packages/knack/cli.py, ln 215, in invoke
    cmd_result = self.invocation.execute(args)
cli/core/commands/__init__.py, ln 654, in execute
    raise ex
cli/core/commands/__init__.py, ln 718, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
cli/core/commands/__init__.py, ln 711, in _run_job
    six.reraise(*sys.exc_info())
...
cli/core/commands/__init__.py, ln 325, in __call__
    return self.handler(*args, **kwargs)
azure/cli/core/__init__.py, ln 784, in default_command_handler
    return op(**command_args)
cli/command_modules/keyvault/custom.py, ln 250, in list_deleted_vault_or_hsm
    return hsm_client.list_deleted()
AttributeError: 'ManagedHsmsOperations' object has no attribute 'list_deleted'
```

New messages:
![image](https://user-images.githubusercontent.com/3250203/97149619-fad25e00-17a7-11eb-9047-185c5bd8bb5b.png)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
