### PR TITLE
{container} Bugfix #15856: az container exec - remove eol check to avoid closing terminal before it even started on linux

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/container/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/container/custom.py
@@ -681,8 +681,6 @@ def _cycle_exec_pipe(ws):
     r, _, _ = select.select([ws.sock, sys.stdin], [], [])
     if ws.sock in r:
         data = ws.recv()
-        if not data:
-            return False
         sys.stdout.write(data)
         sys.stdout.flush()
     if sys.stdin in r:


### PR DESCRIPTION
The backend sends an empty webSocket message after establishing an connection. The removed lines of code interpreted that as an EOL which exits the webSocket read loop.
As the Windows code doesn't do that as well, I removed it here as well now.
The terminal gets closed after the webSocket closes anyway.

Fixes: https://github.com/Azure/azure-cli/issues/15856

**Description**<!--Mandatory-->
As described in https://github.com/Azure/azure-cli/issues/15856 there is currently an issue getting a remote terminal to a container instance with `az container exec` as it immediately closes the connection.

**Testing Guide**
- start a container e.g. with `az container create` with a long living container
- try to execute a shell inside the container with `az container exec --exec-command "/bin/bash" ...`
- currently it just exits without an error or shell

**History Notes**
[container] az container exec: remove eol check to avoid closing terminal before it even started on linux

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
