### PR TITLE
[Resource] az provider register: Add --accept-terms for registering RPaaS

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -1774,7 +1774,7 @@ examples:
     crafted: true
   - name: Register a provider from RPaaS.
     text: |
-        az provider register -n 'Microsoft.Confluent' --accept-term
+        az provider register -n 'Microsoft.Confluent' --accept-terms
 """
 
 helps['provider unregister'] = """

--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -1772,6 +1772,9 @@ examples:
     text: |
         az provider register --namespace 'Microsoft.PolicyInsights'
     crafted: true
+  - name: Register a provider from RPaaS.
+    text: |
+        az provider register -n 'Microsoft.Confluent' --accept-term
 """
 
 helps['provider unregister'] = """

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -137,6 +137,7 @@ def load_arguments(self, _):
         c.argument('resource_provider_namespace', options_list=['--namespace', '-n'], completer=get_providers_completion_list, help=_PROVIDER_HELP_TEXT)
 
     with self.argument_context('provider register') as c:
+        c.argument('accept_term', action='store_true', help='Accept market place terms and RP terms for RPaaS. Required when registering RPs from RPaaS.')
         c.argument('wait', action='store_true', help='wait for the registration to finish')
 
     with self.argument_context('provider unregister') as c:

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -137,7 +137,7 @@ def load_arguments(self, _):
         c.argument('resource_provider_namespace', options_list=['--namespace', '-n'], completer=get_providers_completion_list, help=_PROVIDER_HELP_TEXT)
 
     with self.argument_context('provider register') as c:
-        c.argument('accept_term', action='store_true', help='Accept market place terms and RP terms for RPaaS. Required when registering RPs from RPaaS.')
+        c.argument('accept_term', action='store_true', is_preview=True, help="Accept market place terms and RP terms for RPaaS. Required when registering RPs from RPaaS, such as 'Microsoft.Confluent' and 'Microsoft.Datadog'.")
         c.argument('wait', action='store_true', help='wait for the registration to finish')
 
     with self.argument_context('provider unregister') as c:

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -137,7 +137,7 @@ def load_arguments(self, _):
         c.argument('resource_provider_namespace', options_list=['--namespace', '-n'], completer=get_providers_completion_list, help=_PROVIDER_HELP_TEXT)
 
     with self.argument_context('provider register') as c:
-        c.argument('accept_term', action='store_true', is_preview=True, help="Accept market place terms and RP terms for RPaaS. Required when registering RPs from RPaaS, such as 'Microsoft.Confluent' and 'Microsoft.Datadog'.")
+        c.argument('accept_terms', action='store_true', is_preview=True, help="Accept market place terms and RP terms for RPaaS. Required when registering RPs from RPaaS, such as 'Microsoft.Confluent' and 'Microsoft.Datadog'.")
         c.argument('wait', action='store_true', help='wait for the registration to finish')
 
     with self.argument_context('provider unregister') as c:

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1001,7 +1001,7 @@ def _update_provider(cli_ctx, namespace, registering, wait, accept_term=None):
         if is_rpaas:
             if not accept_term:
                 from azure.cli.core.azclierror import RequiredArgumentMissingError
-                raise RequiredArgumentMissingError("--accept-term must be specified when registering an RP from RPaaS.")
+                raise RequiredArgumentMissingError("--accept-term must be specified when registering the {} RP from RPaaS.".format(namespace))
             wait = True
         r = rcf.providers.register(namespace)
     else:

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -992,16 +992,16 @@ def _get_auth_provider_latest_api_version(cli_ctx):
     return api_version
 
 
-def _update_provider(cli_ctx, namespace, registering, wait, accept_term=None):
+def _update_provider(cli_ctx, namespace, registering, wait, accept_terms=None):
     import time
     target_state = 'Registered' if registering else 'Unregistered'
     rcf = _resource_client_factory(cli_ctx)
     is_rpaas = namespace.lower() in RPAAS_APIS
     if registering:
         if is_rpaas:
-            if not accept_term:
+            if not accept_terms:
                 from azure.cli.core.azclierror import RequiredArgumentMissingError
-                raise RequiredArgumentMissingError("--accept-term must be specified when registering the {} RP from RPaaS.".format(namespace))
+                raise RequiredArgumentMissingError("--accept-terms must be specified when registering the {} RP from RPaaS.".format(namespace))
             wait = True
         r = rcf.providers.register(namespace)
     else:
@@ -1981,8 +1981,8 @@ def list_resources(cmd, resource_group_name=None,
     return list(resources)
 
 
-def register_provider(cmd, resource_provider_namespace, wait=False, accept_term=None):
-    _update_provider(cmd.cli_ctx, resource_provider_namespace, registering=True, wait=wait, accept_term=accept_term)
+def register_provider(cmd, resource_provider_namespace, wait=False, accept_terms=None):
+    _update_provider(cmd.cli_ctx, resource_provider_namespace, registering=True, wait=wait, accept_terms=accept_terms)
 
 
 def unregister_provider(cmd, resource_provider_namespace, wait=False):

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -49,7 +49,7 @@ from ._formatters import format_what_if_operation_result
 logger = get_logger(__name__)
 
 RPAAS_APIS = {'microsoft.datadog': '/subscriptions/{subscriptionId}/providers/Microsoft.Datadog/agreements/default?api-version=2020-02-01-preview',
-              'microsoft.confluent': '/subscriptions/{subscriptionId}/providers/Microsoft.Confluent/agreements?api-version=2020-03-01-preview'}
+              'microsoft.confluent': '/subscriptions/{subscriptionId}/providers/Microsoft.Confluent/agreements/default?api-version=2020-03-01-preview'}
 
 
 def _build_resource_id(**kwargs):
@@ -1001,7 +1001,7 @@ def _update_provider(cli_ctx, namespace, registering, wait, accept_term=None):
         if is_rpaas:
             if not accept_term:
                 from azure.cli.core.azclierror import RequiredArgumentMissingError
-                raise RequiredArgumentMissingError("--accetp-term must be specified when registering an RP from RPaaS.")
+                raise RequiredArgumentMissingError("--accept-term must be specified when registering an RP from RPaaS.")
             wait = True
         r = rcf.providers.register(namespace)
     else:

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_provider_registration_rpaas.yaml
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_provider_registration_rpaas.yaml
@@ -1,0 +1,716 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Unregistered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1345'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:53:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider register
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n --accept-term
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent/register?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Registering","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1344'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:53:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n --accept-term
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Registering","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1344'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:53:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n --accept-term
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Registering","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1344'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:53:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n --accept-term
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Registering","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1344'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:53:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n --accept-term
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Registering","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1344'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:53:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n --accept-term
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Registering","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1344'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:54:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n --accept-term
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Registering","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1344'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:54:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n --accept-term
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Registering","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1344'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:54:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n --accept-term
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1343'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:54:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"accepted": true}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider register
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n --accept-term
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) AZURECLI/2.15.1
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent/agreements/default?api-version=2020-03-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent/agreements/default","name":"default","type":"Microsoft.Confluent/agreements","properties":{"publisher":null,"product":null,"plan":null,"licenseTextLink":null,"privacyPolicyLink":null,"retrieveDatetime":null,"signature":null,"accepted":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '330'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:54:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1343'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:54:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider unregister
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent/unregister?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Unregistering","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1346'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:54:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - provider show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n
+      User-Agent:
+      - python/3.6.8 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent?api-version=2020-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Confluent","namespace":"Microsoft.Confluent","authorizations":[{"applicationId":"1448fd13-7e74-41f4-b6e3-17e485d8ac2e","roleDefinitionId":"4db34280-b0be-4827-aa5b-418391409cee"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"locations/OperationStatuses","locations":["West
+        US 2","East US 2 EUAP","West Central US","Canada Central","East US","UK South","West
+        Europe","Central US","East US 2","North Europe","Southeast Asia"],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"organizations","locations":["West
+        US 2","West Central US","Canada Central","East US","UK South","West Europe","Central
+        US","East US 2","North Europe","Southeast Asia","East US 2 EUAP"],"apiVersions":["2020-03-01-preview"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"},{"resourceType":"agreements","locations":[],"apiVersions":["2020-03-01-preview"],"capabilities":"None"}],"registrationState":"Unregistering","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1346'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Dec 2020 06:54:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -642,6 +642,29 @@ class ProviderRegistrationTest(ScenarioTest):
             result = self.cmd('provider show -n {prov}').get_output_in_json()
             self.assertTrue(result['registrationState'] in ['Registering', 'Registered'])
 
+    def test_provider_registration_rpaas(self):
+        self.kwargs.update({'prov': 'Microsoft.Confluent'})
+
+        result = self.cmd('provider show -n {prov}').get_output_in_json()
+        if result['registrationState'] == 'Unregistered':
+            with self.assertRaisesRegexp(CLIError, '--accept-term must be specified'):
+                self.cmd('provider register -n {prov}')
+            self.cmd('provider register -n {prov} --accept-term')
+            result = self.cmd('provider show -n {prov}').get_output_in_json()
+            self.assertTrue(result['registrationState'], 'Registered')
+            self.cmd('provider unregister -n {prov}')
+            result = self.cmd('provider show -n {prov}').get_output_in_json()
+            self.assertTrue(result['registrationState'] in ['Unregistering', 'Unregistered'])
+        else:
+            self.cmd('provider unregister -n {prov}')
+            result = self.cmd('provider show -n {prov}').get_output_in_json()
+            self.assertTrue(result['registrationState'] in ['Unregistering', 'Unregistered'])
+            with self.assertRaisesRegexp(CLIError, '--accept-term must be specified'):
+                self.cmd('provider register -n {prov}')
+            self.cmd('provider register -n {prov} --accept-term')
+            result = self.cmd('provider show -n {prov}').get_output_in_json()
+            self.assertTrue(result['registrationState'], 'Registered')
+
 
 class ProviderOperationTest(ScenarioTest):
 

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -647,9 +647,9 @@ class ProviderRegistrationTest(ScenarioTest):
 
         result = self.cmd('provider show -n {prov}').get_output_in_json()
         if result['registrationState'] == 'Unregistered':
-            with self.assertRaisesRegexp(CLIError, '--accept-term must be specified'):
+            with self.assertRaisesRegexp(CLIError, '--accept-terms must be specified'):
                 self.cmd('provider register -n {prov}')
-            self.cmd('provider register -n {prov} --accept-term')
+            self.cmd('provider register -n {prov} --accept-terms')
             result = self.cmd('provider show -n {prov}').get_output_in_json()
             self.assertTrue(result['registrationState'], 'Registered')
             self.cmd('provider unregister -n {prov}')
@@ -659,9 +659,9 @@ class ProviderRegistrationTest(ScenarioTest):
             self.cmd('provider unregister -n {prov}')
             result = self.cmd('provider show -n {prov}').get_output_in_json()
             self.assertTrue(result['registrationState'] in ['Unregistering', 'Unregistered'])
-            with self.assertRaisesRegexp(CLIError, '--accept-term must be specified'):
+            with self.assertRaisesRegexp(CLIError, '--accept-terms must be specified'):
                 self.cmd('provider register -n {prov}')
-            self.cmd('provider register -n {prov} --accept-term')
+            self.cmd('provider register -n {prov} --accept-terms')
             result = self.cmd('provider show -n {prov}').get_output_in_json()
             self.assertTrue(result['registrationState'], 'Registered')
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When registering RPs provided by RPaaS, users must accept the market place terms and service terms. Add `--accept-terms` option in `az provider register` command and make it required when the namespace is in the hard-coded RPaaS map.

The API to accept term can only be called after the RP is registered, so `--accept-terms` implies `--wait`.

**Testing Guide**
<!--Example commands with explanations.-->
1. `az provider register -n "Microsoft.Confluent"` should throw an error: 

> "--accept-terms must be specified when registering the Microsoft.Confluent RP from RPaaS."

2. `az provider register -n "Microsoft.Confluent" --accept-terms` will wait for the register process to succeed.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
