### PR TITLE
{Error Improvement} Error category and error message refining

### DIFF
--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -100,6 +100,16 @@ class UnknownError(AzCLIError):
     def send_telemetry(self):
         super().send_telemetry()
         telemetry.set_failure(self.error_msg)
+
+    def print_error(self):
+        from azure.cli.core.azlogging import CommandLoggerContext
+        with CommandLoggerContext(logger):
+            # print only error message (no error type)
+            logger.error(self.error_msg)
+            # print recommendations to action
+            if self.recommendations:
+                for recommendation in self.recommendations:
+                    print(recommendation, file=sys.stderr)
 # endregion
 
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -173,9 +173,8 @@ def extract_http_operation_error(ex):
         # http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091
         if isinstance(error, dict):
             status_code = error.get('code', 'Unknown Code')
-            code_str = "{} - ".format(status_code)
             message = error.get('message', ex)
-            error_msg = "code: {}, {}".format(code_str, message)
+            error_msg = "{}: {}".format(status_code, message)
         else:
             error_msg = error
     except (ValueError, KeyError):

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -213,6 +213,8 @@ def get_error_type_by_status_code(status_code):
         return azclierror.ForbiddenError
     if status_code == '404':
         return azclierror.ResourceNotFoundError
+    if status_code.startswith('4'):
+        return azclierror.UnclassifiedUserFault
     if status_code.startswith('5'):
         return azclierror.AzureInternalError
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -201,6 +201,7 @@ def get_error_type_by_azure_error(ex):
     return azclierror.UnknownError
 
 
+# pylint: disable=too-many-return-statements
 def get_error_type_by_status_code(status_code):
     import azure.cli.core.azclierror as azclierror
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR provides the following error improvements.
- Suppress `UnknownError` in error message.
- Catgorize the uncommon `4xx` HTTP response errors into the `UnclassifiedUserFaults` instead of `UnknownError`
- Fix the untidy error message issue in HttpOperationError #15872

**Testing Guide**
<!--Example commands with explanations.-->
For the untidy error message in HttpOperationError, just type `az account management-group show --name non-existing` for testing.

Previously,
```
code: AuthorizationFailed - , The client 'test@azuresdkteam.onmicrosoft.com' with object id '6d97229a-391f-473a-893f-f0608b592d7b' does not have authorization to perform action 'Microsoft.Management/managementGroups/read' over scope '/providers/Microsoft.Management/managementGroups/non-existing' or the scope is invalid. If access was recently granted, please refresh your credentials.
```

Now,
```
AuthorizationFailed: The client 'test@azuresdkteam.onmicrosoft.com' with object id '6d97229a-391f-473a-893f-f0608b592d7b' does not have authorization to perform action 'Microsoft.Management/managementGroups/read' over scope '/providers/Microsoft.Management/managementGroups/non-existing' or the scope is invalid. If access was recently granted, please refresh your credentials.
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
