### PR TITLE
{azure-cli-testsdk} add location parameter for VirtualNetworkPreparer

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -266,7 +266,7 @@ class ManagedApplicationPreparer(AbstractPreparer, SingleValueReplacer):
 
 # pylint: disable=too-many-instance-attributes
 class VirtualNetworkPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
-    def __init__(self, name_prefix='clitest.vn',
+    def __init__(self, name_prefix='clitest.vn', location='westus',
                  parameter_name='virtual_network',
                  resource_group_parameter_name='resource_group',
                  resource_group_key=KEY_RESOURCE_GROUP,
@@ -278,6 +278,7 @@ class VirtualNetworkPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
         super(VirtualNetworkPreparer, self).__init__(
             name_prefix, random_name_length)
         self.cli_ctx = get_dummy_cli()
+        self.location = location
         self.parameter_name = parameter_name
         self.key = key
         self.resource_group_parameter_name = resource_group_parameter_name
@@ -295,8 +296,8 @@ class VirtualNetworkPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
             tags['job'] = os.environ['ENV_JOB_NAME']
         tags = ' '.join(['{}={}'.format(key, value)
                          for key, value in tags.items()])
-        template = 'az network vnet create --resource-group {} --name {} --subnet-name default --tag ' + tags
-        self.live_only_execute(self.cli_ctx, template.format(self._get_resource_group(**kwargs), name))
+        template = 'az network vnet create --resource-group {} --location {} --name {} --subnet-name default --tag ' + tags
+        self.live_only_execute(self.cli_ctx, template.format(self._get_resource_group(**kwargs), self.location, name))
 
         self.test_class_instance.kwargs[self.key] = name
         return {self.parameter_name: name}


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Sometimes we need to configure vnet location according to requirement

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
