### PR TITLE
[AppService] Bugfix: Better error handling when trying to create duplicate ASP in diff location

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -46,7 +46,8 @@ from azure.cli.core.util import in_cloud_console, shell_safe_json_parse, open_pa
     ConfiguredDefaultSetter, sdk_no_wait, get_file_json
 from azure.cli.core.util import get_az_user_agent, send_raw_request
 from azure.cli.core.profiles import ResourceType, get_sdk
-from azure.cli.core.azclierror import ResourceNotFoundError, RequiredArgumentMissingError, ValidationError
+from azure.cli.core.azclierror import (ResourceNotFoundError, RequiredArgumentMissingError, ValidationError,
+                                       CLIInternalError, UnclassifiedUserFault, AzureResponseError)
 
 from .tunnel import TunnelServer
 
@@ -3752,9 +3753,9 @@ def webapp_up(cmd, name=None, resource_group_name=None, plan=None, location=None
             try:
                 response_content = json.loads(ex.response._content.decode('utf-8'))  # pylint: disable=protected-access
             except Exception:
-                raise CLIError(ex)
-            raise CLIError(response_content['error']['message'])
-        raise CLIError(ex)
+                raise CLIInternalError(ex)
+            raise UnclassifiedUserFault(response_content['error']['message'])
+        raise AzureResponseError(ex)
 
     if _create_new_app:
         logger.warning("Creating webapp '%s' ...", name)


### PR DESCRIPTION
**Description**<!--Mandatory-->
Fixes #16008

When using `az webapp up` to create an app with existing ASP in a different location, we show the following unhandled error message (notice UnknownError):

![image](https://user-images.githubusercontent.com/14339314/101107712-b3e63e00-3587-11eb-884b-6056383b70eb.png)

This PR is to handle the error msg:

![image](https://user-images.githubusercontent.com/14339314/101107770-d7a98400-3587-11eb-9716-975c94a4bc48.png)


**Testing Guide**
<!--Example commands with explanations.-->

- run `az webapp up --location location1 --name name1`
- re-run using different name and location. plan should be defaulted to the same plan created from the first invocation of the command. `az webapp up --location location2 --name name2`

Should get error message saying ASP exists in different location
cls

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
