### PR TITLE
{Role} az ad app permission add: Add instruction on how to get available permission IDs

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -169,8 +169,8 @@ long-summary: >-
     to get available permissions for Graph API:
       - Azure Active Directory Graph: `az ad sp show --id 00000002-0000-0000-c000-000000000000`
       - Microsoft Graph: `az ad sp show --id 00000003-0000-0000-c000-000000000000`
-    Permissions under the `appRoles` property correspond to `Role` in --api-permissions.
-    Permissions under the `oauth2Permissions` property correspond to `Scope` in --api-permissions.
+    Application permissions under the `appRoles` property correspond to `Role` in --api-permissions.
+    Delegated permissions under the `oauth2Permissions` property correspond to `Scope` in --api-permissions.
 examples:
   - name: Add Azure Active Directory Graph delegated permission User.Read (Sign in and read user profile).
     text: az ad app permission add --id eeba0b46-78e5-4a1a-a1aa-cafe6c123456 --api 00000002-0000-0000-c000-000000000000 --api-permissions 311a71cc-e848-46a1-bdf8-97ff7156d8e6=Scope

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -161,7 +161,16 @@ short-summary: Manage an application's OAuth2 permissions.
 helps['ad app permission add'] = """
 type: command
 short-summary: Add an API permission
-long-summary: Invoking "az ad app permission grant" is needed to activate it
+long-summary: >-
+    Invoking "az ad app permission grant" is needed to activate it.
+
+
+    To get available permissions of the resource app, run `az ad sp show --id <resource-appId>`. For example,
+    to get available permissions for Graph API:
+      - Azure Active Directory Graph: `az ad sp show --id 00000002-0000-0000-c000-000000000000`
+      - Microsoft Graph: `az ad sp show --id 00000003-0000-0000-c000-000000000000`
+    Permissions under the `appRoles` property correspond to `Role` in --api-permissions.
+    Permissions under the `oauth2Permissions` property correspond to `Scope` in --api-permissions.
 examples:
   - name: Add Azure Active Directory Graph delegated permission User.Read (Sign in and read user profile).
     text: az ad app permission add --id eeba0b46-78e5-4a1a-a1aa-cafe6c123456 --api 00000002-0000-0000-c000-000000000000 --api-permissions 311a71cc-e848-46a1-bdf8-97ff7156d8e6=Scope


### PR DESCRIPTION
**Description<!--Mandatory-->**  
Fix #11354: _List of Graph API permission_

`az ad app permission add`: Add instruction on how to get available permission IDs

**Testing Guide**  
```
> az ad app permission add -h

Command
    az ad app permission add : Add an API permission.
        Invoking "az ad app permission grant" is needed to activate it.

        To get available permissions of the resource app, run `az ad sp show --id <resource-appId>`.
        For example, to get available permissions for Graph API:
          - Azure Active Directory Graph: `az ad sp show --id 00000002-0000-0000-c000-000000000000`
          - Microsoft Graph: `az ad sp show --id 00000003-0000-0000-c000-000000000000`
        Application permissions under the `appRoles` property correspond to `Role` in --api-
        permissions. Delegated permissions under the `oauth2Permissions` property correspond to
        `Scope` in --api-permissions.
```
