### PR TITLE
[Profile] az account set: Show JSON for the selected subscription

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -99,6 +99,7 @@ def set_active_subscription(cmd, subscription):
     if not id:
         raise CLIError('Please provide subscription id or unique name.')
     profile.set_active_subscription(subscription)
+    return profile.get_subscription()
 
 
 def account_clear(cmd):


### PR DESCRIPTION
## Description

The current `az account set` returns nothing when it succeeds, and the user has to run `az account show` to see information about the selected subscription.

```powershell
> az account set -s 0b1f6471-1bf0-4dda-aec3-cb9272f09590
> az account show -s 0b1f6471-1bf0-4dda-aec3-cb9272f09590
{
  "environmentName": "AzureCloud",
  "homeTenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "id": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
  "isDefault": true,
  "managedByTenants": [
    {
      "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
    }
  ],
  "name": "AzureSDKTest",
  "state": "Enabled",
  "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "user": {
    "name": "xxx@microsoft.com",
    "type": "user"
  }
}
```

~Also, because `az account set` has no output, **post-output hint** can't give any hint based on the output.~

An alternative is to use **post-output hint** to read the information from `profile.get_subscription()` and show

> The default subscription has been switched to AzureSDKTest (0b1f6471-1bf0-4dda-aec3-cb9272f09590).

## Change

This PR makes `az account set` return the JSON of the selected subscription, so that the user can directly know the information of the subscription without calling `az account show`.

This is NOT a BREAKING CHANGE as no existing information is changed or removed - it only adds more information.

## Testing Guide

```powershell
> az account set -s 0b1f6471-1bf0-4dda-aec3-cb9272f09590
{
  "environmentName": "AzureCloud",
  "homeTenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "id": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
  "isDefault": true,
  "managedByTenants": [
    {
      "tenantId": "2f4a9838-26b7-47ee-be60-ccc1fdec5953"
    }
  ],
  "name": "AzureSDKTest",
  "state": "Enabled",
  "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "user": {
    "name": "xxx@microsoft.com",
    "type": "user"
  }
}
```
