### PR TITLE
{Error Improvement} Remove error type in error message

### DIFF
--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -50,9 +50,8 @@ class AzCLIError(CLIError):
     def print_error(self):
         from azure.cli.core.azlogging import CommandLoggerContext
         with CommandLoggerContext(logger):
-            # print error type and error message
-            message = '{}: {}'.format(self.__class__.__name__, self.error_msg)
-            logger.error(message)
+            # print the error message
+            logger.error(self.error_msg)
             # print exception trace if there is
             if self.exception_trace:
                 logger.exception(self.exception_trace)

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -239,7 +239,7 @@ class TestParser(unittest.TestCase):
         # assert the right type of error msg is logged for command vs argument parsing
         self.assertEqual(len(logger_msgs), 5)
         for msg in logger_msgs[:3]:
-            self.assertIn("CommandNotFoundError", msg)
+            self.assertIn("is misspelled or not recognized by the system", msg)
         for msg in logger_msgs[3:]:
             self.assertIn("not a valid value for '--opt'.", msg)
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR removes the error type info in the error message. For feature request #15692

**Testing Guide**  
<!--Example commands with explanations.-->
Type any command which could cause an UserFault, e.g, `az vm create`

Previously
```
RequiredArgumentMissingError: the following arguments are required: --name/-n, --resource-group/-g
Try this: 'az vm create -n <MyVm> -g <MyResourceGroup> --image <UbuntuLTS>'
Still stuck? Run 'az vm create --help' to view all commands or go to 'https://docs.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest' to learn more
```

Now
```
the following arguments are required: --name/-n, --resource-group/-g
Try this: 'az vm create -n <MyVm> -g <MyResourceGroup> --image <UbuntuLTS>'
Still stuck? Run 'az vm create --help' to view all commands or go to 'https://docs.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest' to learn more
```


