### PR TITLE
{Test} Add retry utility

### DIFF
--- a/src/azure-cli-testsdk/HISTORY.rst
+++ b/src/azure-cli-testsdk/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+0.2.6
++++++
+* Add retry utility
+
+0.2.5
++++++
 * Add resource group name prefix validator in resource group preparer
 
 0.2.4

--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import os
+import time
 from contextlib import contextmanager
 
 from azure_devtools.scenario_tests import (create_random_name as create_random_name_base, RecordingProcessor,
@@ -198,3 +199,18 @@ class GeneralNameReplacer(_BuggyGeneralNameReplacer):
                     request.body = body.replace(old, new)
 
         return request
+
+
+def retry(func, timeout, interval=10):
+    """
+    Retry func until success.
+    :param timeout: in seconds
+    :param func: function
+    :param interval: polling interval
+    :return:
+    """
+    for i in range(0, timeout, interval):
+        try:
+            return func()
+        except Exception:  # pylint: disable=broad-except
+            time.sleep(interval)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Time problem in testing
```
# test delete iaas pool
self.batch_cmd('batch pool delete --pool-id {pool_i} --yes')
self.batch_cmd('batch pool show --pool-id {pool_i} --select "state"').assert_with_checks([
    self.check('state', 'deleting')])
```
The second command will fail if the first command deletes the pool quickly enough.
```
self.cmd('vm simulate-eviction --resource-group {rg} --name {vm2}')
time.sleep(180)
self.cmd('vm get-instance-view --resource-group {rg} --name {vm2}', checks=[
    self.check('name', '{vm2}'),
    self.check('resourceGroup', '{rg}'),
    self.check('length(instanceView.statuses)', 2),
    self.check('instanceView.statuses[0].code', 'ProvisioningState/succeeded'),
    self.check('instanceView.statuses[1].code', 'PowerState/deallocated'),
])
```
This piece of code is not robust. “vm simulate-eviction” command returns before it really takes effect. 180 seconds is an empirical value to wait. Sometimes, the next command fails.
```
self.cmd('az cognitiveservices account identity remove -n {sname} -g {rg}')
E azure.mgmt.cognitiveservices.models._models_py3.ErrorException: (RequestConflict) Cannot modify resource with id '/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/clitest.rgbwjubs5hgprklyfdjebasibxhldpdlspiqzpt2zdstmfmkbevhhke5zk3e3psiw77/providers/Microsoft.CognitiveServices/accounts/cs_cli_test_g3ut' because the resource entity provisioning state is not terminal. Please wait for the provisioning state to become terminal and then retry the request.
```
It is a similar problem. The provisioning is not finished.
A good example,
```
for i in range(10):
    time.sleep(15) # sleep() is mocked in replay mode, so just use a large value.
    account = self.cmd('az cognitiveservices account show -n {sname} -g {rg}').get_output_in_json()
    if 'Creating' != account['properties']['provisioningState']:
        break
```
The benefit of this approach is that it can exit fast and doesn’t need to wait for the entire timeout. We can extract a function for it. That is `retry` is TestSDK.



**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
