### PR TITLE
[Network] az network network watcher configure: Fix NetworkWatcherCountLimitReached error caused by case sensitivity of location value

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -4039,7 +4039,8 @@ def _delete_network_watchers(cmd, client, watchers):
 
 def configure_network_watcher(cmd, client, locations, resource_group_name=None, enabled=None, tags=None):
     watcher_list = list(client.list_all())
-    existing_watchers = [w for w in watcher_list if w.location in locations]
+    locations_list = [location.lower() for location in locations]
+    existing_watchers = [w for w in watcher_list if w.location in locations_list]
     nonenabled_regions = list(set(locations) - set(watcher.location for watcher in existing_watchers))
 
     if enabled is None:

--- a/src/azure-cli/azure/cli/command_modules/network/tests/hybrid_2018_03_01/test_network_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/hybrid_2018_03_01/test_network_commands.py
@@ -1873,7 +1873,7 @@ class NetworkWatcherScenarioTest(LiveScenarioTest):
         return 1
 
     def _network_watcher_configure(self):
-        self.cmd('network watcher configure -g {rg} --locations westus westus2 westcentralus --enabled')
+        self.cmd('network watcher configure -g {rg} --locations westus Westus2 westcentraluS --enabled')
         self.cmd('network watcher configure --locations westus westus2 --tags foo=doo')
         self.cmd('network watcher configure -l westus2 --enabled false')
         self.cmd('network watcher list')


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Hi all,

the PR is the fix for the created issue. Fix #15796

**Testing Guide**  
<!--Example commands with explanations.-->
To test the PR see the full guide in the issue.

Before the fix the second statement returns an error **NetworkWatcherCountLimitReached**
`az network watcher configure --subscription {} --locations eastus --resource-group {} --enabled {} --debug`
`az network watcher configure --subscription {} --locations Eastus --resource-group {} --enabled {} --debug`

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
