### PR TITLE
{Core} Use custom tag message

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -80,6 +80,18 @@ class AzCli(CLI):
 
         self.progress_controller = None
 
+        cli_status_msg = "See https://aka.cli/cli-command-status to learn more about Azure CLI command status " \
+                         "and support."
+        # Override the experimental message
+        import knack.experimental
+        knack.experimental.EXPERIMENTAL_MESSAGE = "This {} is experimental. " + cli_status_msg
+        knack.experimental.IMPLICIT_EXPERIMENTAL_MESSAGE = "Command group '{}' is experimental. " + cli_status_msg
+
+        # Override the preview message
+        import knack.preview
+        knack.preview.PREVIEW_MESSAGE = "This {} is in preview. " + cli_status_msg
+        knack.preview.IMPLICIT_PREVIEW_MESSAGE = "Command group '{}' is in preview. " + cli_status_msg
+
     def refresh_request_id(self):
         """Assign a new random GUID as x-ms-client-request-id
 

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -80,14 +80,7 @@ class AzCli(CLI):
 
         self.progress_controller = None
 
-        ref_message = "Reference and support levels: https://aka.ms/CLI_refstatus"
-        # Override the experimental message
-        import knack.experimental
-        knack.experimental.EXPERIMENTAL_MESSAGE = "{} is experimental and under development. " + ref_message
-
-        # Override the preview message
-        import knack.preview
-        knack.preview.PREVIEW_MESSAGE = "{} is in preview and under development. " + ref_message
+        _configure_knack()
 
     def refresh_request_id(self):
         """Assign a new random GUID as x-ms-client-request-id
@@ -860,3 +853,13 @@ def get_default_cli():
                  logging_cls=AzCliLogging,
                  output_cls=AzOutputProducer,
                  help_cls=AzCliHelp)
+
+
+def _configure_knack():
+    """Override consts defined in knack to make them Azure CLI-specific."""
+    from knack.util import status_tag_messages
+    ref_message = "Reference and support levels: https://aka.ms/CLI_refstatus"
+    # Override the preview message
+    status_tag_messages['preview'] = "{} is in preview and under development. " + ref_message
+    # Override the experimental message
+    status_tag_messages['experimental'] = "{} is experimental and under development. " + ref_message

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -80,17 +80,14 @@ class AzCli(CLI):
 
         self.progress_controller = None
 
-        cli_status_msg = "See https://aka.cli/cli-command-status to learn more about Azure CLI command status " \
-                         "and support."
+        ref_message = "Reference and support levels: https://aka.cli/cli-command-status"
         # Override the experimental message
         import knack.experimental
-        knack.experimental.EXPERIMENTAL_MESSAGE = "This {} is experimental. " + cli_status_msg
-        knack.experimental.IMPLICIT_EXPERIMENTAL_MESSAGE = "Command group '{}' is experimental. " + cli_status_msg
+        knack.experimental.EXPERIMENTAL_MESSAGE = "{} is experimental. " + ref_message
 
         # Override the preview message
         import knack.preview
-        knack.preview.PREVIEW_MESSAGE = "This {} is in preview. " + cli_status_msg
-        knack.preview.IMPLICIT_PREVIEW_MESSAGE = "Command group '{}' is in preview. " + cli_status_msg
+        knack.preview.PREVIEW_MESSAGE = "{} is in preview. " + ref_message
 
     def refresh_request_id(self):
         """Assign a new random GUID as x-ms-client-request-id

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -80,14 +80,14 @@ class AzCli(CLI):
 
         self.progress_controller = None
 
-        ref_message = "Reference and support levels: https://aka.cli/cli-command-status"
+        ref_message = "Reference and support levels: https://aka.ms/CLI_refstatus"
         # Override the experimental message
         import knack.experimental
-        knack.experimental.EXPERIMENTAL_MESSAGE = "{} is experimental. " + ref_message
+        knack.experimental.EXPERIMENTAL_MESSAGE = "{} is experimental and under development. " + ref_message
 
         # Override the preview message
         import knack.preview
-        knack.preview.PREVIEW_MESSAGE = "{} is in preview. " + ref_message
+        knack.preview.PREVIEW_MESSAGE = "{} is in preview and under development. " + ref_message
 
     def refresh_request_id(self):
         """Assign a new random GUID as x-ms-client-request-id


### PR DESCRIPTION
**Description<!--Mandatory-->**  

This PR requires https://github.com/microsoft/knack/pull/223

Refine and override tag messages from Knack to be more user-friendly.

See email: _Refining our experimental message to be more positive_

```sh
# Direct experimental message
> az account subscription -h

        This command group is experimental and under development. Reference and support levels:
        https://aka.ms/CLI_refstatus

# Implicit experimental message
> az account subscription show -h

        Command group 'account subscription' is experimental and under development. Reference
        and support levels: https://aka.ms/CLI_refstatus

# Direct preview message
> az apim -h

        This command group is in preview and under development. Reference and support levels:
        https://aka.ms/CLI_refstatus

# Implicit preview message
> az apim api -h

        Command group 'apim' is in preview and under development. Reference and support levels:
        https://aka.ms/CLI_refstatus

```

