### PR TITLE
{Core} Remove useless codes in core for ai-did-you-mean-this

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -68,12 +68,6 @@ class AzCompletionFinder(argcomplete.CompletionFinder):
 class AzCliCommandParser(CLICommandParser):
     """ArgumentParser implementation specialized for the Azure CLI utility."""
 
-    @staticmethod
-    def recommendation_provider(version, command, parameters, extension):  # pylint: disable=unused-argument
-        logger.debug("recommendation_provider: version: %s, command: %s, parameters: %s, extension: %s",
-                     version, command, parameters, extension)
-        return []
-
     def __init__(self, cli_ctx=None, cli_help=None, **kwargs):
         self.command_source = kwargs.pop('_command_source', None)
         self._raw_arguments = None

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -374,6 +374,7 @@ class AzCliCommandParser(CLICommandParser):
             # use cli_ctx from cli_help which is not lost.
             cli_ctx = self.cli_ctx or (self.cli_help.cli_ctx if self.cli_help else None)
 
+            caused_by_extension_not_installed = False
             command_name_inferred = self.prog
             error_msg = None
             if not self.command_source:
@@ -392,6 +393,7 @@ class AzCliCommandParser(CLICommandParser):
                     command_str = roughly_parse_command(cmd_list[1:])
                     ext_name = self._search_in_extension_commands(command_str)
                     if ext_name:
+                        caused_by_extension_not_installed = True
                         telemetry.set_command_details(command_str,
                                                       parameters=AzCliCommandInvoker._extract_parameter_names(cmd_list),  # pylint: disable=protected-access
                                                       extension_name=ext_name)
@@ -470,7 +472,8 @@ class AzCliCommandParser(CLICommandParser):
 
             az_error.set_recommendation(OVERVIEW_REFERENCE.format(command=self.prog))
 
-            az_error.print_error()
-            az_error.send_telemetry()
+            if not caused_by_extension_not_installed:
+                az_error.print_error()
+                az_error.send_telemetry()
 
             self.exit(2)

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -266,63 +266,6 @@ class TestParser(unittest.TestCase):
                 parser.parse_args('test new-ext reset pos1 pos2'.split())  # test positional args
             self.assertIn("Extension another-ext-name installed. Please rerun your command.", logger_msgs[6])
 
-    @mock.patch('importlib.import_module', _mock_import_lib)
-    @mock.patch('pkgutil.iter_modules', _mock_iter_modules)
-    @mock.patch('azure.cli.core.commands._load_command_loader', _mock_load_command_loader)
-    @mock.patch('azure.cli.core.extension.get_extension_modname', _mock_extension_modname)
-    @mock.patch('azure.cli.core.extension.get_extensions', _mock_get_extensions)
-    def test_parser_failure_recovery_recommendations(self):
-        cli = DummyCli()
-        main_loader = MainCommandsLoader(cli)
-        cli.loader = main_loader
-
-        cli.loader.load_command_table(None)
-
-        parser = cli.parser_cls(cli)
-        parser.load_command_table(cli.loader)
-
-        recommendation_provider_parameters = []
-
-        version = cli.get_cli_version()
-        expected_recommendation_provider_parameters = [
-            # version, command, parameters, extension
-            ExpectedParameters(version, 'test module1', ['--opt'], False),
-            ExpectedParameters(version, 'test extension1', ['--opt'], False),
-            ExpectedParameters(version, 'foo_bar', ['--opt'], False),
-            ExpectedParameters(version, 'test module', ['--opt'], False),
-            ExpectedParameters(version, 'test extension', ['--opt'], True)
-        ]
-
-        def mock_recommendation_provider(*args):
-            recommendation_provider_parameters.append(tuple(args))
-            return []
-
-        AzCliCommandParser.recommendation_provider = mock_recommendation_provider
-
-        faulty_cmd_args = [
-            'test module1 --opt enum_1',
-            'test extension1 --opt enum_1',
-            'test foo_bar --opt enum_3',
-            'test module --opt enum_3',
-            'test extension --opt enum_3'
-        ]
-
-        for text in faulty_cmd_args:
-            with self.assertRaises(SystemExit):
-                parser.parse_args(text.split())
-
-        for i, parameters in enumerate(recommendation_provider_parameters):
-            version, command, parameters, extension = parameters
-            expected = expected_recommendation_provider_parameters[i]
-            self.assertEqual(expected.version, version)
-            self.assertIn(expected.command, command)
-            self.assertEqual(expected.parameters, parameters)
-
-            if expected.has_extension:
-                self.assertIsNotNone(extension)
-            else:
-                self.assertIsNone(extension)
-
 
 class VerifyError(object):  # pylint: disable=too-few-public-methods
 
@@ -335,9 +278,6 @@ class VerifyError(object):  # pylint: disable=too-few-public-methods
         if self.substr:
             self.test.assertTrue(message.find(self.substr) >= 0)
         self.called = True
-
-
-ExpectedParameters = namedtuple('ExpectedParameters', ['version', 'command', 'parameters', 'has_extension'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR removes the useless codes in core for ai-did-you-mean-this, as the extension was already retired.

- ai-did-you-mean-this is retired: https://github.com/Azure/azure-cli-extensions/pull/2402
- azext_ai_did_you_mean_this is removed from core #15500 