### PR TITLE
{Misc} Remove '?view=' syntax in links where not necessary

### DIFF
--- a/doc/extensions/README.md
+++ b/doc/extensions/README.md
@@ -30,7 +30,7 @@ How to find and install an Extension
 
 - Install an extension: `az extension install --name <extension-name>`
 
-More details on usage in [Extensions for Azure CLI 2.0](https://docs.microsoft.com/cli/azure/azure-cli-extensions-overview?view=azure-cli-latest#install-extensions)
+More details on usage in [Extensions for Azure CLI 2.0](https://docs.microsoft.com/cli/azure/azure-cli-extensions-overview#install-extensions)
 
 
 Doc Sections

--- a/doc/extensions/authoring.md
+++ b/doc/extensions/authoring.md
@@ -53,7 +53,7 @@ The storage fields can be stored in your config file or as environment variables
 
 Once your extension is published, you can view it via `az extension list-avaliable -o table`.
 
-However, if you want your extension to be listed in [Official Available Extensions for Azure CLI](https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-list?view=azure-cli-latest), you have to wait until the next [Azure CLI release](https://github.com/Azure/azure-cli/milestones). We update that document every time Azure CLI is released. Alternatively, you could file a PR to update it manually if it's urgent.
+However, if you want your extension to be listed in [Official Available Extensions for Azure CLI](https://docs.microsoft.com/cli/azure/azure-cli-extensions-list), you have to wait until the next [Azure CLI release](https://github.com/Azure/azure-cli/milestones). We update that document every time Azure CLI is released. Alternatively, you could file a PR to update it manually if it's urgent.
 
 ## Uncommon Flows
 

--- a/doc/install_troubleshooting.md
+++ b/doc/install_troubleshooting.md
@@ -9,7 +9,7 @@ These are issues we have closed because we cannot address them within the CLI du
 lsb_release does not return the correct base distribution version
 -----------------------------------------------------------------
 
-Some Ubuntu- or Debian-derived distributions such as Linux Mint may not return the correct version name from `lsb_release`. This value is used in the install process to determine the package to install. If you know the code name of the Ubuntu or Debian version your distribution is derived from, you can set the `AZ_REPO` value manually when [adding the repository](https://docs.microsoft.com/cli/azure/install-azure-cli-apt?view=azure-cli-latest#set-release). Otherwise, look up information for your distribution on how to determine the base distribution code name and set `AZ_REPO` to the correct value.
+Some Ubuntu- or Debian-derived distributions such as Linux Mint may not return the correct version name from `lsb_release`. This value is used in the install process to determine the package to install. If you know the code name of the Ubuntu or Debian version your distribution is derived from, you can set the `AZ_REPO` value manually when [adding the repository](https://docs.microsoft.com/cli/azure/install-azure-cli-apt#set-release). Otherwise, look up information for your distribution on how to determine the base distribution code name and set `AZ_REPO` to the correct value.
 
 
 No package for your Debian-based distribution
@@ -17,7 +17,7 @@ No package for your Debian-based distribution
 
 Sometimes it may be a while after a distribution is released before there's an Azure CLI package available for it. The Azure CLI is designed to be resilient with regards to future versions of dependencies and rely on as few of them as possible. If there's no package available for your base distribution, try a package for an earlier distribution.
 
-To do this, set the value of `AZ_REPO` manually when [adding the repository](https://docs.microsoft.com/cli/azure/install-azure-cli-apt?view=azure-cli-latest#set-release). For Ubuntu distributions use the `bionic` repository, and for Debian distributions
+To do this, set the value of `AZ_REPO` manually when [adding the repository](https://docs.microsoft.com/cli/azure/install-azure-cli-apt#set-release). For Ubuntu distributions use the `bionic` repository, and for Debian distributions
 use `stretch`. Distributions released before Ubuntu Trusty and Debian Wheezy are not supported.
 
 

--- a/doc/use_cli_in_airgapped_clouds.md
+++ b/doc/use_cli_in_airgapped_clouds.md
@@ -32,10 +32,10 @@ curl -Ls -o azure-cli.deb https://mysa.airgapped.cloud.net/packages/azure-cli.de
 ## Load Cloud Endpoints
 If you are working in an Azure AirGapped Cloud, you should be able to get a cloud metadata URL from its documentation. You can set the environment variable `ARM_CLOUD_METADATA_URL` to this URL, then CLI will load the available clouds and the corresponding cloud endpoints from the URL. The first cloud in the available cloud list will be set as the active cloud by default if the public `AzureCloud` is (most likely) not available.
 
-If you are working with multiple clouds, you can learn more in [Work with multiple clouds](https://docs.microsoft.com/cli/azure/manage-clouds-azure-cli?view=azure-cli-latest).
+If you are working with multiple clouds, you can learn more in [Work with multiple clouds](https://docs.microsoft.com/cli/azure/manage-clouds-azure-cli).
 
 ## Set CA bundle certificate
-Please follow the first solution in [Work behind a proxy](https://docs.microsoft.com/cli/azure/use-cli-effectively?view=azure-cli-latest#work-behind-a-proxy) to set up the certificate in your airgapped cloud environment. For more details, you can also refer to the steps in the [guide](https://docs.microsoft.com/en-us/azure-stack/user/azure-stack-version-profiles-azurecli2) to set up CLI for Azure Stack Hub.
+Please follow the first solution in [Work behind a proxy](https://docs.microsoft.com/cli/azure/use-cli-effectively#work-behind-a-proxy) to set up the certificate in your airgapped cloud environment. For more details, you can also refer to the steps in the [guide](https://docs.microsoft.com/azure-stack/user/azure-stack-version-profiles-azurecli2) to set up CLI for Azure Stack Hub.
 
 ## Login with service principal
 Use the service principal that was granted permission to access a subscription in the airgapped cloud to login.

--- a/doc/version_management.md
+++ b/doc/version_management.md
@@ -11,6 +11,6 @@ Starting from version 2.1.0, Azure CLI updates:
 * PATCH version for bug fixes.
 
 ## Backward Compatibility
-Considering Azure CLI is a command line tool for Azure Services, we tend to just bump the MINOR version for breaking changes in a service command module. All breaking changes for commands will be marked as **BREAKING CHANGE** in [release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli?view=azure-cli-latest).
+Considering Azure CLI is a command line tool for Azure Services, we tend to just bump the MINOR version for breaking changes in a service command module. All breaking changes for commands will be marked as **BREAKING CHANGE** in [release notes](https://docs.microsoft.com/cli/azure/release-notes-azure-cli).
 
 At command level, packages only upgrading the PATCH version guarantee backward compatibility.

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -33,10 +33,10 @@ logger = get_logger(__name__)
 EXTENSION_REFERENCE = ("If the command is from an extension, "
                        "please make sure the corresponding extension is installed. "
                        "To learn more about extensions, please visit "
-                       "'https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview'")
+                       "'https://docs.microsoft.com/cli/azure/azure-cli-extensions-overview'")
 
 OVERVIEW_REFERENCE = ("Still stuck? Run '{command} --help' to view all commands or go to "
-                      "'https://docs.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest' "
+                      "'https://docs.microsoft.com/cli/azure/reference-index' "
                       "to learn more")
 
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -28,10 +28,10 @@ COMPONENT_PREFIX = 'azure-cli-'
 SSLERROR_TEMPLATE = ('Certificate verification failed. This typically happens when using Azure CLI behind a proxy '
                      'that intercepts traffic with a self-signed certificate. '
                      # pylint: disable=line-too-long
-                     'Please add this certificate to the trusted CA bundle. More info: https://docs.microsoft.com/en-us/cli/azure/use-cli-effectively#work-behind-a-proxy.')
+                     'Please add this certificate to the trusted CA bundle. More info: https://docs.microsoft.com/cli/azure/use-cli-effectively#work-behind-a-proxy.')
 
 QUERY_REFERENCE = ("To learn more about --query, please visit: "
-                   "'https://docs.microsoft.com/cli/azure/query-azure-cli?view=azure-cli-latest'")
+                   "'https://docs.microsoft.com/cli/azure/query-azure-cli'")
 
 
 _PROXYID_RE = re.compile(

--- a/src/azure-cli/azure/cli/command_modules/storage/docs/Storage Encryption.md
+++ b/src/azure-cli/azure/cli/command_modules/storage/docs/Storage Encryption.md
@@ -5,7 +5,7 @@ https://docs.microsoft.com/en-us/azure/storage/common/storage-service-encryption
 
 ### How to use ###
 Install Azure CLI in one of the following ways:
-1. [Public Released Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+1. [Public Released Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 2. [Try Features before Release](https://github.com/Azure/azure-cli/blob/dev/doc/try_new_features_before_release.md)
 
 ### Included Features


### PR DESCRIPTION
**Description**<!--Mandatory-->
Only changes are to remove the "?view=azure-cli-latest" and "&preserve-view=true" syntax from Azure CLI-related links. I also removed instances 'en-US' from links per current validation guidelines. These guidelines apply to most, but not all content. I can revert if these links are supposed to go specifically to en-US versions. Please see the user story for more details.

User story [1797650](https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1797650)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
