### PR TITLE
[BACKUP] Fixed Bad Request Error for Correct Workload Type Input

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -22,7 +22,7 @@ from azure.cli.command_modules.backup._validators import \
 
 allowed_container_types = ['AzureIaasVM']
 allowed_workload_types = ['VM', 'AzureFileShare', 'SAPHANA', 'MSSQL', 'SAPHanaDatabase', 'SQLDataBase']
-allowed_azure_workload_types = ['MSSQL', 'SAPHANA', 'SAPASE']
+allowed_azure_workload_types = ['MSSQL', 'SAPHANA', 'SAPASE', 'SAPHanaDatabase', 'SQLDataBase']
 allowed_backup_management_types = ['AzureIaasVM', 'AzureStorage', 'AzureWorkload']
 allowed_protectable_item_type = ['SQLAG', 'SQLInstance', 'SQLDatabase', 'HANAInstance', 'SAPHanaDatabase', 'SAPHanaSystem']
 

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
@@ -34,6 +34,8 @@ logger = get_logger(__name__)
 # Mapping of workload type
 workload_type_map = {'MSSQL': 'SQLDataBase',
                      'SAPHANA': 'SAPHanaDatabase',
+                     'SQLDataBase': 'SQLDataBase',
+                     'SAPHanaDatabase': 'SAPHanaDatabase',
                      'SAPASE': 'SAPAseDatabase'}
 
 # Mapping of module name


### PR DESCRIPTION
**Description**<!--Mandatory-->
In some cases 'SAPHANA' & 'MSSQL' are shown in the help text as allowed values for workload type argument but when these are given as input the command terminates with Bad Error Request. I've included a map in custom_common.py to map these values to the value that the API is expecting.

**Testing Guide**
az backup item list -g {rg} -v {vault} --backup-management-type AzureWorkload --workload-type SAPHANA
az backup policy list -g {rg} -v {vault} --backup-management-type AzureWorkload --workload-type MSSQL

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
