### PR TITLE
{AppConfig} Stop passing resource to get_login_credentials method

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
@@ -149,9 +149,7 @@ def get_appconfig_data_client(cmd, name, connection_string, auth_mode, endpoint)
 
         from azure.cli.core._profile import Profile
         profile = Profile(cli_ctx=cmd.cli_ctx)
-        # Due to this bug in get_login_credentials: https://github.com/Azure/azure-cli/issues/15179,
-        # we need to manage the AAD scope by passing appconfig endpoint as resource
-        cred, _, _ = profile.get_login_credentials(resource=endpoint)
+        cred, _, _ = profile.get_login_credentials()
         try:
             azconfig_client = AzureAppConfigurationClient(credential=cred,
                                                           base_url=endpoint,


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Removing the redundant scope from get_login_credentials call because this functionality has been implemented and merged in #15184 and #15698. 

**Testing Guide**  
<!--Example commands with explanations.-->
There will be no change in any command behavior. 


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
