### PR TITLE
{Core} Add comments to prevent calling AdalAuthentication._token_retriever

### DIFF
--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -22,7 +22,8 @@ class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-meth
 
     def __init__(self, token_retriever, external_tenant_token_retriever=None):
         # DO NOT call _token_retriever from outside azure-cli-core. It is only available for user or
-        # Service Principal credential, but not for Managed Identity credential (MSIAuthenticationWrapper).
+        # Service Principal credential (AdalAuthentication), but not for Managed Identity credential
+        # (MSIAuthenticationWrapper).
         # To retrieve a raw token, either call
         #   - Profile.get_raw_token, which is more direct
         #   - AdalAuthentication.get_token, which is designed for Track 2 SDKs

--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -21,6 +21,11 @@ logger = get_logger(__name__)
 class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-methods
 
     def __init__(self, token_retriever, external_tenant_token_retriever=None):
+        # DO NOT call _token_retriever from outside azure-cli-core. It is only available for user or
+        # Service Principal credential, but not for Managed Identity credential (MSIAuthenticationWrapper).
+        # To retrieve a raw token, either call
+        #   - Profile.get_raw_token, which is more direct
+        #   - AdalAuthentication.get_token, which is designed for Track 2 SDKs
         self._token_retriever = token_retriever
         self._external_tenant_token_retriever = external_tenant_token_retriever
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  

`_token_retriever` is only available for `AdalAuthentication` which is designed for **user or Service Principal credential**. It is not available for **Managed Identity** credential `MSIAuthenticationWrapper`. Therefore, calling `_token_retriever` to retrieve a raw token will fail for Managed Identity credential:

```py
# WRONG!!!
return Profile(cli_ctx=cli_ctx).get_login_credentials(resource)[0]._token_retriever()
```

This has already caused 2 buggy command module and extension: #15805, https://github.com/Azure/azure-cli-extensions/issues/2461

This PR adds comments to prevent calling `AdalAuthentication._token_retriever` in the future by developers.

For more detail including correct ways to get a raw token, see https://github.com/Azure/azure-cli/issues/15805#issuecomment-722914070.
