### PR TITLE
{Role} az role assignment create: Refine unclear help message of `--assignee-object-id`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -186,7 +186,7 @@ def load_arguments(self, _):
         c.argument('include_inherited', action='store_true', help='include assignments applied on parent scopes')
         c.argument('can_delegate', action='store_true', help='when set, the assignee will be able to create further role assignments to the same role')
         c.argument('assignee', help='represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name')
-        c.argument('assignee_object_id', help="Use this parameter instead of '--assignee' to bypass graph permission issues. "
+        c.argument('assignee_object_id', help="Use this parameter instead of '--assignee' to bypass Graph API invocation in case of insufficient privileges. "
                    "This parameter only works with object ids for users, groups, service principals, and "
                    "managed identities. For managed identities use the principal id. For service principals, "
                    "use the object id and not the app id.")


### PR DESCRIPTION
**Description**<!--Mandatory-->
The current description of `--assignee-object-id` is unclear about "graph permission issues":

```
    --assignee-object-id          : Use this parameter instead of '--assignee' to bypass graph
                                    permission issues.
```

Replace it with more explicit description:

```
    --assignee-object-id          : Use this parameter instead of '--assignee' to bypass Graph API
                                    invocation in case of insufficient privileges.
```