### PR TITLE
{Core} Support file name check when using prefix `@` in parameters

### DIFF
--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -194,7 +194,13 @@ class ManualInterrupt(UserFault):
     pass
 
 
-# Unknow error type
+# File not found error type
+class FileNotFoundError(UserFault):
+    """ File not found. """
+    pass
+
+
+# Unknown error type
 class UnknownError(UserFault):
     """ Reserved for the errors which can not be categorized into the error types above.
     Usually for the very general error type like CLIError, AzureError.

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -20,6 +20,7 @@ from importlib import import_module
 import six
 
 # pylint: disable=unused-import
+from azure.cli.core.azclierror import FileNotFoundError
 from azure.cli.core.commands.constants import (
     BLOCKED_MODS, DEFAULT_QUERY_TIME_RANGE, CLI_COMMON_KWARGS, CLI_COMMAND_KWARGS, CLI_PARAM_KWARGS,
     CLI_POSITIONAL_PARAM_KWARGS, CONFIRM_PARAM_NAME)
@@ -80,7 +81,12 @@ def _expand_file_prefixed_files(args):
         if path == '-':
             content = sys.stdin.read()
         else:
-            content = read_file_content(os.path.expanduser(path), allow_binary=True)
+            path = os.path.expanduser(path)
+            if not os.path.exists(path):
+                raise FileNotFoundError('File "{}" does not exist.'.format(path))
+            if not os.path.isfile(path):
+                raise FileNotFoundError('"{}" is not a file.')
+            content = read_file_content(path, allow_binary=True)
 
         return content.rstrip(os.linesep)
 


### PR DESCRIPTION
Background:

There are lots of usages of `get_json_object` in the CLI code base, eg:

```python
c.argument('release_policy', options_list=['--policy'],
                       help='The policy rules under which the key can be exported encoded with JSON. '
                            'Use @{file} to load from a file(e.g. @my_policy.json).',
                       type=get_json_object, is_preview=True)
```

Users can use something like `--policy @"C:\path\file.json"` to specify a file name. If the file name does not exist, CLI will treat the input string as JSON content, and then throw a parser error like this:
![image](https://user-images.githubusercontent.com/3250203/97959860-347c1800-1deb-11eb-8568-9c5bd1fca9c5.png)

After the refinement, it will be more actionable:
![image](https://user-images.githubusercontent.com/3250203/97959905-4a89d880-1deb-11eb-85af-d0ad73f324e4.png)

Also added an error type `FileNotFoudError` which inherits from `UserFault`, synced offline with @houk-ms 


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
