### PR TITLE
[Privatedns] az network private-dns zone import: Raise FileOperationError instead of FileNotFoundError if zone file doesn't exist 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2046,11 +2046,17 @@ def import_zone(cmd, resource_group_name, zone_name, file_name):
     logger.warning("In the future, zone name will be case insensitive.")
     RecordSet = cmd.get_models('RecordSet', resource_type=ResourceType.MGMT_NETWORK_DNS)
 
-    from azure.cli.core.azclierror import FileOperationError
+    from azure.cli.core.azclierror import FileOperationError, UnknownError
     try:
         file_text = read_file_content(file_name)
-    except FileNotFoundError as e:
-        raise FileOperationError(e)
+    except FileNotFoundError:
+        raise FileOperationError("No such file: " + str(file_name))
+    except IsADirectoryError:
+        raise FileOperationError("Is a directory: " + str(file_name))
+    except PermissionError:
+        raise FileOperationError("Permission denied: " + str(file_name))
+    except OSError as e:
+        raise UnknownError(e)
 
     zone_obj = parse_zone_file(file_text, zone_name)
 

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2046,7 +2046,12 @@ def import_zone(cmd, resource_group_name, zone_name, file_name):
     logger.warning("In the future, zone name will be case insensitive.")
     RecordSet = cmd.get_models('RecordSet', resource_type=ResourceType.MGMT_NETWORK_DNS)
 
-    file_text = read_file_content(file_name)
+    from azure.cli.core.azclierror import FileOperationError
+    try:
+        file_text = read_file_content(file_name)
+    except FileNotFoundError as e:
+        raise FileOperationError(e)
+
     zone_obj = parse_zone_file(file_text, zone_name)
 
     origin = zone_name

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_dns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_dns_commands.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 
-from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
+from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, live_only
 
 from azure.cli.command_modules.network.zone_file import parse_zone_file
 
@@ -58,6 +58,14 @@ class DnsZoneImportTest(ScenarioTest):
 
         # verify that each record in the original import is unchanged after export/re-import
         self._check_records(records1, records2)
+
+    @live_only()
+    @ResourceGroupPreparer(name_prefix='test_dns_import_file_not_found')
+    def test_dns_import_file_not_found(self, resource_group):
+        from azure.cli.core.azclierror import FileOperationError
+        with self.assertRaises(FileOperationError) as e:
+            self._test_zone('404zone.com', 'non_existing_zone_description_file.txt')
+            self.assertEqual(e.errno, 1)
 
     @ResourceGroupPreparer(name_prefix='cli_dns_zone1_import')
     def test_dns_zone1_import(self, resource_group):

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_dns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_dns_commands.py
@@ -61,10 +61,22 @@ class DnsZoneImportTest(ScenarioTest):
 
     @live_only()
     @ResourceGroupPreparer(name_prefix='test_dns_import_file_not_found')
-    def test_dns_import_file_not_found(self, resource_group):
+    def test_dns_import_file_operation_error(self, resource_group):
+        import sys
+        if sys.platform != 'linux':
+            self.skip('This test should run on Linux platform')
+
         from azure.cli.core.azclierror import FileOperationError
-        with self.assertRaises(FileOperationError) as e:
+        with self.assertRaisesRegexp(FileOperationError, 'No such file: ') as e:
             self._test_zone('404zone.com', 'non_existing_zone_description_file.txt')
+            self.assertEqual(e.errno, 1)
+
+        with self.assertRaisesRegexp(FileOperationError, 'Is a directory: ') as e:
+            self._test_zone('404zone.com', '')
+            self.assertEqual(e.errno, 1)
+
+        with self.assertRaisesRegexp(FileOperationError, 'Permission denied: ') as e:
+            self._test_zone('404zone.com', '/root/')
             self.assertEqual(e.errno, 1)
 
     @ResourceGroupPreparer(name_prefix='cli_dns_zone1_import')

--- a/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
@@ -27,7 +27,7 @@ def list_privatedns_zones(cmd, resource_group_name=None):
     return client.list()
 
 
-# pylint: disable=too-many-statements, too-many-locals
+# pylint: disable=too-many-statements, too-many-locals, too-many-branches
 def import_zone(cmd, resource_group_name, private_zone_name, file_name):
     from azure.cli.core.util import read_file_content
     import sys

--- a/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
@@ -33,7 +33,12 @@ def import_zone(cmd, resource_group_name, private_zone_name, file_name):
     import sys
     from azure.mgmt.privatedns.models import RecordSet
 
-    file_text = read_file_content(file_name)
+    from azure.cli.core.azclierror import FileOperationError
+    try:
+        file_text = read_file_content(file_name)
+    except FileNotFoundError as e:
+        raise FileOperationError(e)
+
     zone_obj = parse_zone_file(file_text, private_zone_name)
     origin = private_zone_name
     record_sets = {}

--- a/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
@@ -33,11 +33,17 @@ def import_zone(cmd, resource_group_name, private_zone_name, file_name):
     import sys
     from azure.mgmt.privatedns.models import RecordSet
 
-    from azure.cli.core.azclierror import FileOperationError
+    from azure.cli.core.azclierror import FileOperationError, UnknownError
     try:
         file_text = read_file_content(file_name)
-    except FileNotFoundError as e:
-        raise FileOperationError(e)
+    except FileNotFoundError:
+        raise FileOperationError("No such file: " + str(file_name))
+    except IsADirectoryError:
+        raise FileOperationError("Is a directory: " + str(file_name))
+    except PermissionError:
+        raise FileOperationError("Permission denied: " + str(file_name))
+    except OSError as e:
+        raise UnknownError(e)
 
     zone_obj = parse_zone_file(file_text, private_zone_name)
     origin = private_zone_name

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
@@ -955,6 +955,13 @@ class PrivateDnsZoneImportTest(ScenarioTest):
         # verify that each record in the original import is unchanged after export/re-import
         self._check_records(records1, records2)
 
+    @ResourceGroupPreparer(name_prefix='test_Private_Dns_import_file_not_found')
+    def test_Private_Dns_import_file_not_found(self, resource_group):
+        from azure.cli.core.azclierror import FileOperationError
+        with self.assertRaises(FileOperationError) as e:
+            self._test_PrivateDnsZone('404zone.com', 'non_existing_zone_description_file.txt')
+            self.assertEqual(e.errno, 1)
+
     @ResourceGroupPreparer(name_prefix='cli_private_dns_zone1_import')
     def test_Private_Dns_Zone1_Import(self, resource_group):
         self._test_PrivateDnsZone('zone1.com', 'zone1.txt')

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
@@ -956,10 +956,22 @@ class PrivateDnsZoneImportTest(ScenarioTest):
         self._check_records(records1, records2)
 
     @ResourceGroupPreparer(name_prefix='test_Private_Dns_import_file_not_found')
-    def test_Private_Dns_import_file_not_found(self, resource_group):
+    def test_Private_Dns_import_file_operation_error_linux(self, resource_group):
+        import sys
+        if sys.platform != 'linux':
+            self.skip('This test should run on Linux platform')
+
         from azure.cli.core.azclierror import FileOperationError
-        with self.assertRaises(FileOperationError) as e:
+        with self.assertRaisesRegexp(FileOperationError, 'No such file: ') as e:
             self._test_PrivateDnsZone('404zone.com', 'non_existing_zone_description_file.txt')
+            self.assertEqual(e.errno, 1)
+
+        with self.assertRaisesRegexp(FileOperationError, 'Is a directory: ') as e:
+            self._test_PrivateDnsZone('404zone.com', '')
+            self.assertEqual(e.errno, 1)
+
+        with self.assertRaisesRegexp(FileOperationError, 'Permission denied: ') as e:
+            self._test_PrivateDnsZone('404zone.com', '/root/')
             self.assertEqual(e.errno, 1)
 
     @ResourceGroupPreparer(name_prefix='cli_private_dns_zone1_import')


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fix the top 1 non-actionable bug (Azure/azure-cli#14984) 
![image](https://user-images.githubusercontent.com/14357159/98779041-2f901780-242e-11eb-96ae-055d9f6ba785.png)

Raise FileOperationError instead of FileNotFoundError if the zone file doesn't exist and catch more expected file operation related errors 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
