### PR TITLE
{Packaging} Add required python version in various setup.py

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -91,10 +91,8 @@ setup(
         'azure.cli.core.profiles',
     ],
     install_requires=DEPENDENCIES,
+    python_requires='>=3.6.0',
     extras_require={
-        ":python_version<'3.4'": ['enum34'],
-        ":python_version<'2.7.9'": ['pyopenssl', 'ndg-httpsclient', 'pyasn1'],
-        ':python_version<"3.0"': ['futures'],
         "test": TESTS_REQUIRE,
     },
     tests_require=TESTS_REQUIRE,

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -174,6 +174,7 @@ setup(
     ],
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests", "azure", "azure.cli"]),
     install_requires=DEPENDENCIES,
+    python_requires='>=3.6.0',
     package_data={
         'azure.cli.command_modules.acr': ['*.json'],
         'azure.cli.command_modules.botservice': ['*.json', '*.config'],


### PR DESCRIPTION
Currently, pip assumes 2.14.0 is the latest version for all python interpreters and installs that version. This causes errors like this on older python versions:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/confus/.local/share/virtualenvs/specter-yzp-I12c/lib/python3.2/site-packages/azure/cli/core/commands/__init__.py", line 425
    def cached_put(cmd_obj, operation, parameters, *args, setter_arg_name='parameters', **kwargs):
                                                                        ^
SyntaxError: invalid syntax
```

This probably a systemic problem in more than one of the azure libraries and because older packages with this error are already on pypi.org and other package repositories (debian, suse, ...), it is hard to solve in retrospect. This PR is just to raise awareness for the issue.