### PR TITLE
{CI} Reduce deb package tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -716,27 +716,9 @@ jobs:
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'))
   strategy:
     matrix:
-      Xenial:
-        deb_system: ubuntu
-        distro: xenial
-      Trusty:
-        deb_system: ubuntu
-        distro: trusty
-      Bionic:
-        deb_system: ubuntu
-        distro: bionic
-      Eoan:
-        deb_system: ubuntu
-        distro: eoan
       Focal:
         deb_system: ubuntu
         distro: focal
-      Jessie:
-        deb_system: debian
-        distro: jessie
-      Stretch:
-        deb_system: debian
-        distro: stretch
       Buster:
         deb_system: debian
         distro: buster


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Only keep Focal for Ubuntu package test and Buster for Debian package test as they are the latest stable distros.
This change helps reduce CI failures caused by race conditions for writing the same configuration files with multiple parallel package tests and also reduce ADO resource usages.

**Testing Guide**  
<!--Example commands with explanations.-->

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
