### PR TITLE
{Storage} az storage queue policy: ignore `--auth-mode` argument

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -1370,6 +1370,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('start', type=get_datetime_type(True),
                    help='start UTC datetime (Y-m-d\'T\'H:M:S\'Z\'). Defaults to time of request.')
         c.argument('expiry', type=get_datetime_type(True), help='expiration UTC datetime in (Y-m-d\'T\'H:M:S\'Z\')')
+        c.ignore('auth_mode')
 
     with self.argument_context('storage message') as c:
         c.argument('queue_name', queue_name_type)


### PR DESCRIPTION
## Description ##
Since `auth_mode=login` is not supported when doing CRUD with `az storage queue policy`. (Service can't find queue resource in that case), we just ignore `--auth-mode` argument in this PR.

## Testing Guide ##
`az storage queue policy create/delete/update/list/show -h`
