### PR TITLE
[AppService] az webapp config ssl sync: Add command to sync imported KV certificate on webapp. 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -340,7 +340,15 @@ type: command
 short-summary: Create a Managed Certificate for a hostname in a function app.
 examples:
   - name: Create a Managed Certificate for $fqdn.
-    text: az functionapp config ssl create --resource-group MyResourceGroup --name MyWebapp --hostname $fqdn
+    text: az functionapp config ssl create --resource-group MyResourceGroup --name MyFunctionApp --hostname $fqdn
+"""
+
+helps['functionapp config ssl sync'] = """
+type: command
+short-summary: Sync a KV imported certificate on a function app with its object in KV.
+examples:
+  - name: Sync a certificate with the its KV object.
+    text: az functionapp config ssl sync --resource-group MyResourceGroup --name MyFunctionApp --certificate-name MyCertificateName --key-vault MyKeyVault
 """
 
 helps['functionapp cors'] = """
@@ -1312,6 +1320,14 @@ short-summary: Create a Managed Certificate for a hostname in a webapp app.
 examples:
   - name: Create a Managed Certificate for $fqdn.
     text: az webapp config ssl create --resource-group MyResourceGroup --name MyWebapp --hostname $fqdn
+"""
+
+helps['webapp config ssl sync'] = """
+type: command
+short-summary: Sync a KV imported certificate on a webapp with its object in KV.
+examples:
+  - name: Sync a certificate with the its KV object.
+    text: az webapp config ssl sync --resource-group MyResourceGroup --name MyWebapp --certificate-name MyCertificateName --key-vault MyKeyVault
 """
 
 helps['webapp config storage-account'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -345,9 +345,9 @@ examples:
 
 helps['functionapp config ssl sync'] = """
 type: command
-short-summary: Sync a KV imported certificate on a function app with its object in KV.
+short-summary: Sync an imported certificate on a function app with its object in KV.
 examples:
-  - name: Sync a certificate with the its KV object.
+  - name: Sync a certificate with its KV object.
     text: az functionapp config ssl sync --resource-group MyResourceGroup --name MyFunctionApp --certificate-name MyCertificateName --key-vault MyKeyVault
 """
 
@@ -1324,9 +1324,9 @@ examples:
 
 helps['webapp config ssl sync'] = """
 type: command
-short-summary: Sync a KV imported certificate on a webapp with its object in KV.
+short-summary: Sync an imported certificate on a webapp with its object in KV.
 examples:
-  - name: Sync a certificate with the its KV object.
+  - name: Sync a certificate with the KV object.
     text: az webapp config ssl sync --resource-group MyResourceGroup --name MyWebapp --certificate-name MyCertificateName --key-vault MyKeyVault
 """
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -181,7 +181,7 @@ def load_command_table(self, _):
         g.custom_command('import', 'import_ssl_cert', exception_handler=ex_handler_factory())
         g.custom_command('create', 'create_managed_ssl_cert', exception_handler=ex_handler_factory(), is_preview=True)
         g.custom_command('sync', 'sync_kv_cert', exception_handler=ex_handler_factory())
-        
+
     with self.command_group('webapp config backup') as g:
         g.custom_command('list', 'list_backups')
         g.custom_show_command('show', 'show_backup_configuration')

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -180,7 +180,8 @@ def load_command_table(self, _):
         g.custom_command('delete', 'delete_ssl_cert', exception_handler=ex_handler_factory())
         g.custom_command('import', 'import_ssl_cert', exception_handler=ex_handler_factory())
         g.custom_command('create', 'create_managed_ssl_cert', exception_handler=ex_handler_factory(), is_preview=True)
-
+        g.custom_command('sync', 'sync_kv_cert', exception_handler=ex_handler_factory())
+        
     with self.command_group('webapp config backup') as g:
         g.custom_command('list', 'list_backups')
         g.custom_show_command('show', 'show_backup_configuration')

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2428,6 +2428,15 @@ def import_ssl_cert(cmd, resource_group_name, name, key_vault, key_vault_certifi
     return client.certificates.create_or_update(name=cert_name, resource_group_name=resource_group_name,
                                                 certificate_envelope=kv_cert_def)
 
+def sync_kv_cert(cmd, resource_group_name, name, key_vault, key_vault_certificate_name):
+    Certificate = cmd.get_models('Certificate')
+    client = web_client_factory(cmd.cli_ctx)
+    webapp = client.web_apps.get(resource_group_name, name)
+    if not webapp:
+        raise CLIError("'{}' app doesn't exist in resource group {}".format(name, resource_group_name))
+    server_farm_id = webapp.server_farm_id
+    location = webapp.location
+
 
 def create_managed_ssl_cert(cmd, resource_group_name, name, hostname, slot=None):
     Certificate = cmd.get_models('Certificate')

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2428,7 +2428,7 @@ def import_ssl_cert(cmd, resource_group_name, name, key_vault, key_vault_certifi
     return client.certificates.create_or_update(name=cert_name, resource_group_name=resource_group_name,
                                                 certificate_envelope=kv_cert_def)
 
-def sync_kv_cert(cmd, resource_group_name, name, key_vault, key_vault_certificate_name):
+def sync_kv_cert(cmd, resource_group_name, name, certificate_name):
     Certificate = cmd.get_models('Certificate')
     client = web_client_factory(cmd.cli_ctx)
     webapp = client.web_apps.get(resource_group_name, name)
@@ -2436,6 +2436,47 @@ def sync_kv_cert(cmd, resource_group_name, name, key_vault, key_vault_certificat
         raise CLIError("'{}' app doesn't exist in resource group {}".format(name, resource_group_name))
     server_farm_id = webapp.server_farm_id
     location = webapp.location
+
+    cert = client.certificates.get(resource_group_name, certificate_name)
+    
+    print(cert)
+    kv_id = None
+    if not is_valid_resource_id(key_vault):
+        kv_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_KEYVAULT)
+        key_vaults = kv_client.vaults.list_by_subscription()
+        for kv in key_vaults:
+            if key_vault == kv.name:
+                kv_id = kv.id
+                break
+    else:
+        kv_id = key_vault
+
+    if kv_id is None:
+        kv_msg = 'The Key Vault {0} was not found in the subscription in context. ' \
+                 'If your Key Vault is in a different subscription, please specify the full Resource ID: ' \
+                 '\naz .. ssl import -n {1} -g {2} --key-vault-certificate-name {3} ' \
+                 '--key-vault /subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/' \
+                 'vaults/{0}'.format(key_vault, name, resource_group_name, key_vault_certificate_name)
+        logger.warning(kv_msg)
+        return
+
+    kv_id_parts = parse_resource_id(kv_id)
+    kv_name = kv_id_parts['name']
+    kv_resource_group_name = kv_id_parts['resource_group']
+    kv_subscription = kv_id_parts['subscription']
+    cert_name = '{}-{}-{}'.format(resource_group_name, kv_name, key_vault_certificate_name)
+    lnk = 'https://azure.github.io/AppService/2016/05/24/Deploying-Azure-Web-App-Certificate-through-Key-Vault.html'
+    lnk_msg = 'Find more details here: {}'.format(lnk)
+    if not _check_service_principal_permissions(cmd, kv_resource_group_name, kv_name, kv_subscription):
+        logger.warning('Unable to verify Key Vault permissions.')
+        logger.warning('You may need to grant Microsoft.Azure.WebSites service principal the Secret:Get permission')
+        logger.warning(lnk_msg)
+
+    kv_cert_def = Certificate(location=location, key_vault_id=kv_id, password='',
+                              key_vault_secret_name=key_vault_certificate_name, server_farm_id=server_farm_id)
+
+    return client.certificates.create_or_update(name=cert_name, resource_group_name=resource_group_name,
+                                                certificate_envelope=kv_cert_def)
 
 
 def create_managed_ssl_cert(cmd, resource_group_name, name, hostname, slot=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -40,6 +40,7 @@ from azure.mgmt.web.models import KeyInfo, DefaultErrorResponseException
 from azure.cli.command_modules.relay._client_factory import hycos_mgmt_client_factory, namespaces_mgmt_client_factory
 from azure.cli.command_modules.network._client_factory import network_client_factory
 
+from azure.cli.core.azclierror import ResourceNotFoundError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.util import in_cloud_console, shell_safe_json_parse, open_page_in_browser, get_json_object, \
@@ -2434,22 +2435,23 @@ def sync_kv_cert(cmd, resource_group_name, name, certificate_name, key_vault):
     client = web_client_factory(cmd.cli_ctx)
     webapp = client.web_apps.get(resource_group_name, name)
     if not webapp:
-        raise CLIError("'{}' app doesn't exist in resource group {}".format(name, resource_group_name))
+        err_msg = "'{}' app doesn't exist in resource group {}".format(name, resource_group_name)
+        raise ResourceNotFoundError(err_msg)
     server_farm_id = webapp.server_farm_id
     location = webapp.location
 
     cert = client.certificates.get(resource_group_name, certificate_name, filter=f"ServerFarmId eq {'server_farm_id'}")
 
     if cert is None:
-        no_cert_msg = "A cert with this name is not assocaited with this site"
+        no_cert_msg = "Cert with name {} is not associated with this site".format(certificate_name)
         logger.warning(no_cert_msg)
         return
     if cert.key_vault_id is None:
-        no_kv_msg = 'In order to sycn a cert, it must be associated with a kv'
+        no_kv_msg = 'In order to sync a cert, it must be associated with a key vault'
         logger.warning(no_kv_msg)
         return
     if key_vault != cert.key_vault_id:
-        kv_not_match = "Key Vault id does not match kv assocaited with cert"
+        kv_not_match = "Key Vault id does not match the key vault associated with this cert"
         logger.warning(kv_not_match)
         return
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -40,7 +40,6 @@ from azure.mgmt.web.models import KeyInfo, DefaultErrorResponseException
 from azure.cli.command_modules.relay._client_factory import hycos_mgmt_client_factory, namespaces_mgmt_client_factory
 from azure.cli.command_modules.network._client_factory import network_client_factory
 
-from azure.cli.core.azclierror import ResourceNotFoundError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.util import in_cloud_console, shell_safe_json_parse, open_page_in_browser, get_json_object, \


### PR DESCRIPTION
**Description<!--Mandatory-->**  
This PR is adding a command to az webapp config ssl that allows customer to sync an imported KV cert. It effectively makes a create call, and updates the certificate in the app service database with whatever is in the KV. 
**Testing Guide**  
<!--Example commands with explanations.-->
az webapp config ssl sync --resource-group testWestEurope --name SofiTestWestEurope --certificate-name testWestEurope-keyvaultSofiTest-test2048 --key-vault testKV

This certificate, if it is already added to that webapp, will be synced with whatever is in KV. If there is a new cert in KV, we will update the version in our system. 

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
