### PR TITLE
{Release} Hotfix: TS Multiline String Support for Template Inputs 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,7 +122,7 @@ jobs:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3'
     inputs:
-      versionSpec: 3.x
+      versionSpec: 3.8
 
   - task: BatchScript@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,7 +122,7 @@ jobs:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3'
     inputs:
-      versionSpec: 3.8
+      versionSpec: 3.x
 
   - task: BatchScript@1
     inputs:

--- a/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
@@ -33,7 +33,7 @@ def process_template(template, preserve_order=True, file_path=None):
     template = re.sub(r'(^[\t ]*//[\s\S]*?\n)|(^[\t ]*/\*{1,2}[\s\S]*?\*/)', '', template, flags=re.M)
     minified = jsmin(template)
 
-    # Get rid of extra spaces.
+    # Remove extra spaces, compress multiline string(s)
     result = re.sub(r'\s\s+', ' ', minified, flags=re.DOTALL)
 
     try:

--- a/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
@@ -3,9 +3,10 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import os
+import re
 import json
 from knack.util import CLIError
-from azure.cli.core.util import read_file_content
+from azure.cli.core.util import read_file_content, shell_safe_json_parse
 from azure.cli.command_modules.resource.custom import _remove_comments_from_json
 from azure.cli.core.profiles import ResourceType, get_sdk
 
@@ -23,6 +24,28 @@ class PackingContext():  # pylint: disable=too-few-public-methods
         self.Artifact = []
 
 
+# pylint: disable=redefined-outer-name
+def process_template(template, preserve_order=True, file_path=None):
+    from jsmin import jsmin
+
+    # When commenting at the bottom of all elements in a JSON object, jsmin has a bug that will wrap lines.
+    # It will affect the subsequent multi-line processing logic, so deal with this situation in advance here.
+    template = re.sub(r'(^[\t ]*//[\s\S]*?\n)|(^[\t ]*/\*{1,2}[\s\S]*?\*/)', '', template, flags=re.M)
+    minified = jsmin(template)
+
+    # Get rid of extra spaces.
+    result = re.sub(r'\s\s+', ' ', minified, flags=re.DOTALL)
+
+    try:
+        return shell_safe_json_parse(result, preserve_order)
+    except CLIError:
+        # Because the processing of removing comments and compression will lead to misplacement of error location,
+        # so the error message should be wrapped.
+        if file_path:
+            raise CLIError("Failed to parse '{}', please check whether it is a valid JSON format".format(file_path))
+        raise CLIError("Failed to parse the JSON data, please check whether it is a valid JSON format")
+
+
 def pack(cmd, template_file):
     """
     Packs the specified template and its referenced artifacts for use in a Template Spec.
@@ -32,8 +55,7 @@ def pack(cmd, template_file):
     root_template_file_path = os.path.abspath(template_file)
     context = PackingContext(os.path.dirname(root_template_file_path))
     template_content = read_file_content(template_file)
-    sanitized_template = _remove_comments_from_json(template_content)
-    template_json = json.loads(json.dumps(sanitized_template))
+    template_json = json.loads(json.dumps(process_template(template_content)))
     _pack_artifacts(cmd, root_template_file_path, context)
     return PackagedTemplate(template_json, getattr(context, 'Artifact'))
 
@@ -54,8 +76,7 @@ def _pack_artifacts(cmd, template_abs_file_path, context):
     try:
         context.CurrentDirectory = os.path.dirname(template_abs_file_path)
         template_content = read_file_content(template_abs_file_path)
-        artifactable_template_obj = sanitized_template = _remove_comments_from_json(template_content)
-        template_json = json.loads(json.dumps(sanitized_template))
+        artifactable_template_obj = _remove_comments_from_json(template_content)
         template_link_to_artifact_objs = _get_template_links_to_artifacts(cmd, artifactable_template_obj,
                                                                           includeNested=True)
 
@@ -94,8 +115,7 @@ def _pack_artifacts(cmd, template_abs_file_path, context):
             TemplateSpecTemplateArtifact = get_sdk(cmd.cli_ctx, ResourceType.MGMT_RESOURCE_TEMPLATESPECS,
                                                    'TemplateSpecTemplateArtifact', mod='models')
             template_content = read_file_content(abs_local_path)
-            sanitized_template = _remove_comments_from_json(template_content)
-            template_json = json.loads(json.dumps(sanitized_template))
+            template_json = json.loads(json.dumps(process_template(template_content)))
             artifact = TemplateSpecTemplateArtifact(path=as_relative_path, template=template_json)
             context.Artifact.append(artifact)
     finally:

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_create_template_specs.yaml
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_create_template_specs.yaml
@@ -11,10 +11,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n -v -l -f -d --description --version-description
+      - -g -n -v -l -f --description --version-description
       User-Agent:
       - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
       accept-language:
       - en-US
     method: GET
@@ -32,7 +32,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Oct 2020 03:04:36 GMT
+      - Thu, 05 Nov 2020 09:20:36 GMT
       expires:
       - '-1'
       pragma:
@@ -58,10 +58,10 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n -v -l -f -d --description --version-description
+      - -g -n -v -l -f --description --version-description
       User-Agent:
       - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
       accept-language:
       - en-US
     method: GET
@@ -79,7 +79,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Oct 2020 03:04:36 GMT
+      - Thu, 05 Nov 2020 09:20:37 GMT
       expires:
       - '-1'
       pragma:
@@ -95,7 +95,7 @@ interactions:
       message: Not Found
 - request:
     body: '{"location": "westus", "properties": {"description": "AzCLI test root template
-      spec", "displayName": "create-spec000003"}}'
+      spec"}}'
     headers:
       Accept:
       - application/json
@@ -106,14 +106,14 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '125'
+      - '86'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - -g -n -v -l -f -d --description --version-description
+      - -g -n -v -l -f --description --version-description
       User-Agent:
       - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
       accept-language:
       - en-US
     method: PUT
@@ -122,21 +122,20 @@ interactions:
     body:
       string: "{\r\n  \"location\": \"westus\",\r\n  \"systemData\": {\r\n    \"createdBy\":
         \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
-        \"2020-10-12T03:04:39.1003262Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2020-10-12T03:04:39.1003262Z\"\r\n
-        \ },\r\n  \"properties\": {\r\n    \"displayName\": \"create-spec000003\",\r\n
-        \   \"description\": \"AzCLI test root template spec\"\r\n  },\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002\",\r\n
+        \"2020-11-05T09:20:38.7022728Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
+        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2020-11-05T09:20:38.7022728Z\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"description\": \"AzCLI test root template
+        spec\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002\",\r\n
         \ \"type\": \"Microsoft.Resources/templateSpecs\",\r\n  \"name\": \"cli-test-create-template-spec000002\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '819'
+      - '775'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Oct 2020 03:04:38 GMT
+      - Thu, 05 Nov 2020 09:20:39 GMT
       expires:
       - '-1'
       pragma:
@@ -153,60 +152,81 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"location": "westus", "properties": {"artifacts": [{"path": "artifacts\\createResourceGroup.json",
-      "kind": "template", "template": {"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "parameters": {"rgName": {"type": "string"}, "rgLocation":
-      {"type": "string"}}, "variables": {}, "resources": [{"type": "Microsoft.Resources/resourceGroups",
-      "apiVersion": "2019-10-01", "name": "[parameters(''rgName'')]", "location":
-      "[parameters(''rgLocation'')]", "properties": {}}], "outputs": {}}}, {"path":
-      "artifacts\\createKeyVault.json", "kind": "template", "template": {"$schema":
-      "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "parameters": {"keyVaultName": {"type": "string"},
-      "location": {"type": "string", "defaultValue": "[resourceGroup().location]"},
-      "skuName": {"type": "string", "defaultValue": "standard"}, "tenantId": {"type":
-      "string", "defaultValue": "[subscription().tenantId]"}, "aadObjectId": {"type":
-      "string", "defaultValue": "177f56a0-9e41-4008-a321-d3676aae9c69"}}, "variables":
-      {}, "resources": [{"type": "Microsoft.KeyVault/vaults", "name": "[parameters(''keyVaultName'')]",
-      "apiVersion": "2018-02-14", "location": "[parameters(''location'')]", "properties":
-      {"tenantId": "[parameters(''tenantId'')]", "accessPolicies": [{"tenantId": "[parameters(''tenantId'')]",
-      "objectId": "[parameters(''aadObjectId'')]", "permissions": {"keys": ["encrypt",
-      "decrypt", "wrapKey", "unwrapKey", "sign", "verify", "get", "list", "create",
-      "update", "import", "delete", "backup", "restore", "recover", "purge"], "secrets":
-      ["get", "list", "set", "delete", "backup", "restore", "recover", "purge"], "certificates":
-      ["get", "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
-      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover", "purge"]}}],
-      "sku": {"name": "[parameters(''skuName'')]", "family": "A"}, "networkAcls":
-      {"defaultAction": "Allow", "bypass": "AzureServices"}}}], "outputs": {}}}, {"path":
-      "artifacts\\createKeyVaultWithSecret.json", "kind": "template", "template":
-      {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "parameters": {"keyVaultName": {"type": "string"},
-      "location": {"type": "string", "defaultValue": "[resourceGroup().location]"},
-      "skuName": {"type": "string", "defaultValue": "standard"}, "tenantId": {"type":
-      "string", "defaultValue": "[subscription().tenantId]"}, "aadObjectId": {"type":
-      "string", "defaultValue": "177f56a0-9e41-4008-a321-d3676aae9c69"}}, "variables":
-      {}, "resources": [{"type": "Microsoft.Resources/deployments", "apiVersion":
-      "2019-10-01", "name": "keyVault", "properties": {"mode": "Incremental", "templateLink":
-      {"relativePath": "createKeyVault.json", "contentVersion": "1.0.0.0"}, "parameters":
-      {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}, "location": {"value":
-      "[parameters(''location'')]"}, "skuName": {"value": "[parameters(''skuName'')]"},
-      "tenantId": {"value": "[parameters(''tenantId'')]"}, "aadObjectId": {"value":
-      "[parameters(''aadObjectId'')]"}}}}, {"type": "Microsoft.KeyVault/vaults/secrets",
-      "apiVersion": "2018-02-14", "name": "[concat(parameters(''keyVaultName''), ''/mySecret'')]",
-      "location": "[parameters(''location'')]", "dependsOn": ["keyVault"], "properties":
-      {"value": "mySecretValue"}}], "outputs": {}}}], "description": "AzCLI test version
-      of root template spec", "template": {"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "parameters": {"rgName": {"type": "string"}, "rgLocation":
-      {"type": "string"}, "keyVaultName": {"type": "string"}}, "variables": {}, "resources":
-      [{"type": "Microsoft.Resources/deployments", "apiVersion": "2019-10-01", "name":
-      "deploymentRg", "location": "[parameters(''rgLocation'')]", "properties": {"mode":
-      "Incremental", "templateLink": {"relativePath": "artifacts/createResourceGroup.json",
-      "contentVersion": "1.0.0.0"}, "parameters": {"rgName": {"value": "[parameters(''rgName'')]"},
-      "rgLocation": {"value": "[parameters(''rgLocation'')]"}}}}, {"type": "Microsoft.Resources/deployments",
-      "apiVersion": "2019-10-01", "name": "keyVaultAndSecret", "resourceGroup": "[parameters(''rgName'')]",
-      "dependsOn": ["deploymentRg"], "properties": {"mode": "Incremental", "templateLink":
-      {"relativePath": "artifacts/createKeyVaultWithSecret.json", "contentVersion":
-      "1.0.0.0"}, "parameters": {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}}}}],
-      "outputs": {}}}}'
+    body: '{"location": "westus", "properties": {"artifacts": [], "description": "AzCLI
+      test version of root template spec", "template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"customer": {"type": "string", "minLength":
+      2, "maxLength": 3, "defaultValue": "[resourceGroup().tags[''customer-short'']]",
+      "metadata": {"description": "A short unique identifer for the customer owning
+      the resource. E.g. ''mc''=''Marel Connect'', ''io''=''Innova''"}}, "environment":
+      {"type": "string", "allowedValues": ["dev", "test", "int", "stage", "prod",
+      "development", "testing", "integration", "staging", "production"], "defaultValue":
+      "[resourceGroup().tags[''environment'']]", "metadata": {"description": "The
+      environment being deployed to."}}, "location": {"type": "string", "allowedValues":
+      ["eastasia", "southeastasia", "centralus", "eastus", "eastus2", "westus", "northcentralus",
+      "southcentralus", "northeurope", "westeurope", "japanwest", "japaneast", "brazilsouth",
+      "australiaeast", "australiasoutheast", "southindia", "centralindia", "westindia",
+      "canadacentral", "canadaeast", "uksouth", "ukwest", "westcentralus", "westus2",
+      "koreacentral", "koreasouth", "francecentral", "francesouth", "australiacentral",
+      "australiacentral2", "southafricanorth", "southafricawest", "global"], "defaultValue":
+      "[if(contains(resourceGroup().tags, ''location''), resourceGroup().tags[''location''],
+      resourceGroup().location)]", "metadata": {"description": "The location of the
+      data center the resorce will be deployed to."}}, "group": {"type": "string",
+      "minLength": 3, "maxLength": 12, "defaultValue": "[resourceGroup().tags[''group'']]",
+      "metadata": {"description": "The group identifier"}}, "resource": {"type": "string",
+      "metadata": {"description": "The type of resource the name is being generated
+      for. e.g. ''Microsoft.Storage/storageAccounts''"}}, "kind": {"type": "string",
+      "defaultValue": "", "metadata": {"description": "Sometimes a ''kind'' needs
+      to be specified. Then this parameter needs to be provided. E.g. resource=''Microsoft.Web/sites''
+      kind=''functionapp''"}}, "instance": {"type": "int", "defaultValue": -1, "metadata":
+      {"description": "If name is for a repeated resource then this should be an integer
+      >= 0"}}, "useHyphen": {"type": "bool", "defaultValue": true, "metadata": {"description":
+      "Determines if the name should include hyphens or not. e.g. ''mc-d-euw-data-kv''
+      vs ''mcdeuwdatakv''"}}}, "functions": [], "variables": {"environments": {"dev":
+      "d", "test": "t", "int": "i", "stage": "s", "prod": "p", "development": "d",
+      "testing": "t", "integration": "i", "staging": "s", "production": "p"}, "locations":
+      {"eastasia": "ase", "southeastasia": "asse", "centralus": "usc", "eastus": "use",
+      "eastus2": "use2", "westus": "usw", "northcentralus": "usnc", "southcentralus":
+      "ussc", "northeurope": "eun", "westeurope": "euw", "japanwest": "jpw", "japaneast":
+      "jpe", "brazilsouth": "brs", "australiaeast": "aue", "australiasoutheast": "ause",
+      "southindia": "ins", "centralindia": "inc", "westindia": "inw", "canadacentral":
+      "cac", "canadaeast": "cae", "uksouth": "uks", "ukwest": "ukw", "westcentralus":
+      "uswe", "westus2": "usw2", "koreacentral": "krc", "koreasouth": "krs", "francecentral":
+      "frc", "francesouth": "frs", "australiacentral": "auc", "australiacentral2":
+      "auc2", "southafricanorth": "zan", "southafricawest": "zaw", "global": "global"},
+      "resources": {"Microsoft.Web": {"publishingUsers": null, "ishostnameavailable":
+      null, "validate": null, "isusernameavailable": null, "sourceControls": null,
+      "availableStacks": null, "staticSites": null, "listSitesAssignedToHostName":
+      null, "locations/getNetworkPolicies": null, "locations/operations": null, "locations/operationResults":
+      null, "sites/networkConfig": null, "sites/slots/networkConfig": null, "sites/hostNameBindings":
+      null, "sites/slots/hostNameBindings": null, "operations": null, "certificates":
+      null, "serverFarms": "asp", "sites": {"api": "appsvc", "app": "appui", "functionapp":
+      "fa"}, "sites/slots": null, "runtimes": null, "recommendations": null, "resourceHealthMetadata":
+      null, "georegions": null, "sites/premieraddons": null, "hostingEnvironments":
+      null, "hostingEnvironments/multiRolePools": null, "hostingEnvironments/workerPools":
+      null, "kubeEnvironments": null, "deploymentLocations": null, "deletedSites":
+      null, "locations/deletedSites": null, "ishostingenvironmentnameavailable": null,
+      "locations/deleteVirtualNetworkOrSubnets": null, "connections": null, "customApis":
+      null, "locations": null, "locations/listWsdlInterfaces": null, "locations/extractApiDefinitionFromWsdl":
+      null, "locations/managedApis": null, "locations/runtimes": null, "locations/apiOperations":
+      null, "connectionGateways": null, "locations/connectionGatewayInstallations":
+      null, "checkNameAvailability": null, "billingMeters": null, "verifyHostingEnvironmentVnet":
+      null, "serverFarms/eventGridFilters": null, "sites/eventGridFilters": null,
+      "sites/slots/eventGridFilters": null, "hostingEnvironments/eventGridFilters":
+      null, "serverFarms/firstPartyApps": null, "serverFarms/firstPartyApps/keyVaultSettings":
+      null}}, "provider": "[split(parameters(''resource''), ''/'')[0]]", "resourceType":
+      "[replace(parameters(''resource''), concat(variables(''provider''), ''/''),
+      '''')]", "hyphenedName": "[format(''[0]-[1]-[2]-[3]-[4]-[5]'', parameters(''customer''),
+      variables(''environments'')[parameters(''environment'')], variables(''locations'')[parameters(''location'')],
+      parameters(''group''), parameters(''service''), if(equals(parameters(''kind''),
+      ''''), variables(''resources'')[variables(''provider'')][variables(''resourceType'')],
+      variables(''resources'')[variables(''provider'')][variables(''resourceType'')][parameters(''kind'')]))]",
+      "removeOptionalsFromHyphenedName": "[replace(variables(''hyphenedName''), ''--'',
+      ''-'')]", "isInstanceCount": "[greater(parameters(''instance''), -1)]", "hyphenedNameAfterInstanceCount":
+      "[if(variables(''isInstanceCount''), format(''[0]-[1]'', variables(''removeOptionalsFromHyphenedName''),
+      string(parameters(''instance''))), variables(''removeOptionalsFromHyphenedName''))]",
+      "name": "[if(parameters(''useHyphen''), variables(''hyphenedNameAfterInstanceCount''),
+      replace(variables(''hyphenedNameAfterInstanceCount''), ''-'', ''''))]"}, "resources":
+      [], "outputs": {"name": {"type": "string", "value": "[toLower(variables(''name''))]"}}}}}'
     headers:
       Accept:
       - application/json
@@ -217,14 +237,14 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '4596'
+      - '6317'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
-      - -g -n -v -l -f -d --description --version-description
+      - -g -n -v -l -f --description --version-description
       User-Agent:
       - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
       accept-language:
       - en-US
     method: PUT
@@ -233,134 +253,138 @@ interactions:
     body:
       string: "{\r\n  \"location\": \"westus\",\r\n  \"systemData\": {\r\n    \"createdBy\":
         \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
-        \"2020-10-12T03:04:40.4403293Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2020-10-12T03:04:40.4403293Z\"\r\n
-        \ },\r\n  \"properties\": {\r\n    \"artifacts\": [\r\n      {\r\n        \"template\":
-        {\r\n          \"$schema\": \"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\r\n
-        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
-        \           \"rgName\": {\r\n              \"type\": \"string\"\r\n            },\r\n
-        \           \"rgLocation\": {\r\n              \"type\": \"string\"\r\n            }\r\n
-        \         },\r\n          \"variables\": {},\r\n          \"resources\": [\r\n
-        \           {\r\n              \"type\": \"Microsoft.Resources/resourceGroups\",\r\n
-        \             \"apiVersion\": \"2019-10-01\",\r\n              \"name\": \"[parameters('rgName')]\",\r\n
-        \             \"location\": \"[parameters('rgLocation')]\",\r\n              \"properties\":
-        {}\r\n            }\r\n          ],\r\n          \"outputs\": {}\r\n        },\r\n
-        \       \"path\": \"artifacts\\\\createResourceGroup.json\",\r\n        \"kind\":
-        \"template\"\r\n      },\r\n      {\r\n        \"template\": {\r\n          \"$schema\":
-        \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n
-        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
-        \           \"keyVaultName\": {\r\n              \"type\": \"string\"\r\n
-        \           },\r\n            \"location\": {\r\n              \"type\": \"string\",\r\n
-        \             \"defaultValue\": \"[resourceGroup().location]\"\r\n            },\r\n
-        \           \"skuName\": {\r\n              \"type\": \"string\",\r\n              \"defaultValue\":
-        \"standard\"\r\n            },\r\n            \"tenantId\": {\r\n              \"type\":
-        \"string\",\r\n              \"defaultValue\": \"[subscription().tenantId]\"\r\n
-        \           },\r\n            \"aadObjectId\": {\r\n              \"type\":
-        \"string\",\r\n              \"defaultValue\": \"177f56a0-9e41-4008-a321-d3676aae9c69\"\r\n
-        \           }\r\n          },\r\n          \"variables\": {},\r\n          \"resources\":
-        [\r\n            {\r\n              \"type\": \"Microsoft.KeyVault/vaults\",\r\n
-        \             \"name\": \"[parameters('keyVaultName')]\",\r\n              \"apiVersion\":
-        \"2018-02-14\",\r\n              \"location\": \"[parameters('location')]\",\r\n
-        \             \"properties\": {\r\n                \"tenantId\": \"[parameters('tenantId')]\",\r\n
-        \               \"accessPolicies\": [\r\n                  {\r\n                    \"tenantId\":
-        \"[parameters('tenantId')]\",\r\n                    \"objectId\": \"[parameters('aadObjectId')]\",\r\n
-        \                   \"permissions\": {\r\n                      \"keys\":
-        [\r\n                        \"encrypt\",\r\n                        \"decrypt\",\r\n
-        \                       \"wrapKey\",\r\n                        \"unwrapKey\",\r\n
-        \                       \"sign\",\r\n                        \"verify\",\r\n
-        \                       \"get\",\r\n                        \"list\",\r\n
-        \                       \"create\",\r\n                        \"update\",\r\n
-        \                       \"import\",\r\n                        \"delete\",\r\n
-        \                       \"backup\",\r\n                        \"restore\",\r\n
-        \                       \"recover\",\r\n                        \"purge\"\r\n
-        \                     ],\r\n                      \"secrets\": [\r\n                        \"get\",\r\n
-        \                       \"list\",\r\n                        \"set\",\r\n
-        \                       \"delete\",\r\n                        \"backup\",\r\n
-        \                       \"restore\",\r\n                        \"recover\",\r\n
-        \                       \"purge\"\r\n                      ],\r\n                      \"certificates\":
-        [\r\n                        \"get\",\r\n                        \"list\",\r\n
-        \                       \"delete\",\r\n                        \"create\",\r\n
-        \                       \"import\",\r\n                        \"update\",\r\n
-        \                       \"managecontacts\",\r\n                        \"getissuers\",\r\n
-        \                       \"listissuers\",\r\n                        \"setissuers\",\r\n
-        \                       \"deleteissuers\",\r\n                        \"manageissuers\",\r\n
-        \                       \"recover\",\r\n                        \"purge\"\r\n
-        \                     ]\r\n                    }\r\n                  }\r\n
-        \               ],\r\n                \"sku\": {\r\n                  \"name\":
-        \"[parameters('skuName')]\",\r\n                  \"family\": \"A\"\r\n                },\r\n
-        \               \"networkAcls\": {\r\n                  \"defaultAction\":
-        \"Allow\",\r\n                  \"bypass\": \"AzureServices\"\r\n                }\r\n
-        \             }\r\n            }\r\n          ],\r\n          \"outputs\":
-        {}\r\n        },\r\n        \"path\": \"artifacts\\\\createKeyVault.json\",\r\n
-        \       \"kind\": \"template\"\r\n      },\r\n      {\r\n        \"template\":
-        {\r\n          \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n
-        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
-        \           \"keyVaultName\": {\r\n              \"type\": \"string\"\r\n
-        \           },\r\n            \"location\": {\r\n              \"type\": \"string\",\r\n
-        \             \"defaultValue\": \"[resourceGroup().location]\"\r\n            },\r\n
-        \           \"skuName\": {\r\n              \"type\": \"string\",\r\n              \"defaultValue\":
-        \"standard\"\r\n            },\r\n            \"tenantId\": {\r\n              \"type\":
-        \"string\",\r\n              \"defaultValue\": \"[subscription().tenantId]\"\r\n
-        \           },\r\n            \"aadObjectId\": {\r\n              \"type\":
-        \"string\",\r\n              \"defaultValue\": \"177f56a0-9e41-4008-a321-d3676aae9c69\"\r\n
-        \           }\r\n          },\r\n          \"variables\": {},\r\n          \"resources\":
-        [\r\n            {\r\n              \"type\": \"Microsoft.Resources/deployments\",\r\n
-        \             \"apiVersion\": \"2019-10-01\",\r\n              \"name\": \"keyVault\",\r\n
-        \             \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n
-        \               \"templateLink\": {\r\n                  \"relativePath\":
-        \"createKeyVault.json\",\r\n                  \"contentVersion\": \"1.0.0.0\"\r\n
-        \               },\r\n                \"parameters\": {\r\n                  \"keyVaultName\":
-        {\r\n                    \"value\": \"[parameters('keyVaultName')]\"\r\n                  },\r\n
-        \                 \"location\": {\r\n                    \"value\": \"[parameters('location')]\"\r\n
-        \                 },\r\n                  \"skuName\": {\r\n                    \"value\":
-        \"[parameters('skuName')]\"\r\n                  },\r\n                  \"tenantId\":
-        {\r\n                    \"value\": \"[parameters('tenantId')]\"\r\n                  },\r\n
-        \                 \"aadObjectId\": {\r\n                    \"value\": \"[parameters('aadObjectId')]\"\r\n
-        \                 }\r\n                }\r\n              }\r\n            },\r\n
-        \           {\r\n              \"type\": \"Microsoft.KeyVault/vaults/secrets\",\r\n
-        \             \"apiVersion\": \"2018-02-14\",\r\n              \"name\": \"[concat(parameters('keyVaultName'),
-        '/mySecret')]\",\r\n              \"location\": \"[parameters('location')]\",\r\n
-        \             \"dependsOn\": [\r\n                \"keyVault\"\r\n              ],\r\n
-        \             \"properties\": {\r\n                \"value\": \"mySecretValue\"\r\n
-        \             }\r\n            }\r\n          ],\r\n          \"outputs\":
-        {}\r\n        },\r\n        \"path\": \"artifacts\\\\createKeyVaultWithSecret.json\",\r\n
-        \       \"kind\": \"template\"\r\n      }\r\n    ],\r\n    \"description\":
+        \"2020-11-05T09:20:39.9796141Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
+        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2020-11-05T09:20:39.9796141Z\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"artifacts\": [],\r\n    \"description\":
         \"AzCLI test version of root template spec\",\r\n    \"template\": {\r\n      \"$schema\":
-        \"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\r\n
-        \     \"contentVersion\": \"1.0.0.0\",\r\n      \"parameters\": {\r\n        \"rgName\":
-        {\r\n          \"type\": \"string\"\r\n        },\r\n        \"rgLocation\":
-        {\r\n          \"type\": \"string\"\r\n        },\r\n        \"keyVaultName\":
-        {\r\n          \"type\": \"string\"\r\n        }\r\n      },\r\n      \"variables\":
-        {},\r\n      \"resources\": [\r\n        {\r\n          \"type\": \"Microsoft.Resources/deployments\",\r\n
-        \         \"apiVersion\": \"2019-10-01\",\r\n          \"name\": \"deploymentRg\",\r\n
-        \         \"location\": \"[parameters('rgLocation')]\",\r\n          \"properties\":
-        {\r\n            \"mode\": \"Incremental\",\r\n            \"templateLink\":
-        {\r\n              \"relativePath\": \"artifacts/createResourceGroup.json\",\r\n
-        \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
-        {\r\n              \"rgName\": {\r\n                \"value\": \"[parameters('rgName')]\"\r\n
-        \             },\r\n              \"rgLocation\": {\r\n                \"value\":
-        \"[parameters('rgLocation')]\"\r\n              }\r\n            }\r\n          }\r\n
-        \       },\r\n        {\r\n          \"type\": \"Microsoft.Resources/deployments\",\r\n
-        \         \"apiVersion\": \"2019-10-01\",\r\n          \"name\": \"keyVaultAndSecret\",\r\n
-        \         \"resourceGroup\": \"[parameters('rgName')]\",\r\n          \"dependsOn\":
-        [\r\n            \"deploymentRg\"\r\n          ],\r\n          \"properties\":
-        {\r\n            \"mode\": \"Incremental\",\r\n            \"templateLink\":
-        {\r\n              \"relativePath\": \"artifacts/createKeyVaultWithSecret.json\",\r\n
-        \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
-        {\r\n              \"keyVaultName\": {\r\n                \"value\": \"[parameters('keyVaultName')]\"\r\n
-        \             }\r\n            }\r\n          }\r\n        }\r\n      ],\r\n
-        \     \"outputs\": {}\r\n    }\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0\",\r\n
+        \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n
+        \     \"contentVersion\": \"1.0.0.0\",\r\n      \"parameters\": {\r\n        \"customer\":
+        {\r\n          \"type\": \"string\",\r\n          \"minLength\": 2,\r\n          \"maxLength\":
+        3,\r\n          \"defaultValue\": \"[resourceGroup().tags['customer-short']]\",\r\n
+        \         \"metadata\": {\r\n            \"description\": \"A short unique
+        identifer for the customer owning the resource. E.g. 'mc'='Marel Connect',
+        'io'='Innova'\"\r\n          }\r\n        },\r\n        \"environment\": {\r\n
+        \         \"type\": \"string\",\r\n          \"allowedValues\": [\r\n            \"dev\",\r\n
+        \           \"test\",\r\n            \"int\",\r\n            \"stage\",\r\n
+        \           \"prod\",\r\n            \"development\",\r\n            \"testing\",\r\n
+        \           \"integration\",\r\n            \"staging\",\r\n            \"production\"\r\n
+        \         ],\r\n          \"defaultValue\": \"[resourceGroup().tags['environment']]\",\r\n
+        \         \"metadata\": {\r\n            \"description\": \"The environment
+        being deployed to.\"\r\n          }\r\n        },\r\n        \"location\":
+        {\r\n          \"type\": \"string\",\r\n          \"allowedValues\": [\r\n
+        \           \"eastasia\",\r\n            \"southeastasia\",\r\n            \"centralus\",\r\n
+        \           \"eastus\",\r\n            \"eastus2\",\r\n            \"westus\",\r\n
+        \           \"northcentralus\",\r\n            \"southcentralus\",\r\n            \"northeurope\",\r\n
+        \           \"westeurope\",\r\n            \"japanwest\",\r\n            \"japaneast\",\r\n
+        \           \"brazilsouth\",\r\n            \"australiaeast\",\r\n            \"australiasoutheast\",\r\n
+        \           \"southindia\",\r\n            \"centralindia\",\r\n            \"westindia\",\r\n
+        \           \"canadacentral\",\r\n            \"canadaeast\",\r\n            \"uksouth\",\r\n
+        \           \"ukwest\",\r\n            \"westcentralus\",\r\n            \"westus2\",\r\n
+        \           \"koreacentral\",\r\n            \"koreasouth\",\r\n            \"francecentral\",\r\n
+        \           \"francesouth\",\r\n            \"australiacentral\",\r\n            \"australiacentral2\",\r\n
+        \           \"southafricanorth\",\r\n            \"southafricawest\",\r\n
+        \           \"global\"\r\n          ],\r\n          \"defaultValue\": \"[if(contains(resourceGroup().tags,
+        'location'), resourceGroup().tags['location'], resourceGroup().location)]\",\r\n
+        \         \"metadata\": {\r\n            \"description\": \"The location of
+        the data center the resorce will be deployed to.\"\r\n          }\r\n        },\r\n
+        \       \"group\": {\r\n          \"type\": \"string\",\r\n          \"minLength\":
+        3,\r\n          \"maxLength\": 12,\r\n          \"defaultValue\": \"[resourceGroup().tags['group']]\",\r\n
+        \         \"metadata\": {\r\n            \"description\": \"The group identifier\"\r\n
+        \         }\r\n        },\r\n        \"resource\": {\r\n          \"type\":
+        \"string\",\r\n          \"metadata\": {\r\n            \"description\": \"The
+        type of resource the name is being generated for. e.g. 'Microsoft.Storage/storageAccounts'\"\r\n
+        \         }\r\n        },\r\n        \"kind\": {\r\n          \"type\": \"string\",\r\n
+        \         \"defaultValue\": \"\",\r\n          \"metadata\": {\r\n            \"description\":
+        \"Sometimes a 'kind' needs to be specified. Then this parameter needs to be
+        provided. E.g. resource='Microsoft.Web/sites' kind='functionapp'\"\r\n          }\r\n
+        \       },\r\n        \"instance\": {\r\n          \"type\": \"int\",\r\n
+        \         \"defaultValue\": -1,\r\n          \"metadata\": {\r\n            \"description\":
+        \"If name is for a repeated resource then this should be an integer >= 0\"\r\n
+        \         }\r\n        },\r\n        \"useHyphen\": {\r\n          \"type\":
+        \"bool\",\r\n          \"defaultValue\": true,\r\n          \"metadata\":
+        {\r\n            \"description\": \"Determines if the name should include
+        hyphens or not. e.g. 'mc-d-euw-data-kv' vs 'mcdeuwdatakv'\"\r\n          }\r\n
+        \       }\r\n      },\r\n      \"functions\": [],\r\n      \"variables\":
+        {\r\n        \"environments\": {\r\n          \"dev\": \"d\",\r\n          \"test\":
+        \"t\",\r\n          \"int\": \"i\",\r\n          \"stage\": \"s\",\r\n          \"prod\":
+        \"p\",\r\n          \"development\": \"d\",\r\n          \"testing\": \"t\",\r\n
+        \         \"integration\": \"i\",\r\n          \"staging\": \"s\",\r\n          \"production\":
+        \"p\"\r\n        },\r\n        \"locations\": {\r\n          \"eastasia\":
+        \"ase\",\r\n          \"southeastasia\": \"asse\",\r\n          \"centralus\":
+        \"usc\",\r\n          \"eastus\": \"use\",\r\n          \"eastus2\": \"use2\",\r\n
+        \         \"westus\": \"usw\",\r\n          \"northcentralus\": \"usnc\",\r\n
+        \         \"southcentralus\": \"ussc\",\r\n          \"northeurope\": \"eun\",\r\n
+        \         \"westeurope\": \"euw\",\r\n          \"japanwest\": \"jpw\",\r\n
+        \         \"japaneast\": \"jpe\",\r\n          \"brazilsouth\": \"brs\",\r\n
+        \         \"australiaeast\": \"aue\",\r\n          \"australiasoutheast\":
+        \"ause\",\r\n          \"southindia\": \"ins\",\r\n          \"centralindia\":
+        \"inc\",\r\n          \"westindia\": \"inw\",\r\n          \"canadacentral\":
+        \"cac\",\r\n          \"canadaeast\": \"cae\",\r\n          \"uksouth\": \"uks\",\r\n
+        \         \"ukwest\": \"ukw\",\r\n          \"westcentralus\": \"uswe\",\r\n
+        \         \"westus2\": \"usw2\",\r\n          \"koreacentral\": \"krc\",\r\n
+        \         \"koreasouth\": \"krs\",\r\n          \"francecentral\": \"frc\",\r\n
+        \         \"francesouth\": \"frs\",\r\n          \"australiacentral\": \"auc\",\r\n
+        \         \"australiacentral2\": \"auc2\",\r\n          \"southafricanorth\":
+        \"zan\",\r\n          \"southafricawest\": \"zaw\",\r\n          \"global\":
+        \"global\"\r\n        },\r\n        \"resources\": {\r\n          \"Microsoft.Web\":
+        {\r\n            \"publishingUsers\": null,\r\n            \"ishostnameavailable\":
+        null,\r\n            \"validate\": null,\r\n            \"isusernameavailable\":
+        null,\r\n            \"sourceControls\": null,\r\n            \"availableStacks\":
+        null,\r\n            \"staticSites\": null,\r\n            \"listSitesAssignedToHostName\":
+        null,\r\n            \"locations/getNetworkPolicies\": null,\r\n            \"locations/operations\":
+        null,\r\n            \"locations/operationResults\": null,\r\n            \"sites/networkConfig\":
+        null,\r\n            \"sites/slots/networkConfig\": null,\r\n            \"sites/hostNameBindings\":
+        null,\r\n            \"sites/slots/hostNameBindings\": null,\r\n            \"operations\":
+        null,\r\n            \"certificates\": null,\r\n            \"serverFarms\":
+        \"asp\",\r\n            \"sites\": {\r\n              \"api\": \"appsvc\",\r\n
+        \             \"app\": \"appui\",\r\n              \"functionapp\": \"fa\"\r\n
+        \           },\r\n            \"sites/slots\": null,\r\n            \"runtimes\":
+        null,\r\n            \"recommendations\": null,\r\n            \"resourceHealthMetadata\":
+        null,\r\n            \"georegions\": null,\r\n            \"sites/premieraddons\":
+        null,\r\n            \"hostingEnvironments\": null,\r\n            \"hostingEnvironments/multiRolePools\":
+        null,\r\n            \"hostingEnvironments/workerPools\": null,\r\n            \"kubeEnvironments\":
+        null,\r\n            \"deploymentLocations\": null,\r\n            \"deletedSites\":
+        null,\r\n            \"locations/deletedSites\": null,\r\n            \"ishostingenvironmentnameavailable\":
+        null,\r\n            \"locations/deleteVirtualNetworkOrSubnets\": null,\r\n
+        \           \"connections\": null,\r\n            \"customApis\": null,\r\n
+        \           \"locations\": null,\r\n            \"locations/listWsdlInterfaces\":
+        null,\r\n            \"locations/extractApiDefinitionFromWsdl\": null,\r\n
+        \           \"locations/managedApis\": null,\r\n            \"locations/runtimes\":
+        null,\r\n            \"locations/apiOperations\": null,\r\n            \"connectionGateways\":
+        null,\r\n            \"locations/connectionGatewayInstallations\": null,\r\n
+        \           \"checkNameAvailability\": null,\r\n            \"billingMeters\":
+        null,\r\n            \"verifyHostingEnvironmentVnet\": null,\r\n            \"serverFarms/eventGridFilters\":
+        null,\r\n            \"sites/eventGridFilters\": null,\r\n            \"sites/slots/eventGridFilters\":
+        null,\r\n            \"hostingEnvironments/eventGridFilters\": null,\r\n            \"serverFarms/firstPartyApps\":
+        null,\r\n            \"serverFarms/firstPartyApps/keyVaultSettings\": null\r\n
+        \         }\r\n        },\r\n        \"provider\": \"[split(parameters('resource'),
+        '/')[0]]\",\r\n        \"resourceType\": \"[replace(parameters('resource'),
+        concat(variables('provider'), '/'), '')]\",\r\n        \"hyphenedName\": \"[format('[0]-[1]-[2]-[3]-[4]-[5]',
+        parameters('customer'), variables('environments')[parameters('environment')],
+        variables('locations')[parameters('location')], parameters('group'), parameters('service'),
+        if(equals(parameters('kind'), ''), variables('resources')[variables('provider')][variables('resourceType')],
+        variables('resources')[variables('provider')][variables('resourceType')][parameters('kind')]))]\",\r\n
+        \       \"removeOptionalsFromHyphenedName\": \"[replace(variables('hyphenedName'),
+        '--', '-')]\",\r\n        \"isInstanceCount\": \"[greater(parameters('instance'),
+        -1)]\",\r\n        \"hyphenedNameAfterInstanceCount\": \"[if(variables('isInstanceCount'),
+        format('[0]-[1]', variables('removeOptionalsFromHyphenedName'), string(parameters('instance'))),
+        variables('removeOptionalsFromHyphenedName'))]\",\r\n        \"name\": \"[if(parameters('useHyphen'),
+        variables('hyphenedNameAfterInstanceCount'), replace(variables('hyphenedNameAfterInstanceCount'),
+        '-', ''))]\"\r\n      },\r\n      \"resources\": [],\r\n      \"outputs\":
+        {\r\n        \"name\": {\r\n          \"type\": \"string\",\r\n          \"value\":
+        \"[toLower(variables('name'))]\"\r\n        }\r\n      }\r\n    }\r\n  },\r\n
+        \ \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0\",\r\n
         \ \"type\": \"Microsoft.Resources/templateSpecs/versions\",\r\n  \"name\":
         \"1.0\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9426'
+      - '9747'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Oct 2020 03:04:40 GMT
+      - Thu, 05 Nov 2020 09:20:40 GMT
       expires:
       - '-1'
       pragma:
@@ -384,329 +408,6 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - ts create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n -v -f --yes
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_template_specs000001?api-version=2020-06-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001","name":"cli_test_template_specs000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-10-12T03:04:34Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '428'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 12 Oct 2020 03:04:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ts create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n -v -f --yes
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002?api-version=2019-06-01-preview
-  response:
-    body:
-      string: "{\r\n  \"location\": \"westus\",\r\n  \"systemData\": {\r\n    \"createdBy\":
-        \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
-        \"2020-10-12T03:04:39.1003262Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2020-10-12T03:04:40.4403293Z\"\r\n
-        \ },\r\n  \"properties\": {\r\n    \"displayName\": \"create-spec000003\",\r\n
-        \   \"description\": \"AzCLI test root template spec\"\r\n  },\r\n  \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002\",\r\n
-        \ \"type\": \"Microsoft.Resources/templateSpecs\",\r\n  \"name\": \"cli-test-create-template-spec000002\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '819'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 12 Oct 2020 03:04:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location": "westus", "properties": {"artifacts": [{"path": "artifacts\\createResourceGroup.json",
-      "kind": "template", "template": {"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "parameters": {"rgName": {"type": "string"}, "rgLocation":
-      {"type": "string"}}, "variables": {}, "resources": [{"type": "Microsoft.Resources/resourceGroups",
-      "apiVersion": "2019-10-01", "name": "[parameters(''rgName'')]", "location":
-      "[parameters(''rgLocation'')]", "properties": {}}], "outputs": {}}}, {"path":
-      "artifacts\\createKeyVault.json", "kind": "template", "template": {"$schema":
-      "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "parameters": {"keyVaultName": {"type": "string"},
-      "location": {"type": "string", "defaultValue": "[resourceGroup().location]"},
-      "skuName": {"type": "string", "defaultValue": "standard"}, "tenantId": {"type":
-      "string", "defaultValue": "[subscription().tenantId]"}, "aadObjectId": {"type":
-      "string", "defaultValue": "177f56a0-9e41-4008-a321-d3676aae9c69"}}, "variables":
-      {}, "resources": [{"type": "Microsoft.KeyVault/vaults", "name": "[parameters(''keyVaultName'')]",
-      "apiVersion": "2018-02-14", "location": "[parameters(''location'')]", "properties":
-      {"tenantId": "[parameters(''tenantId'')]", "accessPolicies": [{"tenantId": "[parameters(''tenantId'')]",
-      "objectId": "[parameters(''aadObjectId'')]", "permissions": {"keys": ["encrypt",
-      "decrypt", "wrapKey", "unwrapKey", "sign", "verify", "get", "list", "create",
-      "update", "import", "delete", "backup", "restore", "recover", "purge"], "secrets":
-      ["get", "list", "set", "delete", "backup", "restore", "recover", "purge"], "certificates":
-      ["get", "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
-      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover", "purge"]}}],
-      "sku": {"name": "[parameters(''skuName'')]", "family": "A"}, "networkAcls":
-      {"defaultAction": "Allow", "bypass": "AzureServices"}}}], "outputs": {}}}, {"path":
-      "artifacts\\createKeyVaultWithSecret.json", "kind": "template", "template":
-      {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "parameters": {"keyVaultName": {"type": "string"},
-      "location": {"type": "string", "defaultValue": "[resourceGroup().location]"},
-      "skuName": {"type": "string", "defaultValue": "standard"}, "tenantId": {"type":
-      "string", "defaultValue": "[subscription().tenantId]"}, "aadObjectId": {"type":
-      "string", "defaultValue": "177f56a0-9e41-4008-a321-d3676aae9c69"}}, "variables":
-      {}, "resources": [{"type": "Microsoft.Resources/deployments", "apiVersion":
-      "2019-10-01", "name": "keyVault", "properties": {"mode": "Incremental", "templateLink":
-      {"relativePath": "createKeyVault.json", "contentVersion": "1.0.0.0"}, "parameters":
-      {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}, "location": {"value":
-      "[parameters(''location'')]"}, "skuName": {"value": "[parameters(''skuName'')]"},
-      "tenantId": {"value": "[parameters(''tenantId'')]"}, "aadObjectId": {"value":
-      "[parameters(''aadObjectId'')]"}}}}, {"type": "Microsoft.KeyVault/vaults/secrets",
-      "apiVersion": "2018-02-14", "name": "[concat(parameters(''keyVaultName''), ''/mySecret'')]",
-      "location": "[parameters(''location'')]", "dependsOn": ["keyVault"], "properties":
-      {"value": "mySecretValue"}}], "outputs": {}}}], "template": {"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-      "contentVersion": "1.0.0.0", "parameters": {"rgName": {"type": "string"}, "rgLocation":
-      {"type": "string"}, "keyVaultName": {"type": "string"}}, "variables": {}, "resources":
-      [{"type": "Microsoft.Resources/deployments", "apiVersion": "2019-10-01", "name":
-      "deploymentRg", "location": "[parameters(''rgLocation'')]", "properties": {"mode":
-      "Incremental", "templateLink": {"relativePath": "artifacts/createResourceGroup.json",
-      "contentVersion": "1.0.0.0"}, "parameters": {"rgName": {"value": "[parameters(''rgName'')]"},
-      "rgLocation": {"value": "[parameters(''rgLocation'')]"}}}}, {"type": "Microsoft.Resources/deployments",
-      "apiVersion": "2019-10-01", "name": "keyVaultAndSecret", "resourceGroup": "[parameters(''rgName'')]",
-      "dependsOn": ["deploymentRg"], "properties": {"mode": "Incremental", "templateLink":
-      {"relativePath": "artifacts/createKeyVaultWithSecret.json", "contentVersion":
-      "1.0.0.0"}, "parameters": {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}}}}],
-      "outputs": {}}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - ts create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '4537'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -g -n -v -f --yes
-      User-Agent:
-      - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0?api-version=2019-06-01-preview
-  response:
-    body:
-      string: "{\r\n  \"location\": \"westus\",\r\n  \"systemData\": {\r\n    \"createdBy\":
-        \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
-        \"2020-10-12T03:04:40.4403293Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2020-10-12T03:04:42.3695799Z\"\r\n
-        \ },\r\n  \"properties\": {\r\n    \"artifacts\": [\r\n      {\r\n        \"template\":
-        {\r\n          \"$schema\": \"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\r\n
-        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
-        \           \"rgName\": {\r\n              \"type\": \"string\"\r\n            },\r\n
-        \           \"rgLocation\": {\r\n              \"type\": \"string\"\r\n            }\r\n
-        \         },\r\n          \"variables\": {},\r\n          \"resources\": [\r\n
-        \           {\r\n              \"type\": \"Microsoft.Resources/resourceGroups\",\r\n
-        \             \"apiVersion\": \"2019-10-01\",\r\n              \"name\": \"[parameters('rgName')]\",\r\n
-        \             \"location\": \"[parameters('rgLocation')]\",\r\n              \"properties\":
-        {}\r\n            }\r\n          ],\r\n          \"outputs\": {}\r\n        },\r\n
-        \       \"path\": \"artifacts\\\\createResourceGroup.json\",\r\n        \"kind\":
-        \"template\"\r\n      },\r\n      {\r\n        \"template\": {\r\n          \"$schema\":
-        \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n
-        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
-        \           \"keyVaultName\": {\r\n              \"type\": \"string\"\r\n
-        \           },\r\n            \"location\": {\r\n              \"type\": \"string\",\r\n
-        \             \"defaultValue\": \"[resourceGroup().location]\"\r\n            },\r\n
-        \           \"skuName\": {\r\n              \"type\": \"string\",\r\n              \"defaultValue\":
-        \"standard\"\r\n            },\r\n            \"tenantId\": {\r\n              \"type\":
-        \"string\",\r\n              \"defaultValue\": \"[subscription().tenantId]\"\r\n
-        \           },\r\n            \"aadObjectId\": {\r\n              \"type\":
-        \"string\",\r\n              \"defaultValue\": \"177f56a0-9e41-4008-a321-d3676aae9c69\"\r\n
-        \           }\r\n          },\r\n          \"variables\": {},\r\n          \"resources\":
-        [\r\n            {\r\n              \"type\": \"Microsoft.KeyVault/vaults\",\r\n
-        \             \"name\": \"[parameters('keyVaultName')]\",\r\n              \"apiVersion\":
-        \"2018-02-14\",\r\n              \"location\": \"[parameters('location')]\",\r\n
-        \             \"properties\": {\r\n                \"tenantId\": \"[parameters('tenantId')]\",\r\n
-        \               \"accessPolicies\": [\r\n                  {\r\n                    \"tenantId\":
-        \"[parameters('tenantId')]\",\r\n                    \"objectId\": \"[parameters('aadObjectId')]\",\r\n
-        \                   \"permissions\": {\r\n                      \"keys\":
-        [\r\n                        \"encrypt\",\r\n                        \"decrypt\",\r\n
-        \                       \"wrapKey\",\r\n                        \"unwrapKey\",\r\n
-        \                       \"sign\",\r\n                        \"verify\",\r\n
-        \                       \"get\",\r\n                        \"list\",\r\n
-        \                       \"create\",\r\n                        \"update\",\r\n
-        \                       \"import\",\r\n                        \"delete\",\r\n
-        \                       \"backup\",\r\n                        \"restore\",\r\n
-        \                       \"recover\",\r\n                        \"purge\"\r\n
-        \                     ],\r\n                      \"secrets\": [\r\n                        \"get\",\r\n
-        \                       \"list\",\r\n                        \"set\",\r\n
-        \                       \"delete\",\r\n                        \"backup\",\r\n
-        \                       \"restore\",\r\n                        \"recover\",\r\n
-        \                       \"purge\"\r\n                      ],\r\n                      \"certificates\":
-        [\r\n                        \"get\",\r\n                        \"list\",\r\n
-        \                       \"delete\",\r\n                        \"create\",\r\n
-        \                       \"import\",\r\n                        \"update\",\r\n
-        \                       \"managecontacts\",\r\n                        \"getissuers\",\r\n
-        \                       \"listissuers\",\r\n                        \"setissuers\",\r\n
-        \                       \"deleteissuers\",\r\n                        \"manageissuers\",\r\n
-        \                       \"recover\",\r\n                        \"purge\"\r\n
-        \                     ]\r\n                    }\r\n                  }\r\n
-        \               ],\r\n                \"sku\": {\r\n                  \"name\":
-        \"[parameters('skuName')]\",\r\n                  \"family\": \"A\"\r\n                },\r\n
-        \               \"networkAcls\": {\r\n                  \"defaultAction\":
-        \"Allow\",\r\n                  \"bypass\": \"AzureServices\"\r\n                }\r\n
-        \             }\r\n            }\r\n          ],\r\n          \"outputs\":
-        {}\r\n        },\r\n        \"path\": \"artifacts\\\\createKeyVault.json\",\r\n
-        \       \"kind\": \"template\"\r\n      },\r\n      {\r\n        \"template\":
-        {\r\n          \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n
-        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
-        \           \"keyVaultName\": {\r\n              \"type\": \"string\"\r\n
-        \           },\r\n            \"location\": {\r\n              \"type\": \"string\",\r\n
-        \             \"defaultValue\": \"[resourceGroup().location]\"\r\n            },\r\n
-        \           \"skuName\": {\r\n              \"type\": \"string\",\r\n              \"defaultValue\":
-        \"standard\"\r\n            },\r\n            \"tenantId\": {\r\n              \"type\":
-        \"string\",\r\n              \"defaultValue\": \"[subscription().tenantId]\"\r\n
-        \           },\r\n            \"aadObjectId\": {\r\n              \"type\":
-        \"string\",\r\n              \"defaultValue\": \"177f56a0-9e41-4008-a321-d3676aae9c69\"\r\n
-        \           }\r\n          },\r\n          \"variables\": {},\r\n          \"resources\":
-        [\r\n            {\r\n              \"type\": \"Microsoft.Resources/deployments\",\r\n
-        \             \"apiVersion\": \"2019-10-01\",\r\n              \"name\": \"keyVault\",\r\n
-        \             \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n
-        \               \"templateLink\": {\r\n                  \"relativePath\":
-        \"createKeyVault.json\",\r\n                  \"contentVersion\": \"1.0.0.0\"\r\n
-        \               },\r\n                \"parameters\": {\r\n                  \"keyVaultName\":
-        {\r\n                    \"value\": \"[parameters('keyVaultName')]\"\r\n                  },\r\n
-        \                 \"location\": {\r\n                    \"value\": \"[parameters('location')]\"\r\n
-        \                 },\r\n                  \"skuName\": {\r\n                    \"value\":
-        \"[parameters('skuName')]\"\r\n                  },\r\n                  \"tenantId\":
-        {\r\n                    \"value\": \"[parameters('tenantId')]\"\r\n                  },\r\n
-        \                 \"aadObjectId\": {\r\n                    \"value\": \"[parameters('aadObjectId')]\"\r\n
-        \                 }\r\n                }\r\n              }\r\n            },\r\n
-        \           {\r\n              \"type\": \"Microsoft.KeyVault/vaults/secrets\",\r\n
-        \             \"apiVersion\": \"2018-02-14\",\r\n              \"name\": \"[concat(parameters('keyVaultName'),
-        '/mySecret')]\",\r\n              \"location\": \"[parameters('location')]\",\r\n
-        \             \"dependsOn\": [\r\n                \"keyVault\"\r\n              ],\r\n
-        \             \"properties\": {\r\n                \"value\": \"mySecretValue\"\r\n
-        \             }\r\n            }\r\n          ],\r\n          \"outputs\":
-        {}\r\n        },\r\n        \"path\": \"artifacts\\\\createKeyVaultWithSecret.json\",\r\n
-        \       \"kind\": \"template\"\r\n      }\r\n    ],\r\n    \"template\": {\r\n
-        \     \"$schema\": \"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\r\n
-        \     \"contentVersion\": \"1.0.0.0\",\r\n      \"parameters\": {\r\n        \"rgName\":
-        {\r\n          \"type\": \"string\"\r\n        },\r\n        \"rgLocation\":
-        {\r\n          \"type\": \"string\"\r\n        },\r\n        \"keyVaultName\":
-        {\r\n          \"type\": \"string\"\r\n        }\r\n      },\r\n      \"variables\":
-        {},\r\n      \"resources\": [\r\n        {\r\n          \"type\": \"Microsoft.Resources/deployments\",\r\n
-        \         \"apiVersion\": \"2019-10-01\",\r\n          \"name\": \"deploymentRg\",\r\n
-        \         \"location\": \"[parameters('rgLocation')]\",\r\n          \"properties\":
-        {\r\n            \"mode\": \"Incremental\",\r\n            \"templateLink\":
-        {\r\n              \"relativePath\": \"artifacts/createResourceGroup.json\",\r\n
-        \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
-        {\r\n              \"rgName\": {\r\n                \"value\": \"[parameters('rgName')]\"\r\n
-        \             },\r\n              \"rgLocation\": {\r\n                \"value\":
-        \"[parameters('rgLocation')]\"\r\n              }\r\n            }\r\n          }\r\n
-        \       },\r\n        {\r\n          \"type\": \"Microsoft.Resources/deployments\",\r\n
-        \         \"apiVersion\": \"2019-10-01\",\r\n          \"name\": \"keyVaultAndSecret\",\r\n
-        \         \"resourceGroup\": \"[parameters('rgName')]\",\r\n          \"dependsOn\":
-        [\r\n            \"deploymentRg\"\r\n          ],\r\n          \"properties\":
-        {\r\n            \"mode\": \"Incremental\",\r\n            \"templateLink\":
-        {\r\n              \"relativePath\": \"artifacts/createKeyVaultWithSecret.json\",\r\n
-        \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
-        {\r\n              \"keyVaultName\": {\r\n                \"value\": \"[parameters('keyVaultName')]\"\r\n
-        \             }\r\n            }\r\n          }\r\n        }\r\n      ],\r\n
-        \     \"outputs\": {}\r\n    }\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0\",\r\n
-        \ \"type\": \"Microsoft.Resources/templateSpecs/versions\",\r\n  \"name\":
-        \"1.0\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '9362'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 12 Oct 2020 03:04:41 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
       - ts delete
       Connection:
       - keep-alive
@@ -716,7 +417,7 @@ interactions:
       - --template-spec --yes
       User-Agent:
       - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.13.0
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
       accept-language:
       - en-US
     method: DELETE
@@ -730,7 +431,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Oct 2020 03:04:44 GMT
+      - Thu, 05 Nov 2020 09:20:42 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_create_template_specs_with_artifacts.yaml
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_create_template_specs_with_artifacts.yaml
@@ -1,0 +1,749 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ts create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -v -l -f -d --description --version-description
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0''
+        under resource group ''cli_test_template_specs000001'' was not found. For
+        more details please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '354'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Nov 2020 09:21:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ts create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -v -l -f -d --description --version-description
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002?api-version=2019-06-01-preview
+  response:
+    body:
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002''
+        under resource group ''cli_test_template_specs000001'' was not found. For
+        more details please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '341'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Nov 2020 09:21:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"location": "westus", "properties": {"description": "AzCLI test root template
+      spec", "displayName": "create-spec000003"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ts create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '125'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n -v -l -f -d --description --version-description
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002?api-version=2019-06-01-preview
+  response:
+    body:
+      string: "{\r\n  \"location\": \"westus\",\r\n  \"systemData\": {\r\n    \"createdBy\":
+        \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
+        \"2020-11-05T09:21:38.3518745Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
+        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2020-11-05T09:21:38.3518745Z\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"displayName\": \"create-spec000003\",\r\n
+        \   \"description\": \"AzCLI test root template spec\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002\",\r\n
+        \ \"type\": \"Microsoft.Resources/templateSpecs\",\r\n  \"name\": \"cli-test-create-template-spec000002\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '819'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Nov 2020 09:21:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"location": "westus", "properties": {"artifacts": [{"path": "artifacts\\createResourceGroup.json",
+      "kind": "template", "template": {"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"rgName": {"type": "string"}, "rgLocation":
+      {"type": "string"}}, "variables": {}, "resources": [{"type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2019-10-01", "name": "[parameters(''rgName'')]", "location":
+      "[parameters(''rgLocation'')]", "properties": {}}], "outputs": {}}}, {"path":
+      "artifacts\\createKeyVault.json", "kind": "template", "template": {"$schema":
+      "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"keyVaultName": {"type": "string"},
+      "location": {"type": "string", "defaultValue": "[resourceGroup().location]"},
+      "skuName": {"type": "string", "defaultValue": "standard"}, "tenantId": {"type":
+      "string", "defaultValue": "[subscription().tenantId]"}, "aadObjectId": {"type":
+      "string", "defaultValue": "177f56a0-9e41-4008-a321-d3676aae9c69"}}, "variables":
+      {}, "resources": [{"type": "Microsoft.KeyVault/vaults", "name": "[parameters(''keyVaultName'')]",
+      "apiVersion": "2018-02-14", "location": "[parameters(''location'')]", "properties":
+      {"tenantId": "[parameters(''tenantId'')]", "accessPolicies": [{"tenantId": "[parameters(''tenantId'')]",
+      "objectId": "[parameters(''aadObjectId'')]", "permissions": {"keys": ["encrypt",
+      "decrypt", "wrapKey", "unwrapKey", "sign", "verify", "get", "list", "create",
+      "update", "import", "delete", "backup", "restore", "recover", "purge"], "secrets":
+      ["get", "list", "set", "delete", "backup", "restore", "recover", "purge"], "certificates":
+      ["get", "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
+      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover", "purge"]}}],
+      "sku": {"name": "[parameters(''skuName'')]", "family": "A"}, "networkAcls":
+      {"defaultAction": "Allow", "bypass": "AzureServices"}}}], "outputs": {}}}, {"path":
+      "artifacts\\createKeyVaultWithSecret.json", "kind": "template", "template":
+      {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"keyVaultName": {"type": "string"},
+      "location": {"type": "string", "defaultValue": "[resourceGroup().location]"},
+      "skuName": {"type": "string", "defaultValue": "standard"}, "tenantId": {"type":
+      "string", "defaultValue": "[subscription().tenantId]"}, "aadObjectId": {"type":
+      "string", "defaultValue": "177f56a0-9e41-4008-a321-d3676aae9c69"}}, "variables":
+      {}, "resources": [{"type": "Microsoft.Resources/deployments", "apiVersion":
+      "2019-10-01", "name": "keyVault", "properties": {"mode": "Incremental", "templateLink":
+      {"relativePath": "createKeyVault.json", "contentVersion": "1.0.0.0"}, "parameters":
+      {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}, "location": {"value":
+      "[parameters(''location'')]"}, "skuName": {"value": "[parameters(''skuName'')]"},
+      "tenantId": {"value": "[parameters(''tenantId'')]"}, "aadObjectId": {"value":
+      "[parameters(''aadObjectId'')]"}}}}, {"type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2018-02-14", "name": "[concat(parameters(''keyVaultName''), ''/mySecret'')]",
+      "location": "[parameters(''location'')]", "dependsOn": ["keyVault"], "properties":
+      {"value": "mySecretValue"}}], "outputs": {}}}], "description": "AzCLI test version
+      of root template spec", "template": {"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"rgName": {"type": "string"}, "rgLocation":
+      {"type": "string"}, "keyVaultName": {"type": "string"}}, "variables": {}, "resources":
+      [{"type": "Microsoft.Resources/deployments", "apiVersion": "2019-10-01", "name":
+      "deploymentRg", "location": "[parameters(''rgLocation'')]", "properties": {"mode":
+      "Incremental", "templateLink": {"relativePath": "artifacts/createResourceGroup.json",
+      "contentVersion": "1.0.0.0"}, "parameters": {"rgName": {"value": "[parameters(''rgName'')]"},
+      "rgLocation": {"value": "[parameters(''rgLocation'')]"}}}}, {"type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01", "name": "keyVaultAndSecret", "resourceGroup": "[parameters(''rgName'')]",
+      "dependsOn": ["deploymentRg"], "properties": {"mode": "Incremental", "templateLink":
+      {"relativePath": "artifacts/createKeyVaultWithSecret.json", "contentVersion":
+      "1.0.0.0"}, "parameters": {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}}}}],
+      "outputs": {}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ts create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4596'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n -v -l -f -d --description --version-description
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0?api-version=2019-06-01-preview
+  response:
+    body:
+      string: "{\r\n  \"location\": \"westus\",\r\n  \"systemData\": {\r\n    \"createdBy\":
+        \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
+        \"2020-11-05T09:21:39.6069069Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
+        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2020-11-05T09:21:39.6069069Z\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"artifacts\": [\r\n      {\r\n        \"template\":
+        {\r\n          \"$schema\": \"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\r\n
+        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
+        \           \"rgName\": {\r\n              \"type\": \"string\"\r\n            },\r\n
+        \           \"rgLocation\": {\r\n              \"type\": \"string\"\r\n            }\r\n
+        \         },\r\n          \"variables\": {},\r\n          \"resources\": [\r\n
+        \           {\r\n              \"type\": \"Microsoft.Resources/resourceGroups\",\r\n
+        \             \"apiVersion\": \"2019-10-01\",\r\n              \"name\": \"[parameters('rgName')]\",\r\n
+        \             \"location\": \"[parameters('rgLocation')]\",\r\n              \"properties\":
+        {}\r\n            }\r\n          ],\r\n          \"outputs\": {}\r\n        },\r\n
+        \       \"path\": \"artifacts\\\\createResourceGroup.json\",\r\n        \"kind\":
+        \"template\"\r\n      },\r\n      {\r\n        \"template\": {\r\n          \"$schema\":
+        \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n
+        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
+        \           \"keyVaultName\": {\r\n              \"type\": \"string\"\r\n
+        \           },\r\n            \"location\": {\r\n              \"type\": \"string\",\r\n
+        \             \"defaultValue\": \"[resourceGroup().location]\"\r\n            },\r\n
+        \           \"skuName\": {\r\n              \"type\": \"string\",\r\n              \"defaultValue\":
+        \"standard\"\r\n            },\r\n            \"tenantId\": {\r\n              \"type\":
+        \"string\",\r\n              \"defaultValue\": \"[subscription().tenantId]\"\r\n
+        \           },\r\n            \"aadObjectId\": {\r\n              \"type\":
+        \"string\",\r\n              \"defaultValue\": \"177f56a0-9e41-4008-a321-d3676aae9c69\"\r\n
+        \           }\r\n          },\r\n          \"variables\": {},\r\n          \"resources\":
+        [\r\n            {\r\n              \"type\": \"Microsoft.KeyVault/vaults\",\r\n
+        \             \"name\": \"[parameters('keyVaultName')]\",\r\n              \"apiVersion\":
+        \"2018-02-14\",\r\n              \"location\": \"[parameters('location')]\",\r\n
+        \             \"properties\": {\r\n                \"tenantId\": \"[parameters('tenantId')]\",\r\n
+        \               \"accessPolicies\": [\r\n                  {\r\n                    \"tenantId\":
+        \"[parameters('tenantId')]\",\r\n                    \"objectId\": \"[parameters('aadObjectId')]\",\r\n
+        \                   \"permissions\": {\r\n                      \"keys\":
+        [\r\n                        \"encrypt\",\r\n                        \"decrypt\",\r\n
+        \                       \"wrapKey\",\r\n                        \"unwrapKey\",\r\n
+        \                       \"sign\",\r\n                        \"verify\",\r\n
+        \                       \"get\",\r\n                        \"list\",\r\n
+        \                       \"create\",\r\n                        \"update\",\r\n
+        \                       \"import\",\r\n                        \"delete\",\r\n
+        \                       \"backup\",\r\n                        \"restore\",\r\n
+        \                       \"recover\",\r\n                        \"purge\"\r\n
+        \                     ],\r\n                      \"secrets\": [\r\n                        \"get\",\r\n
+        \                       \"list\",\r\n                        \"set\",\r\n
+        \                       \"delete\",\r\n                        \"backup\",\r\n
+        \                       \"restore\",\r\n                        \"recover\",\r\n
+        \                       \"purge\"\r\n                      ],\r\n                      \"certificates\":
+        [\r\n                        \"get\",\r\n                        \"list\",\r\n
+        \                       \"delete\",\r\n                        \"create\",\r\n
+        \                       \"import\",\r\n                        \"update\",\r\n
+        \                       \"managecontacts\",\r\n                        \"getissuers\",\r\n
+        \                       \"listissuers\",\r\n                        \"setissuers\",\r\n
+        \                       \"deleteissuers\",\r\n                        \"manageissuers\",\r\n
+        \                       \"recover\",\r\n                        \"purge\"\r\n
+        \                     ]\r\n                    }\r\n                  }\r\n
+        \               ],\r\n                \"sku\": {\r\n                  \"name\":
+        \"[parameters('skuName')]\",\r\n                  \"family\": \"A\"\r\n                },\r\n
+        \               \"networkAcls\": {\r\n                  \"defaultAction\":
+        \"Allow\",\r\n                  \"bypass\": \"AzureServices\"\r\n                }\r\n
+        \             }\r\n            }\r\n          ],\r\n          \"outputs\":
+        {}\r\n        },\r\n        \"path\": \"artifacts\\\\createKeyVault.json\",\r\n
+        \       \"kind\": \"template\"\r\n      },\r\n      {\r\n        \"template\":
+        {\r\n          \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n
+        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
+        \           \"keyVaultName\": {\r\n              \"type\": \"string\"\r\n
+        \           },\r\n            \"location\": {\r\n              \"type\": \"string\",\r\n
+        \             \"defaultValue\": \"[resourceGroup().location]\"\r\n            },\r\n
+        \           \"skuName\": {\r\n              \"type\": \"string\",\r\n              \"defaultValue\":
+        \"standard\"\r\n            },\r\n            \"tenantId\": {\r\n              \"type\":
+        \"string\",\r\n              \"defaultValue\": \"[subscription().tenantId]\"\r\n
+        \           },\r\n            \"aadObjectId\": {\r\n              \"type\":
+        \"string\",\r\n              \"defaultValue\": \"177f56a0-9e41-4008-a321-d3676aae9c69\"\r\n
+        \           }\r\n          },\r\n          \"variables\": {},\r\n          \"resources\":
+        [\r\n            {\r\n              \"type\": \"Microsoft.Resources/deployments\",\r\n
+        \             \"apiVersion\": \"2019-10-01\",\r\n              \"name\": \"keyVault\",\r\n
+        \             \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n
+        \               \"templateLink\": {\r\n                  \"relativePath\":
+        \"createKeyVault.json\",\r\n                  \"contentVersion\": \"1.0.0.0\"\r\n
+        \               },\r\n                \"parameters\": {\r\n                  \"keyVaultName\":
+        {\r\n                    \"value\": \"[parameters('keyVaultName')]\"\r\n                  },\r\n
+        \                 \"location\": {\r\n                    \"value\": \"[parameters('location')]\"\r\n
+        \                 },\r\n                  \"skuName\": {\r\n                    \"value\":
+        \"[parameters('skuName')]\"\r\n                  },\r\n                  \"tenantId\":
+        {\r\n                    \"value\": \"[parameters('tenantId')]\"\r\n                  },\r\n
+        \                 \"aadObjectId\": {\r\n                    \"value\": \"[parameters('aadObjectId')]\"\r\n
+        \                 }\r\n                }\r\n              }\r\n            },\r\n
+        \           {\r\n              \"type\": \"Microsoft.KeyVault/vaults/secrets\",\r\n
+        \             \"apiVersion\": \"2018-02-14\",\r\n              \"name\": \"[concat(parameters('keyVaultName'),
+        '/mySecret')]\",\r\n              \"location\": \"[parameters('location')]\",\r\n
+        \             \"dependsOn\": [\r\n                \"keyVault\"\r\n              ],\r\n
+        \             \"properties\": {\r\n                \"value\": \"mySecretValue\"\r\n
+        \             }\r\n            }\r\n          ],\r\n          \"outputs\":
+        {}\r\n        },\r\n        \"path\": \"artifacts\\\\createKeyVaultWithSecret.json\",\r\n
+        \       \"kind\": \"template\"\r\n      }\r\n    ],\r\n    \"description\":
+        \"AzCLI test version of root template spec\",\r\n    \"template\": {\r\n      \"$schema\":
+        \"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\r\n
+        \     \"contentVersion\": \"1.0.0.0\",\r\n      \"parameters\": {\r\n        \"rgName\":
+        {\r\n          \"type\": \"string\"\r\n        },\r\n        \"rgLocation\":
+        {\r\n          \"type\": \"string\"\r\n        },\r\n        \"keyVaultName\":
+        {\r\n          \"type\": \"string\"\r\n        }\r\n      },\r\n      \"variables\":
+        {},\r\n      \"resources\": [\r\n        {\r\n          \"type\": \"Microsoft.Resources/deployments\",\r\n
+        \         \"apiVersion\": \"2019-10-01\",\r\n          \"name\": \"deploymentRg\",\r\n
+        \         \"location\": \"[parameters('rgLocation')]\",\r\n          \"properties\":
+        {\r\n            \"mode\": \"Incremental\",\r\n            \"templateLink\":
+        {\r\n              \"relativePath\": \"artifacts/createResourceGroup.json\",\r\n
+        \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
+        {\r\n              \"rgName\": {\r\n                \"value\": \"[parameters('rgName')]\"\r\n
+        \             },\r\n              \"rgLocation\": {\r\n                \"value\":
+        \"[parameters('rgLocation')]\"\r\n              }\r\n            }\r\n          }\r\n
+        \       },\r\n        {\r\n          \"type\": \"Microsoft.Resources/deployments\",\r\n
+        \         \"apiVersion\": \"2019-10-01\",\r\n          \"name\": \"keyVaultAndSecret\",\r\n
+        \         \"resourceGroup\": \"[parameters('rgName')]\",\r\n          \"dependsOn\":
+        [\r\n            \"deploymentRg\"\r\n          ],\r\n          \"properties\":
+        {\r\n            \"mode\": \"Incremental\",\r\n            \"templateLink\":
+        {\r\n              \"relativePath\": \"artifacts/createKeyVaultWithSecret.json\",\r\n
+        \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
+        {\r\n              \"keyVaultName\": {\r\n                \"value\": \"[parameters('keyVaultName')]\"\r\n
+        \             }\r\n            }\r\n          }\r\n        }\r\n      ],\r\n
+        \     \"outputs\": {}\r\n    }\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0\",\r\n
+        \ \"type\": \"Microsoft.Resources/templateSpecs/versions\",\r\n  \"name\":
+        \"1.0\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9426'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Nov 2020 09:21:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ts create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -v -f --yes
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_template_specs000001?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001","name":"cli_test_template_specs000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2020-11-05T09:21:33Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '428'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Nov 2020 09:21:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ts create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -v -f --yes
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002?api-version=2019-06-01-preview
+  response:
+    body:
+      string: "{\r\n  \"location\": \"westus\",\r\n  \"systemData\": {\r\n    \"createdBy\":
+        \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
+        \"2020-11-05T09:21:38.3518745Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
+        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2020-11-05T09:21:39.6069069Z\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"displayName\": \"create-spec000003\",\r\n
+        \   \"description\": \"AzCLI test root template spec\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002\",\r\n
+        \ \"type\": \"Microsoft.Resources/templateSpecs\",\r\n  \"name\": \"cli-test-create-template-spec000002\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '819'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Nov 2020 09:21:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus", "properties": {"artifacts": [{"path": "artifacts\\createResourceGroup.json",
+      "kind": "template", "template": {"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"rgName": {"type": "string"}, "rgLocation":
+      {"type": "string"}}, "variables": {}, "resources": [{"type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2019-10-01", "name": "[parameters(''rgName'')]", "location":
+      "[parameters(''rgLocation'')]", "properties": {}}], "outputs": {}}}, {"path":
+      "artifacts\\createKeyVault.json", "kind": "template", "template": {"$schema":
+      "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"keyVaultName": {"type": "string"},
+      "location": {"type": "string", "defaultValue": "[resourceGroup().location]"},
+      "skuName": {"type": "string", "defaultValue": "standard"}, "tenantId": {"type":
+      "string", "defaultValue": "[subscription().tenantId]"}, "aadObjectId": {"type":
+      "string", "defaultValue": "177f56a0-9e41-4008-a321-d3676aae9c69"}}, "variables":
+      {}, "resources": [{"type": "Microsoft.KeyVault/vaults", "name": "[parameters(''keyVaultName'')]",
+      "apiVersion": "2018-02-14", "location": "[parameters(''location'')]", "properties":
+      {"tenantId": "[parameters(''tenantId'')]", "accessPolicies": [{"tenantId": "[parameters(''tenantId'')]",
+      "objectId": "[parameters(''aadObjectId'')]", "permissions": {"keys": ["encrypt",
+      "decrypt", "wrapKey", "unwrapKey", "sign", "verify", "get", "list", "create",
+      "update", "import", "delete", "backup", "restore", "recover", "purge"], "secrets":
+      ["get", "list", "set", "delete", "backup", "restore", "recover", "purge"], "certificates":
+      ["get", "list", "delete", "create", "import", "update", "managecontacts", "getissuers",
+      "listissuers", "setissuers", "deleteissuers", "manageissuers", "recover", "purge"]}}],
+      "sku": {"name": "[parameters(''skuName'')]", "family": "A"}, "networkAcls":
+      {"defaultAction": "Allow", "bypass": "AzureServices"}}}], "outputs": {}}}, {"path":
+      "artifacts\\createKeyVaultWithSecret.json", "kind": "template", "template":
+      {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"keyVaultName": {"type": "string"},
+      "location": {"type": "string", "defaultValue": "[resourceGroup().location]"},
+      "skuName": {"type": "string", "defaultValue": "standard"}, "tenantId": {"type":
+      "string", "defaultValue": "[subscription().tenantId]"}, "aadObjectId": {"type":
+      "string", "defaultValue": "177f56a0-9e41-4008-a321-d3676aae9c69"}}, "variables":
+      {}, "resources": [{"type": "Microsoft.Resources/deployments", "apiVersion":
+      "2019-10-01", "name": "keyVault", "properties": {"mode": "Incremental", "templateLink":
+      {"relativePath": "createKeyVault.json", "contentVersion": "1.0.0.0"}, "parameters":
+      {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}, "location": {"value":
+      "[parameters(''location'')]"}, "skuName": {"value": "[parameters(''skuName'')]"},
+      "tenantId": {"value": "[parameters(''tenantId'')]"}, "aadObjectId": {"value":
+      "[parameters(''aadObjectId'')]"}}}}, {"type": "Microsoft.KeyVault/vaults/secrets",
+      "apiVersion": "2018-02-14", "name": "[concat(parameters(''keyVaultName''), ''/mySecret'')]",
+      "location": "[parameters(''location'')]", "dependsOn": ["keyVault"], "properties":
+      {"value": "mySecretValue"}}], "outputs": {}}}], "template": {"$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"rgName": {"type": "string"}, "rgLocation":
+      {"type": "string"}, "keyVaultName": {"type": "string"}}, "variables": {}, "resources":
+      [{"type": "Microsoft.Resources/deployments", "apiVersion": "2019-10-01", "name":
+      "deploymentRg", "location": "[parameters(''rgLocation'')]", "properties": {"mode":
+      "Incremental", "templateLink": {"relativePath": "artifacts/createResourceGroup.json",
+      "contentVersion": "1.0.0.0"}, "parameters": {"rgName": {"value": "[parameters(''rgName'')]"},
+      "rgLocation": {"value": "[parameters(''rgLocation'')]"}}}}, {"type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01", "name": "keyVaultAndSecret", "resourceGroup": "[parameters(''rgName'')]",
+      "dependsOn": ["deploymentRg"], "properties": {"mode": "Incremental", "templateLink":
+      {"relativePath": "artifacts/createKeyVaultWithSecret.json", "contentVersion":
+      "1.0.0.0"}, "parameters": {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}}}}],
+      "outputs": {}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ts create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4537'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g -n -v -f --yes
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0?api-version=2019-06-01-preview
+  response:
+    body:
+      string: "{\r\n  \"location\": \"westus\",\r\n  \"systemData\": {\r\n    \"createdBy\":
+        \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
+        \"2020-11-05T09:21:39.6069069Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
+        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2020-11-05T09:21:41.2545573Z\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"artifacts\": [\r\n      {\r\n        \"template\":
+        {\r\n          \"$schema\": \"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\r\n
+        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
+        \           \"rgName\": {\r\n              \"type\": \"string\"\r\n            },\r\n
+        \           \"rgLocation\": {\r\n              \"type\": \"string\"\r\n            }\r\n
+        \         },\r\n          \"variables\": {},\r\n          \"resources\": [\r\n
+        \           {\r\n              \"type\": \"Microsoft.Resources/resourceGroups\",\r\n
+        \             \"apiVersion\": \"2019-10-01\",\r\n              \"name\": \"[parameters('rgName')]\",\r\n
+        \             \"location\": \"[parameters('rgLocation')]\",\r\n              \"properties\":
+        {}\r\n            }\r\n          ],\r\n          \"outputs\": {}\r\n        },\r\n
+        \       \"path\": \"artifacts\\\\createResourceGroup.json\",\r\n        \"kind\":
+        \"template\"\r\n      },\r\n      {\r\n        \"template\": {\r\n          \"$schema\":
+        \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n
+        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
+        \           \"keyVaultName\": {\r\n              \"type\": \"string\"\r\n
+        \           },\r\n            \"location\": {\r\n              \"type\": \"string\",\r\n
+        \             \"defaultValue\": \"[resourceGroup().location]\"\r\n            },\r\n
+        \           \"skuName\": {\r\n              \"type\": \"string\",\r\n              \"defaultValue\":
+        \"standard\"\r\n            },\r\n            \"tenantId\": {\r\n              \"type\":
+        \"string\",\r\n              \"defaultValue\": \"[subscription().tenantId]\"\r\n
+        \           },\r\n            \"aadObjectId\": {\r\n              \"type\":
+        \"string\",\r\n              \"defaultValue\": \"177f56a0-9e41-4008-a321-d3676aae9c69\"\r\n
+        \           }\r\n          },\r\n          \"variables\": {},\r\n          \"resources\":
+        [\r\n            {\r\n              \"type\": \"Microsoft.KeyVault/vaults\",\r\n
+        \             \"name\": \"[parameters('keyVaultName')]\",\r\n              \"apiVersion\":
+        \"2018-02-14\",\r\n              \"location\": \"[parameters('location')]\",\r\n
+        \             \"properties\": {\r\n                \"tenantId\": \"[parameters('tenantId')]\",\r\n
+        \               \"accessPolicies\": [\r\n                  {\r\n                    \"tenantId\":
+        \"[parameters('tenantId')]\",\r\n                    \"objectId\": \"[parameters('aadObjectId')]\",\r\n
+        \                   \"permissions\": {\r\n                      \"keys\":
+        [\r\n                        \"encrypt\",\r\n                        \"decrypt\",\r\n
+        \                       \"wrapKey\",\r\n                        \"unwrapKey\",\r\n
+        \                       \"sign\",\r\n                        \"verify\",\r\n
+        \                       \"get\",\r\n                        \"list\",\r\n
+        \                       \"create\",\r\n                        \"update\",\r\n
+        \                       \"import\",\r\n                        \"delete\",\r\n
+        \                       \"backup\",\r\n                        \"restore\",\r\n
+        \                       \"recover\",\r\n                        \"purge\"\r\n
+        \                     ],\r\n                      \"secrets\": [\r\n                        \"get\",\r\n
+        \                       \"list\",\r\n                        \"set\",\r\n
+        \                       \"delete\",\r\n                        \"backup\",\r\n
+        \                       \"restore\",\r\n                        \"recover\",\r\n
+        \                       \"purge\"\r\n                      ],\r\n                      \"certificates\":
+        [\r\n                        \"get\",\r\n                        \"list\",\r\n
+        \                       \"delete\",\r\n                        \"create\",\r\n
+        \                       \"import\",\r\n                        \"update\",\r\n
+        \                       \"managecontacts\",\r\n                        \"getissuers\",\r\n
+        \                       \"listissuers\",\r\n                        \"setissuers\",\r\n
+        \                       \"deleteissuers\",\r\n                        \"manageissuers\",\r\n
+        \                       \"recover\",\r\n                        \"purge\"\r\n
+        \                     ]\r\n                    }\r\n                  }\r\n
+        \               ],\r\n                \"sku\": {\r\n                  \"name\":
+        \"[parameters('skuName')]\",\r\n                  \"family\": \"A\"\r\n                },\r\n
+        \               \"networkAcls\": {\r\n                  \"defaultAction\":
+        \"Allow\",\r\n                  \"bypass\": \"AzureServices\"\r\n                }\r\n
+        \             }\r\n            }\r\n          ],\r\n          \"outputs\":
+        {}\r\n        },\r\n        \"path\": \"artifacts\\\\createKeyVault.json\",\r\n
+        \       \"kind\": \"template\"\r\n      },\r\n      {\r\n        \"template\":
+        {\r\n          \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n
+        \         \"contentVersion\": \"1.0.0.0\",\r\n          \"parameters\": {\r\n
+        \           \"keyVaultName\": {\r\n              \"type\": \"string\"\r\n
+        \           },\r\n            \"location\": {\r\n              \"type\": \"string\",\r\n
+        \             \"defaultValue\": \"[resourceGroup().location]\"\r\n            },\r\n
+        \           \"skuName\": {\r\n              \"type\": \"string\",\r\n              \"defaultValue\":
+        \"standard\"\r\n            },\r\n            \"tenantId\": {\r\n              \"type\":
+        \"string\",\r\n              \"defaultValue\": \"[subscription().tenantId]\"\r\n
+        \           },\r\n            \"aadObjectId\": {\r\n              \"type\":
+        \"string\",\r\n              \"defaultValue\": \"177f56a0-9e41-4008-a321-d3676aae9c69\"\r\n
+        \           }\r\n          },\r\n          \"variables\": {},\r\n          \"resources\":
+        [\r\n            {\r\n              \"type\": \"Microsoft.Resources/deployments\",\r\n
+        \             \"apiVersion\": \"2019-10-01\",\r\n              \"name\": \"keyVault\",\r\n
+        \             \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n
+        \               \"templateLink\": {\r\n                  \"relativePath\":
+        \"createKeyVault.json\",\r\n                  \"contentVersion\": \"1.0.0.0\"\r\n
+        \               },\r\n                \"parameters\": {\r\n                  \"keyVaultName\":
+        {\r\n                    \"value\": \"[parameters('keyVaultName')]\"\r\n                  },\r\n
+        \                 \"location\": {\r\n                    \"value\": \"[parameters('location')]\"\r\n
+        \                 },\r\n                  \"skuName\": {\r\n                    \"value\":
+        \"[parameters('skuName')]\"\r\n                  },\r\n                  \"tenantId\":
+        {\r\n                    \"value\": \"[parameters('tenantId')]\"\r\n                  },\r\n
+        \                 \"aadObjectId\": {\r\n                    \"value\": \"[parameters('aadObjectId')]\"\r\n
+        \                 }\r\n                }\r\n              }\r\n            },\r\n
+        \           {\r\n              \"type\": \"Microsoft.KeyVault/vaults/secrets\",\r\n
+        \             \"apiVersion\": \"2018-02-14\",\r\n              \"name\": \"[concat(parameters('keyVaultName'),
+        '/mySecret')]\",\r\n              \"location\": \"[parameters('location')]\",\r\n
+        \             \"dependsOn\": [\r\n                \"keyVault\"\r\n              ],\r\n
+        \             \"properties\": {\r\n                \"value\": \"mySecretValue\"\r\n
+        \             }\r\n            }\r\n          ],\r\n          \"outputs\":
+        {}\r\n        },\r\n        \"path\": \"artifacts\\\\createKeyVaultWithSecret.json\",\r\n
+        \       \"kind\": \"template\"\r\n      }\r\n    ],\r\n    \"template\": {\r\n
+        \     \"$schema\": \"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\r\n
+        \     \"contentVersion\": \"1.0.0.0\",\r\n      \"parameters\": {\r\n        \"rgName\":
+        {\r\n          \"type\": \"string\"\r\n        },\r\n        \"rgLocation\":
+        {\r\n          \"type\": \"string\"\r\n        },\r\n        \"keyVaultName\":
+        {\r\n          \"type\": \"string\"\r\n        }\r\n      },\r\n      \"variables\":
+        {},\r\n      \"resources\": [\r\n        {\r\n          \"type\": \"Microsoft.Resources/deployments\",\r\n
+        \         \"apiVersion\": \"2019-10-01\",\r\n          \"name\": \"deploymentRg\",\r\n
+        \         \"location\": \"[parameters('rgLocation')]\",\r\n          \"properties\":
+        {\r\n            \"mode\": \"Incremental\",\r\n            \"templateLink\":
+        {\r\n              \"relativePath\": \"artifacts/createResourceGroup.json\",\r\n
+        \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
+        {\r\n              \"rgName\": {\r\n                \"value\": \"[parameters('rgName')]\"\r\n
+        \             },\r\n              \"rgLocation\": {\r\n                \"value\":
+        \"[parameters('rgLocation')]\"\r\n              }\r\n            }\r\n          }\r\n
+        \       },\r\n        {\r\n          \"type\": \"Microsoft.Resources/deployments\",\r\n
+        \         \"apiVersion\": \"2019-10-01\",\r\n          \"name\": \"keyVaultAndSecret\",\r\n
+        \         \"resourceGroup\": \"[parameters('rgName')]\",\r\n          \"dependsOn\":
+        [\r\n            \"deploymentRg\"\r\n          ],\r\n          \"properties\":
+        {\r\n            \"mode\": \"Incremental\",\r\n            \"templateLink\":
+        {\r\n              \"relativePath\": \"artifacts/createKeyVaultWithSecret.json\",\r\n
+        \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
+        {\r\n              \"keyVaultName\": {\r\n                \"value\": \"[parameters('keyVaultName')]\"\r\n
+        \             }\r\n            }\r\n          }\r\n        }\r\n      ],\r\n
+        \     \"outputs\": {}\r\n    }\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0\",\r\n
+        \ \"type\": \"Microsoft.Resources/templateSpecs/versions\",\r\n  \"name\":
+        \"1.0\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '9362'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Nov 2020 09:21:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ts delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --template-spec --yes
+      User-Agent:
+      - python/3.8.3 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002?api-version=2019-06-01-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Nov 2020 09:21:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14998'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/template_spec_with_multiline_strings.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/template_spec_with_multiline_strings.json
@@ -1,0 +1,274 @@
+{
+    /*
+    comment
+    */
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "customer": {
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 3,
+        "defaultValue": "[resourceGroup().tags['customer-short']]",
+        "metadata": {
+          "description": "A short unique identifer for the customer owning the resource. E.g. 'mc'='Marel Connect', 'io'='Innova'"
+        }
+      },
+      "environment": {
+        "type": "string",
+        "allowedValues": [
+          // Short
+          "dev",
+          "test",
+          "int",
+          "stage",
+          "prod",
+  
+          // Long
+          "development",
+          "testing",
+          "integration",
+          "staging",
+          "production"
+        ],
+        "defaultValue": "[resourceGroup().tags['environment']]",
+        "metadata": {
+          "description": "The environment being deployed to."
+        }
+      },
+      "location": {
+        "type": "string",
+        "allowedValues": [
+          "eastasia",
+          "southeastasia",
+          "centralus",
+          "eastus",
+          "eastus2",
+          "westus",
+          "northcentralus",
+          "southcentralus",
+          "northeurope",
+          "westeurope",
+          "japanwest",
+          "japaneast",
+          "brazilsouth",
+          "australiaeast",
+          "australiasoutheast",
+          "southindia",
+          "centralindia",
+          "westindia",
+          "canadacentral",
+          "canadaeast",
+          "uksouth",
+          "ukwest",
+          "westcentralus",
+          "westus2",
+          "koreacentral",
+          "koreasouth",
+          "francecentral",
+          "francesouth",
+          "australiacentral",
+          "australiacentral2",
+          "southafricanorth",
+          "southafricawest",
+          "global"
+        ],
+        "defaultValue": "[if(contains(resourceGroup().tags, 'location'), resourceGroup().tags['location'], resourceGroup().location)]",
+        "metadata": {
+          "description": "The location of the data center the resorce will be deployed to."
+        }
+      },
+      "group": {
+        "type": "string",
+        "minLength": 3,
+        "maxLength": 12,
+        "defaultValue": "[resourceGroup().tags['group']]",
+        "metadata": {
+          "description": "The group identifier"
+        }
+      },
+      "resource": {
+        "type": "string",
+        "metadata": {
+          "description": "The type of resource the name is being generated for. e.g. 'Microsoft.Storage/storageAccounts'"
+        }
+      },
+     "kind": {
+        "type": "string",
+        "defaultValue": "",
+        "metadata": {
+          "description": "Sometimes a 'kind' needs to be specified. Then this parameter needs to be provided. E.g. resource='Microsoft.Web/sites' kind='functionapp'"
+        }
+      },
+      "instance": {
+        "type": "int",
+        "defaultValue": -1,
+        "metadata": {
+          "description": "If name is for a repeated resource then this should be an integer >= 0"
+        }
+      },
+      "useHyphen": {
+        "type": "bool",
+        "defaultValue": true,
+        "metadata": {
+          "description": "Determines if the name should include hyphens or not. e.g. 'mc-d-euw-data-kv' vs 'mcdeuwdatakv'"
+        }
+      }
+    },
+    "functions": [],
+    "variables": {
+  
+      "environments": {
+        // Short
+        "dev": "d",
+        "test": "t",
+        "int": "i",
+        "stage": "s",
+        "prod": "p",
+  
+        // Long
+        "development": "d",
+        "testing": "t",
+        "integration": "i",
+        "staging": "s",
+        "production": "p"
+      },
+  
+      "locations": {
+        "eastasia": "ase",
+        "southeastasia": "asse",
+        "centralus": "usc",
+        "eastus": "use",
+        "eastus2": "use2",
+        "westus": "usw",
+        "northcentralus": "usnc",
+        "southcentralus": "ussc",
+        "northeurope": "eun",
+        "westeurope": "euw",
+        "japanwest": "jpw",
+        "japaneast": "jpe",
+        "brazilsouth": "brs",
+        "australiaeast": "aue",
+        "australiasoutheast": "ause",
+        "southindia": "ins",
+        "centralindia": "inc",
+        "westindia": "inw",
+        "canadacentral": "cac",
+        "canadaeast": "cae",
+        "uksouth": "uks",
+        "ukwest": "ukw",
+        "westcentralus": "uswe",
+        "westus2": "usw2",
+        "koreacentral": "krc",
+        "koreasouth": "krs",
+        "francecentral": "frc",
+        "francesouth": "frs",
+        "australiacentral": "auc",
+        "australiacentral2": "auc2",
+        "southafricanorth": "zan",
+        "southafricawest": "zaw",
+        "global": "global"
+      },
+  
+      /* 
+      comment.
+      comment.
+      comment.
+      */ 
+      "resources": {
+        "Microsoft.Web": {
+          "publishingUsers": null,
+          "ishostnameavailable": null,
+          "validate": null,
+          "isusernameavailable": null,
+          "sourceControls": null,
+          "availableStacks": null,
+          "staticSites": null,
+          "listSitesAssignedToHostName": null,
+          "locations/getNetworkPolicies": null,
+          "locations/operations": null,
+          "locations/operationResults": null,
+          "sites/networkConfig": null,
+          "sites/slots/networkConfig": null,
+          "sites/hostNameBindings": null,
+          "sites/slots/hostNameBindings": null,
+          "operations": null,
+          "certificates": null,
+          "serverFarms": "asp",
+          "sites": {
+            // comment
+            "api": "appsvc",
+            "app": "appui",
+            "functionapp": "fa"
+          },
+          "sites/slots": null,
+          "runtimes": null,
+          "recommendations": null,
+          "resourceHealthMetadata": null,
+          "georegions": null,
+          "sites/premieraddons": null,
+          "hostingEnvironments": null,
+          "hostingEnvironments/multiRolePools": null,
+          "hostingEnvironments/workerPools": null,
+          "kubeEnvironments": null,
+          "deploymentLocations": null,
+          "deletedSites": null,
+          "locations/deletedSites": null,
+          "ishostingenvironmentnameavailable": null,
+          "locations/deleteVirtualNetworkOrSubnets": null,
+          "connections": null,
+          "customApis": null,
+          "locations": null,
+          "locations/listWsdlInterfaces": null,
+          "locations/extractApiDefinitionFromWsdl": null,
+          "locations/managedApis": null,
+          "locations/runtimes": null,
+          "locations/apiOperations": null,
+          "connectionGateways": null,
+          "locations/connectionGatewayInstallations": null,
+          "checkNameAvailability": null,
+          "billingMeters": null,
+          "verifyHostingEnvironmentVnet": null,
+          "serverFarms/eventGridFilters": null,
+          "sites/eventGridFilters": null,
+          "sites/slots/eventGridFilters": null,
+          "hostingEnvironments/eventGridFilters": null,
+          "serverFarms/firstPartyApps": null,
+          "serverFarms/firstPartyApps/keyVaultSettings": null
+        }
+      },
+  
+      "provider": "[split(parameters('resource'), '/')[0]]",
+  
+      "resourceType": "[replace(parameters('resource'), concat(variables('provider'), '/'), '')]",
+  
+      "hyphenedName": "[format('[0]-[1]-[2]-[3]-[4]-[5]',
+                               parameters('customer'),
+                               variables('environments')[parameters('environment')],
+                               variables('locations')[parameters('location')],
+                               parameters('group'),
+                               parameters('service'),
+                               if(equals(parameters('kind'), ''), 
+                                  variables('resources')[variables('provider')][variables('resourceType')],
+                                  variables('resources')[variables('provider')][variables('resourceType')][parameters('kind')]))]",
+  
+      "removeOptionalsFromHyphenedName": "[replace(variables('hyphenedName'), '--', '-')]",
+  
+      "isInstanceCount": "[greater(parameters('instance'), -1)]",
+      "hyphenedNameAfterInstanceCount": "[if(variables('isInstanceCount'),
+                                             format('[0]-[1]', variables('removeOptionalsFromHyphenedName'), string(parameters('instance'))),
+                                             variables('removeOptionalsFromHyphenedName'))]",
+  
+      "name": "[if(parameters('useHyphen'),
+                   variables('hyphenedNameAfterInstanceCount'),
+                   replace(variables('hyphenedNameAfterInstanceCount'), '-', ''))]"
+    },
+    "resources": [
+    ],
+    "outputs": {
+      "name": {
+        "type": "string",
+        "value": "[toLower(variables('name'))]"
+      }
+    }
+  }


### PR DESCRIPTION
Description

Customer reported template specs issue (Azure/template-specs#37) where the contents of multiline strings were replaced with #Azure CLI#. This was the result of the _remove_comments_from_json function used to process the template input. This function is typically used in deployments for processing template inputs; multiline strings are processed to prompt for parameters. The full functionality is not needed for creating a template spec from a template input therefore the function has been replaced by process_template_spec in _packing_engine.py.

Example:

Template Input:
{
"variables": {
"myVar": "[if(equals(parameters('kind'), ''),
variables('resources')[variables('provider')][variables('resourceType')],
variables('resources')[variables('provider')][variables('resourceType')][parameters('kind')]))]"
}
}

Template Specs Created:
{
"variables": {
"myVar": "#Azure Cli#"
}
}

Testing Guide
az ts create -g resource_group --name Issue37 -v 1.0 -l westus --template-file original.json

--> Multiline strings starting on lines 2644, 2657, and 2661 should not be replaced by "#Azure CLI#"

-->Can compare template spec created with postTsCreation.json (showcases issue).
[Issue37Templates.zip](https://github.com/Azure/azure-cli/files/5476485/Issue37Templates.zip)
