### PR TITLE
[Compute] Support update vm/image version when they use cross tenant images

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/commands.py
@@ -286,7 +286,7 @@ def load_command_table(self, _):
         g.command('start', 'start', supports_no_wait=True)
         g.command('stop', 'power_off', supports_no_wait=True, validator=process_vm_vmss_stop)
         g.command('reapply', 'reapply', supports_no_wait=True, min_api='2019-07-01')
-        g.generic_update_command('update', getter_name='get_vm_for_generic_update', setter_name='update_vm', setter_type=compute_custom, command_type=compute_custom, supports_no_wait=True)
+        g.generic_update_command('update', getter_name='get_vm_to_update', setter_name='update_vm', setter_type=compute_custom, command_type=compute_custom, supports_no_wait=True)
         g.wait_command('wait', getter_name='get_instance_view', getter_type=compute_custom)
         g.custom_command('auto-shutdown', 'auto_shutdown_vm')
         g.command('assess-patches', 'assess_patches', min_api='2020-06-01')
@@ -480,7 +480,7 @@ def load_command_table(self, _):
         g.show_command('show', 'get', table_transformer='{Name:name, ResourceGroup:resourceGroup, ProvisioningState:provisioningState, TargetRegions: publishingProfile.targetRegions && join(`, `, publishingProfile.targetRegions[*].name), ReplicationState:replicationStatus.aggregatedState}')
         g.command('list', 'list_by_gallery_image')
         g.custom_command('create', 'create_image_version', supports_no_wait=True)
-        g.generic_update_command('update', getter_name='get_image_version_for_generic_update', setter_arg_name='gallery_image_version', setter_name='update_image_version', setter_type=compute_custom, command_type=compute_custom, supports_no_wait=True)
+        g.generic_update_command('update', getter_name='get_image_version_to_update', setter_arg_name='gallery_image_version', setter_name='update_image_version', setter_type=compute_custom, command_type=compute_custom, supports_no_wait=True)
         g.wait_command('wait')
 
     with self.command_group('ppg', compute_proximity_placement_groups_sdk, min_api='2018-04-01', client_factory=cf_proximity_placement_groups) as g:

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -1004,6 +1004,14 @@ def get_vm(cmd, resource_group_name, vm_name, expand=None):
     return client.virtual_machines.get(resource_group_name, vm_name, expand=expand)
 
 
+def get_vm_to_update(cmd, resource_group_name, vm_name):
+    client = _compute_client_factory(cmd.cli_ctx)
+    vm = client.virtual_machines.get(resource_group_name, vm_name)
+    # To avoid unnecessary permission check of image
+    vm.storage_profile.image_reference = None
+    return vm
+
+
 def get_vm_details(cmd, resource_group_name, vm_name):
     from msrestazure.tools import parse_resource_id
     from azure.cli.command_modules.vm._vm_utils import get_target_network_api
@@ -1195,7 +1203,7 @@ def open_vm_port(cmd, resource_group_name, vm_name, port, priority=900, network_
 
 
 def resize_vm(cmd, resource_group_name, vm_name, size, no_wait=False):
-    vm = get_vm(cmd, resource_group_name, vm_name)
+    vm = get_vm_to_update(cmd, resource_group_name, vm_name)
     if vm.hardware_profile.vm_size == size:
         logger.warning("VM is already %s", size)
         return None
@@ -1234,14 +1242,6 @@ def patch_vm(cmd, resource_group_name, vm_name, vm):
 def show_vm(cmd, resource_group_name, vm_name, show_details=False):
     return get_vm_details(cmd, resource_group_name, vm_name) if show_details \
         else get_vm(cmd, resource_group_name, vm_name)
-
-
-def get_vm_for_generic_update(cmd, resource_group_name, vm_name):
-    client = _compute_client_factory(cmd.cli_ctx)
-    vm = client.virtual_machines.get(resource_group_name, vm_name)
-    # To avoid unnecessary permission check of image
-    vm.storage_profile.image_reference = None
-    return vm
 
 
 def update_vm(cmd, resource_group_name, vm_name, os_disk=None, disk_caching=None,
@@ -1407,7 +1407,7 @@ def list_av_sets(cmd, resource_group_name=None):
 
 # region VirtualMachines BootDiagnostics
 def disable_boot_diagnostics(cmd, resource_group_name, vm_name):
-    vm = get_vm(cmd, resource_group_name, vm_name)
+    vm = get_vm_to_update(cmd, resource_group_name, vm_name)
     diag_profile = vm.diagnostics_profile
     if not (diag_profile and diag_profile.boot_diagnostics and diag_profile.boot_diagnostics.enabled):
         return
@@ -1419,7 +1419,7 @@ def disable_boot_diagnostics(cmd, resource_group_name, vm_name):
 
 def enable_boot_diagnostics(cmd, resource_group_name, vm_name, storage=None):
     from azure.cli.command_modules.vm._vm_utils import get_storage_blob_uri
-    vm = get_vm(cmd, resource_group_name, vm_name)
+    vm = get_vm_to_update(cmd, resource_group_name, vm_name)
     storage_uri = None
     if storage:
         storage_uri = get_storage_blob_uri(cmd.cli_ctx, storage)
@@ -1568,7 +1568,7 @@ def attach_managed_data_disk(cmd, resource_group_name, vm_name, disk, new=False,
                              size_gb=1023, lun=None, caching=None, enable_write_accelerator=False):
     '''attach a managed disk'''
     from msrestazure.tools import parse_resource_id
-    vm = get_vm(cmd, resource_group_name, vm_name)
+    vm = get_vm_to_update(cmd, resource_group_name, vm_name)
     DataDisk, ManagedDiskParameters, DiskCreateOption = cmd.get_models(
         'DataDisk', 'ManagedDiskParameters', 'DiskCreateOptionTypes')
 
@@ -1593,7 +1593,7 @@ def attach_managed_data_disk(cmd, resource_group_name, vm_name, disk, new=False,
 
 def detach_data_disk(cmd, resource_group_name, vm_name, disk_name):
     # here we handle both unmanaged or managed disk
-    vm = get_vm(cmd, resource_group_name, vm_name)
+    vm = get_vm_to_update(cmd, resource_group_name, vm_name)
     # pylint: disable=no-member
     leftovers = [d for d in vm.storage_profile.data_disks if d.name.lower() != disk_name.lower()]
     if len(vm.storage_profile.data_disks) == len(leftovers):
@@ -1872,7 +1872,7 @@ def list_vm_nics(cmd, resource_group_name, vm_name):
 
 
 def add_vm_nic(cmd, resource_group_name, vm_name, nics, primary_nic=None):
-    vm = get_vm(cmd, resource_group_name, vm_name)
+    vm = get_vm_to_update(cmd, resource_group_name, vm_name)
     new_nics = _build_nic_list(cmd, nics)
     existing_nics = _get_existing_nics(vm)
     return _update_vm_nics(cmd, vm, existing_nics + new_nics, primary_nic)
@@ -1883,7 +1883,7 @@ def remove_vm_nic(cmd, resource_group_name, vm_name, nics, primary_nic=None):
     def to_delete(nic_id):
         return [n for n in nics_to_delete if n.id.lower() == nic_id.lower()]
 
-    vm = get_vm(cmd, resource_group_name, vm_name)
+    vm = get_vm_to_update(cmd, resource_group_name, vm_name)
     nics_to_delete = _build_nic_list(cmd, nics)
     existing_nics = _get_existing_nics(vm)
     survived = [x for x in existing_nics if not to_delete(x.id)]
@@ -1891,7 +1891,7 @@ def remove_vm_nic(cmd, resource_group_name, vm_name, nics, primary_nic=None):
 
 
 def set_vm_nic(cmd, resource_group_name, vm_name, nics, primary_nic=None):
-    vm = get_vm(cmd, resource_group_name, vm_name)
+    vm = get_vm_to_update(cmd, resource_group_name, vm_name)
     nics = _build_nic_list(cmd, nics)
     return _update_vm_nics(cmd, vm, nics, primary_nic)
 
@@ -2035,7 +2035,7 @@ def add_vm_secret(cmd, resource_group_name, vm_name, keyvault, certificate, cert
     from ._vm_utils import create_keyvault_data_plane_client, get_key_vault_base_url
     VaultSecretGroup, SubResource, VaultCertificate = cmd.get_models(
         'VaultSecretGroup', 'SubResource', 'VaultCertificate')
-    vm = get_vm(cmd, resource_group_name, vm_name)
+    vm = get_vm_to_update(cmd, resource_group_name, vm_name)
 
     if '://' not in certificate:  # has a cert name rather a full url?
         keyvault_client = create_keyvault_data_plane_client(cmd.cli_ctx)
@@ -2067,7 +2067,7 @@ def list_vm_secrets(cmd, resource_group_name, vm_name):
 
 
 def remove_vm_secret(cmd, resource_group_name, vm_name, keyvault, certificate=None):
-    vm = get_vm(cmd, resource_group_name, vm_name)
+    vm = get_vm_to_update(cmd, resource_group_name, vm_name)
 
     # support 2 kinds of filter:
     # a. if only keyvault is supplied, we delete its whole vault group.
@@ -2106,7 +2106,7 @@ def attach_unmanaged_data_disk(cmd, resource_group_name, vm_name, new=False, vhd
         raise CLIError('Please provide the name of the existing disk to attach')
     create_option = DiskCreateOptionTypes.empty if new else DiskCreateOptionTypes.attach
 
-    vm = get_vm(cmd, resource_group_name, vm_name)
+    vm = get_vm_to_update(cmd, resource_group_name, vm_name)
     if disk_name is None:
         import datetime
         disk_name = vm_name + '-' + datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
@@ -3173,7 +3173,6 @@ def list_image_galleries(cmd, resource_group_name=None):
 
 def create_image_gallery(cmd, resource_group_name, gallery_name, description=None,
                          location=None, no_wait=False, tags=None):
-    client = _compute_client_factory(cmd.cli_ctx)
     Gallery = cmd.get_models('Gallery')
     location = location or _get_resource_group_location(cmd.cli_ctx, resource_group_name)
 
@@ -3226,6 +3225,23 @@ def create_gallery_image(cmd, resource_group_name, gallery_name, gallery_image_n
     return client.gallery_images.create_or_update(resource_group_name, gallery_name, gallery_image_name, image)
 
 
+def _add_aux_subscription(aux_subscriptions, resource_id):
+    if resource_id:
+        aux_subs = _parse_aux_subscriptions(resource_id)
+        if aux_subs and aux_subs[0] not in aux_subscriptions:
+            aux_subscriptions.extend(aux_subs)
+
+
+def _get_image_version_aux_subscription(managed_image, os_snapshot, data_snapshots):
+    aux_subscriptions = []
+    _add_aux_subscription(aux_subscriptions, managed_image)
+    _add_aux_subscription(aux_subscriptions, os_snapshot)
+    if data_snapshots:
+        for data_snapshot in data_snapshots:
+            _add_aux_subscription(aux_subscriptions, data_snapshot)
+    return aux_subscriptions if aux_subscriptions else None
+
+
 def create_image_version(cmd, resource_group_name, gallery_name, gallery_image_name, gallery_image_version,
                          location=None, target_regions=None, storage_account_type=None,
                          end_of_life_date=None, exclude_from_latest=None, replica_count=None, tags=None,
@@ -3236,10 +3252,9 @@ def create_image_version(cmd, resource_group_name, gallery_name, gallery_image_n
     ImageVersionPublishingProfile, GalleryArtifactSource, ManagedArtifact, ImageVersion, TargetRegion = cmd.get_models(
         'GalleryImageVersionPublishingProfile', 'GalleryArtifactSource', 'ManagedArtifact', 'GalleryImageVersion',
         'TargetRegion')
-    aux_subscriptions = None
-    if managed_image:
-        aux_subscriptions = _parse_aux_subscriptions(managed_image)
+    aux_subscriptions = _get_image_version_aux_subscription(managed_image, os_snapshot, data_snapshots)
     client = _compute_client_factory(cmd.cli_ctx, aux_subscriptions=aux_subscriptions)
+
     location = location or _get_resource_group_location(cmd.cli_ctx, resource_group_name)
     end_of_life_date = fix_gallery_image_date_info(end_of_life_date)
     if managed_image and not is_valid_resource_id(managed_image):
@@ -3306,11 +3321,17 @@ def fix_gallery_image_date_info(date_info):
 
 
 # pylint: disable=line-too-long
-def get_image_version_for_generic_update(cmd, resource_group_name, gallery_name, gallery_image_name, gallery_image_version_name):
+def get_image_version_to_update(cmd, resource_group_name, gallery_name, gallery_image_name, gallery_image_version_name):
     client = _compute_client_factory(cmd.cli_ctx)
     version = client.gallery_image_versions.get(resource_group_name, gallery_name, gallery_image_name, gallery_image_version_name)
     # To avoid unnecessary permission check of image
     version.storage_profile.source = None
+    if version.storage_profile.os_disk_image and version.storage_profile.os_disk_image.source:
+        version.storage_profile.os_disk_image.source = None
+    if version.storage_profile.data_disk_images:
+        for i in range(len(version.storage_profile.data_disk_images)):
+            if version.storage_profile.data_disk_images[i].source:
+                version.storage_profile.data_disk_images[i].source = None
     return version
 
 
@@ -3325,11 +3346,7 @@ def update_image_version(cmd, resource_group_name, gallery_name, gallery_image_n
     if image_version.storage_profile.source is not None:
         image_version.storage_profile.os_disk_image = image_version.storage_profile.data_disk_images = None
 
-    aux_subscriptions = None
-    if image_version.storage_profile and image_version.storage_profile.source and \
-            'id' in image_version.storage_profile.source:
-        aux_subscriptions = _parse_aux_subscriptions(image_version.storage_profile.source['id'])
-    client = _compute_client_factory(cmd.cli_ctx, aux_subscriptions=aux_subscriptions)
+    client = _compute_client_factory(cmd.cli_ctx)
 
     return sdk_no_wait(no_wait, client.gallery_image_versions.create_or_update, resource_group_name, gallery_name,
                        gallery_image_name, gallery_image_version_name, **kwargs)

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_custom_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_custom_vm_commands.py
@@ -88,49 +88,49 @@ class TestVmCustom(unittest.TestCase):
         self.assertEqual('1.5', version)
         self.assertEqual(True, auto_upgrade)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_enable_boot_diagnostics_on_vm_never_enabled(self, mock_vm_set, mock_vm_get):
+    def test_enable_boot_diagnostics_on_vm_never_enabled(self, mock_vm_set, mock_vm_get_to_update):
         vm_fake = mock.MagicMock()
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm_fake
+        mock_vm_get_to_update.return_value = vm_fake
         enable_boot_diagnostics(cmd, 'g1', 'vm1', 'https://storage_uri1')
         self.assertTrue(vm_fake.diagnostics_profile.boot_diagnostics.enabled)
         self.assertEqual('https://storage_uri1',
                          vm_fake.diagnostics_profile.boot_diagnostics.storage_uri)
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm_fake, mock.ANY)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_disable_boot_diagnostics_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_disable_boot_diagnostics_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         vm_fake = mock.MagicMock()
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm_fake
+        mock_vm_get_to_update.return_value = vm_fake
         vm_fake.diagnostics_profile.boot_diagnostics.enabled = True
         vm_fake.diagnostics_profile.boot_diagnostics.storage_uri = 'storage_uri1'
         disable_boot_diagnostics(cmd, 'g1', 'vm1')
         self.assertFalse(vm_fake.diagnostics_profile.boot_diagnostics.enabled)
         self.assertIsNone(vm_fake.diagnostics_profile.boot_diagnostics.storage_uri)
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm_fake, mock.ANY)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_attach_new_datadisk_default_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_attach_new_datadisk_default_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
 
         # stub to get the vm which has no datadisks
         vm = FakedVM(None, None)
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         attach_unmanaged_data_disk(cmd, 'rg1', 'vm1', True, faked_vhd_uri)
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 1)
         data_disk = vm.storage_profile.data_disks[0]
@@ -141,9 +141,9 @@ class TestVmCustom(unittest.TestCase):
         self.assertTrue(data_disk.name.startswith('vm1-'))
         self.assertEqual(data_disk.vhd.uri, faked_vhd_uri)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_attach_new_datadisk_custom_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_attach_new_datadisk_custom_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
         faked_vhd_uri2 = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d2.vhd'
@@ -152,13 +152,13 @@ class TestVmCustom(unittest.TestCase):
         existing_disk = DataDisk(lun=1, vhd=faked_vhd_uri, name='d1', create_option=DiskCreateOptionTypes.empty)
         vm = FakedVM(None, [existing_disk])
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         attach_unmanaged_data_disk(cmd, 'rg1', 'vm1', True, faked_vhd_uri2, None, 'd2', 512, CachingTypes.read_write)
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 2)
         data_disk = vm.storage_profile.data_disks[1]
@@ -168,22 +168,22 @@ class TestVmCustom(unittest.TestCase):
         self.assertEqual(data_disk.lun, 0)  # the existing disk has '1', so it verifes the second one be picked as '0'
         self.assertEqual(data_disk.vhd.uri, faked_vhd_uri2)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_attach_existing_datadisk_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_attach_existing_datadisk_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
 
         # stub to get the vm which has no datadisks
         vm = FakedVM()
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         attach_unmanaged_data_disk(cmd, 'rg1', 'vm1', False, faked_vhd_uri, disk_name='d1', caching=CachingTypes.read_only)
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 1)
         data_disk = vm.storage_profile.data_disks[0]
@@ -194,22 +194,22 @@ class TestVmCustom(unittest.TestCase):
         self.assertEqual(data_disk.name, 'd1')
         self.assertEqual(data_disk.vhd.uri, faked_vhd_uri)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_deattach_disk_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_deattach_disk_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         # stub to get the vm which has no datadisks
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
         existing_disk = DataDisk(lun=1, vhd=faked_vhd_uri, name='d1', create_option=DiskCreateOptionTypes.empty)
         vm = FakedVM(None, [existing_disk])
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         detach_data_disk(cmd, 'rg1', 'vm1', 'd1')
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 0)
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_custom_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_custom_vm_commands.py
@@ -88,49 +88,49 @@ class TestVmCustom(unittest.TestCase):
         self.assertEqual('1.5', version)
         self.assertEqual(True, auto_upgrade)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_enable_boot_diagnostics_on_vm_never_enabled(self, mock_vm_set, mock_vm_get):
+    def test_enable_boot_diagnostics_on_vm_never_enabled(self, mock_vm_set, mock_vm_get_to_update):
         vm_fake = mock.MagicMock()
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm_fake
+        mock_vm_get_to_update.return_value = vm_fake
         enable_boot_diagnostics(cmd, 'g1', 'vm1', 'https://storage_uri1')
         self.assertTrue(vm_fake.diagnostics_profile.boot_diagnostics.enabled)
         self.assertEqual('https://storage_uri1',
                          vm_fake.diagnostics_profile.boot_diagnostics.storage_uri)
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm_fake, mock.ANY)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_disable_boot_diagnostics_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_disable_boot_diagnostics_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         vm_fake = mock.MagicMock()
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm_fake
+        mock_vm_get_to_update.return_value = vm_fake
         vm_fake.diagnostics_profile.boot_diagnostics.enabled = True
         vm_fake.diagnostics_profile.boot_diagnostics.storage_uri = 'storage_uri1'
         disable_boot_diagnostics(cmd, 'g1', 'vm1')
         self.assertFalse(vm_fake.diagnostics_profile.boot_diagnostics.enabled)
         self.assertIsNone(vm_fake.diagnostics_profile.boot_diagnostics.storage_uri)
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm_fake, mock.ANY)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_attach_new_datadisk_default_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_attach_new_datadisk_default_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
 
         # stub to get the vm which has no datadisks
         vm = FakedVM(None, None)
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         attach_unmanaged_data_disk(cmd, 'rg1', 'vm1', True, faked_vhd_uri)
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 1)
         data_disk = vm.storage_profile.data_disks[0]
@@ -141,9 +141,9 @@ class TestVmCustom(unittest.TestCase):
         self.assertTrue(data_disk.name.startswith('vm1-'))
         self.assertEqual(data_disk.vhd.uri, faked_vhd_uri)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_attach_new_datadisk_custom_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_attach_new_datadisk_custom_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
         faked_vhd_uri2 = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d2.vhd'
@@ -152,13 +152,13 @@ class TestVmCustom(unittest.TestCase):
         existing_disk = DataDisk(lun=1, vhd=faked_vhd_uri, name='d1', create_option=DiskCreateOptionTypes.empty)
         vm = FakedVM(None, [existing_disk])
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         attach_unmanaged_data_disk(cmd, 'rg1', 'vm1', True, faked_vhd_uri2, None, 'd2', 512, CachingTypes.read_write)
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 2)
         data_disk = vm.storage_profile.data_disks[1]
@@ -168,22 +168,22 @@ class TestVmCustom(unittest.TestCase):
         self.assertEqual(data_disk.lun, 0)  # the existing disk has '1', so it verifes the second one be picked as '0'
         self.assertEqual(data_disk.vhd.uri, faked_vhd_uri2)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_attach_existing_datadisk_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_attach_existing_datadisk_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
 
         # stub to get the vm which has no datadisks
         vm = FakedVM()
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         attach_unmanaged_data_disk(cmd, 'rg1', 'vm1', False, faked_vhd_uri, disk_name='d1', caching=CachingTypes.read_only)
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 1)
         data_disk = vm.storage_profile.data_disks[0]
@@ -194,22 +194,22 @@ class TestVmCustom(unittest.TestCase):
         self.assertEqual(data_disk.name, 'd1')
         self.assertEqual(data_disk.vhd.uri, faked_vhd_uri)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_deattach_disk_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_deattach_disk_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         # stub to get the vm which has no datadisks
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
         existing_disk = DataDisk(lun=1, vhd=faked_vhd_uri, name='d1', create_option=DiskCreateOptionTypes.empty)
         vm = FakedVM(None, [existing_disk])
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         detach_data_disk(cmd, 'rg1', 'vm1', 'd1')
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 0)
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
@@ -88,49 +88,49 @@ class TestVmCustom(unittest.TestCase):
         self.assertEqual('1.5', version)
         self.assertEqual(True, auto_upgrade)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_enable_boot_diagnostics_on_vm_never_enabled(self, mock_vm_set, mock_vm_get):
+    def test_enable_boot_diagnostics_on_vm_never_enabled(self, mock_vm_set, mock_vm_get_to_update):
         vm_fake = mock.MagicMock()
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm_fake
+        mock_vm_get_to_update.return_value = vm_fake
         enable_boot_diagnostics(cmd, 'g1', 'vm1', 'https://storage_uri1')
         self.assertTrue(vm_fake.diagnostics_profile.boot_diagnostics.enabled)
         self.assertEqual('https://storage_uri1',
                          vm_fake.diagnostics_profile.boot_diagnostics.storage_uri)
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm_fake, mock.ANY)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_disable_boot_diagnostics_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_disable_boot_diagnostics_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         vm_fake = mock.MagicMock()
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm_fake
+        mock_vm_get_to_update.return_value = vm_fake
         vm_fake.diagnostics_profile.boot_diagnostics.enabled = True
         vm_fake.diagnostics_profile.boot_diagnostics.storage_uri = 'storage_uri1'
         disable_boot_diagnostics(cmd, 'g1', 'vm1')
         self.assertFalse(vm_fake.diagnostics_profile.boot_diagnostics.enabled)
         self.assertIsNone(vm_fake.diagnostics_profile.boot_diagnostics.storage_uri)
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm_fake, mock.ANY)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_attach_new_datadisk_default_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_attach_new_datadisk_default_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
 
         # stub to get the vm which has no datadisks
         vm = FakedVM(None, None)
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         attach_unmanaged_data_disk(cmd, 'rg1', 'vm1', True, faked_vhd_uri)
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 1)
         data_disk = vm.storage_profile.data_disks[0]
@@ -141,9 +141,9 @@ class TestVmCustom(unittest.TestCase):
         self.assertTrue(data_disk.name.startswith('vm1-'))
         self.assertEqual(data_disk.vhd.uri, faked_vhd_uri)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_attach_new_datadisk_custom_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_attach_new_datadisk_custom_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
         faked_vhd_uri2 = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d2.vhd'
@@ -152,13 +152,13 @@ class TestVmCustom(unittest.TestCase):
         existing_disk = DataDisk(lun=1, vhd=faked_vhd_uri, name='d1', create_option=DiskCreateOptionTypes.empty)
         vm = FakedVM(None, [existing_disk])
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         attach_unmanaged_data_disk(cmd, 'rg1', 'vm1', True, faked_vhd_uri2, None, 'd2', 512, CachingTypes.read_write)
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 2)
         data_disk = vm.storage_profile.data_disks[1]
@@ -168,22 +168,22 @@ class TestVmCustom(unittest.TestCase):
         self.assertEqual(data_disk.lun, 0)  # the existing disk has '1', so it verifes the second one be picked as '0'
         self.assertEqual(data_disk.vhd.uri, faked_vhd_uri2)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_attach_existing_datadisk_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_attach_existing_datadisk_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
 
         # stub to get the vm which has no datadisks
         vm = FakedVM()
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         attach_unmanaged_data_disk(cmd, 'rg1', 'vm1', False, faked_vhd_uri, disk_name='d1', caching=CachingTypes.read_only)
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 1)
         data_disk = vm.storage_profile.data_disks[0]
@@ -194,22 +194,22 @@ class TestVmCustom(unittest.TestCase):
         self.assertEqual(data_disk.name, 'd1')
         self.assertEqual(data_disk.vhd.uri, faked_vhd_uri)
 
-    @mock.patch('azure.cli.command_modules.vm.custom.get_vm', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_vm_to_update', autospec=True)
     @mock.patch('azure.cli.command_modules.vm.custom.set_vm', autospec=True)
-    def test_deattach_disk_on_vm(self, mock_vm_set, mock_vm_get):
+    def test_deattach_disk_on_vm(self, mock_vm_set, mock_vm_get_to_update):
         # pylint: disable=line-too-long
         # stub to get the vm which has no datadisks
         faked_vhd_uri = 'https://your_stoage_account_name.blob.core.windows.net/vhds/d1.vhd'
         existing_disk = DataDisk(lun=1, vhd=faked_vhd_uri, name='d1', create_option=DiskCreateOptionTypes.empty)
         vm = FakedVM(None, [existing_disk])
         cmd = _get_test_cmd()
-        mock_vm_get.return_value = vm
+        mock_vm_get_to_update.return_value = vm
 
         # execute
         detach_data_disk(cmd, 'rg1', 'vm1', 'd1')
 
         # assert
-        self.assertTrue(mock_vm_get.called)
+        self.assertTrue(mock_vm_get_to_update.called)
         mock_vm_set.assert_called_once_with(cmd, vm)
         self.assertEqual(len(vm.storage_profile.data_disks), 0)
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
As we use the PUT REST API (create_or_update) to update vm/image version, if this vm or image version uses a cross tenant image/disk, the user will fail to update it later if he/she has no permission to the original image/disk.

@qwordy has helped add support for `vmss create/update` in 2.13.0. However there are still some other commands that have such problems.

In 2.14.0, @arrownj has added support for `sig image-version create/update` and `vm create/update`.

In 2.15.0, we need to add support for below commands:

1. `vm disk attach/detach`
2. `vm resize`
3. `vm boot-diagnostics enable/disable`
4. `vm nic add/set/remove`
5. `vm secret add/remove`
6. `vm unmanaged-disk attach/detach`

For `sig image-version create/update`, in 2.14.0, we only support the case when image version use a managed image. The command will still fail when the image version use a disk. We also cover this case in 2.15.0.

For vm, as the service will throw exception when create a vm with a cross tenant disk, so we currently only support create/update from image case. 

**Testing Guide**
<!--Example commands with explanations.-->
1. login with user A who has permission to use cross tenant image/disk

2. create a vm/image version in subscription A with subscription B's image/disk

3. logout user A

4. login with user B who only has permission in subscription A (make sure he/she has no permission to read subscription B's resource)

5. run above commands to see whether they can work.
**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
