### PR TITLE
[AppService] functionapp: Added warning if customer tries to switch functionapp from premium to consumption.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -706,6 +706,8 @@ def load_arguments(self, _):
 
     with self.argument_context('functionapp update') as c:
         c.argument('plan', required=False, help='The name or resource id of the plan to update the functionapp with.')
+        c.argument('force', required=False, help='Required if attempting to migrate functionapp from Premium to Consumption --plan.',
+                   action='store_true')
 
     with self.argument_context('functionapp plan create') as c:
         c.argument('name', arg_type=name_arg_type, help='The name of the app service plan',

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -40,6 +40,7 @@ def ex_handler_factory(creating_plan=False):
 
 def update_function_ex_handler_factory():
     from knack.util import CLIError
+
     def _ex_handler(ex):
         http_error_response = False
         if hasattr(ex, 'response'):
@@ -49,13 +50,13 @@ def update_function_ex_handler_factory():
         if http_error_response:
             try:
                 detail = ('If using \'--plan\', a consumption plan may be unable to migrate '
-                        'to a given premium plan. Please confirm that the premium plan '
-                        'exists in the same resource group and region. Note: Not all '
-                        'functionapp plans support premium instances. If you have verified '
-                        'your resource group and region and are still unable to migrate, '
-                        'please redeploy on a premium functionapp plan.')
+                          'to a given premium plan. Please confirm that the premium plan '
+                          'exists in the same resource group and region. Note: Not all '
+                          'functionapp plans support premium instances. If you have verified '
+                          'your resource group and region and are still unable to migrate, '
+                          'please redeploy on a premium functionapp plan.')
                 ex = CLIError(ex.args[0] + '\n\n' + detail)
-            except Exception: # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 pass
         raise ex
     return _ex_handler

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -39,7 +39,7 @@ def ex_handler_factory(creating_plan=False):
 
 
 def update_function_ex_handler_factory():
-    from knack.util import CLIError
+    from azure.cli.core.azclierror import ClientRequestError
 
     def _ex_handler(ex):
         http_error_response = False
@@ -55,7 +55,7 @@ def update_function_ex_handler_factory():
                           'functionapp plans support premium instances. If you have verified '
                           'your resource group and region and are still unable to migrate, '
                           'please redeploy on a premium functionapp plan.')
-                ex = CLIError(ex.args[0] + '\n\n' + detail)
+                ex = ClientRequestError(ex.args[0] + '\n\n' + detail)
             except Exception:  # pylint: disable=broad-except
                 pass
         raise ex

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -46,6 +46,7 @@ from azure.cli.core.util import in_cloud_console, shell_safe_json_parse, open_pa
     ConfiguredDefaultSetter, sdk_no_wait, get_file_json
 from azure.cli.core.util import get_az_user_agent
 from azure.cli.core.profiles import ResourceType, get_sdk
+from azure.cli.core.azclierror import ResourceNotFoundError, RequiredArgumentMissingError, ValidationError
 
 from .tunnel import TunnelServer
 
@@ -647,7 +648,7 @@ def update_functionapp(cmd, instance, plan=None, force=False):
         else:
             dest_plan_info = client.app_service_plans.get(instance.resource_group, plan)
         if dest_plan_info is None:
-            raise CLIError("The plan '{}' doesn't exist".format(plan))
+            raise ResourceNotFoundError("The plan '{}' doesn't exist".format(plan))
         validate_plan_switch_compatibility(cmd, client, instance, dest_plan_info, force)
         instance.server_farm_id = dest_plan_info.id
     return instance
@@ -660,35 +661,37 @@ def validate_plan_switch_compatibility(cmd, client, src_functionapp_instance, de
                                                  src_parse_result['name'])
 
     if src_plan_info is None:
-        raise CLIError('Could not determine the current plan of the functionapp')
+        raise ResourceNotFoundError('Could not determine the current plan of the functionapp')
 
     # Ensure all plans involved are windows. Reserved = true indicates Linux.
     if src_plan_info.reserved or dest_plan_instance.reserved:
-        raise CLIError('This feature currently supports windows to windows plan migrations. For other '
-                       'migrations, please redeploy.')
+        raise ValidationError('This feature currently supports windows to windows plan migrations. For other '
+                              'migrations, please redeploy.')
 
     src_is_premium = is_plan_elastic_premium(cmd, src_plan_info)
     dest_is_consumption = is_plan_consumption(cmd, dest_plan_instance)
 
     if not (is_plan_consumption(cmd, src_plan_info) or src_is_premium):
-        raise CLIError('Your functionapp is not using a Consumption or an Elastic Premium plan. ' + general_switch_msg)
+        raise ValidationError('Your functionapp is not using a Consumption or an Elastic Premium plan. ' +
+                              general_switch_msg)
     if not (dest_is_consumption or is_plan_elastic_premium(cmd, dest_plan_instance)):
-        raise CLIError('You are trying to move to a plan that is not a Consumption or an Elastic Premium plan. ' +
-                       general_switch_msg)
+        raise ValidationError('You are trying to move to a plan that is not a Consumption or an '
+                              'Elastic Premium plan. ' +
+                              general_switch_msg)
 
     if src_is_premium and dest_is_consumption:
         logger.warning('WARNING: Moving a functionapp from Premium to Consumption might result in loss of '
                        'functionality and cause the app to break. Please ensure the functionapp is compatible '
                        'with a Consumption plan and is not using any features only available in Premium.')
         if not force:
-            raise CLIError('If you want to migrate a functionapp from a Premium to Consumption plan, please '
-                           're-run this command with the \'--force\' flag.')
+            raise RequiredArgumentMissingError('If you want to migrate a functionapp from a Premium to Consumption '
+                                               'plan, please re-run this command with the \'--force\' flag.')
 
 
 def set_functionapp(cmd, resource_group_name, name, **kwargs):
     instance = kwargs['parameters']
     if 'function' not in instance.kind:
-        raise CLIError('Not a function app to update')
+        raise ValidationError('Not a function app to update')
     client = web_client_factory(cmd.cli_ctx)
     return client.web_apps.create_or_update(resource_group_name, name, site_envelope=instance)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -660,11 +660,20 @@ def validate_plan_switch_compatibility(cmd, client, src_functionapp_instance, de
                                                  src_parse_result['name'])
     if src_plan_info is None:
         raise CLIError('Could not determine the current plan of the functionapp')
-    if not (is_plan_consumption(cmd, src_plan_info) or is_plan_elastic_premium(cmd, src_plan_info)):
+
+    src_is_premium = is_plan_elastic_premium(cmd, src_plan_info)
+    dest_is_consumption = is_plan_consumption(cmd, dest_plan_instance)
+
+    if not (is_plan_consumption(cmd, src_plan_info) or src_is_premium):
         raise CLIError('Your functionapp is not using a Consumption or an Elastic Premium plan. ' + general_switch_msg)
-    if not (is_plan_consumption(cmd, dest_plan_instance) or is_plan_elastic_premium(cmd, dest_plan_instance)):
+    if not (dest_is_consumption or is_plan_elastic_premium(cmd, dest_plan_instance)):
         raise CLIError('You are trying to move to a plan that is not a Consumption or an Elastic Premium plan. ' +
                        general_switch_msg)
+
+    if src_is_premium and dest_is_consumption:
+        logger.warning("Moving a functionapp from Premium to Consumption might result in loss of functionality. "
+                       "Please ensure the functionapp is compatible with a Consumption plan and is not using any "
+                       "premium features.")
 
 
 def set_functionapp(cmd, resource_group_name, name, **kwargs):


### PR DESCRIPTION
Resolves #15694

**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR involves changes to the `az functionapp update` command:

We're now requiring a user specify a `--force` flag to their command if they're attempting to migrate a functionapp from Premium -> Consumption. This is a potentially dangerous action if their functionapp uses Premium features that are not available in consumption. 

This also adds an error message if the user tries to migrate a functionapp to or from a Linux plan. Migration will only work on Windows at this time.

I also changed the exception handling slightly to add a helpful message if a migration attempt fails from the backend letting the customer know that some plans are incapable of upgrading.

**Testing Guide**  
<!--Example commands with explanations.-->

Most of these changes are warnings and error messages. The rest of these changes will either be tested by the move/migration tests we already have. 

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AppService] BREAKING CHANGE: az functionapp update: Migrating a functionapp from Premium to Consumption plans now requires the '--force' flag.
[AppService] az functionapp update: Added error message if functionapp migration involves any plans on Linux.
[AppService] az functionapp update: Added more descriptive error message if functionapp migration fails.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
