### PR TITLE
{Core} Refactor client factory for Track 2 SDK

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -114,7 +114,7 @@ def _prepare_client_kwargs_track2(cli_ctx):
     """Prepare kwargs for Track 2 SDK client."""
     client_kwargs = {}
 
-    # Change SSL verification behavior
+    # Prepare connection_verify to change SSL verification behavior, used by ConnectionConfiguration
     client_kwargs.update(_debug.change_ssl_cert_verification_track2())
 
     # Enable NetworkTraceLoggingPolicy which logs all headers (except Authorization) without being redacted
@@ -124,6 +124,7 @@ def _prepare_client_kwargs_track2(cli_ctx):
     from azure.core.pipeline.policies import SansIOHTTPPolicy
     client_kwargs['http_logging_policy'] = SansIOHTTPPolicy()
 
+    # Prepare User-Agent header, used by UserAgentPolicy
     client_kwargs['user_agent'] = get_az_user_agent()
 
     try:
@@ -133,13 +134,20 @@ def _prepare_client_kwargs_track2(cli_ctx):
     except KeyError:
         pass
 
+    # Prepare custom headers, used by HeadersPolicy
     headers = dict(cli_ctx.data['headers'])
+
+    # - Prepare CommandName header
     command_name_suffix = ';completer-request' if cli_ctx.data['completer_active'] else ''
     headers['CommandName'] = "{}{}".format(cli_ctx.data['command'], command_name_suffix)
+
+    # - Prepare ParameterSetName header
     if cli_ctx.data.get('safe_params'):
         headers['ParameterSetName'] = ' '.join(cli_ctx.data['safe_params'])
+
     client_kwargs['headers'] = headers
 
+    # Prepare x-ms-client-request-id header, used by RequestIdPolicy
     if 'x-ms-client-request-id' in cli_ctx.data['headers']:
         client_kwargs['request_id'] = cli_ctx.data['headers']['x-ms-client-request-id']
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
- Rename `configure_common_settings_track2` to `_prepare_client_kwargs_track2`
  - Add a leading underscore (`_`), because it is a private function which is only used by `_get_mgmt_service_client`
  - In Track 1 SDK, `config` is a public member of the client and can be configured later:
    https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-resource_10.2.0/sdk/resources/azure-mgmt-resource/azure/mgmt/resource/subscriptions/v2019_11_01/_subscription_client.py#L45
    ```py
    self.config = SubscriptionClientConfiguration(credentials, base_url)
    ```
    In Track 2 SDK, `_config` is a private member, so configuration should be done via `kwargs` during `__init__` of the client:
    
    https://github.com/Azure/azure-sdk-for-python/blob/azure-mgmt-resource_15.0.0/sdk/resources/azure-mgmt-resource/azure/mgmt/resource/subscriptions/v2019_11_01/_subscription_client.py#L51
    ```py
    self._config = SubscriptionClientConfiguration(credential, **kwargs)
    ```
    Replace the name to better reflect the functionality of the function.

- Disable `INFO` log from Track 2 SDK for now until it is included in the `--verbose` log of Azure CLI (#15676).