### PR TITLE
[AKS] Fix the addon name for virtual-node

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2727,8 +2727,9 @@ def _handle_addons_args(cmd, addons_str, subscription_id, resource_group_name, a
     if 'virtual-node' in addons:
         if not aci_subnet_name or not vnet_subnet_id:
             raise CLIError('"--enable-addons virtual-node" requires "--aci-subnet-name" and "--vnet-subnet-id".')
-        # TODO: how about aciConnectorwindows, what is its addon name?
-        addon_profiles[CONST_VIRTUAL_NODE_ADDON_NAME] = ManagedClusterAddonProfile(
+        # only Linux is supported for virtual-node
+        vn_addon_name = CONST_VIRTUAL_NODE_ADDON_NAME + "Linux"
+        addon_profiles[vn_addon_name] = ManagedClusterAddonProfile(
             enabled=True,
             config={CONST_VIRTUAL_NODE_SUBNET_NAME: aci_subnet_name}
         )


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

[AKS] Fix the addon name for virtual-node: it should be `aciConnectorLinux` instead of `aciConnector`.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
