### PR TITLE
[AKS] Add custom download url support for 'az aks install-cli'

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -254,7 +254,7 @@ def load_arguments(self, _):
         with self.argument_context('{} install-cli'.format(scope)) as c:
             c.argument('client_version', validator=validate_kubectl_version, help='Version of kubectl to install.')
             c.argument('install_location', default=_get_default_install_location('kubectl'), help='Path at which to install kubectl.')
-            c.argument('base_download_source_url', help='Base download source URL for kubectl releases.')
+            c.argument('base_download_source_url',  options_list=['--node-vm-size', '-s'], help='Base download source URL for kubectl releases.')
             c.argument('kubelogin_version', validator=validate_kubelogin_version, help='Version of kubelogin to install.')
             c.argument('kubelogin_install_location', default=_get_default_install_location('kubelogin'), help='Path at which to install kubelogin.')
             c.argument('kubelogin_base_download_source_url', help='Base download source URL for kubelogin releases.')

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -254,10 +254,10 @@ def load_arguments(self, _):
         with self.argument_context('{} install-cli'.format(scope)) as c:
             c.argument('client_version', validator=validate_kubectl_version, help='Version of kubectl to install.')
             c.argument('install_location', default=_get_default_install_location('kubectl'), help='Path at which to install kubectl.')
-            c.argument('base_download_source_url',  options_list=['--node-vm-size', '-s'], help='Base download source URL for kubectl releases.')
+            c.argument('base_src_url', help='Base download source URL for kubectl releases.')
             c.argument('kubelogin_version', validator=validate_kubelogin_version, help='Version of kubelogin to install.')
             c.argument('kubelogin_install_location', default=_get_default_install_location('kubelogin'), help='Path at which to install kubelogin.')
-            c.argument('kubelogin_base_download_source_url', help='Base download source URL for kubelogin releases.')
+            c.argument('kubelogin_base_src_url', options_list=['--kubelogin-base-src-url', '-l'], help='Base download source URL for kubelogin releases.')
 
     with self.argument_context('aks update-credentials', arg_group='Service Principal') as c:
         c.argument('reset_service_principal', action='store_true')

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -254,8 +254,10 @@ def load_arguments(self, _):
         with self.argument_context('{} install-cli'.format(scope)) as c:
             c.argument('client_version', validator=validate_kubectl_version, help='Version of kubectl to install.')
             c.argument('install_location', default=_get_default_install_location('kubectl'), help='Path at which to install kubectl.')
+            c.argument('base_download_source_url', help='Base download source URL for kubectl releases.')
             c.argument('kubelogin_version', validator=validate_kubelogin_version, help='Version of kubelogin to install.')
             c.argument('kubelogin_install_location', default=_get_default_install_location('kubelogin'), help='Path at which to install kubelogin.')
+            c.argument('kubelogin_base_download_source_url', help='Base download source URL for kubelogin releases.')
 
     with self.argument_context('aks update-credentials', arg_group='Service Principal') as c:
         c.argument('reset_service_principal', action='store_true')

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -323,21 +323,23 @@ def dcos_install_cli(cmd, install_location=None, client_version='1.8'):
         raise CLIError('Connection error while attempting to download client ({})'.format(err))
 
 
-def k8s_install_cli(cmd, client_version='latest', install_location=None,
-                    kubelogin_version='latest', kubelogin_install_location=None):
-    k8s_install_kubectl(cmd, client_version, install_location)
-    k8s_install_kubelogin(cmd, kubelogin_version, kubelogin_install_location)
+def k8s_install_cli(cmd, client_version='latest', install_location=None, base_download_source_url=None,
+                    kubelogin_version='latest', kubelogin_install_location=None,
+                    kubelogin_base_download_source_url=None):
+    k8s_install_kubectl(cmd, client_version, install_location, base_download_source_url)
+    k8s_install_kubelogin(cmd, kubelogin_version, kubelogin_install_location, kubelogin_base_download_source_url)
 
 
-def k8s_install_kubectl(cmd, client_version='latest', install_location=None):
+def k8s_install_kubectl(cmd, client_version='latest', install_location=None, source_url=None):
     """
     Install kubectl, a command-line interface for Kubernetes clusters.
     """
 
-    source_url = "https://storage.googleapis.com/kubernetes-release/release"
-    cloud_name = cmd.cli_ctx.cloud.name
-    if cloud_name.lower() == 'azurechinacloud':
-        source_url = 'https://mirror.azure.cn/kubernetes/kubectl'
+    if not source_url:
+        source_url = "https://storage.googleapis.com/kubernetes-release/release"
+        cloud_name = cmd.cli_ctx.cloud.name
+        if cloud_name.lower() == 'azurechinacloud':
+            source_url = 'https://mirror.azure.cn/kubernetes/kubectl'
 
     if client_version == 'latest':
         context = _ssl_context()
@@ -389,15 +391,17 @@ def k8s_install_kubectl(cmd, client_version='latest', install_location=None):
                        install_dir, cli)
 
 
-def k8s_install_kubelogin(cmd, client_version='latest', install_location=None):
+def k8s_install_kubelogin(cmd, client_version='latest', install_location=None, source_url=None):
     """
     Install kubelogin, a client-go credential (exec) plugin implementing azure authentication.
     """
 
-    source_url = 'https://github.com/Azure/kubelogin/releases/download'
     cloud_name = cmd.cli_ctx.cloud.name
-    if cloud_name.lower() == 'azurechinacloud':
-        source_url = 'https://mirror.azure.cn/kubernetes/kubelogin'
+
+    if not source_url:
+        source_url = 'https://github.com/Azure/kubelogin/releases/download'
+        if cloud_name.lower() == 'azurechinacloud':
+            source_url = 'https://mirror.azure.cn/kubernetes/kubelogin'
 
     if client_version == 'latest':
         context = _ssl_context()

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -323,11 +323,11 @@ def dcos_install_cli(cmd, install_location=None, client_version='1.8'):
         raise CLIError('Connection error while attempting to download client ({})'.format(err))
 
 
-def k8s_install_cli(cmd, client_version='latest', install_location=None, base_download_source_url=None,
+def k8s_install_cli(cmd, client_version='latest', install_location=None, base_src_url=None,
                     kubelogin_version='latest', kubelogin_install_location=None,
-                    kubelogin_base_download_source_url=None):
-    k8s_install_kubectl(cmd, client_version, install_location, base_download_source_url)
-    k8s_install_kubelogin(cmd, kubelogin_version, kubelogin_install_location, kubelogin_base_download_source_url)
+                    kubelogin_base_src_url=None):
+    k8s_install_kubectl(cmd, client_version, install_location, base_src_url)
+    k8s_install_kubelogin(cmd, kubelogin_version, kubelogin_install_location, kubelogin_base_src_url)
 
 
 def k8s_install_kubectl(cmd, client_version='latest', install_location=None, source_url=None):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -773,6 +773,41 @@ class AcsCustomCommandTest(unittest.TestCase):
         finally:
             shutil.rmtree(temp_dir)
 
+    @mock.patch('azure.cli.command_modules.acs.custom._urlretrieve')
+    @mock.patch('azure.cli.command_modules.acs.custom.logger')
+    def test_k8s_install_kubectl_with_custom_source_url(self, logger_mock, mock_url_retrieve):
+        mock_url_retrieve.side_effect = lambda _, install_location: open(install_location, 'a').close()
+        try:
+            temp_dir = tempfile.mkdtemp()
+            test_location = os.path.join(temp_dir, 'foo', 'kubectl')
+            test_ver = '1.2.5'
+            test_source_url = 'http://url1'
+            k8s_install_kubectl(mock.MagicMock(), client_version=test_ver, install_location=test_location, source_url=test_source_url)
+            mock_url_retrieve.assert_called_with(mockUrlretrieveUrlValidator(test_source_url, test_ver), mock.ANY)
+        finally:
+            shutil.rmtree(temp_dir)
+
+    @mock.patch('azure.cli.command_modules.acs.custom._urlretrieve')
+    @mock.patch('azure.cli.command_modules.acs.custom.logger')
+    def test_k8s_install_kubelogin_with_custom_source_url(self, logger_mock, mock_url_retrieve):
+        mock_url_retrieve.side_effect = create_kubelogin_zip
+        try:
+            temp_dir = tempfile.mkdtemp()
+            test_location = os.path.join(temp_dir, 'foo', 'kubelogin')
+            test_ver = '1.2.6'
+            test_source_url = 'http://url2'
+            k8s_install_kubelogin(mock.MagicMock(), client_version=test_ver, install_location=test_location, source_url=test_source_url)
+            mock_url_retrieve.assert_called_with(mockUrlretrieveUrlValidator(test_source_url, test_ver), mock.ANY)
+        finally:
+            shutil.rmtree(temp_dir)
+
+class mockUrlretrieveUrlValidator(object):
+    def __init__(self, url, version):
+        self.url = url
+        self.version = version
+
+    def __eq__(self, other):
+        return other.startswith(self.url) and self.version in other
 
 def create_kubelogin_zip(file_url, download_path):
     import zipfile

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -801,6 +801,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         finally:
             shutil.rmtree(temp_dir)
 
+
 class mockUrlretrieveUrlValidator(object):
     def __init__(self, url, version):
         self.url = url
@@ -808,6 +809,7 @@ class mockUrlretrieveUrlValidator(object):
 
     def __eq__(self, other):
         return other.startswith(self.url) and self.version in other
+
 
 def create_kubelogin_zip(file_url, download_path):
     import zipfile


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Allow customers with no internet access to customize aks related tool download source path to an internal url.

**Testing Guide**  
az aks install-cli --base-src-url <url>

**History Notes**  
[AKS] az aks install-cli: Support customize download url

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
