### PR TITLE
[AKS ] az aks get-credentials: Clarify documentation for get-credentials

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -558,7 +558,8 @@ examples:
 
 helps['aks get-credentials'] = """
 type: command
-short-summary: Get access credentials for a managed Kubernetes cluster. Merge them into .kube/config file so kubectl can use them
+short-summary: Get access credentials for a managed Kubernetes cluster.
+long-summary: By default, the credentials are merged into the .kube/config file so kubectl can use them.  See -f parameter for details.
 parameters:
   - name: --admin -a
     type: bool

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -558,11 +558,12 @@ examples:
 
 helps['aks get-credentials'] = """
 type: command
-short-summary: Get access credentials for a managed Kubernetes cluster.
+short-summary: Get access credentials for a managed Kubernetes cluster. Merge them into .kube/config file so kubectl can use them
 parameters:
   - name: --admin -a
     type: bool
     short-summary: "Get cluster administrator credentials.  Default: cluster user credentials."
+    long-summary: "On clusters with Azure Active Directory integration, this bypasses normal Azure AD authentication and can be used if you're permanently blocked by not having access to a valid Azure AD group with access to your cluster. Requires 'Azure Kubernetes Service Cluster Admin' role."
   - name: --file -f
     type: string
     short-summary: Kubernetes configuration file to update. Use "-" to print YAML to stdout instead.


### PR DESCRIPTION
**Description**<!--Mandatory-->
This PR clarifies the documentation for `az aks get-credentials`. I'm creating it after an AKS customer support incident where there was confusion over the purpose of the --admin flag. This PR:

* Explains how `get-credentials` relates to kubectl (since that explaination is otherwise very hard to find, and not at all obvious to new AKS users)
* Explains `--admin` in an AAD context, as per https://docs.microsoft.com/en-us/azure/aks/managed-aad#troubleshooting-access-issues-with-azure-ad

**Testing Guide**
Make sure `az aks get-credentials --help` looks reasonable.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [Y ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ Y] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [Y] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
