### PR TITLE
{CI} Pin to Python 3.8 for "Verify src/azure-cli/requirements.*.Windows.txt"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,7 +122,7 @@ jobs:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3'
     inputs:
-      versionSpec: 3.x
+      versionSpec: 3.8
 
   - task: BatchScript@1
     inputs:


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Pin to Python 3.8 for CI task "Verify src/azure-cli/requirements.*.Windows.txt".

Using the default `3.x` will make ADO use 3.9 and [fail](https://dev.azure.com/azure-sdk/public/_build/results?buildId=593807&view=logs&j=796343fd-f04d-59ce-7e73-c4eab21e4249&t=b60a609a-95c6-5b22-14c7-727fdb51354a&l=626):

```
...
    File "c:\hostedtoolcache\windows\python\3.9.0\x64\lib\distutils\dist.py", line 985, in run_command
      cmd_obj.run()
    File "setup.py", line 159, in run
      raise Exception("ERROR: The 'make' utility is missing from PATH")
  Exception: ERROR: The 'make' utility is missing from PATH
  ----------------------------------------
  ERROR: Failed building wheel for PyNaCl
ERROR: Could not build wheels for cryptography, PyNaCl which use PEP 517 and cannot be installed directly
```

Not sure if bumping `cryptography` (https://github.com/Azure/azure-cli/pull/15687) can solve this issue. 
