### PR TITLE
{Error Improvement} Catch the more general JMESPathError to cover more exceptions

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -55,7 +55,7 @@ DISALLOWED_USER_NAMES = [
 
 def handle_exception(ex):  # pylint: disable=too-many-locals, too-many-statements, too-many-branches
     # For error code, follow guidelines at https://docs.python.org/2/library/sys.html#sys.exit,
-    from jmespath.exceptions import JMESPathTypeError
+    from jmespath.exceptions import JMESPathError
     from msrestazure.azure_exceptions import CloudError
     from msrest.exceptions import HttpOperationError, ValidationError, ClientRequestError
     from azure.cli.core.azlogging import CommandLoggerContext
@@ -76,7 +76,7 @@ def handle_exception(ex):  # pylint: disable=too-many-locals, too-many-statement
         if isinstance(ex, azclierror.AzCLIError):
             az_error = ex
 
-        elif isinstance(ex, JMESPathTypeError):
+        elif isinstance(ex, JMESPathError):
             error_msg = "Invalid jmespath query supplied for `--query`: {}".format(error_msg)
             az_error = azclierror.InvalidArgumentValueError(error_msg)
             az_error.set_recommendation(QUERY_REFERENCE)


### PR DESCRIPTION
**Description<!--Mandatory-->**  
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
There are other JMESPath exceptions besides the `JMESPathTypeError`. For instance, with `az group list --query "length()"`, the following error will be thrown: 

> jmespath.exceptions.ArityError: Expected 1 argument for function length(), received 0

This PR changes the error type from `JMESPathTypeError` to `JMESPathError` to be processed in exception handler so that more JMESPath errors are wrapped as User Fault.

**Testing Guide**  
<!--Example commands with explanations.-->
Run `az group list --query "length()"`, the following error message will be shown:

> InvalidArgumentValueError: Invalid jmespath query supplied for `--query`: Expected 1 argument for function length(), received 0
> To learn more about --query, please visit: 'https://docs.microsoft.com/cli/azure/query-azure-cli?view=azure-cli-latest'

**History Notes**  
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.  
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
