### PR TITLE
{Core} Use semver for azure-mgmt-core

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -59,7 +59,7 @@ DEPENDENCIES = [
     'requests~=2.22',
     'six~=1.12',
     'pkginfo>=1.5.0.1',
-    'azure-mgmt-core==1.2.1',
+    'azure-mgmt-core~=1.2',
     # Dependencies of the vendored subscription SDK
     # https://github.com/Azure/azure-sdk-for-python/blob/ab12b048ddf676fe0ccec16b2167117f0609700d/sdk/resources/azure-mgmt-resource/setup.py#L82-L86
     'msrest>=0.5.0',

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -59,7 +59,7 @@ DEPENDENCIES = [
     'requests~=2.22',
     'six~=1.12',
     'pkginfo>=1.5.0.1',
-    'azure-mgmt-core~=1.2',
+    'azure-mgmt-core>=1.2.0,<2.0.0',
     # Dependencies of the vendored subscription SDK
     # https://github.com/Azure/azure-sdk-for-python/blob/ab12b048ddf676fe0ccec16b2167117f0609700d/sdk/resources/azure-mgmt-resource/setup.py#L82-L86
     'msrest>=0.5.0',


### PR DESCRIPTION
**Description**<!--Mandatory-->
Trying to package this for nixpkgs, but I get:
```
ERROR: No matching distribution found for azure-mgmt-core==1.2.1 (from azure-cli-core==2.15.1)
```
when it's being given 1.2.2

Azure-sdk generally follows semver, so no need to pin.

**Testing Guide**

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
