### PR TITLE
{Core} Workaround empty and multiple scopes provided by old Track 2 SDKs

### DIFF
--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -68,13 +68,6 @@ class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-meth
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
         logger.debug("AdalAuthentication.get_token invoked by Track 2 SDK with scopes=%s", scopes)
 
-        # Deal with an old Track 2 SDK issue where the default credential_scopes is extended with
-        # custom credential_scopes. Instead, credential_scopes should be replaced by custom credential_scopes.
-        # https://github.com/Azure/azure-sdk-for-python/issues/12947
-        # We simply remove the first one if there are multiple scopes provided.
-        if len(scopes) > 1:
-            scopes = scopes[1:]
-
         _, token, full_token, _ = self._get_token(_try_scopes_to_resource(scopes))
         try:
             return AccessToken(token, int(full_token['expiresIn'] + time.time()))
@@ -154,7 +147,7 @@ def _try_scopes_to_resource(scopes):
     # custom credential_scopes. https://github.com/Azure/azure-sdk-for-python/issues/12947
     # As a workaround, remove the first one if there are multiple scopes provided.
     if len(scopes) > 1:
-        logger.debug("Multiple scopes are provided by the SDK, discarding the first one: %s.", scopes[0])
+        logger.debug("Multiple scopes are provided by the SDK, discarding the first one: %s", scopes[0])
         return scopes_to_resource(scopes[1:])
 
     # Exactly only one scope is provided

--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -75,7 +75,7 @@ class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-meth
         if len(scopes) > 1:
             scopes = scopes[1:]
 
-        _, token, full_token, _ = self._get_token(scopes_to_resource(scopes))
+        _, token, full_token, _ = self._get_token(_try_scopes_to_resource(scopes))
         try:
             return AccessToken(token, int(full_token['expiresIn'] + time.time()))
         except KeyError:  # needed to deal with differing unserialized MSI token payload
@@ -106,7 +106,9 @@ class MSIAuthenticationWrapper(MSIAuthentication):
     # This method is exposed for Azure Core. Add *scopes, **kwargs to fit azure.core requirement
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
         logger.debug("MSIAuthenticationWrapper.get_token invoked by Track 2 SDK with scopes=%s", scopes)
-        self.resource = scopes_to_resource(scopes)
+        resource = _try_scopes_to_resource(scopes)
+        if resource:
+            self.resource = resource
         self.set_token()
         return AccessToken(self.token['access_token'], int(self.token['expires_on']))
 
@@ -135,3 +137,25 @@ class MSIAuthenticationWrapper(MSIAuthentication):
     def signed_session(self, session=None):
         logger.debug("MSIAuthenticationWrapper.signed_session invoked by Track 1 SDK")
         super().signed_session(session)
+
+
+def _try_scopes_to_resource(scopes):
+    """Wrap scopes_to_resource to workaround some SDK issues."""
+
+    # Track 2 SDKs generated before https://github.com/Azure/autorest.python/pull/239 don't maintain
+    # credential_scopes and call `get_token` with empty scopes.
+    # As a workaround, return None so that the CLI-managed resource is used.
+    if not scopes:
+        logger.debug("No scope is provided by the SDK, use the CLI-managed resource.")
+        return None
+
+    # Track 2 SDKs generated before https://github.com/Azure/autorest.python/pull/745 extend default
+    # credential_scopes with custom credential_scopes. Instead, credential_scopes should be replaced by
+    # custom credential_scopes. https://github.com/Azure/azure-sdk-for-python/issues/12947
+    # As a workaround, remove the first one if there are multiple scopes provided.
+    if len(scopes) > 1:
+        logger.debug("Multiple scopes are provided by the SDK, discarding the first one: %s.", scopes[0])
+        return scopes_to_resource(scopes[1:])
+
+    # Exactly only one scope is provided
+    return scopes_to_resource(scopes)

--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -101,6 +101,7 @@ class MSIAuthenticationWrapper(MSIAuthentication):
         logger.debug("MSIAuthenticationWrapper.get_token invoked by Track 2 SDK with scopes=%s", scopes)
         resource = _try_scopes_to_resource(scopes)
         if resource:
+            # If available, use resource provided by SDK
             self.resource = resource
         self.set_token()
         return AccessToken(self.token['access_token'], int(self.token['expires_on']))

--- a/src/azure-cli-core/azure/cli/core/tests/test_adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_adal_authentication.py
@@ -1,0 +1,30 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+# pylint: disable=line-too-long
+import unittest
+from azure.cli.core.adal_authentication import _try_scopes_to_resource
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_try_scopes_to_resource(self):
+        # Test no scopes
+        self.assertIsNone(_try_scopes_to_resource(()))
+        self.assertIsNone(_try_scopes_to_resource([]))
+        self.assertIsNone(_try_scopes_to_resource(None))
+
+        # Test multiple scopes, with the first one discarded
+        resource = _try_scopes_to_resource(("https://management.core.windows.net//.default",
+                                            "https://management.core.chinacloudapi.cn//.default"))
+        self.assertEqual(resource, "https://management.core.chinacloudapi.cn/")
+
+        # Test single scopes (the correct usage)
+        resource = _try_scopes_to_resource(("https://management.core.chinacloudapi.cn//.default",))
+        self.assertEqual(resource, "https://management.core.chinacloudapi.cn/")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Refine #15184: {Core} Honor `scopes` specified by Track 2 SDK

### Expected flow

The current Track 2 SDK client takes `credential_scopes` with **only one** resource as the `scopes` when calling `get_token`.

https://github.com/Azure/azure-sdk-for-python/blob/27e4203818e227ba2604ff52dcf55ce2293c4c37/sdk/resources/azure-mgmt-resource/azure/mgmt/resource/subscriptions/_configuration.py#L60

```py
self.authentication_policy = policies.BearerTokenCredentialPolicy(self.credential, *self.credential_scopes, **kwargs)
```

### Issue 1: Empty scopes
Some old Track 2 SDKs generated before https://github.com/Azure/autorest.python/pull/239 don't maintain `credential_scopes` and calls `get_token` with an empty `scopes`.

https://github.com/Azure/azure-cli-extensions/blob/db8ea65eb4afa9358de39e06a8c37c85e862a61c/src/datashare/azext_datashare/vendored_sdks/datashare/_configuration.py#L61

https://github.com/Azure/azure-cli-extensions/blob/db8ea65eb4afa9358de39e06a8c37c85e862a61c/src/logic/azext_logic/vendored_sdks/logic/_configuration.py#L61

```py
self.authentication_policy = policies.BearerTokenCredentialPolicy(self.credential, **kwargs)
```

This causes error:

```
File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/azure/cli/core/util.py", line 1196, in scopes_to_resource 
scope = scopes[0] 
IndexError: tuple index out of range 
```

### Issue 2: Multiple scopes

Some old Track 2 SDKs generated before https://github.com/Azure/autorest.python/pull/745 extend default `credential_scopes` with custom `credential_scopes`. Instead, `credential_scopes` should be replaced by custom `credential_scopes`. https://github.com/Azure/azure-sdk-for-python/issues/12947

https://github.com/Azure/azure-cli-extensions/blob/120196e953f7b776fa209f4c49838b5cc7af56b0/src/account/azext_account/vendored_sdks/subscription/_configuration.py#L44-L45

```py
self.credential_scopes = ['https://management.azure.com/.default']
self.credential_scopes.extend(kwargs.pop('credential_scopes', []))
```

### Changes

This PR unifies the fixes for the above 2 issues in one function `_try_scopes_to_resource`:

**Testing Guide**  
```sh
# Test empty scopes
> az extension add --name datashare
> az datashare account list --debug
DEBUG: AdalAuthentication.get_token invoked by Track 2 SDK with scopes=()
DEBUG: No scope is provided by the SDK, use the CLI-managed resource.

# Test multiple scopes
> az extension add --name account
> az account subscription show --id 0b1f6471-1bf0-4dda-aec3-cb9272f09590 --debug
DEBUG: AdalAuthentication.get_token invoked by Track 2 SDK with scopes=('https://management.azure.com/.default', 'https://management.core.windows.net//.default')
DEBUG: Multiple scopes are provided by the SDK, discarding the first one: https://management.azure.com/.default
```

⚠ The workarounds only work for now as `get_token` is implemented by Azure CLI. After migrating to Azure Identity, these workarounds will fail. The old problematic SDKs MUST be regenerated.

