### PR TITLE
{CI} Remove usage of six

### DIFF
--- a/src/azure-cli-core/tox.ini
+++ b/src/azure-cli-core/tox.ini
@@ -6,6 +6,5 @@ skip_missing_interpreters = True
 deps = pytest
        mock
        pip
-       azure-mgmt-resource~=6.0.0
        -e ../azure-cli-telemetry
 commands = pytest

--- a/src/azure-cli-core/tox.ini
+++ b/src/azure-cli-core/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py36,py27,py38
+envlist = py36,py37,py38
 skip_missing_interpreters = True
 
 [testenv]

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_client.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_client.py
@@ -5,7 +5,6 @@
 
 import json
 import datetime
-import six
 
 from applicationinsights import TelemetryClient
 from applicationinsights.channel import SynchronousSender, SynchronousQueue, TelemetryChannel
@@ -49,7 +48,7 @@ class CliTelemetryClient:
                 properties = {}
                 measurements = {}
                 for k, v in raw_properties.items():
-                    if isinstance(v, six.string_types):
+                    if isinstance(v, str):
                         properties[k] = v
                     else:
                         measurements[k] = v

--- a/src/azure-cli-telemetry/tox.ini
+++ b/src/azure-cli-telemetry/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py36,py27,py38
+envlist = py36,py37,py38
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
**Description**<!--Mandatory-->

Thanks to @fengzhou-msft for the finding. 

Previously, `six` is installed by [packaging 20.4](https://pypi.org/project/packaging/20.4/).

```
> pipdeptree -p six -r
six==1.14.0
  - packaging==20.4 [requires: six]
    - pytest==6.1.1 [requires: packaging]
      - azdev==0.1.28 [requires: pytest>=5.0.0]
      - azure-cli-testsdk==0.2.4 [requires: pytest]
      - pytest-forked==1.3.0 [requires: pytest>=3.10]
        - pytest-xdist==2.1.0 [requires: pytest-forked]
          - azdev==0.1.28 [requires: pytest-xdist]
      - pytest-xdist==2.1.0 [requires: pytest>=6.0.0]
        - azdev==0.1.28 [requires: pytest-xdist]
    - tox==3.20.1 [requires: packaging>=14]
      - azdev==0.1.28 [requires: tox]
```

Now `six` has been dropped since [packaging 20.5](https://pypi.org/project/packaging/20.5/) (https://github.com/pypa/packaging/pull/331), causing CI to fail.

https://dev.azure.com/azure-sdk/public/_build/results?buildId=635666&view=logs&jobId=4cf87b3f-d609-5b69-870a-4ac948acfd42&j=4ac732a2-b9e4-5fde-3ff2-aac0b888c429&t=7defb86d-ca26-5ebc-39fe-803ea5c317dd

```
==================================== ERRORS ====================================
_____ ERROR collecting azure/cli/telemetry/tests/test_telemetry_client.py ______
ImportError while importing test module '/home/vsts/work/1/s/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_telemetry_client.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
azure/cli/telemetry/tests/test_telemetry_client.py:22: in <module>
    from azure.cli.telemetry.components.telemetry_client import (CliTelemetryClient, _NoRetrySender, http_client_t)
azure/cli/telemetry/components/telemetry_client.py:8: in <module>
    import six
E   ModuleNotFoundError: No module named 'six'
=========================== short test summary info ============================
ERROR azure/cli/telemetry/tests/test_telemetry_client.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.25s ===============================
ERROR: InvocationError for command /home/vsts/work/1/s/src/azure-cli-telemetry/.tox/py38/bin/pytest (exited with code 2)
___________________________________ summary ____________________________________
ERROR:   py38: commands failed
```

This PR fixes the CI by removing the usage of `six` as Azure CLI has dropped Python 2 support.
