### PR TITLE
[AKS] az aks use-dev-spaces: Indicate that dev-spaces commands are deprecated

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -762,7 +762,7 @@ parameters:
 
 helps['aks remove-dev-spaces'] = """
 type: command
-short-summary: (Deprecated) Remove Azure Dev Spaces from a managed Kubernetes cluster.
+short-summary: (DEPRECATED) Remove Azure Dev Spaces from a managed Kubernetes cluster.
 examples:
   - name: Remove Azure Dev Spaces from a managed Kubernetes cluster.
     text: |-
@@ -854,7 +854,7 @@ examples:
 
 helps['aks use-dev-spaces'] = """
 type: command
-short-summary: (Deprecated) Use Azure Dev Spaces with a managed Kubernetes cluster.
+short-summary: (DEPRECATED) Use Azure Dev Spaces with a managed Kubernetes cluster.
 parameters:
   - name: --update
     type: bool

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -762,7 +762,7 @@ parameters:
 
 helps['aks remove-dev-spaces'] = """
 type: command
-short-summary: (DEPRECATED) Remove Azure Dev Spaces from a managed Kubernetes cluster.
+short-summary: Remove Azure Dev Spaces from a managed Kubernetes cluster.
 examples:
   - name: Remove Azure Dev Spaces from a managed Kubernetes cluster.
     text: |-
@@ -854,7 +854,7 @@ examples:
 
 helps['aks use-dev-spaces'] = """
 type: command
-short-summary: (DEPRECATED) Use Azure Dev Spaces with a managed Kubernetes cluster.
+short-summary: Use Azure Dev Spaces with a managed Kubernetes cluster.
 parameters:
   - name: --update
     type: bool

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -762,7 +762,7 @@ parameters:
 
 helps['aks remove-dev-spaces'] = """
 type: command
-short-summary: Remove Azure Dev Spaces from a managed Kubernetes cluster.
+short-summary: (Deprecated) Remove Azure Dev Spaces from a managed Kubernetes cluster.
 examples:
   - name: Remove Azure Dev Spaces from a managed Kubernetes cluster.
     text: |-
@@ -854,7 +854,7 @@ examples:
 
 helps['aks use-dev-spaces'] = """
 type: command
-short-summary: Use Azure Dev Spaces with a managed Kubernetes cluster.
+short-summary: (Deprecated) Use Azure Dev Spaces with a managed Kubernetes cluster.
 parameters:
   - name: --update
     type: bool

--- a/src/azure-cli/azure/cli/command_modules/acs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/commands.py
@@ -87,12 +87,12 @@ def load_command_table(self, _):
         g.command('get-upgrades', 'get_upgrade_profile', table_transformer=aks_upgrades_table_format)
         g.custom_command('install-cli', 'k8s_install_cli', client_factory=None)
         g.custom_command('list', 'aks_list', table_transformer=aks_list_table_format)
-        g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces', 
+        g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces',
                          deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
         g.custom_command('scale', 'aks_scale', supports_no_wait=True)
         g.custom_show_command('show', 'aks_show', table_transformer=aks_show_table_format)
         g.custom_command('upgrade', 'aks_upgrade', supports_no_wait=True)
-        g.custom_command('use-dev-spaces', 'aks_use_dev_spaces', 
+        g.custom_command('use-dev-spaces', 'aks_use_dev_spaces',
                          deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
         g.custom_command('rotate-certs', 'aks_rotate_certs', supports_no_wait=True,
                          confirmation='Kubernetes will be unavailable during certificate rotation process.\n' +

--- a/src/azure-cli/azure/cli/command_modules/acs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/commands.py
@@ -87,13 +87,11 @@ def load_command_table(self, _):
         g.command('get-upgrades', 'get_upgrade_profile', table_transformer=aks_upgrades_table_format)
         g.custom_command('install-cli', 'k8s_install_cli', client_factory=None)
         g.custom_command('list', 'aks_list', table_transformer=aks_list_table_format)
-        g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces',
-                         deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
+        g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces', deprecate_info=g.deprecate())
         g.custom_command('scale', 'aks_scale', supports_no_wait=True)
         g.custom_show_command('show', 'aks_show', table_transformer=aks_show_table_format)
         g.custom_command('upgrade', 'aks_upgrade', supports_no_wait=True)
-        g.custom_command('use-dev-spaces', 'aks_use_dev_spaces',
-                         deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
+        g.custom_command('use-dev-spaces', 'aks_use_dev_spaces', deprecate_info=g.deprecate())
         g.custom_command('rotate-certs', 'aks_rotate_certs', supports_no_wait=True,
                          confirmation='Kubernetes will be unavailable during certificate rotation process.\n' +
                          'Are you sure you want to perform this operation?')

--- a/src/azure-cli/azure/cli/command_modules/acs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/commands.py
@@ -87,11 +87,13 @@ def load_command_table(self, _):
         g.command('get-upgrades', 'get_upgrade_profile', table_transformer=aks_upgrades_table_format)
         g.custom_command('install-cli', 'k8s_install_cli', client_factory=None)
         g.custom_command('list', 'aks_list', table_transformer=aks_list_table_format)
-        g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces', deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
+        g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces', 
+                         cd deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
         g.custom_command('scale', 'aks_scale', supports_no_wait=True)
         g.custom_show_command('show', 'aks_show', table_transformer=aks_show_table_format)
         g.custom_command('upgrade', 'aks_upgrade', supports_no_wait=True)
-        g.custom_command('use-dev-spaces', 'aks_use_dev_spaces', deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
+        g.custom_command('use-dev-spaces', 'aks_use_dev_spaces', 
+                         deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
         g.custom_command('rotate-certs', 'aks_rotate_certs', supports_no_wait=True,
                          confirmation='Kubernetes will be unavailable during certificate rotation process.\n' +
                          'Are you sure you want to perform this operation?')

--- a/src/azure-cli/azure/cli/command_modules/acs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/commands.py
@@ -88,7 +88,7 @@ def load_command_table(self, _):
         g.custom_command('install-cli', 'k8s_install_cli', client_factory=None)
         g.custom_command('list', 'aks_list', table_transformer=aks_list_table_format)
         g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces', 
-                         cd deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
+                         deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
         g.custom_command('scale', 'aks_scale', supports_no_wait=True)
         g.custom_show_command('show', 'aks_show', table_transformer=aks_show_table_format)
         g.custom_command('upgrade', 'aks_upgrade', supports_no_wait=True)

--- a/src/azure-cli/azure/cli/command_modules/acs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/commands.py
@@ -87,11 +87,11 @@ def load_command_table(self, _):
         g.command('get-upgrades', 'get_upgrade_profile', table_transformer=aks_upgrades_table_format)
         g.custom_command('install-cli', 'k8s_install_cli', client_factory=None)
         g.custom_command('list', 'aks_list', table_transformer=aks_list_table_format)
-        g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces')
+        g.custom_command('remove-dev-spaces', 'aks_remove_dev_spaces', deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
         g.custom_command('scale', 'aks_scale', supports_no_wait=True)
         g.custom_show_command('show', 'aks_show', table_transformer=aks_show_table_format)
         g.custom_command('upgrade', 'aks_upgrade', supports_no_wait=True)
-        g.custom_command('use-dev-spaces', 'aks_use_dev_spaces')
+        g.custom_command('use-dev-spaces', 'aks_use_dev_spaces', deprecate_info=g.deprecate(redirect='Bridge To Kubernetes'))
         g.custom_command('rotate-certs', 'aks_rotate_certs', supports_no_wait=True,
                          confirmation='Kubernetes will be unavailable during certificate rotation process.\n' +
                          'Are you sure you want to perform this operation?')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
The dev-spaces CLI extension, which gets called by the aks submodule, has been deprecated. This change is to indicate this using the help text. 


**Testing Guide**  
The change can be validated with: `az aks --help`

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[aks submodule]: Deprecate dev-spaces commands

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
