### PR TITLE
{Core} az login: Remove the extra linebreak from warning message

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -1283,7 +1283,7 @@ def _get_authorization_code_worker(authority_url, resource, results):
 
     # Emit a warning to inform that a browser is opened.
     # Only show the path part of the URL and hide the query string.
-    logger.warning("The default web browser has been opened at %s. Please continue the login in the web browser.\n"
+    logger.warning("The default web browser has been opened at %s. Please continue the login in the web browser. "
                    "If no web browser is available or if the web browser fails to open, use device code flow "
                    "with `az login --use-device-code`.", url.split('?')[0])
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Refine #14505. Remove the extra linebreak from warning message

Before:
```
The default web browser has been opened at https://login.microsoftonline.com/common/oauth2/authorize. Please continue 
the login in the web browser. 
If no web browser is available or if the web browser fails to open, use device code flow with `az login --use-device-
code`.
```

After
```
The default web browser has been opened at https://login.microsoftonline.com/common/oauth2/authorize. Please continue 
the login in the web browser. If no web browser is available or if the web browser fails to open, use device code flow 
with `az login --use-device-code`.
```
