### PR TITLE
[Core] Print INFO log from SDK

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -127,8 +127,8 @@ def _prepare_client_kwargs_track2(cli_ctx):
     client_kwargs['logging_enable'] = True
 
     # Disable ARMHttpLoggingPolicy which logs only allowed headers
-    from azure.core.pipeline.policies import SansIOHTTPPolicy
-    client_kwargs['http_logging_policy'] = SansIOHTTPPolicy()
+    # from azure.core.pipeline.policies import SansIOHTTPPolicy
+    # client_kwargs['http_logging_policy'] = SansIOHTTPPolicy()
 
     # Prepare User-Agent header, used by UserAgentPolicy
     client_kwargs['user_agent'] = get_az_user_agent()


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR requires https://github.com/microsoft/knack/pull/221. 

Previously when `--verbose` is specified, only `cli.*` loggers' `INFO` logs are printed. Now all `azure.*` loggers' `INFO` logs are printed, including the CLI loggers which are renamed to `azure.cli.*`.

Example:

```
> az group show -n fy --debug
...
DEBUG: azure.cli.core: Modules found from index for 'group': ['azure.cli.command_modules.resource']
DEBUG: azure.cli.core: Loading command modules:
DEBUG: azure.cli.core: Name                  Load Time    Groups  Commands
DEBUG: azure.cli.core: resource                  0.009        35       164
DEBUG: azure.cli.core: Total (1)                 0.009        35       164
...
INFO: azure.core.pipeline.policies.http_logging_policy: Request URL: 'https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/fy?api-version=REDACTED'
INFO: azure.core.pipeline.policies.http_logging_policy: Request method: 'GET'
INFO: azure.core.pipeline.policies.http_logging_policy: Request headers:
INFO: azure.core.pipeline.policies.http_logging_policy:     'Accept': 'application/json'
INFO: azure.core.pipeline.policies.http_logging_policy:     'x-ms-client-request-id': 'd8fa889e-1822-11eb-b2f8-84a93e63aa78'

> az group show -n fy --verbose
...
INFO: azure.core.pipeline.policies.http_logging_policy: Request URL: 'https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/fy?api-version=REDACTED'
INFO: azure.core.pipeline.policies.http_logging_policy: Request method: 'GET'
INFO: azure.core.pipeline.policies.http_logging_policy: Request headers:
INFO: azure.core.pipeline.policies.http_logging_policy:     'Accept': 'application/json'
INFO: azure.core.pipeline.policies.http_logging_policy:     'x-ms-client-request-id': 'd8fa889e-1822-11eb-b2f8-84a93e63aa78'
```
