### PR TITLE
{ARM} az account management-group show: Refine help for --name

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -122,7 +122,7 @@ long-summary: Get the details of the management group.
 parameters:
   - name: --name -n
     type: string
-    short-summary: Name of the management group.
+    short-summary: Name of the management group (the last segment of the resource ID). Do not use display name.
   - name: --expand -e
     type: bool
     short-summary: If given, lists the children in the first level of hierarchy.


### PR DESCRIPTION
## Description
Reported in #15589.

When calling `az account management-group show`, users may use the `displayName` of the management group with `--name` which is not the correct usage and will result in a failure:

```
> az account management-group show --name mg20201111-display
code: AuthorizationFailed - , The client 'test@azuresdkteam.onmicrosoft.com' with object id 
'6d97229a-391f-473a-893f-f0608b592d7b' does not have authorization to perform action 
'Microsoft.Management/managementGroups/read' over scope 
'/providers/Microsoft.Management/managementGroups/mg20201111-display' or the scope is invalid. 
If access was recently granted, please refresh your credentials.
```

Refine the help message for `--name` to avoid confusion.

## Testing Guide

```
> az account management-group show --help

Command
    az account management-group show : Get a specific management group.
        Get the details of the management group.

Arguments
    --name -n            [Required] : Name of the management group (the last segment of the resource
                                      ID). Do not use display name.
```
