### PR TITLE
[ARO] az aro update: Add RBAC validation on cluster update

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/_aad.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_aad.py
@@ -19,7 +19,7 @@ from knack.log import get_logger
 logger = get_logger(__name__)
 
 
-class AADManager:
+class AADManager():
     MANAGED_APP_PREFIX = 'https://az.aro.azure.com/'
 
     def __init__(self, cli_ctx):

--- a/src/azure-cli/azure/cli/command_modules/aro/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_help.py
@@ -19,7 +19,7 @@ helps['aro create'] = """
     text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet
   - name: Create a cluster with 5 compute nodes and Red Hat pull secret.
     text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --worker-count 5 --pull-secret @pullsecret.txt
-  - name: Create a Private cluster
+  - name: Create a private cluster.
     text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --apiserver-visibility Private --ingress-visibility Private
 """
 

--- a/src/azure-cli/azure/cli/command_modules/aro/_rbac.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_rbac.py
@@ -11,7 +11,6 @@ from azure.cli.core.profiles import get_sdk
 from azure.cli.core.profiles import ResourceType
 from knack.log import get_logger
 from msrest.exceptions import ValidationError
-from msrestazure.tools import parse_resource_id
 from msrestazure.tools import resource_id
 
 
@@ -39,7 +38,7 @@ def _create_role_assignment(auth_client, resource, params):
             logger.warning("%s; retry %d of %d", ex, retries, max_retries)
 
 
-def assign_contributor_to_vnet(cli_ctx, vnet, object_id):
+def assign_network_contributor_to_resource(cli_ctx, resource, object_id):
     auth_client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_AUTHORIZATION)
 
     RoleAssignmentCreateParameters = get_sdk(cli_ctx, ResourceType.MGMT_AUTHORIZATION,
@@ -53,23 +52,15 @@ def assign_contributor_to_vnet(cli_ctx, vnet, object_id):
         name=NETWORK_CONTRIBUTOR,
     )
 
-    if has_assignment(auth_client.role_assignments.list_for_scope(vnet), role_definition_id, object_id):
-        return
-
-    _create_role_assignment(auth_client, vnet, RoleAssignmentCreateParameters(
+    _create_role_assignment(auth_client, resource, RoleAssignmentCreateParameters(
         role_definition_id=role_definition_id,
         principal_id=object_id,
         principal_type='ServicePrincipal',
     ))
 
 
-def assign_contributor_to_routetable(cli_ctx, subnets, object_id):
+def has_network_contributor_on_resource(cli_ctx, resource, object_id):
     auth_client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_AUTHORIZATION)
-    network_client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_NETWORK)
-
-    RoleAssignmentCreateParameters = get_sdk(cli_ctx, ResourceType.MGMT_AUTHORIZATION,
-                                             'RoleAssignmentCreateParameters', mod='models',
-                                             operation_group='role_assignments')
 
     role_definition_id = resource_id(
         subscription=get_subscription_id(cli_ctx),
@@ -78,31 +69,7 @@ def assign_contributor_to_routetable(cli_ctx, subnets, object_id):
         name=NETWORK_CONTRIBUTOR,
     )
 
-    route_tables = set()
-    for sn in subnets:
-        sid = parse_resource_id(sn)
-
-        subnet = network_client.subnets.get(resource_group_name=sid['resource_group'],
-                                            virtual_network_name=sid['name'],
-                                            subnet_name=sid['resource_name'])
-
-        if subnet.route_table is not None:
-            route_tables.add(subnet.route_table.id)
-
-    for rt in route_tables:
-        if has_assignment(auth_client.role_assignments.list_for_scope(rt),
-                          role_definition_id, object_id):
-            continue
-
-        _create_role_assignment(auth_client, rt, RoleAssignmentCreateParameters(
-            role_definition_id=role_definition_id,
-            principal_id=object_id,
-            principal_type='ServicePrincipal',
-        ))
-
-
-def has_assignment(assignments, role_definition_id, object_id):
-    for assignment in assignments:
+    for assignment in auth_client.role_assignments.list_for_scope(resource):
         if assignment.role_definition_id.lower() == role_definition_id.lower() and \
                 assignment.principal_id.lower() == object_id.lower():
             return True

--- a/src/azure-cli/azure/cli/command_modules/aro/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_validators.py
@@ -11,8 +11,9 @@ import uuid
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.client_factory import get_subscription_id
 from azure.cli.core.profiles import ResourceType
+from azure.cli.core.azclierror import CLIInternalError, InvalidArgumentValueError, \
+    RequiredArgumentMissingError
 from knack.log import get_logger
-from knack.util import CLIError
 from msrestazure.azure_exceptions import CloudError
 from msrestazure.tools import is_valid_resource_id
 from msrestazure.tools import parse_resource_id
@@ -28,8 +29,8 @@ def validate_cidr(key):
             try:
                 ipaddress.IPv4Network(cidr)
             except ValueError:
-                raise CLIError("Invalid --%s '%s'." %
-                               (key.replace('_', '-'), cidr))
+                raise InvalidArgumentValueError("Invalid --%s '%s'." %
+                                                (key.replace('_', '-'), cidr))
 
     return _validate_cidr
 
@@ -39,16 +40,16 @@ def validate_client_id(namespace):
         try:
             uuid.UUID(namespace.client_id)
         except ValueError:
-            raise CLIError("Invalid --client-id '%s'." % namespace.client_id)
+            raise InvalidArgumentValueError("Invalid --client-id '%s'." % namespace.client_id)
 
         if namespace.client_secret is None or not str(namespace.client_secret):
-            raise CLIError('Must specify --client-secret with --client-id.')
+            raise RequiredArgumentMissingError('Must specify --client-secret with --client-id.')
 
 
 def validate_client_secret(namespace):
     if namespace.client_secret is not None:
         if namespace.client_id is None or not str(namespace.client_id):
-            raise CLIError('Must specify --client-id with --client-secret.')
+            raise RequiredArgumentMissingError('Must specify --client-id with --client-secret.')
 
 
 def validate_cluster_resource_group(cmd, namespace):
@@ -57,7 +58,7 @@ def validate_cluster_resource_group(cmd, namespace):
             cmd.cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES)
 
         if client.resource_groups.check_existence(namespace.cluster_resource_group):
-            raise CLIError(
+            raise InvalidArgumentValueError(
                 "Invalid --cluster-resource-group '%s': resource group must not exist." %
                 namespace.cluster_resource_group)
 
@@ -68,8 +69,8 @@ def validate_domain(namespace):
                         r'([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9])' +
                         r'(\.([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9]))*' +
                         r'$', namespace.domain):
-            raise CLIError("Invalid --domain '%s'." %
-                           namespace.domain)
+            raise InvalidArgumentValueError("Invalid --domain '%s'." %
+                                            namespace.domain)
 
 
 def validate_pull_secret(namespace):
@@ -85,7 +86,7 @@ def validate_pull_secret(namespace):
             if not isinstance(json.loads(namespace.pull_secret), dict):
                 raise Exception()
         except:
-            raise CLIError("Invalid --pull-secret.")
+            raise InvalidArgumentValueError("Invalid --pull-secret.")
 
 
 def validate_subnet(key):
@@ -94,8 +95,8 @@ def validate_subnet(key):
 
         if not is_valid_resource_id(subnet):
             if not namespace.vnet:
-                raise CLIError(
-                    'Must specify --vnet if --%s is not an id.' % key.replace('_', '-'))
+                raise RequiredArgumentMissingError('Must specify --vnet if --%s is not an id.' %
+                                                   key.replace('_', '-'))
 
             validate_vnet(cmd, namespace)
 
@@ -105,28 +106,28 @@ def validate_subnet(key):
         parts = parse_resource_id(subnet)
 
         if parts['subscription'] != get_subscription_id(cmd.cli_ctx):
-            raise CLIError("--%s subscription '%s' must equal cluster subscription." %
-                           (key.replace('_', '-'), parts["subscription"]))
+            raise InvalidArgumentValueError("--%s subscription '%s' must equal cluster subscription." %
+                                            (key.replace('_', '-'), parts["subscription"]))
 
         if parts['namespace'].lower() != 'microsoft.network':
-            raise CLIError("--%s namespace '%s' must equal Microsoft.Network." %
-                           (key.replace('_', '-'), parts["namespace"]))
+            raise InvalidArgumentValueError("--%s namespace '%s' must equal Microsoft.Network." %
+                                            (key.replace('_', '-'), parts["namespace"]))
 
         if parts['type'].lower() != 'virtualnetworks':
-            raise CLIError("--%s type '%s' must equal virtualNetworks." %
-                           (key.replace('_', '-'), parts["type"]))
+            raise InvalidArgumentValueError("--%s type '%s' must equal virtualNetworks." %
+                                            (key.replace('_', '-'), parts["type"]))
 
         if parts['last_child_num'] != 1:
-            raise CLIError("--%s '%s' must have one child." %
-                           (key.replace('_', '-'), subnet))
+            raise InvalidArgumentValueError("--%s '%s' must have one child." %
+                                            (key.replace('_', '-'), subnet))
 
         if 'child_namespace_1' in parts:
-            raise CLIError("--%s '%s' must not have child namespace." %
-                           (key.replace('_', '-'), subnet))
+            raise InvalidArgumentValueError("--%s '%s' must not have child namespace." %
+                                            (key.replace('_', '-'), subnet))
 
         if parts['child_type_1'].lower() != 'subnets':
-            raise CLIError("--%s child type '%s' must equal subnets." %
-                           (key.replace('_', '-'), subnet))
+            raise InvalidArgumentValueError("--%s child type '%s' must equal subnets." %
+                                            (key.replace('_', '-'), subnet))
 
         client = get_mgmt_service_client(
             cmd.cli_ctx, ResourceType.MGMT_NETWORK)
@@ -134,7 +135,7 @@ def validate_subnet(key):
             client.subnets.get(parts['resource_group'],
                                parts['name'], parts['child_name_1'])
         except CloudError as err:
-            raise CLIError(err.message)
+            raise CLIInternalError(err.message)
 
     return _validate_subnet
 
@@ -144,16 +145,17 @@ def validate_subnets(master_subnet, worker_subnet):
     worker_parts = parse_resource_id(worker_subnet)
 
     if master_parts['resource_group'].lower() != worker_parts['resource_group'].lower():
-        raise CLIError("--master-subnet resource group '%s' must equal --worker-subnet resource group '%s'." %
-                       (master_parts['resource_group'], worker_parts['resource_group']))
+        raise InvalidArgumentValueError("--master-subnet resource group '%s' must equal "
+                                        "--worker-subnet resource group '%s'." %
+                                        (master_parts['resource_group'], worker_parts['resource_group']))
 
     if master_parts['name'].lower() != worker_parts['name'].lower():
-        raise CLIError("--master-subnet vnet name '%s' must equal --worker-subnet vnet name '%s'." %
-                       (master_parts['name'], worker_parts['name']))
+        raise InvalidArgumentValueError("--master-subnet vnet name '%s' must equal --worker-subnet vnet name '%s'." %
+                                        (master_parts['name'], worker_parts['name']))
 
     if master_parts['child_name_1'].lower() == worker_parts['child_name_1'].lower():
-        raise CLIError("--master-subnet name '%s' must not equal --worker-subnet name '%s'." %
-                       (master_parts['child_name_1'], worker_parts['child_name_1']))
+        raise InvalidArgumentValueError("--master-subnet name '%s' must not equal --worker-subnet name '%s'." %
+                                        (master_parts['child_name_1'], worker_parts['child_name_1']))
 
     return resource_id(
         subscription=master_parts['subscription'],
@@ -170,8 +172,8 @@ def validate_visibility(key):
         if visibility is not None:
             visibility = visibility.capitalize()
             if visibility not in ['Private', 'Public']:
-                raise CLIError("Invalid --%s '%s'." %
-                               (key.replace('_', '-'), visibility))
+                raise InvalidArgumentValueError("Invalid --%s '%s'." %
+                                                (key.replace('_', '-'), visibility))
 
     return _validate_visibility
 
@@ -198,12 +200,10 @@ def validate_vnet_resource_group_name(namespace):
 def validate_worker_count(namespace):
     if namespace.worker_count:
         if namespace.worker_count < 3:
-            raise CLIError(
-                '--worker-count must be greater than or equal to 3.')
+            raise InvalidArgumentValueError('--worker-count must be greater than or equal to 3.')
 
 
 def validate_worker_vm_disk_size_gb(namespace):
     if namespace.worker_vm_disk_size_gb:
         if namespace.worker_vm_disk_size_gb < 128:
-            raise CLIError(
-                '--worker-vm-disk-size-gb must be greater than or equal to 128.')
+            raise InvalidArgumentValueError('--worker-vm-disk-size-gb must be greater than or equal to 128.')

--- a/src/azure-cli/azure/cli/command_modules/aro/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/custom.py
@@ -5,7 +5,7 @@
 
 import random
 
-import azure.mgmt.redhatopenshift.models as v2020_04_30
+import azure.mgmt.redhatopenshift.models as openshiftcluster
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.client_factory import get_subscription_id
@@ -23,7 +23,6 @@ from knack.log import get_logger
 from msrestazure.azure_exceptions import CloudError
 from msrestazure.tools import resource_id, parse_resource_id
 from msrest.exceptions import HttpOperationError
-
 
 logger = get_logger(__name__)
 
@@ -96,29 +95,29 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
     if ingress_visibility is not None:
         ingress_visibility = ingress_visibility.capitalize()
 
-    oc = v2020_04_30.OpenShiftCluster(
+    oc = openshiftcluster.OpenShiftCluster(
         location=location,
         tags=tags,
-        cluster_profile=v2020_04_30.ClusterProfile(
+        cluster_profile=openshiftcluster.ClusterProfile(
             pull_secret=pull_secret or "",
             domain=domain or random_id,
             resource_group_id='/subscriptions/%s/resourceGroups/%s' %
             (subscription_id, cluster_resource_group or "aro-" + random_id),
         ),
-        service_principal_profile=v2020_04_30.ServicePrincipalProfile(
+        service_principal_profile=openshiftcluster.ServicePrincipalProfile(
             client_id=client_id,
             client_secret=client_secret,
         ),
-        network_profile=v2020_04_30.NetworkProfile(
+        network_profile=openshiftcluster.NetworkProfile(
             pod_cidr=pod_cidr or '10.128.0.0/14',
             service_cidr=service_cidr or '172.30.0.0/16',
         ),
-        master_profile=v2020_04_30.MasterProfile(
+        master_profile=openshiftcluster.MasterProfile(
             vm_size=master_vm_size or 'Standard_D8s_v3',
             subnet_id=master_subnet,
         ),
         worker_profiles=[
-            v2020_04_30.WorkerProfile(
+            openshiftcluster.WorkerProfile(
                 name='worker',  # TODO: 'worker' should not be hard-coded
                 vm_size=worker_vm_size,
                 disk_size_gb=worker_vm_disk_size_gb or 128,
@@ -126,11 +125,11 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                 count=worker_count or 3,
             )
         ],
-        apiserver_profile=v2020_04_30.APIServerProfile(
+        apiserver_profile=openshiftcluster.APIServerProfile(
             visibility=apiserver_visibility or 'Public',
         ),
         ingress_profiles=[
-            v2020_04_30.IngressProfile(
+            openshiftcluster.IngressProfile(
                 name='default',  # TODO: 'default' should not be hard-coded
                 visibility=ingress_visibility or 'Public',
             )
@@ -259,7 +258,7 @@ def aro_update(cmd, client, resource_group_name, resource_name, no_wait=False):
             if not resource_contributor_exists:
                 assign_network_contributor_to_resource(cmd.cli_ctx, resource, sp_id)
 
-    oc = v2020_04_30.OpenShiftClusterUpdate()
+    oc = openshiftcluster.OpenShiftClusterUpdate()
 
     return sdk_no_wait(no_wait, client.update,
                        resource_group_name=resource_group_name,

--- a/src/azure-cli/azure/cli/command_modules/aro/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/custom.py
@@ -7,18 +7,23 @@ import random
 
 import azure.mgmt.redhatopenshift.models as v2020_04_30
 
-from azure.cli.command_modules.aro._aad import AADManager
-from azure.cli.command_modules.aro._rbac import assign_contributor_to_vnet, assign_contributor_to_routetable
-from azure.cli.command_modules.aro._validators import validate_subnets
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.client_factory import get_subscription_id
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.util import sdk_no_wait
-from msrest.exceptions import HttpOperationError
+from azure.cli.core.azclierror import ResourceNotFoundError, UnauthorizedError
+from azure.cli.command_modules.aro._aad import AADManager
+from azure.cli.command_modules.aro._rbac import assign_network_contributor_to_resource, \
+    has_network_contributor_on_resource
+from azure.cli.command_modules.aro._validators import validate_subnets
+from azure.graphrbac.models import GraphErrorException
+
+from knack.log import get_logger
+
 from msrestazure.azure_exceptions import CloudError
 from msrestazure.tools import resource_id, parse_resource_id
-from knack.log import get_logger
-from knack.util import CLIError
+from msrest.exceptions import HttpOperationError
+
 
 logger = get_logger(__name__)
 
@@ -54,10 +59,11 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
         cmd.cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES)
     provider = resource_client.providers.get('Microsoft.RedHatOpenShift')
     if provider.registration_state != 'Registered':
-        raise CLIError('Microsoft.RedHatOpenShift provider is not registered.  Run `az provider ' +
-                       'register -n Microsoft.RedHatOpenShift --wait`.')
+        raise UnauthorizedError('Microsoft.RedHatOpenShift provider is not registered.',
+                                'Run `az provider register -n Microsoft.RedHatOpenShift --wait`.')
 
     vnet = validate_subnets(master_subnet, worker_subnet)
+    resources = get_network_resources(cmd.cli_ctx, [master_subnet, worker_subnet], vnet)
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
 
@@ -74,10 +80,13 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
 
     rp_client_id = FP_CLIENT_ID
     rp_client_sp = aad.get_service_principal(rp_client_id)
+    if not rp_client_sp:
+        raise ResourceNotFoundError("RP service principal not found.")
 
     for sp_id in [client_sp.object_id, rp_client_sp.object_id]:
-        assign_contributor_to_vnet(cmd.cli_ctx, vnet, sp_id)
-        assign_contributor_to_routetable(cmd.cli_ctx, [master_subnet, worker_subnet], sp_id)
+        for resource in sorted(resources):
+            if not has_network_contributor_on_resource(cmd.cli_ctx, resource, sp_id):
+                assign_network_contributor_to_resource(cmd.cli_ctx, resource, sp_id)
 
     worker_vm_size = worker_vm_size or 'Standard_D4s_v3'
 
@@ -136,39 +145,45 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
 
 def aro_delete(cmd, client, resource_group_name, resource_name, no_wait=False):
     # TODO: clean up rbac
+    rp_client_sp = None
+    resources = set()
 
     try:
         oc = client.get(resource_group_name, resource_name)
 
-        master_subnet = oc.master_profile.subnet_id
-        worker_subnets = {w.subnet_id for w in oc.worker_profiles}
-
-        master_parts = parse_resource_id(master_subnet)
-        vnet = resource_id(
-            subscription=master_parts['subscription'],
-            resource_group=master_parts['resource_group'],
-            namespace='Microsoft.Network',
-            type='virtualNetworks',
-            name=master_parts['name'],
-        )
-
-        aad = AADManager(cmd.cli_ctx)
-        rp_client_id = FP_CLIENT_ID
-        rp_client_sp = aad.get_service_principal(rp_client_id)
-
-        # Customers frequently remove the RP's permissions, then cannot
-        # delete the cluster. Where possible, fix this before attempting
-        # deletion.
-        if rp_client_sp:
-            sp_id = rp_client_sp.object_id
-            assign_contributor_to_vnet(cmd.cli_ctx, vnet, sp_id)
-            assign_contributor_to_routetable(cmd.cli_ctx,
-                                             worker_subnets | {master_subnet},
-                                             sp_id)
+        # Get cluster resources we need to assign network contributor on
+        resources = get_cluster_network_resources(cmd.cli_ctx, oc)
     except (CloudError, HttpOperationError) as e:
-        # Default to old deletion behaviour in case operations throw an
-        # exception above. Log the error.
         logger.info(e.message)
+
+    aad = AADManager(cmd.cli_ctx)
+    rp_client_id = FP_CLIENT_ID
+
+    # Best effort - assume the role assignments on the SP exist if exception raised
+    try:
+        rp_client_sp = aad.get_service_principal(rp_client_id)
+        if not rp_client_sp:
+            raise ResourceNotFoundError("RP service principal not found.")
+    except GraphErrorException as e:
+        logger.info(e.message)
+
+    # Customers frequently remove the Cluster or RP's service principal permissions.
+    # Attempt to fix this before performing any action against the cluster
+    if rp_client_sp:
+        for resource in sorted(resources):
+            # Create the role assignment if it doesn't exist
+            # Assume that the role assignment exists if we fail to look it up
+            resource_contributor_exists = True
+
+            try:
+                resource_contributor_exists = has_network_contributor_on_resource(cmd.cli_ctx, resource,
+                                                                                  rp_client_sp.object_id)
+            except CloudError as e:
+                logger.info(e.message)
+                continue
+
+            if not resource_contributor_exists:
+                assign_network_contributor_to_resource(cmd.cli_ctx, resource, rp_client_sp.object_id)
 
     return sdk_no_wait(no_wait, client.delete,
                        resource_group_name=resource_group_name,
@@ -189,7 +204,61 @@ def aro_list_credentials(client, resource_group_name, resource_name):
     return client.list_credentials(resource_group_name, resource_name)
 
 
-def aro_update(client, resource_group_name, resource_name, no_wait=False):
+def aro_update(cmd, client, resource_group_name, resource_name, no_wait=False):
+    rp_client_sp = None
+    client_sp = None
+    resources = set()
+
+    try:
+        oc = client.get(resource_group_name, resource_name)
+
+        # Get cluster resources we need to assign network contributor on
+        resources = get_cluster_network_resources(cmd.cli_ctx, oc)
+    except (CloudError, HttpOperationError) as e:
+        logger.info(e.message)
+
+    aad = AADManager(cmd.cli_ctx)
+    rp_client_id = FP_CLIENT_ID
+
+    # Best effort - assume the role assignments on the SP exist if exception raised
+    try:
+
+        rp_client_sp = aad.get_service_principal(rp_client_id)
+        if not rp_client_sp:
+            raise ResourceNotFoundError("RP service principal not found.")
+    except GraphErrorException as e:
+        logger.info(e.message)
+
+    client_id = oc.service_principal_profile.client_id
+
+    # Best effort - assume the role assignments on the SP exist if exception raised
+    try:
+        client_sp = aad.get_service_principal(client_id)
+        if not client_sp:
+            raise ResourceNotFoundError("Cluster service principal not found.")
+    except GraphErrorException as e:
+        logger.info(e.message)
+
+    # Drop any None service principal objects
+    sp_obj_ids = [sp.object_id for sp in [rp_client_sp, client_sp] if sp]
+
+    # Customers frequently remove the Cluster or RP's service principal permissions.
+    # Attempt to fix this before performing any action against the cluster
+    for sp_id in sp_obj_ids:
+        for resource in sorted(resources):
+            # Create the role assignment if it doesn't exist
+            # Assume that the role assignment exists if we fail to look it up
+            resource_contributor_exists = True
+
+            try:
+                resource_contributor_exists = has_network_contributor_on_resource(cmd.cli_ctx, resource, sp_id)
+            except CloudError as e:
+                logger.info(e.message)
+                continue
+
+            if not resource_contributor_exists:
+                assign_network_contributor_to_resource(cmd.cli_ctx, resource, sp_id)
+
     oc = v2020_04_30.OpenShiftClusterUpdate()
 
     return sdk_no_wait(no_wait, client.update,
@@ -203,3 +272,46 @@ def generate_random_id():
                  ''.join(random.choice('abcdefghijklmnopqrstuvwxyz1234567890')
                          for _ in range(7)))
     return random_id
+
+
+def get_route_tables_from_subnets(cli_ctx, subnets):
+    network_client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_NETWORK)
+
+    route_tables = set()
+    for sn in subnets:
+        sid = parse_resource_id(sn)
+
+        subnet = network_client.subnets.get(resource_group_name=sid['resource_group'],
+                                            virtual_network_name=sid['name'],
+                                            subnet_name=sid['resource_name'])
+
+        if subnet.route_table is not None:
+            route_tables.add(subnet.route_table.id)
+
+    return route_tables
+
+
+def get_cluster_network_resources(cli_ctx, oc):
+    master_subnet = oc.master_profile.subnet_id
+    worker_subnets = {w.subnet_id for w in oc.worker_profiles}
+
+    master_parts = parse_resource_id(master_subnet)
+    vnet = resource_id(
+        subscription=master_parts['subscription'],
+        resource_group=master_parts['resource_group'],
+        namespace='Microsoft.Network',
+        type='virtualNetworks',
+        name=master_parts['name'],
+    )
+
+    return get_network_resources(cli_ctx, worker_subnets | {master_subnet}, vnet)
+
+
+def get_network_resources(cli_ctx, subnets, vnet):
+    route_tables = get_route_tables_from_subnets(cli_ctx, subnets)
+
+    resources = set()
+    resources.add(vnet)
+    resources.update(route_tables)
+
+    return resources

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_create.yaml
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_create.yaml
@@ -13,15 +13,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-resource/10.3.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_create000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001","name":"cli_test_aro_create000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-09-08T06:59:58Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001","name":"cli_test_aro_create000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-09T22:42:38Z","createdAt":"2020-12-09T22:42:39.7181188Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:00 GMT
+      - Wed, 09 Dec 2020 22:42:39 GMT
       expires:
       - '-1'
       pragma:
@@ -63,8 +64,9 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -72,10 +74,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"6ea82635-3ee7-40e2-ad85-fe319fb48f1e\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"4616fd7f-ad12-498e-a113-db1ce4ea88c1\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"cb5d197d-6ec2-4fe9-8236-6063ba3096b7\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"ded418e9-d2fd-45d9-b449-7b61247e7bc0\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -85,7 +87,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/d5f9f6d9-f482-4876-ab51-1a2e740492a0?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/3ff2cefa-e8f3-40d3-aa91-6d3739b45148?api-version=2020-07-01
       cache-control:
       - no-cache
       content-length:
@@ -93,7 +95,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:03 GMT
+      - Wed, 09 Dec 2020 22:42:41 GMT
       expires:
       - '-1'
       pragma:
@@ -106,7 +108,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 38717fa8-b037-49f3-9084-3891a48e99d7
+      - 21988bb9-bc87-4804-8abb-657c7858c36b
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -126,10 +128,11 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/d5f9f6d9-f482-4876-ab51-1a2e740492a0?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/3ff2cefa-e8f3-40d3-aa91-6d3739b45148?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -141,7 +144,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:07 GMT
+      - Wed, 09 Dec 2020 22:42:45 GMT
       expires:
       - '-1'
       pragma:
@@ -158,7 +161,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 2f536d10-1034-4924-ab35-dd6550ced749
+      - 0c19f281-6ae0-418f-b0fb-855348d35e20
     status:
       code: 200
       message: OK
@@ -176,17 +179,18 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"f868fb9c-b212-4f26-88b2-b68b50753c9e\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"fbc55f4f-bc2e-457e-bc21-1e20eab9c2c6\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"cb5d197d-6ec2-4fe9-8236-6063ba3096b7\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"ded418e9-d2fd-45d9-b449-7b61247e7bc0\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -200,9 +204,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:07 GMT
+      - Wed, 09 Dec 2020 22:42:45 GMT
       etag:
-      - W/"f868fb9c-b212-4f26-88b2-b68b50753c9e"
+      - W/"fbc55f4f-bc2e-457e-bc21-1e20eab9c2c6"
       expires:
       - '-1'
       pragma:
@@ -219,7 +223,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 5f7fa31a-9a1d-4e53-bbf2-cca8778d02e8
+      - b6ff5bd3-3ae5-4a2b-bff0-8ec35af53396
     status:
       code: 200
       message: OK
@@ -237,8 +241,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -246,10 +251,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"f868fb9c-b212-4f26-88b2-b68b50753c9e\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"fbc55f4f-bc2e-457e-bc21-1e20eab9c2c6\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"cb5d197d-6ec2-4fe9-8236-6063ba3096b7\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"ded418e9-d2fd-45d9-b449-7b61247e7bc0\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -263,9 +268,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:07 GMT
+      - Wed, 09 Dec 2020 22:42:45 GMT
       etag:
-      - W/"f868fb9c-b212-4f26-88b2-b68b50753c9e"
+      - W/"fbc55f4f-bc2e-457e-bc21-1e20eab9c2c6"
       expires:
       - '-1'
       pragma:
@@ -282,7 +287,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - ef6b59d1-fe82-4494-8af5-26325f3ddaef
+      - b9521bb3-490f-4d6e-a438-1718274cd554
     status:
       code: 200
       message: OK
@@ -290,7 +295,7 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"properties":
-      {"addressPrefix": "10.81.194.0/24", "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]},
+      {"addressPrefix": "10.19.30.0/24", "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]},
       "name": "dev_master000002"}], "virtualNetworkPeerings": [], "enableDdosProtection":
       false, "enableVmProtection": false}}'
     headers:
@@ -303,14 +308,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '544'
+      - '543'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -318,17 +324,17 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"9d9d4a0a-33b1-4000-ad4b-6aa71c812a94\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"2a97e453-ab6d-418c-88f2-c489ca10a5fe\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"cb5d197d-6ec2-4fe9-8236-6063ba3096b7\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"ded418e9-d2fd-45d9-b449-7b61247e7bc0\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"9d9d4a0a-33b1-4000-ad4b-6aa71c812a94\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"2a97e453-ab6d-418c-88f2-c489ca10a5fe\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"addressPrefix\": \"10.81.194.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.19.30.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Updating\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -339,15 +345,15 @@ interactions:
         : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e0ca2fe5-395b-4bae-8cce-ef5be61798bf?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/afe4098c-e652-4435-aa31-31dd1c63ab74?api-version=2020-07-01
       cache-control:
       - no-cache
       content-length:
-      - '1618'
+      - '1617'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:07 GMT
+      - Wed, 09 Dec 2020 22:42:46 GMT
       expires:
       - '-1'
       pragma:
@@ -364,7 +370,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e1092c2e-7b13-4026-8fab-8d2bf9d35ff9
+      - dc69f255-c44a-4afd-a7d1-375bed0cd70e
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -384,10 +390,11 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e0ca2fe5-395b-4bae-8cce-ef5be61798bf?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/afe4098c-e652-4435-aa31-31dd1c63ab74?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -399,7 +406,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:11 GMT
+      - Wed, 09 Dec 2020 22:42:50 GMT
       expires:
       - '-1'
       pragma:
@@ -416,7 +423,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 2f195bf8-1e78-4ca3-a7ca-11d40672c6a1
+      - 9d5759b7-b928-451c-be6f-7b1c71f59eb4
     status:
       code: 200
       message: OK
@@ -434,24 +441,25 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"975cc736-4f17-4cbd-a8aa-fe7e93f4d0da\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"d26e7c63-dff2-4e2a-8baf-1bb916bc3123\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"cb5d197d-6ec2-4fe9-8236-6063ba3096b7\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"ded418e9-d2fd-45d9-b449-7b61247e7bc0\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"975cc736-4f17-4cbd-a8aa-fe7e93f4d0da\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"d26e7c63-dff2-4e2a-8baf-1bb916bc3123\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.81.194.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.19.30.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -464,13 +472,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1621'
+      - '1620'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:11 GMT
+      - Wed, 09 Dec 2020 22:42:51 GMT
       etag:
-      - W/"975cc736-4f17-4cbd-a8aa-fe7e93f4d0da"
+      - W/"d26e7c63-dff2-4e2a-8baf-1bb916bc3123"
       expires:
       - '-1'
       pragma:
@@ -487,7 +495,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 0ce1d9c2-5356-4f65-9723-b1cc1a8c5f04
+      - f1d53706-1ce7-43b2-bbde-5e5c50a1ffaf
     status:
       code: 200
       message: OK
@@ -505,8 +513,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -514,17 +523,17 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"975cc736-4f17-4cbd-a8aa-fe7e93f4d0da\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"d26e7c63-dff2-4e2a-8baf-1bb916bc3123\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"cb5d197d-6ec2-4fe9-8236-6063ba3096b7\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"ded418e9-d2fd-45d9-b449-7b61247e7bc0\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"975cc736-4f17-4cbd-a8aa-fe7e93f4d0da\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"d26e7c63-dff2-4e2a-8baf-1bb916bc3123\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.81.194.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.19.30.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -537,13 +546,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1621'
+      - '1620'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:12 GMT
+      - Wed, 09 Dec 2020 22:42:50 GMT
       etag:
-      - W/"975cc736-4f17-4cbd-a8aa-fe7e93f4d0da"
+      - W/"d26e7c63-dff2-4e2a-8baf-1bb916bc3123"
       expires:
       - '-1'
       pragma:
@@ -560,7 +569,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 2507a96c-4e93-46e6-a990-a9d3bf97b90d
+      - 7c1556f0-7da5-41b9-8cf5-f2c5025ad1fd
     status:
       code: 200
       message: OK
@@ -568,10 +577,10 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "properties": {"addressPrefix": "10.81.194.0/24", "serviceEndpoints": [{"service":
+      "properties": {"addressPrefix": "10.19.30.0/24", "serviceEndpoints": [{"service":
       "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
       "Enabled", "privateLinkServiceNetworkPolicies": "Enabled"}, "name": "dev_master000002"},
-      {"properties": {"addressPrefix": "10.110.118.0/24", "serviceEndpoints": [{"service":
+      {"properties": {"addressPrefix": "10.96.177.0/24", "serviceEndpoints": [{"service":
       "Microsoft.ContainerRegistry"}]}, "name": "dev_worker000003"}], "virtualNetworkPeerings":
       [], "enableDdosProtection": false, "enableVmProtection": false}}'
     headers:
@@ -584,14 +593,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1003'
+      - '1001'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -599,17 +609,17 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"412e934c-3e3e-4322-bd18-8df911a5cc1c\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"9da90b4c-bebf-4922-b648-05127f63febf\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"cb5d197d-6ec2-4fe9-8236-6063ba3096b7\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"ded418e9-d2fd-45d9-b449-7b61247e7bc0\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"412e934c-3e3e-4322-bd18-8df911a5cc1c\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"9da90b4c-bebf-4922-b648-05127f63febf\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"addressPrefix\": \"10.81.194.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.19.30.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -618,9 +628,9 @@ interactions:
         : \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
         \r\n      },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n   \
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n        \"etag\": \"W/\\\"412e934c-3e3e-4322-bd18-8df911a5cc1c\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"9da90b4c-bebf-4922-b648-05127f63febf\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"addressPrefix\": \"10.110.118.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.96.177.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Updating\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -631,15 +641,15 @@ interactions:
         : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6a0b583d-ee98-4183-a9e1-cbd67acd6443?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/67e440b1-73d5-4066-b2d3-8c79ed848f7d?api-version=2020-07-01
       cache-control:
       - no-cache
       content-length:
-      - '2509'
+      - '2507'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:13 GMT
+      - Wed, 09 Dec 2020 22:42:51 GMT
       expires:
       - '-1'
       pragma:
@@ -656,7 +666,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 6bb69c32-3eb1-46df-b57f-63d98b6bfd0d
+      - abc9f03d-cf79-414b-8a8f-ecf28624f2d0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -676,10 +686,11 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6a0b583d-ee98-4183-a9e1-cbd67acd6443?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/67e440b1-73d5-4066-b2d3-8c79ed848f7d?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -691,7 +702,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:16 GMT
+      - Wed, 09 Dec 2020 22:42:55 GMT
       expires:
       - '-1'
       pragma:
@@ -708,7 +719,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 318db253-3342-4224-ae83-c21e6c5dac51
+      - 215d14c0-d8be-4cbd-ab14-db3038bda1ab
     status:
       code: 200
       message: OK
@@ -726,24 +737,25 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"e34570fe-e770-4308-be74-c3172de41e5a\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"cbbc6dac-39c4-4ac0-b485-b59f3ea8c154\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"cb5d197d-6ec2-4fe9-8236-6063ba3096b7\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"ded418e9-d2fd-45d9-b449-7b61247e7bc0\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"e34570fe-e770-4308-be74-c3172de41e5a\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"cbbc6dac-39c4-4ac0-b485-b59f3ea8c154\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.81.194.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.19.30.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -752,9 +764,9 @@ interactions:
         : \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
         \r\n      },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n   \
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n        \"etag\": \"W/\\\"e34570fe-e770-4308-be74-c3172de41e5a\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"cbbc6dac-39c4-4ac0-b485-b59f3ea8c154\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.110.118.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.96.177.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -767,13 +779,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2513'
+      - '2511'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:17 GMT
+      - Wed, 09 Dec 2020 22:42:55 GMT
       etag:
-      - W/"e34570fe-e770-4308-be74-c3172de41e5a"
+      - W/"cbbc6dac-39c4-4ac0-b485-b59f3ea8c154"
       expires:
       - '-1'
       pragma:
@@ -790,7 +802,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 712a6cb1-8476-4b41-a0bd-11f068f55c10
+      - c4736d6c-fa38-4971-ab3c-145e61d29e80
     status:
       code: 200
       message: OK
@@ -808,8 +820,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -817,10 +830,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"e34570fe-e770-4308-be74-c3172de41e5a\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"cbbc6dac-39c4-4ac0-b485-b59f3ea8c154\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.81.194.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
-        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        addressPrefix\": \"10.19.30.0/24\",\r\n    \"serviceEndpoints\": [\r\n   \
+        \   {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
         : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
         \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
         \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
@@ -830,13 +843,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '755'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:17 GMT
+      - Wed, 09 Dec 2020 22:42:57 GMT
       etag:
-      - W/"e34570fe-e770-4308-be74-c3172de41e5a"
+      - W/"cbbc6dac-39c4-4ac0-b485-b59f3ea8c154"
       expires:
       - '-1'
       pragma:
@@ -853,13 +866,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - fe6bf3e5-6a1d-46e7-8d36-abc0648230ee
+      - 90db2440-d2c3-4240-bd87-310be7a138e8
     status:
       code: 200
       message: OK
 - request:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "properties": {"addressPrefix": "10.81.194.0/24", "serviceEndpoints": [{"service":
+      "properties": {"addressPrefix": "10.19.30.0/24", "serviceEndpoints": [{"service":
       "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
       "Enabled", "privateLinkServiceNetworkPolicies": "Disabled"}, "name": "dev_master000002"}'
     headers:
@@ -872,14 +885,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '457'
+      - '456'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -887,10 +901,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"d53ef464-a818-4eec-96b4-31fcf4f2d36a\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"6fd79b04-1611-4994-9f2a-ff14e1a8e629\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
-        addressPrefix\": \"10.81.194.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
-        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        addressPrefix\": \"10.19.30.0/24\",\r\n    \"serviceEndpoints\": [\r\n   \
+        \   {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
         : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
         \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
         \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
@@ -898,15 +912,15 @@ interactions:
         \r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e42c0b33-7221-46d5-b27f-9284469bdf15?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/b57896ce-bd5f-4fc7-bbd7-59dd44439954?api-version=2020-07-01
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '755'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:16 GMT
+      - Wed, 09 Dec 2020 22:42:58 GMT
       expires:
       - '-1'
       pragma:
@@ -923,9 +937,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 311e52a4-4a80-458b-91a3-c8740afb7954
+      - de7f7792-9931-4eba-90e2-4c631a87dc1f
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 200
       message: OK
@@ -943,10 +957,11 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e42c0b33-7221-46d5-b27f-9284469bdf15?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/b57896ce-bd5f-4fc7-bbd7-59dd44439954?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -958,7 +973,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:20 GMT
+      - Wed, 09 Dec 2020 22:43:02 GMT
       expires:
       - '-1'
       pragma:
@@ -975,7 +990,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 5c58a8fb-5d16-4ef0-ac3a-bc5243dfd1b0
+      - 5cd0734f-6e8d-4a37-bae0-7627ffcd7702
     status:
       code: 200
       message: OK
@@ -993,17 +1008,18 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"d9d55412-3bf4-482c-83d2-c6d41039a082\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"3002affd-e16d-4451-96c5-6e38b8b06a7b\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.81.194.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
-        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        addressPrefix\": \"10.19.30.0/24\",\r\n    \"serviceEndpoints\": [\r\n   \
+        \   {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
         : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
         \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
         \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
@@ -1013,13 +1029,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '757'
+      - '756'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:20 GMT
+      - Wed, 09 Dec 2020 22:43:03 GMT
       etag:
-      - W/"d9d55412-3bf4-482c-83d2-c6d41039a082"
+      - W/"3002affd-e16d-4451-96c5-6e38b8b06a7b"
       expires:
       - '-1'
       pragma:
@@ -1036,7 +1052,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 0df1ffb8-787b-44ac-9de8-d8681123803b
+      - fd9e78ba-5bd8-40e4-bdbb-4e5511e8deef
     status:
       code: 200
       message: OK
@@ -1054,8 +1070,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -1063,10 +1080,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"d9d55412-3bf4-482c-83d2-c6d41039a082\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"3002affd-e16d-4451-96c5-6e38b8b06a7b\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.81.194.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
-        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        addressPrefix\": \"10.19.30.0/24\",\r\n    \"serviceEndpoints\": [\r\n   \
+        \   {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
         : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
         \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
         \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
@@ -1076,13 +1093,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '757'
+      - '756'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:21 GMT
+      - Wed, 09 Dec 2020 22:43:03 GMT
       etag:
-      - W/"d9d55412-3bf4-482c-83d2-c6d41039a082"
+      - W/"3002affd-e16d-4451-96c5-6e38b8b06a7b"
       expires:
       - '-1'
       pragma:
@@ -1099,7 +1116,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - d1f29111-521c-4739-97ef-1964dc88dde0
+      - 436949e1-8fb3-4583-94b9-63fd441f9f79
     status:
       code: 200
       message: OK
@@ -1117,8 +1134,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -1126,10 +1144,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n  \"etag\": \"W/\\\"d9d55412-3bf4-482c-83d2-c6d41039a082\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"3002affd-e16d-4451-96c5-6e38b8b06a7b\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.110.118.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        addressPrefix\": \"10.96.177.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
         : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
         \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
         \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
@@ -1139,13 +1157,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '757'
+      - '756'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:21 GMT
+      - Wed, 09 Dec 2020 22:43:03 GMT
       etag:
-      - W/"d9d55412-3bf4-482c-83d2-c6d41039a082"
+      - W/"3002affd-e16d-4451-96c5-6e38b8b06a7b"
       expires:
       - '-1'
       pragma:
@@ -1162,7 +1180,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 229e81ce-36ff-4aec-8f51-e2f0a6a6d393
+      - e316fbd8-daeb-48a9-810f-aad130d1b9af
     status:
       code: 200
       message: OK
@@ -1180,15 +1198,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-resource/10.3.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_create000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001","name":"cli_test_aro_create000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-09-08T06:59:58Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001","name":"cli_test_aro_create000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-09T22:42:38Z","createdAt":"2020-12-09T22:42:39.7181188Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1197,7 +1216,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:21 GMT
+      - Wed, 09 Dec 2020 22:43:03 GMT
       expires:
       - '-1'
       pragma:
@@ -1225,8 +1244,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-resource/10.3.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -1234,31 +1254,34 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift","namespace":"Microsoft.RedHatOpenShift","authorizations":[{"applicationId":"f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875","roleDefinitionId":"640c5ac9-6f32-4891-94f4-d20f7aa9a7e6","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635","managedByAuthorization":{"allowManagedByInheritance":true}}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2020-04-30","2019-12-31-preview"],"capabilities":"None"},{"resourceType":"locations/operationresults","locations":["Australia
-        East","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East US","East US 2","France Central","Japan East","Japan West","Korea
-        Central","North Central US","North Europe","South Africa North","South Central
-        US","Southeast Asia","Switzerland North","UK South","UK West","West Europe","West
-        US 2","West US"],"apiVersions":["2020-04-30"],"capabilities":"None"},{"resourceType":"locations/operationsstatus","locations":["Australia
-        East","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East US","East US 2","France Central","Japan East","Japan West","Korea
-        Central","North Central US","North Europe","South Africa North","South Central
-        US","Southeast Asia","Switzerland North","UK South","UK West","West Europe","West
-        US 2","West US"],"apiVersions":["2020-04-30"],"capabilities":"None"},{"resourceType":"OpenShiftClusters","locations":["Australia
-        East","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East US","East US 2","France Central","Japan East","Japan West","Korea
-        Central","North Central US","North Europe","South Africa North","South Central
-        US","Southeast Asia","Switzerland North","UK South","UK West","West Europe","West
-        US 2","West US"],"apiVersions":["2020-04-30"],"defaultApiVersion":"2020-04-30","capabilities":"SystemAssignedResourceIdentity,
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US 2","France Central","Germany West
+        Central","Japan East","Japan West","Korea Central","North Central US","North
+        Europe","Norway East","South Africa North","South Central US","Southeast Asia","Switzerland
+        North","Switzerland West","UAE North","UK South","UK West","West Europe","West
+        US 2","West US","East US"],"apiVersions":["2020-04-30"],"capabilities":"None"},{"resourceType":"locations/operationsstatus","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US 2","France Central","Germany West
+        Central","Japan East","Japan West","Korea Central","North Central US","North
+        Europe","Norway East","South Africa North","South Central US","Southeast Asia","Switzerland
+        North","Switzerland West","UAE North","UK South","UK West","West Europe","West
+        US 2","West US","East US"],"apiVersions":["2020-04-30"],"capabilities":"None"},{"resourceType":"OpenShiftClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US 2","France Central","Germany West
+        Central","Japan East","Japan West","Korea Central","North Central US","North
+        Europe","Norway East","South Africa North","South Central US","Southeast Asia","Switzerland
+        North","Switzerland West","UAE North","UK South","UK West","West Europe","West
+        US 2","West US","East US"],"apiVersions":["2020-04-30"],"defaultApiVersion":"2020-04-30","capabilities":"SystemAssignedResourceIdentity,
         SupportsTags, SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-04-30","2019-12-31-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2163'
+      - '2469'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:20 GMT
+      - Wed, 09 Dec 2020 22:43:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1273,9 +1296,137 @@ interactions:
       code: 200
       message: OK
 - request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
+        ,\r\n  \"etag\": \"W/\\\"3002affd-e16d-4451-96c5-6e38b8b06a7b\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.19.30.0/24\",\r\n    \"serviceEndpoints\": [\r\n   \
+        \   {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '756'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 22:43:04 GMT
+      etag:
+      - W/"3002affd-e16d-4451-96c5-6e38b8b06a7b"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 17417dd9-a4f7-4e29-99e4-fd7235166098
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\r\n  \"etag\": \"W/\\\"3002affd-e16d-4451-96c5-6e38b8b06a7b\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.96.177.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '756'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 22:43:04 GMT
+      etag:
+      - W/"3002affd-e16d-4451-96c5-6e38b8b06a7b"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 0929d273-ca44-42b5-aa6a-8a37661040a6
+    status:
+      code: 200
+      message: OK
+- request:
     body: '{"passwordCredentials": [{"endDate": "2299-12-31T00:00:00.000Z", "value":
-      "ReplacedSPPassword123*"}], "displayName": "aro-bcw4l0nr", "identifierUris":
-      ["https://az.aro.azure.com/0ddc255f-6506-4acc-8311-530aa7ed927f"]}'
+      "ReplacedSPPassword123*"}], "displayName": "aro-nb25qvuk", "identifierUris":
+      ["https://az.aro.azure.com/34e7b07e-8b9e-4075-9d70-4bda54810029"]}'
     headers:
       Accept:
       - application/json
@@ -1292,8 +1443,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
@@ -1302,30 +1454,30 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "1cb08156-ab6b-4ed0-8e81-545131caf702", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "2f1b33cc-af5a-4633-aeee-875b15c50c71",
+        "objectId": "1b8ed36e-df3c-4fec-82fb-158ecabbfec2", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "4bdcbdbe-b405-4ffd-b8dc-696176de4f62",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
-        false, "displayName": "aro-bcw4l0nr", "errorUrl": null, "groupMembershipClaims":
-        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/0ddc255f-6506-4acc-8311-530aa7ed927f"],
+        false, "displayName": "aro-nb25qvuk", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/34e7b07e-8b9e-4075-9d70-4bda54810029"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/1cb08156-ab6b-4ed0-8e81-545131caf702/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/1b8ed36e-df3c-4fec-82fb-158ecabbfec2/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/1cb08156-ab6b-4ed0-8e81-545131caf702/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/1b8ed36e-df3c-4fec-82fb-158ecabbfec2/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
-        "Allow the application to access aro-bcw4l0nr on behalf of the signed-in user.",
-        "adminConsentDisplayName": "Access aro-bcw4l0nr", "id": "038fe5f7-5caf-46e4-8920-5296eda49b9d",
+        "Allow the application to access aro-nb25qvuk on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Access aro-nb25qvuk", "id": "1d27a455-306d-4d33-ad35-81afb23c26e8",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
-        to access aro-bcw4l0nr on your behalf.", "userConsentDisplayName": "Access
-        aro-bcw4l0nr", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        to access aro-nb25qvuk on your behalf.", "userConsentDisplayName": "Access
+        aro-nb25qvuk", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
         [{"customKeyIdentifier": null, "endDate": "2299-12-31T00:00:00Z", "keyId":
-        "576a8845-87f9-4cab-ba3a-2e552de9c96a", "startDate": "2020-09-08T07:00:22.2226932Z",
+        "ab20f029-2fd1-4909-a539-8101a53c3cc7", "startDate": "2020-12-09T22:43:06.2593156Z",
         "value": "ReplacedSPPassword123*"}], "publicClient": null, "publisherDomain":
-        "AzureSDKTeam.onmicrosoft.com", "recordConsentConditions": null, "replyUrls":
+        "rhcuppettgmail.onmicrosoft.com", "recordConsentConditions": null, "replyUrls":
         [], "requiredResourceAccess": [], "samlMetadataUrl": null, "signInAudience":
         "AzureADMyOrg", "tokenEncryptionKeyId": null}'
     headers:
@@ -1334,27 +1486,27 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2265'
+      - '2267'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 08 Sep 2020 07:00:22 GMT
+      - Wed, 09 Dec 2020 22:43:06 GMT
       duration:
-      - '5090426'
+      - '5556561'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/1cb08156-ab6b-4ed0-8e81-545131caf702/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/1b8ed36e-df3c-4fec-82fb-158ecabbfec2/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - dt1ud5RBv6pDfyRELV4xlatMS+y168uJT4lkzUFSJmg=
+      - ezMUSfTaf0pXjw17yL9nxuuedTkxByuL9OAQe9M9lRE=
       ocp-aad-session-key:
-      - 4HdZlFLjZoerlI5hmBgjPdkJVhV2l2DgUBD9QAhHJp37c14ChmcXjKzVSEHswXerZUEvF9m87SvsKuSMj8_0mDZL6NylE-A1p2jG-oAGeJvZqsbnmhQgDVd7Tvb4fJYLmPr0zskQXS46xi2NHmAC0C5SjYNSZVh37_5QP75W258.y2Sg9YRr2jRg85g1BW60lHv2OdYA4LpbV4JgRQ4V2so
+      - _o-l8pdu5a7KZlfp2ZjvB69Adh0gq_739298mgPt5EQEL4Lc1vFkfVJqaf6Mdwem-IYoBNb-GEamPjghCnCHATD-kva0mTs5nZpfZ8jaHQtvJf5LGCUmvyarHiXzIMiWjPbkzdrZ5aDUw723ne9jg4CXcEcog9avJ4F54lu72MQ.qT0SLsyQ7DU_woEllnDR8wNzaEDcs08jsAcWO4ilU58
       pragma:
       - no-cache
       request-id:
-      - 518373ed-c7cf-4559-ba7a-aa363e3b9c55
+      - dabfb034-9982-4371-9d4d-8792e45e0a90
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1382,12 +1534,13 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%272f1b33cc-af5a-4633-aeee-875b15c50c71%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%274bdcbdbe-b405-4ffd-b8dc-696176de4f62%27&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -1403,19 +1556,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 08 Sep 2020 07:00:22 GMT
+      - Wed, 09 Dec 2020 22:43:06 GMT
       duration:
-      - '431603'
+      - '317216'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 68S1qiYTGdlYlteO57AcAfRdh6gxMgQ4BOpjpsClWbY=
+      - 32xFaR4J2bpg9eM9GlbubeIxl32PYMYeYN9UuXr6rxM=
       ocp-aad-session-key:
-      - mq4Mi3x446B6AyanpIpSLFiAJo1vdy-OhJagdnXqPoZnPvkS4Ib3eUbiIrNXNS70uWcb3uvlIfaobkBbChDOj41HdPFUxF-IGFUe5bcrceuu8UGCxD6HDba7G8gLNKX1R3wpX4-w5P3bHwg9E8ixGTVhcrPmMIpBbJl7m241IC8.bHGb_zSoJ8DenmHBlJDD_CAhda01OExKMg_vjSi3180
+      - ULiD2i6hsrGG95goeLngv1yI-F9f8VaB9kJFesbmQWZTbgSa8Epk6URibSRZNplQfEYfq7ShFjPJQipaDzaZSBCnvPeR0-zIVDppiPRZEYJSfW0t0lpbifIfqV4sbwJOwN9nU6pMBo-JHPzMM1ctZaqBKKvCB4aDPepwVxEePvQ.5jL8FjqX8raQBIuwysNNBmW48bItSdddSsJ8MtxLUIU
       pragma:
       - no-cache
       request-id:
-      - 8a044d11-2a89-4329-a085-9cce79c70524
+      - 2d6061cc-34ea-4a32-b674-9b5e136be2d4
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1430,7 +1583,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"appId": "2f1b33cc-af5a-4633-aeee-875b15c50c71"}'
+    body: '{"appId": "4bdcbdbe-b405-4ffd-b8dc-696176de4f62"}'
     headers:
       Accept:
       - application/json
@@ -1447,46 +1600,48 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"34fb9cc8-8fc9-4ae8-80cc-116d31c04f46","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-bcw4l0nr","appId":"2f1b33cc-af5a-4633-aeee-875b15c50c71","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-bcw4l0nr","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access aro-bcw4l0nr on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        aro-bcw4l0nr","id":"038fe5f7-5caf-46e4-8920-5296eda49b9d","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access aro-bcw4l0nr on your behalf.","userConsentDisplayName":"Access
-        aro-bcw4l0nr","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["2f1b33cc-af5a-4633-aeee-875b15c50c71","https://az.aro.azure.com/0ddc255f-6506-4acc-8311-530aa7ed927f"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"434760c4-8e4b-49e9-80be-3ed37b7a0aa3","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-nb25qvuk","appId":"4bdcbdbe-b405-4ffd-b8dc-696176de4f62","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-nb25qvuk","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access aro-nb25qvuk on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        aro-nb25qvuk","id":"1d27a455-306d-4d33-ad35-81afb23c26e8","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access aro-nb25qvuk on your behalf.","userConsentDisplayName":"Access
+        aro-nb25qvuk","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
+        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["4bdcbdbe-b405-4ffd-b8dc-696176de4f62","https://az.aro.azure.com/34e7b07e-8b9e-4075-9d70-4bda54810029"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '1674'
+      - '1695'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 08 Sep 2020 07:00:22 GMT
+      - Wed, 09 Dec 2020 22:43:06 GMT
       duration:
-      - '1966524'
+      - '2773953'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/34fb9cc8-8fc9-4ae8-80cc-116d31c04f46/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/434760c4-8e4b-49e9-80be-3ed37b7a0aa3/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - gs8C01f5KRN9nNLnTmZX5CWrEWq6NpXoaIB755uhVTs=
+      - 9+3Xukos+xnKDo6vhqXjS3cj3+qrcJ+KT5tvQfBgax4=
       ocp-aad-session-key:
-      - KxO73fZga5DUjcktc2jJNwzNag0YLOiJHdiOwT9PwCQJa9b3NJ1cTWJDI6hfDLpifGXfhXJGdOKHomEDxf9fcJn-zRLm5v2XCvY4bi7xkC1StcZvfwiWIWZIB5etLIHg-LdPjcm9YHhM3f3wJY6q_WnCZdoWRPNw_VtawoiqfEw.7poFQMGchF-vqZtMaqdp9vQvUmHomClMtMmAESgs6cY
+      - uoAIUAwdehDMSOO7_tDrMcHGF0wl778XjooNlSMz1eNQrM1NiRqmlJqyR9kAFDNHEKj8CEsH37WTi03F06mvOhmBqXZOLCLPxjDidNl6O5P7UmrK_SMMsNHDh1I2WqcTzcHADQffnLC2leHXZoSpmEjhQhYd_Fii7Bkpj-mWqB8.2M3XH-2coJpiM8JPGcEHN13dpvcih8RkByUoszwMj0o
       pragma:
       - no-cache
       request-id:
-      - 033f9ffa-d6db-4471-afb3-26c32bf6113e
+      - bbf640c1-9411-4495-9edf-402114817ff6
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1514,15 +1669,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"3e675290-31e1-49f6-a3cd-03df3d7d6e2e","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Azure
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Azure
         Red Hat OpenShift RP","appId":"f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875","applicationTemplateId":null,"appOwnerTenantId":"f8cdef31-a31e-4b4a-93e4-5f571e91255a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Azure
         Red Hat OpenShift RP","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft
         Services","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
@@ -1538,19 +1694,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 08 Sep 2020 07:00:22 GMT
+      - Wed, 09 Dec 2020 22:43:07 GMT
       duration:
-      - '489208'
+      - '428841'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - G2swZNyf+0sfKJORG+YsDqNDjltnzy2a9KB8/pulCBY=
+      - b4knqZe2rnHigNaUPuLaCUdUX0KDH7YzUGDQZK8v4H8=
       ocp-aad-session-key:
-      - 96Pbg3G9ypoCaoHZ8eIyKBcmCjXvVw3VhiHDXPoDplKx893pdtaFGyCWkz0k-B-WKhWpfznSsVeYi0UbQ-e6Dp_MKdIEfV5RZ7D-9PByIR3WdwH5T9TgJa8kKJxLVRyuCl2YifGLt6nsY54rg8K807EfBkFrFN6BNrWmka_Wh-E.KhNAodcwNS-Eik3QnatEd9hfPKv0FSyjRaSmJvabYtQ
+      - oBYJPkF4U67yt8ECVwUU50nvMCUr4pwfJf5rNnl-OBJMaKtfweg94dhA8gvbPT7cKzAbEV7Dh0rfPweuQaoJ7hIjp8prnrKOYVc8MfZUbHRgyC8h4AXlo17m_kYMi3NXM0gljlufU5Os2W0WQ0pM0E3FLQhTaeoWtQWPLtPDjis.0cyIuMRBzyY3pcn24xg7_slaIsiZQSpUujMsTjL6W0I
       pragma:
       - no-cache
       request-id:
-      - e9ee6d64-5569-4d13-bb9c-1d15c617ad7e
+      - 8549bdb2-4a83-403f-bece-7fa1f1d5a3cf
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1578,26 +1734,25 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2019-09-04T08:09:42.0835929Z","updatedOn":"2019-09-04T08:09:42.0835929Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/9d0c9433-a2c8-403f-ba1c-6310772291a5","type":"Microsoft.Authorization/roleAssignments","name":"9d0c9433-a2c8-403f-ba1c-6310772291a5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-14T05:22:05.1776921Z","updatedOn":"2020-03-14T05:22:05.1776921Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/eed777be-eb1b-4af7-9ec2-e4a74afba39e","type":"Microsoft.Authorization/roleAssignments","name":"eed777be-eb1b-4af7-9ec2-e4a74afba39e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-04T08:35:06.1202192Z","updatedOn":"2020-03-04T08:35:06.1202192Z","createdBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","updatedBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/67f6c798-74b6-41f7-ba07-ae40134ce8c1","type":"Microsoft.Authorization/roleAssignments","name":"67f6c798-74b6-41f7-ba07-ae40134ce8c1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T03:47:15.1734978Z","updatedOn":"2020-03-19T03:47:15.1734978Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/888c7688-4ae3-406f-948b-fd569da173fc","type":"Microsoft.Authorization/roleAssignments","name":"888c7688-4ae3-406f-948b-fd569da173fc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T04:06:32.7642459Z","updatedOn":"2020-03-19T04:06:32.7642459Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/b4bdedde-4f10-4610-9201-2421bb032107","type":"Microsoft.Authorization/roleAssignments","name":"b4bdedde-4f10-4610-9201-2421bb032107"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"02d52e0b-1c85-4aa9-a229-bca89f5fc079","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:06:31.6888688Z","updatedOn":"2020-07-15T07:06:31.6888688Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/e2f3fd89-b1cc-42c7-ae59-1ef03b4e731a","type":"Microsoft.Authorization/roleAssignments","name":"e2f3fd89-b1cc-42c7-ae59-1ef03b4e731a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-01-29T13:27:35.7170489Z","updatedOn":"2020-01-29T13:27:35.7170489Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/b6899915-1e85-4406-aa1f-f346ec3ded50","type":"Microsoft.Authorization/roleAssignments","name":"b6899915-1e85-4406-aa1f-f346ec3ded50"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"22bd72d9-4e93-4a74-b5ad-679cabe53baf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:27:36.1276006Z","updatedOn":"2020-07-15T07:27:36.1276006Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/06f37651-eecf-4b6c-a0e7-b26822697224","type":"Microsoft.Authorization/roleAssignments","name":"06f37651-eecf-4b6c-a0e7-b26822697224"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b304d026-311a-4be0-9994-8c578fc3697f","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:14:11.6612918Z","updatedOn":"2020-07-15T07:14:11.6612918Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/a75bb3e5-3b36-488f-a1a4-32be0a44e1a1","type":"Microsoft.Authorization/roleAssignments","name":"a75bb3e5-3b36-488f-a1a4-32be0a44e1a1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3","principalId":"30601973-dcd6-4c4e-85e8-dc6e057238fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-14T15:35:54.7519315Z","updatedOn":"2020-06-14T15:35:54.7519315Z","createdBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","updatedBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/02d00457-a5a7-4da3-b12a-e944705f4170","type":"Microsoft.Authorization/roleAssignments","name":"02d00457-a5a7-4da3-b12a-e944705f4170"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab","principalId":"677a61e9-086e-4f13-986a-11aaedc31416","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T03:31:37.3848580Z","updatedOn":"2019-11-26T03:31:37.3848580Z","createdBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","updatedBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aac8538d-8226-4b91-9232-03d3f3a40214","type":"Microsoft.Authorization/roleAssignments","name":"aac8538d-8226-4b91-9232-03d3f3a40214"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-04T08:40:46.0862758Z","updatedOn":"2020-03-04T08:40:46.0862758Z","createdBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","updatedBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5f32c47e-50b5-4be3-8774-ea1467857752","type":"Microsoft.Authorization/roleAssignments","name":"5f32c47e-50b5-4be3-8774-ea1467857752"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-20T09:03:02.6644378Z","updatedOn":"2020-01-20T09:03:02.6644378Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dd2121da-11a7-4ff5-bab0-053cc344b0b0","type":"Microsoft.Authorization/roleAssignments","name":"dd2121da-11a7-4ff5-bab0-053cc344b0b0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0444ccf8-fddb-43c4-b42b-ea036211229f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-25T07:18:48.8610796Z","updatedOn":"2020-03-25T07:18:48.8610796Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4f7c6762-b335-43e7-9c13-d42ab9bc6884","type":"Microsoft.Authorization/roleAssignments","name":"4f7c6762-b335-43e7-9c13-d42ab9bc6884"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"05b1f982-1404-4e2d-b2e8-af3ee7a330b4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-22T14:58:56.7424484Z","updatedOn":"2019-09-22T14:58:56.7424484Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a5d758f5-4ec2-4dd5-ba95-cee5405e367c","type":"Microsoft.Authorization/roleAssignments","name":"a5d758f5-4ec2-4dd5-ba95-cee5405e367c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-21T03:37:35.1867759Z","updatedOn":"2019-11-21T03:37:35.1867759Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f93778f-00f5-4efb-a56f-6aff1d668df7","type":"Microsoft.Authorization/roleAssignments","name":"6f93778f-00f5-4efb-a56f-6aff1d668df7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0a592c45-613e-4f1b-9023-7c4414fd53bf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-08-08T01:47:13.5745250Z","updatedOn":"2019-08-08T01:47:13.5745250Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d320644f-c08b-47f4-ae3b-9df595a5c368","type":"Microsoft.Authorization/roleAssignments","name":"d320644f-c08b-47f4-ae3b-9df595a5c368"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-26T04:16:43.3784273Z","updatedOn":"2019-07-26T04:16:43.3784273Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a567d42-8a33-4cad-9f7b-5299a16dc269","type":"Microsoft.Authorization/roleAssignments","name":"9a567d42-8a33-4cad-9f7b-5299a16dc269"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0eae5543-750d-4b1a-89bc-7bfd80671fbd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T05:52:20.5117449Z","updatedOn":"2020-04-13T05:52:20.5117449Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b2a0bc46-da6a-4ca0-b518-81cc1f0a14d3","type":"Microsoft.Authorization/roleAssignments","name":"b2a0bc46-da6a-4ca0-b518-81cc1f0a14d3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"182c8534-f413-487c-91a3-7addc80e35d5","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-09-06T13:37:05.6480940Z","updatedOn":"2017-09-06T13:37:05.6480940Z","createdBy":"bed854bc-89d1-444b-914a-8984c7a9d73d","updatedBy":"bed854bc-89d1-444b-914a-8984c7a9d73d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d0560ab5-dd8d-4978-8c9b-84768b4a9467","type":"Microsoft.Authorization/roleAssignments","name":"d0560ab5-dd8d-4978-8c9b-84768b4a9467"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"18f53146-1f6c-462a-96a5-d50e1293b770","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-05-24T02:53:04.7484734Z","updatedOn":"2019-05-24T02:53:04.7484734Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/553a3d02-d0da-4b7c-a0f1-d1298f556001","type":"Microsoft.Authorization/roleAssignments","name":"553a3d02-d0da-4b7c-a0f1-d1298f556001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1aa92e15-ee4e-4dda-9e61-5b4dc35d280b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-29T06:05:52.7948049Z","updatedOn":"2020-04-29T06:05:52.7948049Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/039870e3-5852-4b2f-a3a9-9e172adfd72b","type":"Microsoft.Authorization/roleAssignments","name":"039870e3-5852-4b2f-a3a9-9e172adfd72b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1c93a1ad-59cf-42fc-b6ce-0f5ffd464a70","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-04-09T20:12:14.4602372Z","updatedOn":"2018-04-09T20:12:14.4602372Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d5397a6-f185-4b65-bcba-6b9f2248093a","type":"Microsoft.Authorization/roleAssignments","name":"8d5397a6-f185-4b65-bcba-6b9f2248093a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"2262dfe7-375f-4597-a47c-2766489ecbe7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-06-14T17:54:39.3919633Z","updatedOn":"2019-06-14T17:54:39.3919633Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3f58856e-c1e1-4269-9055-f9fbe4cb6506","type":"Microsoft.Authorization/roleAssignments","name":"3f58856e-c1e1-4269-9055-f9fbe4cb6506"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"2ed08755-e5b9-42ef-8638-38e95105e710","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-23T06:01:53.1357543Z","updatedOn":"2019-12-23T06:01:53.1357543Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1986d758-ee67-4fc7-9eb2-c0d52d4a075d","type":"Microsoft.Authorization/roleAssignments","name":"1986d758-ee67-4fc7-9eb2-c0d52d4a075d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1b1b6446-6585-4988-b9ab-a8cdf9035b8a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-11T09:21:11.3066024Z","updatedOn":"2020-02-11T09:21:11.3066024Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ae57b317-873d-4242-a539-32b3e934259d","type":"Microsoft.Authorization/roleAssignments","name":"ae57b317-873d-4242-a539-32b3e934259d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-17T08:29:55.3047288Z","updatedOn":"2019-09-17T08:29:55.3047288Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e3591e24-669e-475f-a315-7d581996b864","type":"Microsoft.Authorization/roleAssignments","name":"e3591e24-669e-475f-a315-7d581996b864"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"32fe2882-ca97-44f9-8e0d-dfe916b9dfee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-06T03:03:50.0740099Z","updatedOn":"2019-09-06T03:03:50.0740099Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/01c1fcc9-4df3-4107-832f-42f245309750","type":"Microsoft.Authorization/roleAssignments","name":"01c1fcc9-4df3-4107-832f-42f245309750"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"378df7ee-31fd-4c54-945e-a1ed4f025a28","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-08-10T19:00:33.4173527Z","updatedOn":"2017-08-10T19:00:33.4173527Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e0ddb7cd-de16-42ce-bab6-6a0d4d3903d8","type":"Microsoft.Authorization/roleAssignments","name":"e0ddb7cd-de16-42ce-bab6-6a0d4d3903d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"37aa63b3-0814-4c36-9641-d9c3120b1f1b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-25T22:21:28.6870688Z","updatedOn":"2019-02-25T22:21:28.6870688Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/185a89d4-23f9-4fb8-827c-6d7f8e26c49d","type":"Microsoft.Authorization/roleAssignments","name":"185a89d4-23f9-4fb8-827c-6d7f8e26c49d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"37e77055-3c53-4ae5-bf04-d2459236b6a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:25:07.0794530Z","updatedOn":"2020-01-09T06:25:07.0794530Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ec3d1379-1350-4894-98dc-4742280ba73b","type":"Microsoft.Authorization/roleAssignments","name":"ec3d1379-1350-4894-98dc-4742280ba73b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"39029da9-0fef-42a9-b478-2fe4e19b8c7b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-19T02:54:07.7981142Z","updatedOn":"2020-06-19T02:54:07.7981142Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/90fa5166-2ffa-44a8-ad5d-da4f3eaab642","type":"Microsoft.Authorization/roleAssignments","name":"90fa5166-2ffa-44a8-ad5d-da4f3eaab642"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-19T03:54:40.3617093Z","updatedOn":"2020-01-19T03:54:40.3617093Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c9b97fb4-3b05-49af-97de-2950204d9066","type":"Microsoft.Authorization/roleAssignments","name":"c9b97fb4-3b05-49af-97de-2950204d9066"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3e675290-31e1-49f6-a3cd-03df3d7d6e2e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-03T04:39:51.0517217Z","updatedOn":"2020-05-03T04:39:51.0517217Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/49eedfad-3250-441e-8a85-03026008e57c","type":"Microsoft.Authorization/roleAssignments","name":"49eedfad-3250-441e-8a85-03026008e57c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"4582e5fb-504d-4b21-89be-9e11352ac837","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-27T01:17:48.4170577Z","updatedOn":"2020-02-27T01:17:48.4170577Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/43cfb5ae-8271-433b-8799-85858d658f59","type":"Microsoft.Authorization/roleAssignments","name":"43cfb5ae-8271-433b-8799-85858d658f59"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"4c1e34fd-dcf5-4516-bb96-b8ac22e138da","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T08:54:40.6904887Z","updatedOn":"2020-06-08T08:54:40.6904887Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/386dc123-cb36-4f9f-ac58-7aaaf5d7ed58","type":"Microsoft.Authorization/roleAssignments","name":"386dc123-cb36-4f9f-ac58-7aaaf5d7ed58"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"56b6b563-1341-4632-96cd-06252b81665d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-05T08:50:50.2703536Z","updatedOn":"2019-09-05T08:50:50.2703536Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e17d3c8b-26f3-4cdd-bcc1-211c3e490299","type":"Microsoft.Authorization/roleAssignments","name":"e17d3c8b-26f3-4cdd-bcc1-211c3e490299"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"596c247a-9db0-4c20-8ddb-d944102067ac","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-25T08:06:17.3145960Z","updatedOn":"2019-10-25T08:06:17.3145960Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5383f6ae-0e25-43d5-a448-2fd0d2699d72","type":"Microsoft.Authorization/roleAssignments","name":"5383f6ae-0e25-43d5-a448-2fd0d2699d72"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5a7755a0-33cc-4bcc-9064-12f1bf05c991","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-11T05:55:15.7549140Z","updatedOn":"2020-05-11T05:55:15.7549140Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5584dc94-54e6-4a61-af7c-09934f06b4d1","type":"Microsoft.Authorization/roleAssignments","name":"5584dc94-54e6-4a61-af7c-09934f06b4d1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5accae2a-f109-44ba-8549-8c682acd4ad1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-11-06T23:33:48.6032970Z","updatedOn":"2017-11-06T23:33:48.6032970Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b35dfe77-4bb3-4956-b644-16d58904b1bf","type":"Microsoft.Authorization/roleAssignments","name":"b35dfe77-4bb3-4956-b644-16d58904b1bf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"669ef724-96ef-462e-b760-a398c8d49f12","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-10-16T00:01:10.8880293Z","updatedOn":"2018-10-16T00:01:10.8880293Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1fb698ad-cef0-442e-8fa0-c5c4609b12ec","type":"Microsoft.Authorization/roleAssignments","name":"1fb698ad-cef0-442e-8fa0-c5c4609b12ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6ba8d12f-faf3-4859-918b-80f93e471e38","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-05T07:42:22.6383489Z","updatedOn":"2019-09-05T07:42:22.6383489Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1b0df1c0-baf0-41ed-9560-6495d40dfa06","type":"Microsoft.Authorization/roleAssignments","name":"1b0df1c0-baf0-41ed-9560-6495d40dfa06"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T05:03:40.5214262Z","updatedOn":"2020-04-26T05:03:40.5214262Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73651752-e48b-47b6-8ce6-770e1bf56e80","type":"Microsoft.Authorization/roleAssignments","name":"73651752-e48b-47b6-8ce6-770e1bf56e80"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-24T09:14:30.5134753Z","updatedOn":"2020-04-24T09:14:30.5134753Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1ba14abb-5c95-4d45-be2c-5429d47ba9b3","type":"Microsoft.Authorization/roleAssignments","name":"1ba14abb-5c95-4d45-be2c-5429d47ba9b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-10T06:36:08.0241793Z","updatedOn":"2019-09-10T06:36:08.0241793Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10b1e634-f9af-4434-bd13-55eb43a57124","type":"Microsoft.Authorization/roleAssignments","name":"10b1e634-f9af-4434-bd13-55eb43a57124"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7b29ef09-268a-44a7-b1f8-094beba68028","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-04-05T17:27:17.7281001Z","updatedOn":"2018-04-05T17:27:17.7281001Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a5c8a26b-80ac-421d-a137-2951374bca62","type":"Microsoft.Authorization/roleAssignments","name":"a5c8a26b-80ac-421d-a137-2951374bca62"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T06:26:40.9453629Z","updatedOn":"2019-11-26T06:26:40.9453629Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2ba40e27-d44f-48e7-9462-1561128bed69","type":"Microsoft.Authorization/roleAssignments","name":"2ba40e27-d44f-48e7-9462-1561128bed69"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-23T08:57:03.4127112Z","updatedOn":"2019-10-23T08:57:03.4127112Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ec55b030-cffa-46ab-a296-78f606400df8","type":"Microsoft.Authorization/roleAssignments","name":"ec55b030-cffa-46ab-a296-78f606400df8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7e58ddef-4719-4c36-a485-4c2a0a843a46","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-25T05:07:15.7863485Z","updatedOn":"2019-12-25T05:07:15.7863485Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/999c61a0-361b-416f-91ee-68f515f910ec","type":"Microsoft.Authorization/roleAssignments","name":"999c61a0-361b-416f-91ee-68f515f910ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-15T08:49:50.8762611Z","updatedOn":"2019-11-15T08:49:50.8762611Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/233c612a-f4d8-41fb-bf58-8e2a587142df","type":"Microsoft.Authorization/roleAssignments","name":"233c612a-f4d8-41fb-bf58-8e2a587142df"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"864a275e-8c80-4efb-ad1c-0c0ab3081788","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-12T02:40:02.3180608Z","updatedOn":"2020-06-12T02:40:02.3180608Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7c5ea86e-a5a6-4750-b95f-5ba47a93ff60","type":"Microsoft.Authorization/roleAssignments","name":"7c5ea86e-a5a6-4750-b95f-5ba47a93ff60"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-23T05:48:03.4970209Z","updatedOn":"2019-12-23T05:48:03.4970209Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8cbac001-17ff-4ba4-ade1-cbbb4924e6d6","type":"Microsoft.Authorization/roleAssignments","name":"8cbac001-17ff-4ba4-ade1-cbbb4924e6d6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"8d594fee-5764-49c9-ad85-35d3ee728386","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-23T09:22:57.7278029Z","updatedOn":"2019-10-23T09:22:57.7278029Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/66da1b82-8f84-41cc-995f-867498db9ae3","type":"Microsoft.Authorization/roleAssignments","name":"66da1b82-8f84-41cc-995f-867498db9ae3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-10T06:47:24.5464704Z","updatedOn":"2019-07-10T06:47:24.5464704Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/83b44361-6e27-4ed1-923c-b10ce84b3926","type":"Microsoft.Authorization/roleAssignments","name":"83b44361-6e27-4ed1-923c-b10ce84b3926"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-21T06:37:44.9936263Z","updatedOn":"2019-10-21T06:37:44.9936263Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7e96cad1-9fe5-49d6-b754-cbe33ce49882","type":"Microsoft.Authorization/roleAssignments","name":"7e96cad1-9fe5-49d6-b754-cbe33ce49882"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-04T03:06:42.9265284Z","updatedOn":"2019-12-04T03:06:42.9265284Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fe0b9591-410f-4229-a288-98d8bfb7ffe5","type":"Microsoft.Authorization/roleAssignments","name":"fe0b9591-410f-4229-a288-98d8bfb7ffe5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a9668459-3905-4e76-a681-a1633c50f368","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-16T02:39:39.2120161Z","updatedOn":"2019-12-16T02:39:39.2120161Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/263dab0a-bf9f-4eec-9ff6-387f87ed056b","type":"Microsoft.Authorization/roleAssignments","name":"263dab0a-bf9f-4eec-9ff6-387f87ed056b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-14T02:32:43.7202100Z","updatedOn":"2020-01-14T02:32:43.7202100Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/93adfbfa-f811-47e3-8ff7-e3a4675b579f","type":"Microsoft.Authorization/roleAssignments","name":"93adfbfa-f811-47e3-8ff7-e3a4675b579f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"ac47bda7-ff61-4451-9bb5-ad30ebcc2863","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-20T02:31:32.7276952Z","updatedOn":"2019-09-20T02:31:32.7276952Z","createdBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","updatedBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bf29019-3c72-44c1-97d4-58ef4d1a540f","type":"Microsoft.Authorization/roleAssignments","name":"4bf29019-3c72-44c1-97d4-58ef4d1a540f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b1eb9d0b-6ca2-4c64-8c13-31e5aa59065f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T07:10:10.5329285Z","updatedOn":"2020-06-08T07:10:10.5329285Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3bb3e257-89a9-4168-ae8b-99807e3819f3","type":"Microsoft.Authorization/roleAssignments","name":"3bb3e257-89a9-4168-ae8b-99807e3819f3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"93a01e49-673a-4e15-8230-51214a737962","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-07-05T21:56:39.5905773Z","updatedOn":"2017-07-05T21:56:39.5905773Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d09787d-0a89-40a8-abf2-a7b60e95d24b","type":"Microsoft.Authorization/roleAssignments","name":"8d09787d-0a89-40a8-abf2-a7b60e95d24b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-03T09:04:20.9413623Z","updatedOn":"2019-12-03T09:04:20.9413623Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6e6cc759-072e-47b8-b35d-ca5b95266e59","type":"Microsoft.Authorization/roleAssignments","name":"6e6cc759-072e-47b8-b35d-ca5b95266e59"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c0526f76-a841-4a3a-bdee-59a5db599e34","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-11T19:18:19.9314682Z","updatedOn":"2018-12-11T19:18:19.9314682Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d9e73a14-4984-4d89-8048-04773fb32344","type":"Microsoft.Authorization/roleAssignments","name":"d9e73a14-4984-4d89-8048-04773fb32344"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c7cc3390-43d1-4a59-8ab8-190092db8184","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T09:49:01.2994155Z","updatedOn":"2020-06-08T09:49:01.2994155Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/184cdda7-d40a-4c78-b71d-9e947e48a488","type":"Microsoft.Authorization/roleAssignments","name":"184cdda7-d40a-4c78-b71d-9e947e48a488"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c87f79eb-8113-4168-83c8-3a0e99ac67be","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-20T09:31:14.0133249Z","updatedOn":"2020-01-20T09:31:14.0133249Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5465d5e4-7123-4cd3-b584-f51ea72c2b79","type":"Microsoft.Authorization/roleAssignments","name":"5465d5e4-7123-4cd3-b584-f51ea72c2b79"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"cdc7828e-c6c1-4822-9b0b-ca54f3d92bcd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-03-15T23:45:46.1042773Z","updatedOn":"2018-03-15T23:45:46.1042773Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d194606-3a10-428a-9ce5-876fec5096c8","type":"Microsoft.Authorization/roleAssignments","name":"8d194606-3a10-428a-9ce5-876fec5096c8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1178d20-4ca4-45f0-ba9a-5a08f588da8d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-05T11:26:44.9370825Z","updatedOn":"2020-05-05T11:26:44.9370825Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d7689797-3689-4c92-b472-a9aaa7c54570","type":"Microsoft.Authorization/roleAssignments","name":"d7689797-3689-4c92-b472-a9aaa7c54570"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d36e0017-aac8-4dd3-8ccf-0ab8a7049c35","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-18T11:38:03.9624602Z","updatedOn":"2020-01-18T11:38:03.9624602Z","createdBy":"dca37046-82cf-4fbb-8088-faa399010380","updatedBy":"dca37046-82cf-4fbb-8088-faa399010380","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/86ebcfe8-2caa-40b5-aebe-ac5a928368ef","type":"Microsoft.Authorization/roleAssignments","name":"86ebcfe8-2caa-40b5-aebe-ac5a928368ef"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"dabd5159-ba4a-42fb-9e4d-7d841445695d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-16T04:29:39.1910424Z","updatedOn":"2020-01-16T04:29:39.1910424Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8ae1af04-181f-418f-a55d-cbdfa2327b75","type":"Microsoft.Authorization/roleAssignments","name":"8ae1af04-181f-418f-a55d-cbdfa2327b75"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-10T02:54:02.2514605Z","updatedOn":"2019-11-10T02:54:02.2514605Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/de186952-0e06-4557-89b5-31257c33093b","type":"Microsoft.Authorization/roleAssignments","name":"de186952-0e06-4557-89b5-31257c33093b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-24T03:28:22.7145389Z","updatedOn":"2019-09-24T03:28:22.7145389Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/16b3fb1c-befa-4dfd-8fbc-9838444af841","type":"Microsoft.Authorization/roleAssignments","name":"16b3fb1c-befa-4dfd-8fbc-9838444af841"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f19e5031-d73d-4d9a-86b7-d540f1bc6cd7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-07T09:51:42.8397254Z","updatedOn":"2020-05-07T09:51:42.8397254Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da43c24c-31f6-47e5-b44f-e1852b61cde6","type":"Microsoft.Authorization/roleAssignments","name":"da43c24c-31f6-47e5-b44f-e1852b61cde6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f3ea48f6-a16e-4b37-8260-f69cf2200525","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T04:53:43.7428061Z","updatedOn":"2020-04-13T04:53:43.7428061Z","createdBy":"7e58ddef-4719-4c36-a485-4c2a0a843a46","updatedBy":"7e58ddef-4719-4c36-a485-4c2a0a843a46","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4d3c5439-0e6d-4dba-afd2-36d6aa289238","type":"Microsoft.Authorization/roleAssignments","name":"4d3c5439-0e6d-4dba-afd2-36d6aa289238"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f4ed124d-6acb-49a5-a6ac-bd96f35d8d16","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T06:25:17.5556287Z","updatedOn":"2020-04-26T06:25:17.5556287Z","createdBy":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","updatedBy":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fcef0c4c-0b40-423a-937e-fb6493374993","type":"Microsoft.Authorization/roleAssignments","name":"fcef0c4c-0b40-423a-937e-fb6493374993"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f802089b-0ae0-4e9b-984a-4e37eef96b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T07:52:39.3088894Z","updatedOn":"2020-04-13T07:52:39.3088894Z","createdBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","updatedBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/82a5d3eb-6393-4a30-9d62-93d9b272d628","type":"Microsoft.Authorization/roleAssignments","name":"82a5d3eb-6393-4a30-9d62-93d9b272d628"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"ffbb9ca1-43fc-498d-b8db-ca965f1684ef","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-12-18T23:20:41.1586895Z","updatedOn":"2017-12-18T23:20:41.1586895Z","createdBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","updatedBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7e012250-6450-4432-b6dd-9e148ab64455","type":"Microsoft.Authorization/roleAssignments","name":"7e012250-6450-4432-b6dd-9e148ab64455"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T04:01:23.9885462Z","updatedOn":"2020-03-19T04:01:23.9885462Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a96438a6-6252-499b-b391-710446ac8ddb","type":"Microsoft.Authorization/roleAssignments","name":"a96438a6-6252-499b-b391-710446ac8ddb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/abec5297-d72c-4fbc-acaf-868482d345c2","principalId":"7a938a30-4226-420e-996f-4d48bca6d537","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-06-14T22:25:43.4944951Z","updatedOn":"2018-06-14T22:25:43.4944951Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a3662714-8332-43d4-a2cf-836f9367c53d","type":"Microsoft.Authorization/roleAssignments","name":"a3662714-8332-43d4-a2cf-836f9367c53d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"27c363a5-7016-4ae0-8540-818ec05673f1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T15:34:53.2206231Z","updatedOn":"2020-04-26T15:34:53.2206231Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/88670ac0-08a0-40af-8cb3-cfecc39224a6","type":"Microsoft.Authorization/roleAssignments","name":"88670ac0-08a0-40af-8cb3-cfecc39224a6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"5963f50c-7c43-405c-af7e-53294de76abd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-11T01:35:58.0239576Z","updatedOn":"2020-01-11T01:35:58.0239576Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/332cf847-f85f-4e42-93c0-ac2d2269c9c6","type":"Microsoft.Authorization/roleAssignments","name":"332cf847-f85f-4e42-93c0-ac2d2269c9c6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"63bdf800-9003-4644-b23c-0caeabf62a42","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T09:34:30.7345716Z","updatedOn":"2020-04-26T09:34:30.7345716Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1f6b6d83-0880-477a-a232-5d15410b189f","type":"Microsoft.Authorization/roleAssignments","name":"1f6b6d83-0880-477a-a232-5d15410b189f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"9e6a992a-0530-43ad-bcd7-e9e0e84ae703","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-11T05:47:51.9435473Z","updatedOn":"2020-03-11T05:47:51.9435473Z","createdBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","updatedBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/07371d4e-e9de-4ef7-84c6-0694afc57163","type":"Microsoft.Authorization/roleAssignments","name":"07371d4e-e9de-4ef7-84c6-0694afc57163"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"d8422fc6-cc80-4990-b5d9-15dfc33bd4ce","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-16T07:05:29.5235140Z","updatedOn":"2020-01-16T07:13:20.5220097Z","createdBy":"9abd3759-d4a6-4297-a26e-19f728a9bc15","updatedBy":"9abd3759-d4a6-4297-a26e-19f728a9bc15","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/20cbf68b-1170-7660-526a-0ce148ad6b9f","type":"Microsoft.Authorization/roleAssignments","name":"20cbf68b-1170-7660-526a-0ce148ad6b9f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-28T02:17:47.3517737Z","updatedOn":"2019-10-28T02:17:47.3517737Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fa59db41-bdc7-4934-9105-138c49aa3b25","type":"Microsoft.Authorization/roleAssignments","name":"fa59db41-bdc7-4934-9105-138c49aa3b25"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0216022c-0a14-4682-b106-fe0de377fba8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-11T10:14:11.4652781Z","updatedOn":"2020-06-11T10:14:11.4652781Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0bdccc57-790d-47b5-ab25-3b25b2c383f5","type":"Microsoft.Authorization/roleAssignments","name":"0bdccc57-790d-47b5-ab25-3b25b2c383f5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"025742e3-96b0-462b-92b8-c6f8a2467315","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T02:30:48.9213321Z","updatedOn":"2019-11-13T02:30:48.9213321Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8e56fee5-34b2-4fda-94f5-4d16d0f316c9","type":"Microsoft.Authorization/roleAssignments","name":"8e56fee5-34b2-4fda-94f5-4d16d0f316c9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"048c9bb6-913e-4ce6-99c5-35198246627b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T08:20:44.1467077Z","updatedOn":"2019-11-13T08:20:44.1467077Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ee9a0273-478f-49c1-ab8b-c391f00ab24a","type":"Microsoft.Authorization/roleAssignments","name":"ee9a0273-478f-49c1-ab8b-c391f00ab24a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"05b1f982-1404-4e2d-b2e8-af3ee7a330b4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-16T02:20:33.6180302Z","updatedOn":"2019-09-16T02:20:33.6180302Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dd290ec1-928e-4be9-bf1a-5444db3c31a9","type":"Microsoft.Authorization/roleAssignments","name":"dd290ec1-928e-4be9-bf1a-5444db3c31a9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0b9debbf-74a2-4090-9e79-6f814c15c64f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-13T23:58:24.6590895Z","updatedOn":"2019-02-13T23:58:24.6590895Z","createdBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","updatedBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/84210bda-8759-422b-b6ea-f95ba2a645cc","type":"Microsoft.Authorization/roleAssignments","name":"84210bda-8759-422b-b6ea-f95ba2a645cc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d1408bc-e090-4bb3-b430-608cc2fb2a0c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T13:25:32.0800552Z","updatedOn":"2020-05-12T13:25:32.0800552Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/95c1ae5a-01de-4f0c-9c56-8e87c017cf36","type":"Microsoft.Authorization/roleAssignments","name":"95c1ae5a-01de-4f0c-9c56-8e87c017cf36"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0444ccf8-fddb-43c4-b42b-ea036211229f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-18T09:31:46.3880250Z","updatedOn":"2019-09-18T09:31:46.3880250Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e7e0e4be-da1c-4e63-8872-b2486e10fbaf","type":"Microsoft.Authorization/roleAssignments","name":"e7e0e4be-da1c-4e63-8872-b2486e10fbaf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-29T13:26:41.7796634Z","updatedOn":"2020-01-29T13:26:41.7796634Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/185c46f5-737c-4e7e-bdeb-5bafee91059d","type":"Microsoft.Authorization/roleAssignments","name":"185c46f5-737c-4e7e-bdeb-5bafee91059d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0dbbe202-a46d-4ade-8f74-0927ccff3bb6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T07:04:08.1661319Z","updatedOn":"2020-06-09T07:04:08.1661319Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3322b8ab-16df-464e-9b80-b555950e6d56","type":"Microsoft.Authorization/roleAssignments","name":"3322b8ab-16df-464e-9b80-b555950e6d56"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"16253a8a-cc24-475a-a5cf-e58491ffd350","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-30T10:22:53.8662664Z","updatedOn":"2019-10-30T10:22:53.8662664Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0d7cca1c-37d2-492a-92ed-c9ae8323e2e2","type":"Microsoft.Authorization/roleAssignments","name":"0d7cca1c-37d2-492a-92ed-c9ae8323e2e2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"182c8534-f413-487c-91a3-7addc80e35d5","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-08T08:26:11.9991435Z","updatedOn":"2020-04-08T08:26:11.9991435Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7ec462b1-f831-472f-8e1b-ff3a11068385","type":"Microsoft.Authorization/roleAssignments","name":"7ec462b1-f831-472f-8e1b-ff3a11068385"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"23304842-3c9b-46fb-9f34-ae0afe0e9a82","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:34:09.9873389Z","updatedOn":"2020-01-09T06:34:09.9873389Z","createdBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","updatedBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79d401d9-e585-43bf-a874-1ecc9685e823","type":"Microsoft.Authorization/roleAssignments","name":"79d401d9-e585-43bf-a874-1ecc9685e823"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-11T15:04:11.6940972Z","updatedOn":"2020-03-14T14:47:34.7417244Z","createdBy":"2c4ad291-088a-4833-9d12-65562168e61f","updatedBy":"f238ba61-2e60-495f-8044-5abc249758fe","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9b26c70e-48e6-9170-677d-d2e0c5c9304e","type":"Microsoft.Authorization/roleAssignments","name":"9b26c70e-48e6-9170-677d-d2e0c5c9304e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"34dd2730-0adb-4bb0-973b-d020e4ae4284","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T02:45:08.7641129Z","updatedOn":"2020-06-08T02:45:08.7641129Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/201a6827-570f-4c37-9e6f-f128e3cd5d85","type":"Microsoft.Authorization/roleAssignments","name":"201a6827-570f-4c37-9e6f-f128e3cd5d85"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"37aa63b3-0814-4c36-9641-d9c3120b1f1b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-01-08T18:58:20.9990189Z","updatedOn":"2019-01-08T18:58:20.9990189Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/54925852-e514-4e06-9023-14b82e9060e7","type":"Microsoft.Authorization/roleAssignments","name":"54925852-e514-4e06-9023-14b82e9060e7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"46b61f8c-9b9c-48e4-912e-243041a7c6c5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:34:13.1774942Z","updatedOn":"2020-01-09T06:34:13.1774942Z","createdBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","updatedBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10e987b4-b922-471c-994b-ccd01cf71780","type":"Microsoft.Authorization/roleAssignments","name":"10e987b4-b922-471c-994b-ccd01cf71780"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4759ce24-1955-4c57-bc53-357a69cc065f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T05:42:58.0364828Z","updatedOn":"2019-09-11T05:42:58.0364828Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/096db8b9-6da1-41d6-91fc-a44386feca3f","type":"Microsoft.Authorization/roleAssignments","name":"096db8b9-6da1-41d6-91fc-a44386feca3f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"478ac2b7-8882-45d7-b424-6d8339728ea9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-01T00:51:52.9057101Z","updatedOn":"2019-11-01T00:51:52.9057101Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9eb79b9d-a384-4d48-83b7-5b31896a4f92","type":"Microsoft.Authorization/roleAssignments","name":"9eb79b9d-a384-4d48-83b7-5b31896a4f92"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4b5f89be-be88-448d-90bd-1148b6c6deb2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-23T02:16:34.2523880Z","updatedOn":"2019-07-23T02:16:34.2523880Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1da14562-3dee-4c97-a071-1b2937796647","type":"Microsoft.Authorization/roleAssignments","name":"1da14562-3dee-4c97-a071-1b2937796647"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4559f5d9-0272-48bd-b6af-fde7f60744dc","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-05T02:39:11.3496688Z","updatedOn":"2020-02-05T02:39:11.3496688Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/108c3348-6445-49c8-8a02-1e9088373505","type":"Microsoft.Authorization/roleAssignments","name":"108c3348-6445-49c8-8a02-1e9088373505"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"50d1b7ca-6643-4aac-a7b6-aba7bffecb30","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-05-30T21:23:34.5623608Z","updatedOn":"2019-05-30T21:23:34.5623608Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff3f8887-b570-4cd2-80d9-31c3c0d780aa","type":"Microsoft.Authorization/roleAssignments","name":"ff3f8887-b570-4cd2-80d9-31c3c0d780aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5230081f-d9b5-4af6-8d26-c648d9cf8ddd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-25T12:43:47.6193708Z","updatedOn":"2020-03-25T12:43:47.6193708Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/13f1d803-4dbb-4cf7-b199-35653a04bf75","type":"Microsoft.Authorization/roleAssignments","name":"13f1d803-4dbb-4cf7-b199-35653a04bf75"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5a17d64a-7ad7-432b-8622-88e4897b4cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-17T08:29:12.7481081Z","updatedOn":"2020-06-17T08:29:12.7481081Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0a0e59b8-4570-4bbc-90c1-87cfdbb3d9b0","type":"Microsoft.Authorization/roleAssignments","name":"0a0e59b8-4570-4bbc-90c1-87cfdbb3d9b0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"60a5c23b-3773-41b6-b27f-74805f1d2d9c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-04T10:54:04.8614591Z","updatedOn":"2020-02-04T10:54:04.8614591Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/47ad8fd8-84be-48d1-8d7a-923163696cdd","type":"Microsoft.Authorization/roleAssignments","name":"47ad8fd8-84be-48d1-8d7a-923163696cdd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"69ed4898-0851-4ea4-9813-dfc9864cbaf6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-11T19:26:34.1746649Z","updatedOn":"2018-12-11T19:26:34.1746649Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/27564201-65a3-4a09-bdaf-70c08ecd1786","type":"Microsoft.Authorization/roleAssignments","name":"27564201-65a3-4a09-bdaf-70c08ecd1786"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6a0911c8-758b-458a-8a36-7d6a4c2d450b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-21T05:12:27.5158666Z","updatedOn":"2020-01-21T05:12:27.5158666Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3e8820a3-637f-4a61-922b-abdf163ea9d5","type":"Microsoft.Authorization/roleAssignments","name":"3e8820a3-637f-4a61-922b-abdf163ea9d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"12af389a-3835-46c4-abe9-39d62a64c8e4","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-15T07:17:19.3982425Z","updatedOn":"2020-05-15T07:17:19.3982425Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4944a8a7-76af-49ad-9951-9b4526e228b3","type":"Microsoft.Authorization/roleAssignments","name":"4944a8a7-76af-49ad-9951-9b4526e228b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6aef5178-c2d2-41f6-a180-a296155ddf40","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-21T05:12:34.7950106Z","updatedOn":"2019-11-21T05:12:34.7950106Z","createdBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","updatedBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b5c83b39-f8a1-425f-984b-79e74f9ea79a","type":"Microsoft.Authorization/roleAssignments","name":"b5c83b39-f8a1-425f-984b-79e74f9ea79a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6cc662e7-785f-4759-ae7d-faf16eae02ab","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-29T05:58:51.6260835Z","updatedOn":"2020-04-29T05:58:51.6260835Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c394d91b-6eb5-4ccb-8350-c53c391e98b2","type":"Microsoft.Authorization/roleAssignments","name":"c394d91b-6eb5-4ccb-8350-c53c391e98b2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6f1ee714-b0e7-4abf-aa1e-3457f3205f0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-08T08:17:55.0153562Z","updatedOn":"2020-05-08T08:17:55.0153562Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1af0247f-6055-4bb1-9ee6-e8ea37f5413d","type":"Microsoft.Authorization/roleAssignments","name":"1af0247f-6055-4bb1-9ee6-e8ea37f5413d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"76b6ea71-288a-4e62-b904-3f3013201fb7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-17T06:36:55.9940820Z","updatedOn":"2020-06-17T06:36:55.9940820Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/21364cd1-07fd-407d-b94f-c341679a1ad6","type":"Microsoft.Authorization/roleAssignments","name":"21364cd1-07fd-407d-b94f-c341679a1ad6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6d61a178-3216-4ba7-bdc3-0fbc62b65ac9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-18T14:13:16.1350734Z","updatedOn":"2019-11-18T14:13:16.1350734Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/951d7466-f489-49df-88a3-9790ad814153","type":"Microsoft.Authorization/roleAssignments","name":"951d7466-f489-49df-88a3-9790ad814153"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"76d7bb0b-b614-4497-a519-7a46689f537c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-13T05:59:17.2737425Z","updatedOn":"2020-05-13T05:59:17.2737425Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d34fdce-9cef-427a-bfa0-fb81ffba52f2","type":"Microsoft.Authorization/roleAssignments","name":"6d34fdce-9cef-427a-bfa0-fb81ffba52f2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T06:25:38.6656804Z","updatedOn":"2019-11-26T06:25:38.6656804Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/02287c55-f42c-4852-9b08-c20c8a3b7e3b","type":"Microsoft.Authorization/roleAssignments","name":"02287c55-f42c-4852-9b08-c20c8a3b7e3b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T11:44:45.7387983Z","updatedOn":"2020-05-26T11:44:45.7387983Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6a878581-11bf-4bd4-a7ab-b1fb64e555aa","type":"Microsoft.Authorization/roleAssignments","name":"6a878581-11bf-4bd4-a7ab-b1fb64e555aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"81e54268-6800-49d3-b90f-a2ea6e20c110","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-12T09:05:37.5222708Z","updatedOn":"2020-04-12T09:05:37.5222708Z","createdBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","updatedBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f6bb8b0d-7009-454a-a489-610c6e23b559","type":"Microsoft.Authorization/roleAssignments","name":"f6bb8b0d-7009-454a-a489-610c6e23b559"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"838439dc-f0fa-4a37-ba56-daa13ff730ed","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T09:15:50.5935627Z","updatedOn":"2019-09-11T09:15:50.5935627Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/253c1f18-9f2b-490d-961d-520ba222a9b3","type":"Microsoft.Authorization/roleAssignments","name":"253c1f18-9f2b-490d-961d-520ba222a9b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"864a275e-8c80-4efb-ad1c-0c0ab3081788","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T06:17:44.5858739Z","updatedOn":"2020-06-09T06:17:44.5858739Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0565f4e2-558c-40b3-860e-3e910285cae7","type":"Microsoft.Authorization/roleAssignments","name":"0565f4e2-558c-40b3-860e-3e910285cae7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"885ee9c5-df35-4d21-bd29-33d930ef4721","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-08-08T07:30:25.7405858Z","updatedOn":"2019-08-08T07:30:25.7405858Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9e1de6d0-412e-4425-8e11-897f4aa32d65","type":"Microsoft.Authorization/roleAssignments","name":"9e1de6d0-412e-4425-8e11-897f4aa32d65"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8ce13a5d-7120-4635-b792-8cc697798e81","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-03T05:23:07.9499351Z","updatedOn":"2019-10-03T05:23:07.9499351Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ca192630-0f9b-47ea-bc2a-0cc0f9dc27d7","type":"Microsoft.Authorization/roleAssignments","name":"ca192630-0f9b-47ea-bc2a-0cc0f9dc27d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"90c3d926-9c03-4d90-86f4-12866a6da212","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-02T20:57:30.6864609Z","updatedOn":"2019-04-02T20:57:30.6864609Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bf3be37-b85e-49f9-ace5-e14c018302b5","type":"Microsoft.Authorization/roleAssignments","name":"6bf3be37-b85e-49f9-ace5-e14c018302b5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-27T01:19:27.7003320Z","updatedOn":"2020-02-27T01:19:27.7003320Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/363f553a-f660-4bcc-9c18-855b870f7bc8","type":"Microsoft.Authorization/roleAssignments","name":"363f553a-f660-4bcc-9c18-855b870f7bc8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"973fdd79-4ab9-438e-87c3-954cca1889e1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-09-21T19:09:54.9071757Z","updatedOn":"2018-09-21T19:09:54.9071757Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a4890276-7fa1-47a7-9d82-f0a4ceff9bd6","type":"Microsoft.Authorization/roleAssignments","name":"a4890276-7fa1-47a7-9d82-f0a4ceff9bd6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"97885433-e8ee-463f-9db0-194661924999","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-05T09:50:17.9261390Z","updatedOn":"2020-03-05T09:50:17.9261390Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7934da9a-5ac8-4145-b917-d9e061fc10fc","type":"Microsoft.Authorization/roleAssignments","name":"7934da9a-5ac8-4145-b917-d9e061fc10fc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"99220f34-fe4d-4bb9-a54f-8cef2c114bec","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T02:24:15.1904918Z","updatedOn":"2019-11-13T02:24:15.1904918Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/35b39af0-258c-488a-91d0-a744d937d7d0","type":"Microsoft.Authorization/roleAssignments","name":"35b39af0-258c-488a-91d0-a744d937d7d0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4e6a3ef-370d-4b96-8484-0f0e7ae097cc","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-23T04:54:51.7233330Z","updatedOn":"2019-02-23T04:54:51.7233330Z","createdBy":"4a399fbb-7213-47d3-b6ad-59284286d50a","updatedBy":"4a399fbb-7213-47d3-b6ad-59284286d50a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/44a09d24-8afc-4e6f-8194-92c41bc03d2c","type":"Microsoft.Authorization/roleAssignments","name":"44a09d24-8afc-4e6f-8194-92c41bc03d2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ac49f0af-daf1-40c5-a7c5-976a80349806","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-25T19:29:43.0393638Z","updatedOn":"2019-02-25T19:29:43.0393638Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2990befc-9d32-467c-82e6-f6d4b9989731","type":"Microsoft.Authorization/roleAssignments","name":"2990befc-9d32-467c-82e6-f6d4b9989731"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9085a307-933c-452f-ae3a-9a8e13e68500","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-02T09:57:16.5579321Z","updatedOn":"2020-04-02T09:57:16.5579321Z","createdBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","updatedBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1e74faf5-14cb-443a-a960-986c993decbc","type":"Microsoft.Authorization/roleAssignments","name":"1e74faf5-14cb-443a-a960-986c993decbc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b0460b1a-d53a-42e8-a6a4-d9f43f0ccc73","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-28T04:23:35.8222484Z","updatedOn":"2020-05-28T04:23:35.8222484Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a8cb3f2a-31d8-4e9f-999a-ec8894bb13d5","type":"Microsoft.Authorization/roleAssignments","name":"a8cb3f2a-31d8-4e9f-999a-ec8894bb13d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-22T06:33:53.8936608Z","updatedOn":"2020-01-22T06:33:53.8936608Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a4075ce9-efa5-4df6-a196-2538407da770","type":"Microsoft.Authorization/roleAssignments","name":"a4075ce9-efa5-4df6-a196-2538407da770"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b95d1b0f-145c-480a-915a-3fb867fb598b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-07T05:49:02.0078574Z","updatedOn":"2020-04-07T05:49:02.0078574Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bd310d01-f783-4f08-8b88-948f0b348a11","type":"Microsoft.Authorization/roleAssignments","name":"bd310d01-f783-4f08-8b88-948f0b348a11"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"be76b331-83ac-423a-83de-a97b6a990735","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-22T10:26:36.6728187Z","updatedOn":"2020-05-22T10:26:36.6728187Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/12e50c31-99da-4248-a195-0ab7ac62c504","type":"Microsoft.Authorization/roleAssignments","name":"12e50c31-99da-4248-a195-0ab7ac62c504"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c11b39f7-26c3-4dfc-8d0f-20dde3187845","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-13T18:31:05.4586182Z","updatedOn":"2018-12-13T18:31:05.4586182Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4901f853-a3c6-47e4-9495-2aeb09fb4491","type":"Microsoft.Authorization/roleAssignments","name":"4901f853-a3c6-47e4-9495-2aeb09fb4491"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c87f79eb-8113-4168-83c8-3a0e99ac67be","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T08:20:56.3783272Z","updatedOn":"2020-06-09T08:20:56.3783272Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/60aed0e0-6e97-4ca9-90ac-1f604f8c374e","type":"Microsoft.Authorization/roleAssignments","name":"60aed0e0-6e97-4ca9-90ac-1f604f8c374e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cfca31cb-14a9-4e95-a9b7-f905ab23db3c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-03T04:01:25.5862636Z","updatedOn":"2020-02-03T04:01:25.5862636Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c9fd36d4-1cfe-48c2-bbfc-1ff34a1d1f1f","type":"Microsoft.Authorization/roleAssignments","name":"c9fd36d4-1cfe-48c2-bbfc-1ff34a1d1f1f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d04239cd-f0db-4151-91e9-df98af92d231","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-15T05:29:57.8724060Z","updatedOn":"2020-06-15T05:29:57.8724060Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8bfc3a45-0214-4e85-bd1a-e4ab3c3bdb92","type":"Microsoft.Authorization/roleAssignments","name":"8bfc3a45-0214-4e85-bd1a-e4ab3c3bdb92"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d22a37ff-94a3-46b9-a549-e16b8b71a43c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T04:51:28.2854740Z","updatedOn":"2019-11-13T04:51:28.2854740Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b362e66e-bf5f-4ba5-adaf-88034544377b","type":"Microsoft.Authorization/roleAssignments","name":"b362e66e-bf5f-4ba5-adaf-88034544377b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d80964f8-f04a-4e50-8803-35e571cfb2d9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-07T10:01:41.1345273Z","updatedOn":"2020-02-07T10:01:41.1345273Z","createdBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","updatedBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f1ef5acb-1958-4cd3-a981-0aa430cb0fbd","type":"Microsoft.Authorization/roleAssignments","name":"f1ef5acb-1958-4cd3-a981-0aa430cb0fbd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d8422fc6-cc80-4990-b5d9-15dfc33bd4ce","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-28T05:13:52.5233941Z","updatedOn":"2019-11-28T05:13:52.5233941Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a2e5207-3e10-4ca2-9784-6e7bb8050194","type":"Microsoft.Authorization/roleAssignments","name":"9a2e5207-3e10-4ca2-9784-6e7bb8050194"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"db65a597-9bd4-4259-9632-ffcbfd208b04","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-01-31T18:43:41.6069289Z","updatedOn":"2019-01-31T18:43:41.6069289Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa2a3117-6ca4-4ddf-83c7-511b370735dd","type":"Microsoft.Authorization/roleAssignments","name":"aa2a3117-6ca4-4ddf-83c7-511b370735dd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dc1a3549-229c-4971-93d1-dd2a12439b19","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-18T02:46:17.6374569Z","updatedOn":"2019-09-18T02:46:17.6374569Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79ee6058-9515-427b-a19d-f9a245e4172b","type":"Microsoft.Authorization/roleAssignments","name":"79ee6058-9515-427b-a19d-f9a245e4172b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ddab67ba-ea88-4673-9802-b5393ef85c81","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-13T09:32:56.5200842Z","updatedOn":"2020-03-13T09:32:56.5200842Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/60066209-df2b-4102-bf3a-6a405afe485c","type":"Microsoft.Authorization/roleAssignments","name":"60066209-df2b-4102-bf3a-6a405afe485c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e12f87e2-42fe-4081-a272-85eee50a8062","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T04:19:32.2862854Z","updatedOn":"2019-12-05T04:19:32.2862854Z","createdBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","updatedBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3076ac0b-96c1-40da-b47c-cc8b1a6f60d7","type":"Microsoft.Authorization/roleAssignments","name":"3076ac0b-96c1-40da-b47c-cc8b1a6f60d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f19e5031-d73d-4d9a-86b7-d540f1bc6cd7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T11:59:35.4100543Z","updatedOn":"2020-05-26T11:59:35.4100543Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a156d12a-0595-4273-870e-26b43b10eefb","type":"Microsoft.Authorization/roleAssignments","name":"a156d12a-0595-4273-870e-26b43b10eefb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f22c2b35-e81d-4fa5-afa4-e6178a257deb","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T13:25:32.1208963Z","updatedOn":"2020-05-12T13:25:32.1208963Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a898ad94-406c-429f-8221-1d2e7b9cd5bb","type":"Microsoft.Authorization/roleAssignments","name":"a898ad94-406c-429f-8221-1d2e7b9cd5bb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f6c2f6f7-1bbf-4c17-87c6-28c02d7c0637","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-11-08T18:01:59.1260407Z","updatedOn":"2018-11-08T18:01:59.1260407Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c4b79dcb-c95a-44c2-82cd-e550faad8ac5","type":"Microsoft.Authorization/roleAssignments","name":"c4b79dcb-c95a-44c2-82cd-e550faad8ac5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f757bcca-02d6-4279-8f2d-61a7dcdbccd6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-21T05:32:27.2840541Z","updatedOn":"2020-01-21T05:32:27.2840541Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da4d3dfe-5384-4144-a9c2-5bd2124ddc51","type":"Microsoft.Authorization/roleAssignments","name":"da4d3dfe-5384-4144-a9c2-5bd2124ddc51"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f77592c5-1eb8-4ed3-8615-ddbb75adb4fe","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-19T05:03:29.3633566Z","updatedOn":"2020-06-19T05:03:29.3633566Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2194737b-2f80-4b24-bcd1-45b4c72bce84","type":"Microsoft.Authorization/roleAssignments","name":"2194737b-2f80-4b24-bcd1-45b4c72bce84"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f802089b-0ae0-4e9b-984a-4e37eef96b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-19T05:51:35.7314750Z","updatedOn":"2020-01-19T05:51:35.7314750Z","createdBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","updatedBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3cc61a45-01f3-45df-8661-e7bdd3cf0ef5","type":"Microsoft.Authorization/roleAssignments","name":"3cc61a45-01f3-45df-8661-e7bdd3cf0ef5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-11T08:57:15.2589033Z","updatedOn":"2020-06-11T08:57:15.2589033Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f14cf4c3-66bb-4cb4-aa88-de46c43a5235","type":"Microsoft.Authorization/roleAssignments","name":"f14cf4c3-66bb-4cb4-aa88-de46c43a5235"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"838439dc-f0fa-4a37-ba56-daa13ff730ed","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T09:19:13.9288977Z","updatedOn":"2019-09-11T09:19:13.9288977Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b02d8e07-7398-4236-bf13-6293699c6862","type":"Microsoft.Authorization/roleAssignments","name":"b02d8e07-7398-4236-bf13-6293699c6862"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-10-25T19:47:09.8058411Z","updatedOn":"2018-10-25T19:47:09.8058411Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/abd19ae1-8e0c-4e31-b1ab-25e85d987378","type":"Microsoft.Authorization/roleAssignments","name":"abd19ae1-8e0c-4e31-b1ab-25e85d987378"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/cdda3590-29a3-44f6-95f2-9f980659eb04","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-25T02:29:00.1905156Z","updatedOn":"2019-11-25T02:29:00.1905156Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/774d0387-22b2-41fb-9025-c689ab821fb0","type":"Microsoft.Authorization/roleAssignments","name":"774d0387-22b2-41fb-9025-c689ab821fb0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3e587269-2f98-4906-8e35-7c6af32219d1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-23T03:47:43.1586800Z","updatedOn":"2020-06-23T03:47:43.1586800Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8fcf9b86-69ae-4033-bb78-7f21b15375c4","type":"Microsoft.Authorization/roleAssignments","name":"8fcf9b86-69ae-4033-bb78-7f21b15375c4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"8adc2845-bd5a-4a35-b00f-b83f0640facd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-24T04:56:37.2992825Z","updatedOn":"2020-06-24T04:56:37.2992825Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3921853b-f10d-4c32-9f3c-4ba978198495","type":"Microsoft.Authorization/roleAssignments","name":"3921853b-f10d-4c32-9f3c-4ba978198495"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"8adc2845-bd5a-4a35-b00f-b83f0640facd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-24T05:56:50.0401266Z","updatedOn":"2020-06-24T05:56:50.0401266Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3620fe85-c1cb-46f3-a138-f96236bc1bb0","type":"Microsoft.Authorization/roleAssignments","name":"3620fe85-c1cb-46f3-a138-f96236bc1bb0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1952a856-3972-421d-b257-ae7d8d62e244","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-30T10:09:32.8969837Z","updatedOn":"2020-06-30T10:09:32.8969837Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3274beac-a4e5-43e2-86cc-2247a4e81e45","type":"Microsoft.Authorization/roleAssignments","name":"3274beac-a4e5-43e2-86cc-2247a4e81e45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T02:08:52.2449294Z","updatedOn":"2020-07-01T02:08:52.2449294Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/72cedbfc-50c9-44fa-ad63-d9d32f5215f9","type":"Microsoft.Authorization/roleAssignments","name":"72cedbfc-50c9-44fa-ad63-d9d32f5215f9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9bc33702-a011-4e3b-80f7-927356668049","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T03:00:59.1715198Z","updatedOn":"2020-07-01T03:00:59.1715198Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/89304b85-648a-403d-ab10-f246b2db26b6","type":"Microsoft.Authorization/roleAssignments","name":"89304b85-648a-403d-ab10-f246b2db26b6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9bc33702-a011-4e3b-80f7-927356668049","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T03:27:54.5201710Z","updatedOn":"2020-07-01T03:27:54.5201710Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e5367e0d-da08-4a30-819c-f496ccaa4bfa","type":"Microsoft.Authorization/roleAssignments","name":"e5367e0d-da08-4a30-819c-f496ccaa4bfa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ee38ef12-23d7-4595-8f6f-b4aaa15933f9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T04:46:10.4023148Z","updatedOn":"2020-07-01T04:46:10.4023148Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d3f0718-3404-4f68-b88f-01d3852d40c2","type":"Microsoft.Authorization/roleAssignments","name":"6d3f0718-3404-4f68-b88f-01d3852d40c2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T06:40:44.5009970Z","updatedOn":"2020-07-01T06:40:44.5009970Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/beed1228-2a59-415d-b3c1-7cde7e454ffb","type":"Microsoft.Authorization/roleAssignments","name":"beed1228-2a59-415d-b3c1-7cde7e454ffb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9ec9777a-d786-409e-91c4-da25125576e4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-07T03:23:39.3280578Z","updatedOn":"2020-08-07T03:23:39.3280578Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a7d71d52-c222-4e2f-8ee3-a8ebbfbd8305","type":"Microsoft.Authorization/roleAssignments","name":"a7d71d52-c222-4e2f-8ee3-a8ebbfbd8305"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f013c31e-6903-492d-9f8f-8a2b0097a737","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:25:12.2160705Z","updatedOn":"2020-08-10T05:25:12.2160705Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/218b7750-72ff-4972-8251-0dd31c91c0f5","type":"Microsoft.Authorization/roleAssignments","name":"218b7750-72ff-4972-8251-0dd31c91c0f5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2bb241ba-8f4e-4d58-9812-1f730a9bb04f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:26:33.0105360Z","updatedOn":"2020-08-10T05:26:33.0105360Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e140f43a-4943-4839-a7ad-3c88eda426a3","type":"Microsoft.Authorization/roleAssignments","name":"e140f43a-4943-4839-a7ad-3c88eda426a3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"497a3fb5-4a8b-4fdb-a358-b1c7384d1297","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:39:03.3686314Z","updatedOn":"2020-08-10T05:39:03.3686314Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0ced53d7-64d1-45c2-b08b-7fbdb293d299","type":"Microsoft.Authorization/roleAssignments","name":"0ced53d7-64d1-45c2-b08b-7fbdb293d299"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T06:07:40.7376298Z","updatedOn":"2020-08-10T06:07:40.7376298Z","createdBy":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","updatedBy":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8e606ca9-ad53-4135-837b-c2cde19b8a8e","type":"Microsoft.Authorization/roleAssignments","name":"8e606ca9-ad53-4135-837b-c2cde19b8a8e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b98fae7f-2c20-443f-ab5c-ef3a7be6eae1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T09:03:55.9162129Z","updatedOn":"2020-08-10T09:03:55.9162129Z","createdBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","updatedBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f2241eaf-def8-425f-83ea-6afc474524ae","type":"Microsoft.Authorization/roleAssignments","name":"f2241eaf-def8-425f-83ea-6afc474524ae"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3aca7341-bda7-4fd7-b5e9-c2b97e0de8a7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:10:41.9755999Z","updatedOn":"2020-08-14T14:10:41.9755999Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cb5d9b2a-326e-49b9-8b8e-73b207413e7a","type":"Microsoft.Authorization/roleAssignments","name":"cb5d9b2a-326e-49b9-8b8e-73b207413e7a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e0e3d203-4502-40cb-a021-639bafd28ad5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:23:15.5278986Z","updatedOn":"2020-08-14T14:23:15.5278986Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/91acbf07-9cbd-4f4e-b1d8-cc7828058ec9","type":"Microsoft.Authorization/roleAssignments","name":"91acbf07-9cbd-4f4e-b1d8-cc7828058ec9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5da9b62e-db61-48df-b7cb-983d777e2ff2","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:28:46.5840210Z","updatedOn":"2020-08-14T14:28:46.5840210Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6efa18b8-42bc-47ca-8813-d30e73cf53db","type":"Microsoft.Authorization/roleAssignments","name":"6efa18b8-42bc-47ca-8813-d30e73cf53db"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7b6eac7a-88af-454f-b145-c76749e9a29b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T19:29:47.4188577Z","updatedOn":"2020-08-14T19:29:47.4188577Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d001d53-d8f4-4fff-b679-d80a7040eac7","type":"Microsoft.Authorization/roleAssignments","name":"6d001d53-d8f4-4fff-b679-d80a7040eac7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8ac0350b-22e2-4160-a726-34c6caa4184f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T19:48:28.7252041Z","updatedOn":"2020-08-14T19:48:28.7252041Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e0d4187d-1ee3-4056-8250-14f5e12ec79a","type":"Microsoft.Authorization/roleAssignments","name":"e0d4187d-1ee3-4056-8250-14f5e12ec79a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1141514b-1bef-48de-b565-d44152e1062b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:27:12.9790197Z","updatedOn":"2020-08-17T07:27:12.9790197Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3ab310ca-f5aa-4cfe-aac7-1cd7bb778936","type":"Microsoft.Authorization/roleAssignments","name":"3ab310ca-f5aa-4cfe-aac7-1cd7bb778936"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"06f8821b-7fbf-4980-886d-665d9db57b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:40:08.6067489Z","updatedOn":"2020-08-17T07:40:08.6067489Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1cabdfaf-a394-44c3-affc-81aff3ba6ae2","type":"Microsoft.Authorization/roleAssignments","name":"1cabdfaf-a394-44c3-affc-81aff3ba6ae2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cf2a17da-9812-4844-9ae0-3ae15ec76cad","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:46:00.6157836Z","updatedOn":"2020-08-17T07:46:00.6157836Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4fd3d281-3cc9-40e7-9b52-583f1dd816ee","type":"Microsoft.Authorization/roleAssignments","name":"4fd3d281-3cc9-40e7-9b52-583f1dd816ee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60f762f9-4b9d-4819-8447-b96770d393f7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":"@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:Name]
-        stringEquals ''foo''","conditionVersion":"2.0","createdOn":"2020-08-18T07:10:10.3636738Z","updatedOn":"2020-08-18T07:10:10.3636738Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":"Role
-        assignment foo to check on bar"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6da08c78-7567-4c5c-88a4-880a2ace7352","type":"Microsoft.Authorization/roleAssignments","name":"6da08c78-7567-4c5c-88a4-880a2ace7352"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"16aec3a5-3759-4e41-a69e-7e2b2680eafd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T09:52:17.6795896Z","updatedOn":"2020-08-18T09:52:17.6795896Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/75161d12-2bb2-42ae-a4e7-582440b6c4f4","type":"Microsoft.Authorization/roleAssignments","name":"75161d12-2bb2-42ae-a4e7-582440b6c4f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"acb2e9d2-2452-4577-a05e-d21a637a10fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T11:06:21.1901058Z","updatedOn":"2020-08-18T11:06:21.1901058Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/14218d21-a768-490e-8618-c15affc6937c","type":"Microsoft.Authorization/roleAssignments","name":"14218d21-a768-490e-8618-c15affc6937c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"79fe61e0-fd04-47f9-82e9-dba4d7d21b2e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T11:07:15.5617349Z","updatedOn":"2020-08-18T11:07:15.5617349Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/589f009b-6553-4743-972a-4ce54c29a635","type":"Microsoft.Authorization/roleAssignments","name":"589f009b-6553-4743-972a-4ce54c29a635"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a9dc1ee2-52a6-4092-868a-816237d2e662","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:29.9317048Z","updatedOn":"2020-08-19T07:03:29.9317048Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a3cde6c2-db59-403b-815b-f599d2575d08","type":"Microsoft.Authorization/roleAssignments","name":"a3cde6c2-db59-403b-815b-f599d2575d08"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"119ba358-4192-473a-b06d-181459705162","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:29.7818867Z","updatedOn":"2020-08-19T07:03:29.7818867Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/133bdd44-fcf5-49b5-878a-87416f8ae60d","type":"Microsoft.Authorization/roleAssignments","name":"133bdd44-fcf5-49b5-878a-87416f8ae60d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"34ea07e2-7262-40a9-aadc-afdf3a92fe21","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:45.6787321Z","updatedOn":"2020-08-19T07:03:45.6787321Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09848f3b-57c3-4f72-a8f4-df0aaa3270f1","type":"Microsoft.Authorization/roleAssignments","name":"09848f3b-57c3-4f72-a8f4-df0aaa3270f1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf3ceccf-4953-42e1-b3df-edcabdd83461","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:04:52.1212465Z","updatedOn":"2020-08-19T07:04:52.1212465Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a47f705e-40ad-4dbb-ac53-4493a0b44991","type":"Microsoft.Authorization/roleAssignments","name":"a47f705e-40ad-4dbb-ac53-4493a0b44991"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b8bec651-22e5-4a25-be13-6b1f9df8a00a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:05:25.2684558Z","updatedOn":"2020-08-19T07:05:25.2684558Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/93e123a2-8f6a-450a-aa0d-e4dc04de68d6","type":"Microsoft.Authorization/roleAssignments","name":"93e123a2-8f6a-450a-aa0d-e4dc04de68d6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c8b802a4-9966-4de2-b39b-6d4266c6bfff","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:57:35.2037157Z","updatedOn":"2020-08-19T07:57:35.2037157Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/549e00ed-6b04-4930-b359-4d0f43f4950d","type":"Microsoft.Authorization/roleAssignments","name":"549e00ed-6b04-4930-b359-4d0f43f4950d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6d97229a-391f-473a-893f-f0608b592d7b","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:38:20.3090190Z","updatedOn":"2020-08-19T08:38:20.3090190Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a7686d39-2951-4c27-8cbf-c3c36d701d24","type":"Microsoft.Authorization/roleAssignments","name":"a7686d39-2951-4c27-8cbf-c3c36d701d24"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7bbbac61-5311-40e7-a9e2-2dd92c54144b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:40:47.6961897Z","updatedOn":"2020-08-19T08:40:47.6961897Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f13a2128-645b-4b42-be6a-7b8a174d6dda","type":"Microsoft.Authorization/roleAssignments","name":"f13a2128-645b-4b42-be6a-7b8a174d6dda"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"10741bcb-37eb-4b5d-b73d-b22e72e4c7dd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:45:43.8141578Z","updatedOn":"2020-08-19T08:45:43.8141578Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d4366a87-a683-4232-8270-8475b5105a7b","type":"Microsoft.Authorization/roleAssignments","name":"d4366a87-a683-4232-8270-8475b5105a7b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"667a932e-e24b-4684-aa4a-1db1fd704cc3","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:47:19.3260541Z","updatedOn":"2020-08-19T08:47:19.3260541Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e430a73b-7548-4fee-a45d-25c71c70d8b3","type":"Microsoft.Authorization/roleAssignments","name":"e430a73b-7548-4fee-a45d-25c71c70d8b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a9111493-85b7-43f0-b388-333c160780c6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T05:05:29.5232338Z","updatedOn":"2020-08-21T05:05:29.5232338Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/417d7e21-636b-441a-90ae-106afe45fab1","type":"Microsoft.Authorization/roleAssignments","name":"417d7e21-636b-441a-90ae-106afe45fab1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a0192903-a3ce-47e2-b3d0-ae831e62a518","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T06:29:50.5909137Z","updatedOn":"2020-08-21T06:29:50.5909137Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cc5e851d-a6f5-45f2-82f5-3e8e2638814c","type":"Microsoft.Authorization/roleAssignments","name":"cc5e851d-a6f5-45f2-82f5-3e8e2638814c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"63c25c04-362b-42d9-9e3f-83af045d0a3c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T07:14:04.1824643Z","updatedOn":"2020-08-21T07:14:04.1824643Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bf019dd5-58f4-4fbc-9206-845cf65a7d07","type":"Microsoft.Authorization/roleAssignments","name":"bf019dd5-58f4-4fbc-9206-845cf65a7d07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8e510330-6da3-437c-9d16-b6875c47b73b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:10:19.9912043Z","updatedOn":"2020-08-21T19:10:19.9912043Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/14e6ffd6-9879-4134-9ae2-6e2b8d528ad3","type":"Microsoft.Authorization/roleAssignments","name":"14e6ffd6-9879-4134-9ae2-6e2b8d528ad3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1c60843c-84f3-4dfc-8b47-ede4ead019a9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:29:23.4218009Z","updatedOn":"2020-08-21T19:29:23.4218009Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/411c5f77-af95-4f2f-9e27-9b0c3a5c3a8a","type":"Microsoft.Authorization/roleAssignments","name":"411c5f77-af95-4f2f-9e27-9b0c3a5c3a8a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6d94ee65-e779-469a-a4b5-d56a0b07c685","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:34:28.1634489Z","updatedOn":"2020-08-21T19:34:28.1634489Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e76d93b3-6b01-4778-84e7-799c8b676e9c","type":"Microsoft.Authorization/roleAssignments","name":"e76d93b3-6b01-4778-84e7-799c8b676e9c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2b6f181-9d6c-4e10-876f-b995612db461","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:09:42.7361350Z","updatedOn":"2020-08-24T14:09:42.7361350Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c46c851d-b430-4494-a15c-a07fb87a90ae","type":"Microsoft.Authorization/roleAssignments","name":"c46c851d-b430-4494-a15c-a07fb87a90ae"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b3d54681-34f2-47b8-a790-97ed4c5a7a8d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:23:13.0411929Z","updatedOn":"2020-08-24T14:23:13.0411929Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9f100957-31b1-468b-b2d9-58574bc56a9d","type":"Microsoft.Authorization/roleAssignments","name":"9f100957-31b1-468b-b2d9-58574bc56a9d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a7c9a5c2-8e7a-4f42-abb7-018d3b8e845f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:27:43.7812740Z","updatedOn":"2020-08-24T14:27:43.7812740Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/de3f15f5-edcb-4bcd-81b2-1140597849ac","type":"Microsoft.Authorization/roleAssignments","name":"de3f15f5-edcb-4bcd-81b2-1140597849ac"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-26T06:39:56.9154641Z","updatedOn":"2020-08-26T06:39:56.9154641Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/52185ca9-744e-443f-8d95-5ddb2c963891","type":"Microsoft.Authorization/roleAssignments","name":"52185ca9-744e-443f-8d95-5ddb2c963891"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8cf96a92-f77b-4f11-b378-bc65f571dd97","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-28T19:11:18.2902598Z","updatedOn":"2020-08-28T19:11:18.2902598Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aaa8ba85-b7e1-4267-9120-44c9bb88d6cf","type":"Microsoft.Authorization/roleAssignments","name":"aaa8ba85-b7e1-4267-9120-44c9bb88d6cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"aceba178-3429-4628-a918-9c2d07605ce4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-28T19:34:05.2521949Z","updatedOn":"2020-08-28T19:34:05.2521949Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/db744c26-387e-450c-af33-9f650d3e081a","type":"Microsoft.Authorization/roleAssignments","name":"db744c26-387e-450c-af33-9f650d3e081a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T02:18:54.8314918Z","updatedOn":"2020-08-31T02:18:54.8314918Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0c5c20de-7830-4420-b9a8-319bc24fd068","type":"Microsoft.Authorization/roleAssignments","name":"0c5c20de-7830-4420-b9a8-319bc24fd068"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"63a25eaf-4d6f-491e-9ee6-c1583073b797","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T03:56:52.4047017Z","updatedOn":"2020-08-31T03:56:52.4047017Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e5b45c0c-0568-48f2-b3e6-8f2a7c8a7480","type":"Microsoft.Authorization/roleAssignments","name":"e5b45c0c-0568-48f2-b3e6-8f2a7c8a7480"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bb6ddbae-c27c-4d59-8f74-7f3ae86b09cf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T08:13:57.1050454Z","updatedOn":"2020-08-31T08:13:57.1050454Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e19bab66-9aa8-4185-8022-4f12d711bd41","type":"Microsoft.Authorization/roleAssignments","name":"e19bab66-9aa8-4185-8022-4f12d711bd41"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b3e8f037-9df3-48d7-a200-ea26adbec31b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T16:38:12.9366042Z","updatedOn":"2020-08-31T16:38:12.9366042Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7a52c17e-ffcb-4fda-a6ec-00ce6ce0ec00","type":"Microsoft.Authorization/roleAssignments","name":"7a52c17e-ffcb-4fda-a6ec-00ce6ce0ec00"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f24c1379-3bff-4ef9-a12c-f2144e606f70","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-02T07:08:09.2474084Z","updatedOn":"2020-09-02T07:08:09.2474084Z","createdBy":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","updatedBy":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/617ef96e-12a4-4c5a-8d31-57d08a7a3d7a","type":"Microsoft.Authorization/roleAssignments","name":"617ef96e-12a4-4c5a-8d31-57d08a7a3d7a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2c830430-942c-49f3-85d5-47b113077c10","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-04T19:09:41.0321006Z","updatedOn":"2020-09-04T19:09:41.0321006Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b6663c97-f1e1-43b7-a4e6-48fab343ba41","type":"Microsoft.Authorization/roleAssignments","name":"b6663c97-f1e1-43b7-a4e6-48fab343ba41"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"82b73c5f-d0b6-4922-bee4-d4c15c6de7df","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-04T19:31:27.3400870Z","updatedOn":"2020-09-04T19:31:27.3400870Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff7c33ab-2fad-456e-a3cc-7b229b5368d5","type":"Microsoft.Authorization/roleAssignments","name":"ff7c33ab-2fad-456e-a3cc-7b229b5368d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2e888925-16dd-4a44-b8b1-ba406c26f5d7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:24:37.4713613Z","updatedOn":"2020-09-07T06:24:37.4713613Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/44f8b319-a262-4d13-b71f-333447b5a805","type":"Microsoft.Authorization/roleAssignments","name":"44f8b319-a262-4d13-b71f-333447b5a805"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9df1aedd-86b5-4ed0-b8ff-a88acb8650fb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:25:06.2141876Z","updatedOn":"2020-09-07T06:25:06.2141876Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/85e919b7-5319-413e-a542-afa0b9beeb62","type":"Microsoft.Authorization/roleAssignments","name":"85e919b7-5319-413e-a542-afa0b9beeb62"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"43ef2449-ad33-4be0-8ed0-5c683286f37a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:36:55.7776057Z","updatedOn":"2020-09-07T06:36:55.7776057Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/76ac0e9c-d79b-42f2-bd51-4cbc37748e64","type":"Microsoft.Authorization/roleAssignments","name":"76ac0e9c-d79b-42f2-bd51-4cbc37748e64"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f7365134-0464-4e1f-9b14-d7eec002fcf5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T07:05:11.6942078Z","updatedOn":"2020-09-07T07:05:11.6942078Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fbf2c497-545e-4588-8684-7b9ee6da6b1e","type":"Microsoft.Authorization/roleAssignments","name":"fbf2c497-545e-4588-8684-7b9ee6da6b1e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"93d51f04-4891-476a-8c64-06d57c749216","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T07:08:02.2196156Z","updatedOn":"2020-09-07T07:08:02.2196156Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2f30eec3-4fb4-4703-b46d-e4477070136f","type":"Microsoft.Authorization/roleAssignments","name":"2f30eec3-4fb4-4703-b46d-e4477070136f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d7715695-4665-4845-a99e-9893013479f9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T08:02:32.0378468Z","updatedOn":"2020-09-07T08:02:32.0378468Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7cf24871-6fd5-487e-a65e-c1ebfd911403","type":"Microsoft.Authorization/roleAssignments","name":"7cf24871-6fd5-487e-a65e-c1ebfd911403"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"18082f29-fabc-4d67-bc7e-d83a98f5df1e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T08:11:12.8568998Z","updatedOn":"2020-09-07T08:11:12.8568998Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6ebb62b0-b2cf-4db0-a7bf-9c7ff68a646f","type":"Microsoft.Authorization/roleAssignments","name":"6ebb62b0-b2cf-4db0-a7bf-9c7ff68a646f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"af994901-af8c-453d-947f-f35bd0f3762c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-04T01:15:27.8872966Z","updatedOn":"2020-07-04T01:15:27.8872966Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18b767b4-51f8-4bdc-8da9-98296b1cde8e","type":"Microsoft.Authorization/roleAssignments","name":"18b767b4-51f8-4bdc-8da9-98296b1cde8e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"68cc3003-9653-4bb3-a7c8-97d773f3ad69","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-06T02:38:51.7937810Z","updatedOn":"2020-07-06T02:38:51.7937810Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5235eab1-3e36-4012-b4a2-5f158ef93897","type":"Microsoft.Authorization/roleAssignments","name":"5235eab1-3e36-4012-b4a2-5f158ef93897"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"7402cbf1-d2ef-41cd-8fb4-d1dbee1fa54f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-06T04:08:01.5967452Z","updatedOn":"2020-07-06T04:08:01.5967452Z","createdBy":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","updatedBy":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b6cae0d1-4e24-42fa-8d89-341128d64407","type":"Microsoft.Authorization/roleAssignments","name":"b6cae0d1-4e24-42fa-8d89-341128d64407"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8328816a-0c23-48d8-bb6a-ed9dcf5691b0","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T03:14:22.0872359Z","updatedOn":"2020-07-07T03:14:22.0872359Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61fd3f76-16c6-4482-8193-ccf22532b437","type":"Microsoft.Authorization/roleAssignments","name":"61fd3f76-16c6-4482-8193-ccf22532b437"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:07.9267881Z","updatedOn":"2020-07-07T07:53:07.9267881Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cb1f995e-258c-4174-9f1f-b21038b6fe15","type":"Microsoft.Authorization/roleAssignments","name":"cb1f995e-258c-4174-9f1f-b21038b6fe15"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:53.3178813Z","updatedOn":"2020-07-07T07:53:53.3178813Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/300179b3-b4bc-4d43-a800-14a538c341f2","type":"Microsoft.Authorization/roleAssignments","name":"300179b3-b4bc-4d43-a800-14a538c341f2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:53.3373852Z","updatedOn":"2020-07-07T07:53:53.3373852Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6a385b91-b1ce-4f5b-800d-6b449bb808f4","type":"Microsoft.Authorization/roleAssignments","name":"6a385b91-b1ce-4f5b-800d-6b449bb808f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"038ceaf0-2c3a-4a46-b572-cf9c7c444bd2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-08T15:15:49.6291826Z","updatedOn":"2020-07-08T15:15:49.6291826Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/719a4419-b972-4af8-95e8-741c53fb6c52","type":"Microsoft.Authorization/roleAssignments","name":"719a4419-b972-4af8-95e8-741c53fb6c52"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1422d4db-8270-4ae7-8437-8cccba2922f2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T06:00:40.8283738Z","updatedOn":"2020-07-09T06:00:40.8283738Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/92636771-3b6d-420b-9f6f-31070fbf0b28","type":"Microsoft.Authorization/roleAssignments","name":"92636771-3b6d-420b-9f6f-31070fbf0b28"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"08cae1fd-4869-4440-b9ff-a97cd9c00e6e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T12:14:15.9609308Z","updatedOn":"2020-07-09T12:14:15.9609308Z","createdBy":"182c8534-f413-487c-91a3-7addc80e35d5","updatedBy":"182c8534-f413-487c-91a3-7addc80e35d5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dbc76c65-b271-4f11-b84b-0b41e3c13f04","type":"Microsoft.Authorization/roleAssignments","name":"dbc76c65-b271-4f11-b84b-0b41e3c13f04"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2fbc569b-038b-456d-b496-168b4d2647b3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T12:20:45.2035119Z","updatedOn":"2020-07-09T12:20:45.2035119Z","createdBy":"182c8534-f413-487c-91a3-7addc80e35d5","updatedBy":"182c8534-f413-487c-91a3-7addc80e35d5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/49e83287-ab00-4c77-8e75-0c44324555d7","type":"Microsoft.Authorization/roleAssignments","name":"49e83287-ab00-4c77-8e75-0c44324555d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a5928636-70a5-4dc6-9a39-83f4261ab739","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-11T01:21:44.1115337Z","updatedOn":"2020-07-11T01:21:44.1115337Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1ec24764-f578-4712-82d0-4cf303f8cd94","type":"Microsoft.Authorization/roleAssignments","name":"1ec24764-f578-4712-82d0-4cf303f8cd94"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1a0bac8e-d2d2-40d0-af60-3821fc4aad21","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T03:55:34.9995817Z","updatedOn":"2020-07-13T03:55:34.9995817Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79904528-b82f-426b-ba34-911b9b9d9bb1","type":"Microsoft.Authorization/roleAssignments","name":"79904528-b82f-426b-ba34-911b9b9d9bb1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"aa1452f8-438b-4993-a853-211244f65fd4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T06:08:09.4651196Z","updatedOn":"2020-07-13T06:08:09.4651196Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9f12bf7c-fb56-401f-8358-b1bb205a79c1","type":"Microsoft.Authorization/roleAssignments","name":"9f12bf7c-fb56-401f-8358-b1bb205a79c1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4bc2639f-4b4d-4507-9e1e-5560658dadcf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T06:11:38.7509627Z","updatedOn":"2020-07-13T06:11:38.7509627Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/80221d18-b98c-4114-b192-94febf5cdad1","type":"Microsoft.Authorization/roleAssignments","name":"80221d18-b98c-4114-b192-94febf5cdad1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6c7c1341-56f8-4dea-9015-ddeae7fcdc18","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T11:41:59.7653882Z","updatedOn":"2020-07-13T11:41:59.7653882Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/215ec308-e62e-409f-a0cf-6f7b18257cd3","type":"Microsoft.Authorization/roleAssignments","name":"215ec308-e62e-409f-a0cf-6f7b18257cd3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"76b9eb22-0091-49d2-847f-dc4831337de8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T03:06:52.4968477Z","updatedOn":"2020-07-14T03:06:52.4968477Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/876a1623-fed3-4ac9-9bd3-6373f166eb91","type":"Microsoft.Authorization/roleAssignments","name":"876a1623-fed3-4ac9-9bd3-6373f166eb91"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f0ec8449-0089-40c0-a539-430080dd51d5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T05:09:22.8572441Z","updatedOn":"2020-07-14T05:09:22.8572441Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/81c82fd2-ee9b-4636-a13c-c2fc290b1339","type":"Microsoft.Authorization/roleAssignments","name":"81c82fd2-ee9b-4636-a13c-c2fc290b1339"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3a62feb4-dd11-437d-8bf5-324bbcf2ca71","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T08:34:11.1314930Z","updatedOn":"2020-07-14T08:34:11.1314930Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10166085-8319-44c1-b39e-7c2e8a859606","type":"Microsoft.Authorization/roleAssignments","name":"10166085-8319-44c1-b39e-7c2e8a859606"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1768ac75-eb78-4760-904b-bf1daf362ed8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T13:24:26.4777748Z","updatedOn":"2020-07-14T13:24:26.4777748Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/89b22e91-fbe1-4519-9c28-55116cb4b449","type":"Microsoft.Authorization/roleAssignments","name":"89b22e91-fbe1-4519-9c28-55116cb4b449"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0c8ec4af-1f95-43d0-abdc-e98c7c377093","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T02:27:50.9285382Z","updatedOn":"2020-07-15T02:27:50.9285382Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6aa196a2-0d57-4ced-a7c4-e4309e305930","type":"Microsoft.Authorization/roleAssignments","name":"6aa196a2-0d57-4ced-a7c4-e4309e305930"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2f394b98-15c2-4a67-b5e4-59524a559fbe","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T06:04:05.5602990Z","updatedOn":"2020-07-15T06:04:05.5602990Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/29b52c6e-ef41-4228-be25-062bb7c962b2","type":"Microsoft.Authorization/roleAssignments","name":"29b52c6e-ef41-4228-be25-062bb7c962b2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d3ee15d8-bfc2-40e3-91ce-38f84f29b4fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:37:38.4755184Z","updatedOn":"2020-07-15T07:37:38.4755184Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/94971c0b-9b3c-4014-a9f3-0283d64c1b29","type":"Microsoft.Authorization/roleAssignments","name":"94971c0b-9b3c-4014-a9f3-0283d64c1b29"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"243b9ed2-a31b-4b74-abb7-fce2fa7b7d85","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:46:59.5663841Z","updatedOn":"2020-07-15T07:46:59.5663841Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0d8d5363-48b8-4bea-895a-0ca92c1737aa","type":"Microsoft.Authorization/roleAssignments","name":"0d8d5363-48b8-4bea-895a-0ca92c1737aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"936679b1-be85-401f-906b-1338954018e1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T08:01:13.4164296Z","updatedOn":"2020-07-15T08:01:13.4164296Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/56a43ec4-3148-4c7e-b526-817d25a836da","type":"Microsoft.Authorization/roleAssignments","name":"56a43ec4-3148-4c7e-b526-817d25a836da"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ee082e62-485a-4e27-8cbe-c3effae3cd9c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T08:49:06.7210416Z","updatedOn":"2020-07-15T08:49:06.7210416Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a78fc2bf-58e2-4e37-bc92-b7195a03fbee","type":"Microsoft.Authorization/roleAssignments","name":"a78fc2bf-58e2-4e37-bc92-b7195a03fbee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"28c339aa-6a69-4038-9085-b9de491ab4e8","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T02:40:49.7073175Z","updatedOn":"2020-07-16T02:40:49.7073175Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/47d4f9d6-ef56-4d94-9dcb-f79e11ed5e50","type":"Microsoft.Authorization/roleAssignments","name":"47d4f9d6-ef56-4d94-9dcb-f79e11ed5e50"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"59a64430-12a8-4f39-be98-d1dd2614aeea","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T07:46:36.5695565Z","updatedOn":"2020-07-16T07:46:36.5695565Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d5232861-40f7-44e1-b5dc-230787ad1927","type":"Microsoft.Authorization/roleAssignments","name":"d5232861-40f7-44e1-b5dc-230787ad1927"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a55ceb34-c21b-4a68-96c6-88eb4cc5e099","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T11:38:50.4745508Z","updatedOn":"2020-07-16T11:38:50.4745508Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/74d051bd-1538-486e-954d-12ba05d58a90","type":"Microsoft.Authorization/roleAssignments","name":"74d051bd-1538-486e-954d-12ba05d58a90"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e5e99afa-9231-46fd-acfc-92c8a8ff4489","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-17T07:29:54.2160514Z","updatedOn":"2020-07-17T07:29:54.2160514Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ceb853a2-799d-4948-990d-e0650efe5d4a","type":"Microsoft.Authorization/roleAssignments","name":"ceb853a2-799d-4948-990d-e0650efe5d4a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f1f3476e-5aa5-4e0e-8632-a6f8728860b8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-18T01:17:47.1042571Z","updatedOn":"2020-07-18T01:17:47.1042571Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3b69d82b-e9f6-432e-b75c-f93b2d88efd7","type":"Microsoft.Authorization/roleAssignments","name":"3b69d82b-e9f6-432e-b75c-f93b2d88efd7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9431860d-6e2d-4227-9829-7b00afbdfb64","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:19:08.9724715Z","updatedOn":"2020-07-21T08:19:08.9724715Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7a335959-fbd8-42b5-9e34-dfa0cf86dedb","type":"Microsoft.Authorization/roleAssignments","name":"7a335959-fbd8-42b5-9e34-dfa0cf86dedb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6e931f32-10eb-43f4-883d-86a7991108f7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:21:22.6590948Z","updatedOn":"2020-07-21T08:21:22.6590948Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a92bcbb4-ef43-43db-a151-2b11cb2131a3","type":"Microsoft.Authorization/roleAssignments","name":"a92bcbb4-ef43-43db-a151-2b11cb2131a3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8b26643c-1bce-4669-ba85-48403e88103d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:28:00.4744129Z","updatedOn":"2020-07-21T08:28:00.4744129Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3939f612-6d79-496c-bf5d-4f92e1d1b5e5","type":"Microsoft.Authorization/roleAssignments","name":"3939f612-6d79-496c-bf5d-4f92e1d1b5e5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"af02e2c0-437c-4fbf-8769-fe6b43600a11","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T12:39:54.0428636Z","updatedOn":"2020-07-21T12:39:54.0428636Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff44e8d6-b72d-43fc-91b6-ead0de501f65","type":"Microsoft.Authorization/roleAssignments","name":"ff44e8d6-b72d-43fc-91b6-ead0de501f65"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5eef490b-41df-460b-ab98-7e8d3f8a1559","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T03:20:01.9422980Z","updatedOn":"2020-07-22T03:20:01.9422980Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e3d03863-6d79-4535-b692-15ca1e2ec3be","type":"Microsoft.Authorization/roleAssignments","name":"e3d03863-6d79-4535-b692-15ca1e2ec3be"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"86609d61-9b24-4e62-8c38-8361f202f09f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T04:26:09.1052343Z","updatedOn":"2020-07-22T04:26:09.1052343Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a78eda47-9ef1-4c22-bfa4-0d996c5d599c","type":"Microsoft.Authorization/roleAssignments","name":"a78eda47-9ef1-4c22-bfa4-0d996c5d599c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ed0ebe06-e932-4087-8ba8-03478368e7c6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:23.4466032Z","updatedOn":"2020-07-22T06:09:23.4466032Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f03258ee-4f5a-48cd-a003-d23a60a3a014","type":"Microsoft.Authorization/roleAssignments","name":"f03258ee-4f5a-48cd-a003-d23a60a3a014"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d126d0bb-79bb-472f-8b80-a9a346f6f100","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:45.2929087Z","updatedOn":"2020-07-22T06:09:45.2929087Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3581753e-74ab-4e9d-b79d-0799442862b3","type":"Microsoft.Authorization/roleAssignments","name":"3581753e-74ab-4e9d-b79d-0799442862b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2d627045-009d-4074-8bcd-52d7eeabb18c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:54.6260798Z","updatedOn":"2020-07-22T06:09:54.6260798Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cf80890b-2e9e-424a-a8ab-1795078643d2","type":"Microsoft.Authorization/roleAssignments","name":"cf80890b-2e9e-424a-a8ab-1795078643d2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"535b5697-6115-4f18-92f3-20fc9a07cce7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:18:56.2452865Z","updatedOn":"2020-07-22T06:18:56.2452865Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6b91e17e-56de-4229-8453-5338337d3c6f","type":"Microsoft.Authorization/roleAssignments","name":"6b91e17e-56de-4229-8453-5338337d3c6f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d048d4f7-7edb-4712-aeca-af4fb5c61b5a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:19:12.0666094Z","updatedOn":"2020-07-22T06:19:12.0666094Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/051d8d7e-2bf8-400c-af8e-4cdea07dedf0","type":"Microsoft.Authorization/roleAssignments","name":"051d8d7e-2bf8-400c-af8e-4cdea07dedf0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b45b251f-c8a2-4d3a-af7f-a9739cbe0d68","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:15.0908010Z","updatedOn":"2020-07-22T06:20:15.0908010Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bcb6a1f9-fd6e-441b-aaf7-09cf14414872","type":"Microsoft.Authorization/roleAssignments","name":"bcb6a1f9-fd6e-441b-aaf7-09cf14414872"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5c709f8c-397c-40d2-a147-1040fb282e24","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:26.8312576Z","updatedOn":"2020-07-22T06:20:26.8312576Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ceb67739-0cce-4a0e-9d2a-bd8a1ea65485","type":"Microsoft.Authorization/roleAssignments","name":"ceb67739-0cce-4a0e-9d2a-bd8a1ea65485"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a3d2b5a7-f9ce-4ab2-9155-e47bc8121b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:31.6051855Z","updatedOn":"2020-07-22T06:20:31.6051855Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b151b8cc-8569-4dd6-97a3-a0652015d9ab","type":"Microsoft.Authorization/roleAssignments","name":"b151b8cc-8569-4dd6-97a3-a0652015d9ab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b56fdd17-ee35-4381-9aea-00dfa70a3872","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:24:16.5402929Z","updatedOn":"2020-07-22T06:24:16.5402929Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7d078199-8ce2-44ed-8eb3-c7aca7590bee","type":"Microsoft.Authorization/roleAssignments","name":"7d078199-8ce2-44ed-8eb3-c7aca7590bee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0ef05f56-75da-4e69-8886-cf7eb25921bf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:28:20.2615489Z","updatedOn":"2020-07-22T06:28:20.2615489Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f126b61c-58bb-40d5-90b5-035320097c81","type":"Microsoft.Authorization/roleAssignments","name":"f126b61c-58bb-40d5-90b5-035320097c81"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2b7f66f5-e2b4-4e90-a6c0-48fd09c6941c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:31:13.8352773Z","updatedOn":"2020-07-22T06:31:13.8352773Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a3fb647-a48a-4fb2-b9be-5c0ec0c1dd9f","type":"Microsoft.Authorization/roleAssignments","name":"9a3fb647-a48a-4fb2-b9be-5c0ec0c1dd9f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-24T03:54:19.5994989Z","updatedOn":"2020-07-24T03:54:19.5994989Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dc91700c-9959-4179-80b7-f2bfb957d4ec","type":"Microsoft.Authorization/roleAssignments","name":"dc91700c-9959-4179-80b7-f2bfb957d4ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d0daf77e-df2b-4f08-93a9-53bc40d2b65e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-25T01:20:25.7612859Z","updatedOn":"2020-07-25T01:20:25.7612859Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/01c4a64d-636d-4f02-8b51-1e52794b0065","type":"Microsoft.Authorization/roleAssignments","name":"01c4a64d-636d-4f02-8b51-1e52794b0065"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"75e0401f-c382-49bc-9681-5891889d6090","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-25T01:20:48.2269442Z","updatedOn":"2020-07-25T01:20:48.2269442Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d14294b-2a12-4034-98ed-d79fc8967004","type":"Microsoft.Authorization/roleAssignments","name":"8d14294b-2a12-4034-98ed-d79fc8967004"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cfa73ec2-e91c-4de2-9b7f-3886f1b1a7e9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-01T01:15:28.6134386Z","updatedOn":"2020-08-01T01:15:28.6134386Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2880df4d-a219-4208-8f53-11ba91fe5ee6","type":"Microsoft.Authorization/roleAssignments","name":"2880df4d-a219-4208-8f53-11ba91fe5ee6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4ffca8c7-2d31-4f24-9e03-a1a836f60ba8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-01T01:34:29.3212794Z","updatedOn":"2020-08-01T01:34:29.3212794Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/39e1d3ed-13fb-432e-a0cb-8b294fddc63a","type":"Microsoft.Authorization/roleAssignments","name":"39e1d3ed-13fb-432e-a0cb-8b294fddc63a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"26e698cd-9d87-41f6-9a7e-06b3627e6ca5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-04T05:20:53.6187620Z","updatedOn":"2020-08-04T05:20:53.6187620Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97f68035-e05b-4e7f-aa80-a3799725076a","type":"Microsoft.Authorization/roleAssignments","name":"97f68035-e05b-4e7f-aa80-a3799725076a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5fcaa3b3-d5b2-44ce-92e2-28a4241f1e6b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-04T05:29:27.6127065Z","updatedOn":"2020-08-04T05:29:27.6127065Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ae95584d-6d28-4372-872b-b96e6a1f9c1f","type":"Microsoft.Authorization/roleAssignments","name":"ae95584d-6d28-4372-872b-b96e6a1f9c1f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-05T03:43:59.8598863Z","updatedOn":"2020-08-05T03:43:59.8598863Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/254a30cf-3bdd-4e6c-aa9e-9d96397bf63a","type":"Microsoft.Authorization/roleAssignments","name":"254a30cf-3bdd-4e6c-aa9e-9d96397bf63a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"800eadcf-0a23-4298-939b-6cf9f3dbceef","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-05T05:51:54.9501785Z","updatedOn":"2020-08-05T05:51:54.9501785Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8b806af6-57f8-45f4-849f-6d0d0f43d093","type":"Microsoft.Authorization/roleAssignments","name":"8b806af6-57f8-45f4-849f-6d0d0f43d093"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ef53cdce-e483-4aa2-8260-58249cc1e7b1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-02T16:57:34.4713679Z","updatedOn":"2020-07-02T16:57:34.4713679Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/54fe41af-b32f-43d4-aac4-9e9be5b142a7","type":"Microsoft.Authorization/roleAssignments","name":"54fe41af-b32f-43d4-aac4-9e9be5b142a7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/providers/Microsoft.Management/managementGroups/CliMgmtGroup","condition":null,"conditionVersion":null,"createdOn":"2019-12-26T10:45:42.1154685Z","updatedOn":"2019-12-26T10:45:42.1154685Z","createdBy":"dfb7f346-f217-474e-ba6c-49895fd9cc13","updatedBy":"dfb7f346-f217-474e-ba6c-49895fd9cc13","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Management/managementGroups/CliMgmtGroup/providers/Microsoft.Authorization/roleAssignments/f0b07cf8-a079-446e-a391-c6fb1d115b59","type":"Microsoft.Authorization/roleAssignments","name":"f0b07cf8-a079-446e-a391-c6fb1d115b59"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.4824942Z","updatedOn":"2020-06-16T16:25:39.4824942Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e77058da-a7bf-4e89-8e48-7d9f61fa8246","type":"Microsoft.Authorization/roleAssignments","name":"e77058da-a7bf-4e89-8e48-7d9f61fa8246"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:12:52.8054393Z","updatedOn":"2020-11-25T05:12:52.8054393Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dea2d3a8-cf99-4169-b8dd-819b4c611a32","type":"Microsoft.Authorization/roleAssignments","name":"dea2d3a8-cf99-4169-b8dd-819b4c611a32"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:34:01.2642084Z","updatedOn":"2020-11-25T05:34:01.2642084Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bacc53c-9077-49ce-a14d-370bc09f72d8","type":"Microsoft.Authorization/roleAssignments","name":"4bacc53c-9077-49ce-a14d-370bc09f72d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6949b2a1-9b3e-42c8-b228-0b6c14927377","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-30T19:34:16.5100204Z","updatedOn":"2020-07-30T19:34:16.5100204Z","createdBy":"5bc13990-50e4-4898-835e-d026e066bba5","updatedBy":"5bc13990-50e4-4898-835e-d026e066bba5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/53b0d735-2402-41c6-9d6d-b2338a287741","type":"Microsoft.Authorization/roleAssignments","name":"53b0d735-2402-41c6-9d6d-b2338a287741"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4c480e6-1f29-4163-9a37-2b16a7e8e5c8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-16T13:48:13.9171700Z","updatedOn":"2020-09-16T13:48:13.9171700Z","createdBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","updatedBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8476200c-5011-42c4-9028-360ef1739a8d","type":"Microsoft.Authorization/roleAssignments","name":"8476200c-5011-42c4-9028-360ef1739a8d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '237237'
+      - '25670'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:23 GMT
+      - Wed, 09 Dec 2020 22:43:07 GMT
       expires:
       - '-1'
       pragma:
@@ -1616,8 +1771,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
-      "principalId": "34fb9cc8-8fc9-4ae8-80cc-116d31c04f46", "principalType": "ServicePrincipal"}}'
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+      "principalId": "434760c4-8e4b-49e9-80be-3ed37b7a0aa3", "principalType": "ServicePrincipal"}}'
     headers:
       Accept:
       - application/json
@@ -1631,20 +1786,19 @@ interactions:
       - '270'
       Content-Type:
       - application/json; charset=utf-8
-      Cookie:
-      - x-ms-gateway-slice=Production
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"34fb9cc8-8fc9-4ae8-80cc-116d31c04f46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-09-08T07:00:24.1335944Z","updatedOn":"2020-09-08T07:00:24.1335944Z","createdBy":null,"updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"434760c4-8e4b-49e9-80be-3ed37b7a0aa3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T22:43:09.2220137Z","updatedOn":"2020-12-09T22:43:09.2220137Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
     headers:
       cache-control:
       - no-cache
@@ -1653,7 +1807,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:26 GMT
+      - Wed, 09 Dec 2020 22:43:10 GMT
       expires:
       - '-1'
       pragma:
@@ -1665,7 +1819,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -1683,152 +1837,25 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"d9d55412-3bf4-482c-83d2-c6d41039a082\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.81.194.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
-        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:26 GMT
-      etag:
-      - W/"d9d55412-3bf4-482c-83d2-c6d41039a082"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - ca693eea-184c-4bb0-9822-ab504d1bd1a6
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n  \"etag\": \"W/\\\"d9d55412-3bf4-482c-83d2-c6d41039a082\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.110.118.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:26 GMT
-      etag:
-      - W/"d9d55412-3bf4-482c-83d2-c6d41039a082"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - b3273e4f-2ded-42a2-9132-a8ffb1a22948
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"34fb9cc8-8fc9-4ae8-80cc-116d31c04f46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-09-08T07:00:24.5536073Z","updatedOn":"2020-09-08T07:00:24.5536073Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2019-09-04T08:09:42.0835929Z","updatedOn":"2019-09-04T08:09:42.0835929Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/9d0c9433-a2c8-403f-ba1c-6310772291a5","type":"Microsoft.Authorization/roleAssignments","name":"9d0c9433-a2c8-403f-ba1c-6310772291a5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-14T05:22:05.1776921Z","updatedOn":"2020-03-14T05:22:05.1776921Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/eed777be-eb1b-4af7-9ec2-e4a74afba39e","type":"Microsoft.Authorization/roleAssignments","name":"eed777be-eb1b-4af7-9ec2-e4a74afba39e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-04T08:35:06.1202192Z","updatedOn":"2020-03-04T08:35:06.1202192Z","createdBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","updatedBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/67f6c798-74b6-41f7-ba07-ae40134ce8c1","type":"Microsoft.Authorization/roleAssignments","name":"67f6c798-74b6-41f7-ba07-ae40134ce8c1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T03:47:15.1734978Z","updatedOn":"2020-03-19T03:47:15.1734978Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/888c7688-4ae3-406f-948b-fd569da173fc","type":"Microsoft.Authorization/roleAssignments","name":"888c7688-4ae3-406f-948b-fd569da173fc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T04:06:32.7642459Z","updatedOn":"2020-03-19T04:06:32.7642459Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/b4bdedde-4f10-4610-9201-2421bb032107","type":"Microsoft.Authorization/roleAssignments","name":"b4bdedde-4f10-4610-9201-2421bb032107"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"02d52e0b-1c85-4aa9-a229-bca89f5fc079","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:06:31.6888688Z","updatedOn":"2020-07-15T07:06:31.6888688Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/e2f3fd89-b1cc-42c7-ae59-1ef03b4e731a","type":"Microsoft.Authorization/roleAssignments","name":"e2f3fd89-b1cc-42c7-ae59-1ef03b4e731a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-01-29T13:27:35.7170489Z","updatedOn":"2020-01-29T13:27:35.7170489Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/b6899915-1e85-4406-aa1f-f346ec3ded50","type":"Microsoft.Authorization/roleAssignments","name":"b6899915-1e85-4406-aa1f-f346ec3ded50"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"22bd72d9-4e93-4a74-b5ad-679cabe53baf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:27:36.1276006Z","updatedOn":"2020-07-15T07:27:36.1276006Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/06f37651-eecf-4b6c-a0e7-b26822697224","type":"Microsoft.Authorization/roleAssignments","name":"06f37651-eecf-4b6c-a0e7-b26822697224"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b304d026-311a-4be0-9994-8c578fc3697f","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:14:11.6612918Z","updatedOn":"2020-07-15T07:14:11.6612918Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/a75bb3e5-3b36-488f-a1a4-32be0a44e1a1","type":"Microsoft.Authorization/roleAssignments","name":"a75bb3e5-3b36-488f-a1a4-32be0a44e1a1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3","principalId":"30601973-dcd6-4c4e-85e8-dc6e057238fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-14T15:35:54.7519315Z","updatedOn":"2020-06-14T15:35:54.7519315Z","createdBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","updatedBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/02d00457-a5a7-4da3-b12a-e944705f4170","type":"Microsoft.Authorization/roleAssignments","name":"02d00457-a5a7-4da3-b12a-e944705f4170"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab","principalId":"677a61e9-086e-4f13-986a-11aaedc31416","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T03:31:37.3848580Z","updatedOn":"2019-11-26T03:31:37.3848580Z","createdBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","updatedBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aac8538d-8226-4b91-9232-03d3f3a40214","type":"Microsoft.Authorization/roleAssignments","name":"aac8538d-8226-4b91-9232-03d3f3a40214"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-04T08:40:46.0862758Z","updatedOn":"2020-03-04T08:40:46.0862758Z","createdBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","updatedBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5f32c47e-50b5-4be3-8774-ea1467857752","type":"Microsoft.Authorization/roleAssignments","name":"5f32c47e-50b5-4be3-8774-ea1467857752"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-20T09:03:02.6644378Z","updatedOn":"2020-01-20T09:03:02.6644378Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dd2121da-11a7-4ff5-bab0-053cc344b0b0","type":"Microsoft.Authorization/roleAssignments","name":"dd2121da-11a7-4ff5-bab0-053cc344b0b0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0444ccf8-fddb-43c4-b42b-ea036211229f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-25T07:18:48.8610796Z","updatedOn":"2020-03-25T07:18:48.8610796Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4f7c6762-b335-43e7-9c13-d42ab9bc6884","type":"Microsoft.Authorization/roleAssignments","name":"4f7c6762-b335-43e7-9c13-d42ab9bc6884"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"05b1f982-1404-4e2d-b2e8-af3ee7a330b4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-22T14:58:56.7424484Z","updatedOn":"2019-09-22T14:58:56.7424484Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a5d758f5-4ec2-4dd5-ba95-cee5405e367c","type":"Microsoft.Authorization/roleAssignments","name":"a5d758f5-4ec2-4dd5-ba95-cee5405e367c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-21T03:37:35.1867759Z","updatedOn":"2019-11-21T03:37:35.1867759Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f93778f-00f5-4efb-a56f-6aff1d668df7","type":"Microsoft.Authorization/roleAssignments","name":"6f93778f-00f5-4efb-a56f-6aff1d668df7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0a592c45-613e-4f1b-9023-7c4414fd53bf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-08-08T01:47:13.5745250Z","updatedOn":"2019-08-08T01:47:13.5745250Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d320644f-c08b-47f4-ae3b-9df595a5c368","type":"Microsoft.Authorization/roleAssignments","name":"d320644f-c08b-47f4-ae3b-9df595a5c368"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-26T04:16:43.3784273Z","updatedOn":"2019-07-26T04:16:43.3784273Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a567d42-8a33-4cad-9f7b-5299a16dc269","type":"Microsoft.Authorization/roleAssignments","name":"9a567d42-8a33-4cad-9f7b-5299a16dc269"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0eae5543-750d-4b1a-89bc-7bfd80671fbd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T05:52:20.5117449Z","updatedOn":"2020-04-13T05:52:20.5117449Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b2a0bc46-da6a-4ca0-b518-81cc1f0a14d3","type":"Microsoft.Authorization/roleAssignments","name":"b2a0bc46-da6a-4ca0-b518-81cc1f0a14d3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"182c8534-f413-487c-91a3-7addc80e35d5","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-09-06T13:37:05.6480940Z","updatedOn":"2017-09-06T13:37:05.6480940Z","createdBy":"bed854bc-89d1-444b-914a-8984c7a9d73d","updatedBy":"bed854bc-89d1-444b-914a-8984c7a9d73d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d0560ab5-dd8d-4978-8c9b-84768b4a9467","type":"Microsoft.Authorization/roleAssignments","name":"d0560ab5-dd8d-4978-8c9b-84768b4a9467"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"18f53146-1f6c-462a-96a5-d50e1293b770","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-05-24T02:53:04.7484734Z","updatedOn":"2019-05-24T02:53:04.7484734Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/553a3d02-d0da-4b7c-a0f1-d1298f556001","type":"Microsoft.Authorization/roleAssignments","name":"553a3d02-d0da-4b7c-a0f1-d1298f556001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1aa92e15-ee4e-4dda-9e61-5b4dc35d280b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-29T06:05:52.7948049Z","updatedOn":"2020-04-29T06:05:52.7948049Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/039870e3-5852-4b2f-a3a9-9e172adfd72b","type":"Microsoft.Authorization/roleAssignments","name":"039870e3-5852-4b2f-a3a9-9e172adfd72b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1c93a1ad-59cf-42fc-b6ce-0f5ffd464a70","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-04-09T20:12:14.4602372Z","updatedOn":"2018-04-09T20:12:14.4602372Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d5397a6-f185-4b65-bcba-6b9f2248093a","type":"Microsoft.Authorization/roleAssignments","name":"8d5397a6-f185-4b65-bcba-6b9f2248093a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"2262dfe7-375f-4597-a47c-2766489ecbe7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-06-14T17:54:39.3919633Z","updatedOn":"2019-06-14T17:54:39.3919633Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3f58856e-c1e1-4269-9055-f9fbe4cb6506","type":"Microsoft.Authorization/roleAssignments","name":"3f58856e-c1e1-4269-9055-f9fbe4cb6506"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"2ed08755-e5b9-42ef-8638-38e95105e710","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-23T06:01:53.1357543Z","updatedOn":"2019-12-23T06:01:53.1357543Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1986d758-ee67-4fc7-9eb2-c0d52d4a075d","type":"Microsoft.Authorization/roleAssignments","name":"1986d758-ee67-4fc7-9eb2-c0d52d4a075d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1b1b6446-6585-4988-b9ab-a8cdf9035b8a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-11T09:21:11.3066024Z","updatedOn":"2020-02-11T09:21:11.3066024Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ae57b317-873d-4242-a539-32b3e934259d","type":"Microsoft.Authorization/roleAssignments","name":"ae57b317-873d-4242-a539-32b3e934259d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-17T08:29:55.3047288Z","updatedOn":"2019-09-17T08:29:55.3047288Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e3591e24-669e-475f-a315-7d581996b864","type":"Microsoft.Authorization/roleAssignments","name":"e3591e24-669e-475f-a315-7d581996b864"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"32fe2882-ca97-44f9-8e0d-dfe916b9dfee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-06T03:03:50.0740099Z","updatedOn":"2019-09-06T03:03:50.0740099Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/01c1fcc9-4df3-4107-832f-42f245309750","type":"Microsoft.Authorization/roleAssignments","name":"01c1fcc9-4df3-4107-832f-42f245309750"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"378df7ee-31fd-4c54-945e-a1ed4f025a28","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-08-10T19:00:33.4173527Z","updatedOn":"2017-08-10T19:00:33.4173527Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e0ddb7cd-de16-42ce-bab6-6a0d4d3903d8","type":"Microsoft.Authorization/roleAssignments","name":"e0ddb7cd-de16-42ce-bab6-6a0d4d3903d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"37aa63b3-0814-4c36-9641-d9c3120b1f1b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-25T22:21:28.6870688Z","updatedOn":"2019-02-25T22:21:28.6870688Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/185a89d4-23f9-4fb8-827c-6d7f8e26c49d","type":"Microsoft.Authorization/roleAssignments","name":"185a89d4-23f9-4fb8-827c-6d7f8e26c49d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"37e77055-3c53-4ae5-bf04-d2459236b6a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:25:07.0794530Z","updatedOn":"2020-01-09T06:25:07.0794530Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ec3d1379-1350-4894-98dc-4742280ba73b","type":"Microsoft.Authorization/roleAssignments","name":"ec3d1379-1350-4894-98dc-4742280ba73b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"39029da9-0fef-42a9-b478-2fe4e19b8c7b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-19T02:54:07.7981142Z","updatedOn":"2020-06-19T02:54:07.7981142Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/90fa5166-2ffa-44a8-ad5d-da4f3eaab642","type":"Microsoft.Authorization/roleAssignments","name":"90fa5166-2ffa-44a8-ad5d-da4f3eaab642"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-19T03:54:40.3617093Z","updatedOn":"2020-01-19T03:54:40.3617093Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c9b97fb4-3b05-49af-97de-2950204d9066","type":"Microsoft.Authorization/roleAssignments","name":"c9b97fb4-3b05-49af-97de-2950204d9066"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3e675290-31e1-49f6-a3cd-03df3d7d6e2e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-03T04:39:51.0517217Z","updatedOn":"2020-05-03T04:39:51.0517217Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/49eedfad-3250-441e-8a85-03026008e57c","type":"Microsoft.Authorization/roleAssignments","name":"49eedfad-3250-441e-8a85-03026008e57c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"4582e5fb-504d-4b21-89be-9e11352ac837","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-27T01:17:48.4170577Z","updatedOn":"2020-02-27T01:17:48.4170577Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/43cfb5ae-8271-433b-8799-85858d658f59","type":"Microsoft.Authorization/roleAssignments","name":"43cfb5ae-8271-433b-8799-85858d658f59"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"4c1e34fd-dcf5-4516-bb96-b8ac22e138da","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T08:54:40.6904887Z","updatedOn":"2020-06-08T08:54:40.6904887Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/386dc123-cb36-4f9f-ac58-7aaaf5d7ed58","type":"Microsoft.Authorization/roleAssignments","name":"386dc123-cb36-4f9f-ac58-7aaaf5d7ed58"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"56b6b563-1341-4632-96cd-06252b81665d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-05T08:50:50.2703536Z","updatedOn":"2019-09-05T08:50:50.2703536Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e17d3c8b-26f3-4cdd-bcc1-211c3e490299","type":"Microsoft.Authorization/roleAssignments","name":"e17d3c8b-26f3-4cdd-bcc1-211c3e490299"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"596c247a-9db0-4c20-8ddb-d944102067ac","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-25T08:06:17.3145960Z","updatedOn":"2019-10-25T08:06:17.3145960Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5383f6ae-0e25-43d5-a448-2fd0d2699d72","type":"Microsoft.Authorization/roleAssignments","name":"5383f6ae-0e25-43d5-a448-2fd0d2699d72"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5a7755a0-33cc-4bcc-9064-12f1bf05c991","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-11T05:55:15.7549140Z","updatedOn":"2020-05-11T05:55:15.7549140Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5584dc94-54e6-4a61-af7c-09934f06b4d1","type":"Microsoft.Authorization/roleAssignments","name":"5584dc94-54e6-4a61-af7c-09934f06b4d1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5accae2a-f109-44ba-8549-8c682acd4ad1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-11-06T23:33:48.6032970Z","updatedOn":"2017-11-06T23:33:48.6032970Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b35dfe77-4bb3-4956-b644-16d58904b1bf","type":"Microsoft.Authorization/roleAssignments","name":"b35dfe77-4bb3-4956-b644-16d58904b1bf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"669ef724-96ef-462e-b760-a398c8d49f12","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-10-16T00:01:10.8880293Z","updatedOn":"2018-10-16T00:01:10.8880293Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1fb698ad-cef0-442e-8fa0-c5c4609b12ec","type":"Microsoft.Authorization/roleAssignments","name":"1fb698ad-cef0-442e-8fa0-c5c4609b12ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6ba8d12f-faf3-4859-918b-80f93e471e38","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-05T07:42:22.6383489Z","updatedOn":"2019-09-05T07:42:22.6383489Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1b0df1c0-baf0-41ed-9560-6495d40dfa06","type":"Microsoft.Authorization/roleAssignments","name":"1b0df1c0-baf0-41ed-9560-6495d40dfa06"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T05:03:40.5214262Z","updatedOn":"2020-04-26T05:03:40.5214262Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73651752-e48b-47b6-8ce6-770e1bf56e80","type":"Microsoft.Authorization/roleAssignments","name":"73651752-e48b-47b6-8ce6-770e1bf56e80"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-24T09:14:30.5134753Z","updatedOn":"2020-04-24T09:14:30.5134753Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1ba14abb-5c95-4d45-be2c-5429d47ba9b3","type":"Microsoft.Authorization/roleAssignments","name":"1ba14abb-5c95-4d45-be2c-5429d47ba9b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-10T06:36:08.0241793Z","updatedOn":"2019-09-10T06:36:08.0241793Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10b1e634-f9af-4434-bd13-55eb43a57124","type":"Microsoft.Authorization/roleAssignments","name":"10b1e634-f9af-4434-bd13-55eb43a57124"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7b29ef09-268a-44a7-b1f8-094beba68028","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-04-05T17:27:17.7281001Z","updatedOn":"2018-04-05T17:27:17.7281001Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a5c8a26b-80ac-421d-a137-2951374bca62","type":"Microsoft.Authorization/roleAssignments","name":"a5c8a26b-80ac-421d-a137-2951374bca62"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T06:26:40.9453629Z","updatedOn":"2019-11-26T06:26:40.9453629Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2ba40e27-d44f-48e7-9462-1561128bed69","type":"Microsoft.Authorization/roleAssignments","name":"2ba40e27-d44f-48e7-9462-1561128bed69"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-23T08:57:03.4127112Z","updatedOn":"2019-10-23T08:57:03.4127112Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ec55b030-cffa-46ab-a296-78f606400df8","type":"Microsoft.Authorization/roleAssignments","name":"ec55b030-cffa-46ab-a296-78f606400df8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7e58ddef-4719-4c36-a485-4c2a0a843a46","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-25T05:07:15.7863485Z","updatedOn":"2019-12-25T05:07:15.7863485Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/999c61a0-361b-416f-91ee-68f515f910ec","type":"Microsoft.Authorization/roleAssignments","name":"999c61a0-361b-416f-91ee-68f515f910ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-15T08:49:50.8762611Z","updatedOn":"2019-11-15T08:49:50.8762611Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/233c612a-f4d8-41fb-bf58-8e2a587142df","type":"Microsoft.Authorization/roleAssignments","name":"233c612a-f4d8-41fb-bf58-8e2a587142df"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"864a275e-8c80-4efb-ad1c-0c0ab3081788","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-12T02:40:02.3180608Z","updatedOn":"2020-06-12T02:40:02.3180608Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7c5ea86e-a5a6-4750-b95f-5ba47a93ff60","type":"Microsoft.Authorization/roleAssignments","name":"7c5ea86e-a5a6-4750-b95f-5ba47a93ff60"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-23T05:48:03.4970209Z","updatedOn":"2019-12-23T05:48:03.4970209Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8cbac001-17ff-4ba4-ade1-cbbb4924e6d6","type":"Microsoft.Authorization/roleAssignments","name":"8cbac001-17ff-4ba4-ade1-cbbb4924e6d6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"8d594fee-5764-49c9-ad85-35d3ee728386","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-23T09:22:57.7278029Z","updatedOn":"2019-10-23T09:22:57.7278029Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/66da1b82-8f84-41cc-995f-867498db9ae3","type":"Microsoft.Authorization/roleAssignments","name":"66da1b82-8f84-41cc-995f-867498db9ae3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-10T06:47:24.5464704Z","updatedOn":"2019-07-10T06:47:24.5464704Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/83b44361-6e27-4ed1-923c-b10ce84b3926","type":"Microsoft.Authorization/roleAssignments","name":"83b44361-6e27-4ed1-923c-b10ce84b3926"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-21T06:37:44.9936263Z","updatedOn":"2019-10-21T06:37:44.9936263Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7e96cad1-9fe5-49d6-b754-cbe33ce49882","type":"Microsoft.Authorization/roleAssignments","name":"7e96cad1-9fe5-49d6-b754-cbe33ce49882"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-04T03:06:42.9265284Z","updatedOn":"2019-12-04T03:06:42.9265284Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fe0b9591-410f-4229-a288-98d8bfb7ffe5","type":"Microsoft.Authorization/roleAssignments","name":"fe0b9591-410f-4229-a288-98d8bfb7ffe5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a9668459-3905-4e76-a681-a1633c50f368","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-16T02:39:39.2120161Z","updatedOn":"2019-12-16T02:39:39.2120161Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/263dab0a-bf9f-4eec-9ff6-387f87ed056b","type":"Microsoft.Authorization/roleAssignments","name":"263dab0a-bf9f-4eec-9ff6-387f87ed056b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-14T02:32:43.7202100Z","updatedOn":"2020-01-14T02:32:43.7202100Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/93adfbfa-f811-47e3-8ff7-e3a4675b579f","type":"Microsoft.Authorization/roleAssignments","name":"93adfbfa-f811-47e3-8ff7-e3a4675b579f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"ac47bda7-ff61-4451-9bb5-ad30ebcc2863","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-20T02:31:32.7276952Z","updatedOn":"2019-09-20T02:31:32.7276952Z","createdBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","updatedBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bf29019-3c72-44c1-97d4-58ef4d1a540f","type":"Microsoft.Authorization/roleAssignments","name":"4bf29019-3c72-44c1-97d4-58ef4d1a540f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b1eb9d0b-6ca2-4c64-8c13-31e5aa59065f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T07:10:10.5329285Z","updatedOn":"2020-06-08T07:10:10.5329285Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3bb3e257-89a9-4168-ae8b-99807e3819f3","type":"Microsoft.Authorization/roleAssignments","name":"3bb3e257-89a9-4168-ae8b-99807e3819f3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"93a01e49-673a-4e15-8230-51214a737962","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-07-05T21:56:39.5905773Z","updatedOn":"2017-07-05T21:56:39.5905773Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d09787d-0a89-40a8-abf2-a7b60e95d24b","type":"Microsoft.Authorization/roleAssignments","name":"8d09787d-0a89-40a8-abf2-a7b60e95d24b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-03T09:04:20.9413623Z","updatedOn":"2019-12-03T09:04:20.9413623Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6e6cc759-072e-47b8-b35d-ca5b95266e59","type":"Microsoft.Authorization/roleAssignments","name":"6e6cc759-072e-47b8-b35d-ca5b95266e59"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c0526f76-a841-4a3a-bdee-59a5db599e34","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-11T19:18:19.9314682Z","updatedOn":"2018-12-11T19:18:19.9314682Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d9e73a14-4984-4d89-8048-04773fb32344","type":"Microsoft.Authorization/roleAssignments","name":"d9e73a14-4984-4d89-8048-04773fb32344"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c7cc3390-43d1-4a59-8ab8-190092db8184","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T09:49:01.2994155Z","updatedOn":"2020-06-08T09:49:01.2994155Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/184cdda7-d40a-4c78-b71d-9e947e48a488","type":"Microsoft.Authorization/roleAssignments","name":"184cdda7-d40a-4c78-b71d-9e947e48a488"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c87f79eb-8113-4168-83c8-3a0e99ac67be","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-20T09:31:14.0133249Z","updatedOn":"2020-01-20T09:31:14.0133249Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5465d5e4-7123-4cd3-b584-f51ea72c2b79","type":"Microsoft.Authorization/roleAssignments","name":"5465d5e4-7123-4cd3-b584-f51ea72c2b79"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"cdc7828e-c6c1-4822-9b0b-ca54f3d92bcd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-03-15T23:45:46.1042773Z","updatedOn":"2018-03-15T23:45:46.1042773Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d194606-3a10-428a-9ce5-876fec5096c8","type":"Microsoft.Authorization/roleAssignments","name":"8d194606-3a10-428a-9ce5-876fec5096c8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1178d20-4ca4-45f0-ba9a-5a08f588da8d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-05T11:26:44.9370825Z","updatedOn":"2020-05-05T11:26:44.9370825Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d7689797-3689-4c92-b472-a9aaa7c54570","type":"Microsoft.Authorization/roleAssignments","name":"d7689797-3689-4c92-b472-a9aaa7c54570"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d36e0017-aac8-4dd3-8ccf-0ab8a7049c35","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-18T11:38:03.9624602Z","updatedOn":"2020-01-18T11:38:03.9624602Z","createdBy":"dca37046-82cf-4fbb-8088-faa399010380","updatedBy":"dca37046-82cf-4fbb-8088-faa399010380","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/86ebcfe8-2caa-40b5-aebe-ac5a928368ef","type":"Microsoft.Authorization/roleAssignments","name":"86ebcfe8-2caa-40b5-aebe-ac5a928368ef"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"dabd5159-ba4a-42fb-9e4d-7d841445695d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-16T04:29:39.1910424Z","updatedOn":"2020-01-16T04:29:39.1910424Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8ae1af04-181f-418f-a55d-cbdfa2327b75","type":"Microsoft.Authorization/roleAssignments","name":"8ae1af04-181f-418f-a55d-cbdfa2327b75"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-10T02:54:02.2514605Z","updatedOn":"2019-11-10T02:54:02.2514605Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/de186952-0e06-4557-89b5-31257c33093b","type":"Microsoft.Authorization/roleAssignments","name":"de186952-0e06-4557-89b5-31257c33093b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-24T03:28:22.7145389Z","updatedOn":"2019-09-24T03:28:22.7145389Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/16b3fb1c-befa-4dfd-8fbc-9838444af841","type":"Microsoft.Authorization/roleAssignments","name":"16b3fb1c-befa-4dfd-8fbc-9838444af841"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f19e5031-d73d-4d9a-86b7-d540f1bc6cd7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-07T09:51:42.8397254Z","updatedOn":"2020-05-07T09:51:42.8397254Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da43c24c-31f6-47e5-b44f-e1852b61cde6","type":"Microsoft.Authorization/roleAssignments","name":"da43c24c-31f6-47e5-b44f-e1852b61cde6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f3ea48f6-a16e-4b37-8260-f69cf2200525","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T04:53:43.7428061Z","updatedOn":"2020-04-13T04:53:43.7428061Z","createdBy":"7e58ddef-4719-4c36-a485-4c2a0a843a46","updatedBy":"7e58ddef-4719-4c36-a485-4c2a0a843a46","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4d3c5439-0e6d-4dba-afd2-36d6aa289238","type":"Microsoft.Authorization/roleAssignments","name":"4d3c5439-0e6d-4dba-afd2-36d6aa289238"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f4ed124d-6acb-49a5-a6ac-bd96f35d8d16","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T06:25:17.5556287Z","updatedOn":"2020-04-26T06:25:17.5556287Z","createdBy":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","updatedBy":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fcef0c4c-0b40-423a-937e-fb6493374993","type":"Microsoft.Authorization/roleAssignments","name":"fcef0c4c-0b40-423a-937e-fb6493374993"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f802089b-0ae0-4e9b-984a-4e37eef96b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T07:52:39.3088894Z","updatedOn":"2020-04-13T07:52:39.3088894Z","createdBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","updatedBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/82a5d3eb-6393-4a30-9d62-93d9b272d628","type":"Microsoft.Authorization/roleAssignments","name":"82a5d3eb-6393-4a30-9d62-93d9b272d628"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"ffbb9ca1-43fc-498d-b8db-ca965f1684ef","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-12-18T23:20:41.1586895Z","updatedOn":"2017-12-18T23:20:41.1586895Z","createdBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","updatedBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7e012250-6450-4432-b6dd-9e148ab64455","type":"Microsoft.Authorization/roleAssignments","name":"7e012250-6450-4432-b6dd-9e148ab64455"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T04:01:23.9885462Z","updatedOn":"2020-03-19T04:01:23.9885462Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a96438a6-6252-499b-b391-710446ac8ddb","type":"Microsoft.Authorization/roleAssignments","name":"a96438a6-6252-499b-b391-710446ac8ddb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/abec5297-d72c-4fbc-acaf-868482d345c2","principalId":"7a938a30-4226-420e-996f-4d48bca6d537","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-06-14T22:25:43.4944951Z","updatedOn":"2018-06-14T22:25:43.4944951Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a3662714-8332-43d4-a2cf-836f9367c53d","type":"Microsoft.Authorization/roleAssignments","name":"a3662714-8332-43d4-a2cf-836f9367c53d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"27c363a5-7016-4ae0-8540-818ec05673f1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T15:34:53.2206231Z","updatedOn":"2020-04-26T15:34:53.2206231Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/88670ac0-08a0-40af-8cb3-cfecc39224a6","type":"Microsoft.Authorization/roleAssignments","name":"88670ac0-08a0-40af-8cb3-cfecc39224a6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"5963f50c-7c43-405c-af7e-53294de76abd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-11T01:35:58.0239576Z","updatedOn":"2020-01-11T01:35:58.0239576Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/332cf847-f85f-4e42-93c0-ac2d2269c9c6","type":"Microsoft.Authorization/roleAssignments","name":"332cf847-f85f-4e42-93c0-ac2d2269c9c6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"63bdf800-9003-4644-b23c-0caeabf62a42","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T09:34:30.7345716Z","updatedOn":"2020-04-26T09:34:30.7345716Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1f6b6d83-0880-477a-a232-5d15410b189f","type":"Microsoft.Authorization/roleAssignments","name":"1f6b6d83-0880-477a-a232-5d15410b189f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"9e6a992a-0530-43ad-bcd7-e9e0e84ae703","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-11T05:47:51.9435473Z","updatedOn":"2020-03-11T05:47:51.9435473Z","createdBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","updatedBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/07371d4e-e9de-4ef7-84c6-0694afc57163","type":"Microsoft.Authorization/roleAssignments","name":"07371d4e-e9de-4ef7-84c6-0694afc57163"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"d8422fc6-cc80-4990-b5d9-15dfc33bd4ce","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-16T07:05:29.5235140Z","updatedOn":"2020-01-16T07:13:20.5220097Z","createdBy":"9abd3759-d4a6-4297-a26e-19f728a9bc15","updatedBy":"9abd3759-d4a6-4297-a26e-19f728a9bc15","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/20cbf68b-1170-7660-526a-0ce148ad6b9f","type":"Microsoft.Authorization/roleAssignments","name":"20cbf68b-1170-7660-526a-0ce148ad6b9f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-28T02:17:47.3517737Z","updatedOn":"2019-10-28T02:17:47.3517737Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fa59db41-bdc7-4934-9105-138c49aa3b25","type":"Microsoft.Authorization/roleAssignments","name":"fa59db41-bdc7-4934-9105-138c49aa3b25"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0216022c-0a14-4682-b106-fe0de377fba8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-11T10:14:11.4652781Z","updatedOn":"2020-06-11T10:14:11.4652781Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0bdccc57-790d-47b5-ab25-3b25b2c383f5","type":"Microsoft.Authorization/roleAssignments","name":"0bdccc57-790d-47b5-ab25-3b25b2c383f5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"025742e3-96b0-462b-92b8-c6f8a2467315","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T02:30:48.9213321Z","updatedOn":"2019-11-13T02:30:48.9213321Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8e56fee5-34b2-4fda-94f5-4d16d0f316c9","type":"Microsoft.Authorization/roleAssignments","name":"8e56fee5-34b2-4fda-94f5-4d16d0f316c9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"048c9bb6-913e-4ce6-99c5-35198246627b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T08:20:44.1467077Z","updatedOn":"2019-11-13T08:20:44.1467077Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ee9a0273-478f-49c1-ab8b-c391f00ab24a","type":"Microsoft.Authorization/roleAssignments","name":"ee9a0273-478f-49c1-ab8b-c391f00ab24a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"05b1f982-1404-4e2d-b2e8-af3ee7a330b4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-16T02:20:33.6180302Z","updatedOn":"2019-09-16T02:20:33.6180302Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dd290ec1-928e-4be9-bf1a-5444db3c31a9","type":"Microsoft.Authorization/roleAssignments","name":"dd290ec1-928e-4be9-bf1a-5444db3c31a9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0b9debbf-74a2-4090-9e79-6f814c15c64f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-13T23:58:24.6590895Z","updatedOn":"2019-02-13T23:58:24.6590895Z","createdBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","updatedBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/84210bda-8759-422b-b6ea-f95ba2a645cc","type":"Microsoft.Authorization/roleAssignments","name":"84210bda-8759-422b-b6ea-f95ba2a645cc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d1408bc-e090-4bb3-b430-608cc2fb2a0c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T13:25:32.0800552Z","updatedOn":"2020-05-12T13:25:32.0800552Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/95c1ae5a-01de-4f0c-9c56-8e87c017cf36","type":"Microsoft.Authorization/roleAssignments","name":"95c1ae5a-01de-4f0c-9c56-8e87c017cf36"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0444ccf8-fddb-43c4-b42b-ea036211229f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-18T09:31:46.3880250Z","updatedOn":"2019-09-18T09:31:46.3880250Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e7e0e4be-da1c-4e63-8872-b2486e10fbaf","type":"Microsoft.Authorization/roleAssignments","name":"e7e0e4be-da1c-4e63-8872-b2486e10fbaf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-29T13:26:41.7796634Z","updatedOn":"2020-01-29T13:26:41.7796634Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/185c46f5-737c-4e7e-bdeb-5bafee91059d","type":"Microsoft.Authorization/roleAssignments","name":"185c46f5-737c-4e7e-bdeb-5bafee91059d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0dbbe202-a46d-4ade-8f74-0927ccff3bb6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T07:04:08.1661319Z","updatedOn":"2020-06-09T07:04:08.1661319Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3322b8ab-16df-464e-9b80-b555950e6d56","type":"Microsoft.Authorization/roleAssignments","name":"3322b8ab-16df-464e-9b80-b555950e6d56"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"16253a8a-cc24-475a-a5cf-e58491ffd350","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-30T10:22:53.8662664Z","updatedOn":"2019-10-30T10:22:53.8662664Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0d7cca1c-37d2-492a-92ed-c9ae8323e2e2","type":"Microsoft.Authorization/roleAssignments","name":"0d7cca1c-37d2-492a-92ed-c9ae8323e2e2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"182c8534-f413-487c-91a3-7addc80e35d5","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-08T08:26:11.9991435Z","updatedOn":"2020-04-08T08:26:11.9991435Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7ec462b1-f831-472f-8e1b-ff3a11068385","type":"Microsoft.Authorization/roleAssignments","name":"7ec462b1-f831-472f-8e1b-ff3a11068385"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"23304842-3c9b-46fb-9f34-ae0afe0e9a82","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:34:09.9873389Z","updatedOn":"2020-01-09T06:34:09.9873389Z","createdBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","updatedBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79d401d9-e585-43bf-a874-1ecc9685e823","type":"Microsoft.Authorization/roleAssignments","name":"79d401d9-e585-43bf-a874-1ecc9685e823"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-11T15:04:11.6940972Z","updatedOn":"2020-03-14T14:47:34.7417244Z","createdBy":"2c4ad291-088a-4833-9d12-65562168e61f","updatedBy":"f238ba61-2e60-495f-8044-5abc249758fe","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9b26c70e-48e6-9170-677d-d2e0c5c9304e","type":"Microsoft.Authorization/roleAssignments","name":"9b26c70e-48e6-9170-677d-d2e0c5c9304e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"34dd2730-0adb-4bb0-973b-d020e4ae4284","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T02:45:08.7641129Z","updatedOn":"2020-06-08T02:45:08.7641129Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/201a6827-570f-4c37-9e6f-f128e3cd5d85","type":"Microsoft.Authorization/roleAssignments","name":"201a6827-570f-4c37-9e6f-f128e3cd5d85"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"37aa63b3-0814-4c36-9641-d9c3120b1f1b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-01-08T18:58:20.9990189Z","updatedOn":"2019-01-08T18:58:20.9990189Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/54925852-e514-4e06-9023-14b82e9060e7","type":"Microsoft.Authorization/roleAssignments","name":"54925852-e514-4e06-9023-14b82e9060e7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"46b61f8c-9b9c-48e4-912e-243041a7c6c5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:34:13.1774942Z","updatedOn":"2020-01-09T06:34:13.1774942Z","createdBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","updatedBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10e987b4-b922-471c-994b-ccd01cf71780","type":"Microsoft.Authorization/roleAssignments","name":"10e987b4-b922-471c-994b-ccd01cf71780"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4759ce24-1955-4c57-bc53-357a69cc065f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T05:42:58.0364828Z","updatedOn":"2019-09-11T05:42:58.0364828Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/096db8b9-6da1-41d6-91fc-a44386feca3f","type":"Microsoft.Authorization/roleAssignments","name":"096db8b9-6da1-41d6-91fc-a44386feca3f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"478ac2b7-8882-45d7-b424-6d8339728ea9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-01T00:51:52.9057101Z","updatedOn":"2019-11-01T00:51:52.9057101Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9eb79b9d-a384-4d48-83b7-5b31896a4f92","type":"Microsoft.Authorization/roleAssignments","name":"9eb79b9d-a384-4d48-83b7-5b31896a4f92"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4b5f89be-be88-448d-90bd-1148b6c6deb2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-23T02:16:34.2523880Z","updatedOn":"2019-07-23T02:16:34.2523880Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1da14562-3dee-4c97-a071-1b2937796647","type":"Microsoft.Authorization/roleAssignments","name":"1da14562-3dee-4c97-a071-1b2937796647"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4559f5d9-0272-48bd-b6af-fde7f60744dc","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-05T02:39:11.3496688Z","updatedOn":"2020-02-05T02:39:11.3496688Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/108c3348-6445-49c8-8a02-1e9088373505","type":"Microsoft.Authorization/roleAssignments","name":"108c3348-6445-49c8-8a02-1e9088373505"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"50d1b7ca-6643-4aac-a7b6-aba7bffecb30","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-05-30T21:23:34.5623608Z","updatedOn":"2019-05-30T21:23:34.5623608Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff3f8887-b570-4cd2-80d9-31c3c0d780aa","type":"Microsoft.Authorization/roleAssignments","name":"ff3f8887-b570-4cd2-80d9-31c3c0d780aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5230081f-d9b5-4af6-8d26-c648d9cf8ddd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-25T12:43:47.6193708Z","updatedOn":"2020-03-25T12:43:47.6193708Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/13f1d803-4dbb-4cf7-b199-35653a04bf75","type":"Microsoft.Authorization/roleAssignments","name":"13f1d803-4dbb-4cf7-b199-35653a04bf75"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5a17d64a-7ad7-432b-8622-88e4897b4cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-17T08:29:12.7481081Z","updatedOn":"2020-06-17T08:29:12.7481081Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0a0e59b8-4570-4bbc-90c1-87cfdbb3d9b0","type":"Microsoft.Authorization/roleAssignments","name":"0a0e59b8-4570-4bbc-90c1-87cfdbb3d9b0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"60a5c23b-3773-41b6-b27f-74805f1d2d9c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-04T10:54:04.8614591Z","updatedOn":"2020-02-04T10:54:04.8614591Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/47ad8fd8-84be-48d1-8d7a-923163696cdd","type":"Microsoft.Authorization/roleAssignments","name":"47ad8fd8-84be-48d1-8d7a-923163696cdd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"69ed4898-0851-4ea4-9813-dfc9864cbaf6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-11T19:26:34.1746649Z","updatedOn":"2018-12-11T19:26:34.1746649Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/27564201-65a3-4a09-bdaf-70c08ecd1786","type":"Microsoft.Authorization/roleAssignments","name":"27564201-65a3-4a09-bdaf-70c08ecd1786"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6a0911c8-758b-458a-8a36-7d6a4c2d450b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-21T05:12:27.5158666Z","updatedOn":"2020-01-21T05:12:27.5158666Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3e8820a3-637f-4a61-922b-abdf163ea9d5","type":"Microsoft.Authorization/roleAssignments","name":"3e8820a3-637f-4a61-922b-abdf163ea9d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"12af389a-3835-46c4-abe9-39d62a64c8e4","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-15T07:17:19.3982425Z","updatedOn":"2020-05-15T07:17:19.3982425Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4944a8a7-76af-49ad-9951-9b4526e228b3","type":"Microsoft.Authorization/roleAssignments","name":"4944a8a7-76af-49ad-9951-9b4526e228b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6aef5178-c2d2-41f6-a180-a296155ddf40","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-21T05:12:34.7950106Z","updatedOn":"2019-11-21T05:12:34.7950106Z","createdBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","updatedBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b5c83b39-f8a1-425f-984b-79e74f9ea79a","type":"Microsoft.Authorization/roleAssignments","name":"b5c83b39-f8a1-425f-984b-79e74f9ea79a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6cc662e7-785f-4759-ae7d-faf16eae02ab","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-29T05:58:51.6260835Z","updatedOn":"2020-04-29T05:58:51.6260835Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c394d91b-6eb5-4ccb-8350-c53c391e98b2","type":"Microsoft.Authorization/roleAssignments","name":"c394d91b-6eb5-4ccb-8350-c53c391e98b2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6f1ee714-b0e7-4abf-aa1e-3457f3205f0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-08T08:17:55.0153562Z","updatedOn":"2020-05-08T08:17:55.0153562Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1af0247f-6055-4bb1-9ee6-e8ea37f5413d","type":"Microsoft.Authorization/roleAssignments","name":"1af0247f-6055-4bb1-9ee6-e8ea37f5413d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"76b6ea71-288a-4e62-b904-3f3013201fb7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-17T06:36:55.9940820Z","updatedOn":"2020-06-17T06:36:55.9940820Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/21364cd1-07fd-407d-b94f-c341679a1ad6","type":"Microsoft.Authorization/roleAssignments","name":"21364cd1-07fd-407d-b94f-c341679a1ad6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6d61a178-3216-4ba7-bdc3-0fbc62b65ac9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-18T14:13:16.1350734Z","updatedOn":"2019-11-18T14:13:16.1350734Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/951d7466-f489-49df-88a3-9790ad814153","type":"Microsoft.Authorization/roleAssignments","name":"951d7466-f489-49df-88a3-9790ad814153"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"76d7bb0b-b614-4497-a519-7a46689f537c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-13T05:59:17.2737425Z","updatedOn":"2020-05-13T05:59:17.2737425Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d34fdce-9cef-427a-bfa0-fb81ffba52f2","type":"Microsoft.Authorization/roleAssignments","name":"6d34fdce-9cef-427a-bfa0-fb81ffba52f2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T06:25:38.6656804Z","updatedOn":"2019-11-26T06:25:38.6656804Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/02287c55-f42c-4852-9b08-c20c8a3b7e3b","type":"Microsoft.Authorization/roleAssignments","name":"02287c55-f42c-4852-9b08-c20c8a3b7e3b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T11:44:45.7387983Z","updatedOn":"2020-05-26T11:44:45.7387983Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6a878581-11bf-4bd4-a7ab-b1fb64e555aa","type":"Microsoft.Authorization/roleAssignments","name":"6a878581-11bf-4bd4-a7ab-b1fb64e555aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"81e54268-6800-49d3-b90f-a2ea6e20c110","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-12T09:05:37.5222708Z","updatedOn":"2020-04-12T09:05:37.5222708Z","createdBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","updatedBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f6bb8b0d-7009-454a-a489-610c6e23b559","type":"Microsoft.Authorization/roleAssignments","name":"f6bb8b0d-7009-454a-a489-610c6e23b559"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"838439dc-f0fa-4a37-ba56-daa13ff730ed","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T09:15:50.5935627Z","updatedOn":"2019-09-11T09:15:50.5935627Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/253c1f18-9f2b-490d-961d-520ba222a9b3","type":"Microsoft.Authorization/roleAssignments","name":"253c1f18-9f2b-490d-961d-520ba222a9b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"864a275e-8c80-4efb-ad1c-0c0ab3081788","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T06:17:44.5858739Z","updatedOn":"2020-06-09T06:17:44.5858739Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0565f4e2-558c-40b3-860e-3e910285cae7","type":"Microsoft.Authorization/roleAssignments","name":"0565f4e2-558c-40b3-860e-3e910285cae7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"885ee9c5-df35-4d21-bd29-33d930ef4721","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-08-08T07:30:25.7405858Z","updatedOn":"2019-08-08T07:30:25.7405858Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9e1de6d0-412e-4425-8e11-897f4aa32d65","type":"Microsoft.Authorization/roleAssignments","name":"9e1de6d0-412e-4425-8e11-897f4aa32d65"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8ce13a5d-7120-4635-b792-8cc697798e81","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-03T05:23:07.9499351Z","updatedOn":"2019-10-03T05:23:07.9499351Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ca192630-0f9b-47ea-bc2a-0cc0f9dc27d7","type":"Microsoft.Authorization/roleAssignments","name":"ca192630-0f9b-47ea-bc2a-0cc0f9dc27d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"90c3d926-9c03-4d90-86f4-12866a6da212","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-02T20:57:30.6864609Z","updatedOn":"2019-04-02T20:57:30.6864609Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bf3be37-b85e-49f9-ace5-e14c018302b5","type":"Microsoft.Authorization/roleAssignments","name":"6bf3be37-b85e-49f9-ace5-e14c018302b5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-27T01:19:27.7003320Z","updatedOn":"2020-02-27T01:19:27.7003320Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/363f553a-f660-4bcc-9c18-855b870f7bc8","type":"Microsoft.Authorization/roleAssignments","name":"363f553a-f660-4bcc-9c18-855b870f7bc8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"973fdd79-4ab9-438e-87c3-954cca1889e1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-09-21T19:09:54.9071757Z","updatedOn":"2018-09-21T19:09:54.9071757Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a4890276-7fa1-47a7-9d82-f0a4ceff9bd6","type":"Microsoft.Authorization/roleAssignments","name":"a4890276-7fa1-47a7-9d82-f0a4ceff9bd6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"97885433-e8ee-463f-9db0-194661924999","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-05T09:50:17.9261390Z","updatedOn":"2020-03-05T09:50:17.9261390Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7934da9a-5ac8-4145-b917-d9e061fc10fc","type":"Microsoft.Authorization/roleAssignments","name":"7934da9a-5ac8-4145-b917-d9e061fc10fc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"99220f34-fe4d-4bb9-a54f-8cef2c114bec","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T02:24:15.1904918Z","updatedOn":"2019-11-13T02:24:15.1904918Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/35b39af0-258c-488a-91d0-a744d937d7d0","type":"Microsoft.Authorization/roleAssignments","name":"35b39af0-258c-488a-91d0-a744d937d7d0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4e6a3ef-370d-4b96-8484-0f0e7ae097cc","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-23T04:54:51.7233330Z","updatedOn":"2019-02-23T04:54:51.7233330Z","createdBy":"4a399fbb-7213-47d3-b6ad-59284286d50a","updatedBy":"4a399fbb-7213-47d3-b6ad-59284286d50a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/44a09d24-8afc-4e6f-8194-92c41bc03d2c","type":"Microsoft.Authorization/roleAssignments","name":"44a09d24-8afc-4e6f-8194-92c41bc03d2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ac49f0af-daf1-40c5-a7c5-976a80349806","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-25T19:29:43.0393638Z","updatedOn":"2019-02-25T19:29:43.0393638Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2990befc-9d32-467c-82e6-f6d4b9989731","type":"Microsoft.Authorization/roleAssignments","name":"2990befc-9d32-467c-82e6-f6d4b9989731"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9085a307-933c-452f-ae3a-9a8e13e68500","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-02T09:57:16.5579321Z","updatedOn":"2020-04-02T09:57:16.5579321Z","createdBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","updatedBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1e74faf5-14cb-443a-a960-986c993decbc","type":"Microsoft.Authorization/roleAssignments","name":"1e74faf5-14cb-443a-a960-986c993decbc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b0460b1a-d53a-42e8-a6a4-d9f43f0ccc73","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-28T04:23:35.8222484Z","updatedOn":"2020-05-28T04:23:35.8222484Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a8cb3f2a-31d8-4e9f-999a-ec8894bb13d5","type":"Microsoft.Authorization/roleAssignments","name":"a8cb3f2a-31d8-4e9f-999a-ec8894bb13d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-22T06:33:53.8936608Z","updatedOn":"2020-01-22T06:33:53.8936608Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a4075ce9-efa5-4df6-a196-2538407da770","type":"Microsoft.Authorization/roleAssignments","name":"a4075ce9-efa5-4df6-a196-2538407da770"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b95d1b0f-145c-480a-915a-3fb867fb598b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-07T05:49:02.0078574Z","updatedOn":"2020-04-07T05:49:02.0078574Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bd310d01-f783-4f08-8b88-948f0b348a11","type":"Microsoft.Authorization/roleAssignments","name":"bd310d01-f783-4f08-8b88-948f0b348a11"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"be76b331-83ac-423a-83de-a97b6a990735","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-22T10:26:36.6728187Z","updatedOn":"2020-05-22T10:26:36.6728187Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/12e50c31-99da-4248-a195-0ab7ac62c504","type":"Microsoft.Authorization/roleAssignments","name":"12e50c31-99da-4248-a195-0ab7ac62c504"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c11b39f7-26c3-4dfc-8d0f-20dde3187845","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-13T18:31:05.4586182Z","updatedOn":"2018-12-13T18:31:05.4586182Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4901f853-a3c6-47e4-9495-2aeb09fb4491","type":"Microsoft.Authorization/roleAssignments","name":"4901f853-a3c6-47e4-9495-2aeb09fb4491"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c87f79eb-8113-4168-83c8-3a0e99ac67be","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T08:20:56.3783272Z","updatedOn":"2020-06-09T08:20:56.3783272Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/60aed0e0-6e97-4ca9-90ac-1f604f8c374e","type":"Microsoft.Authorization/roleAssignments","name":"60aed0e0-6e97-4ca9-90ac-1f604f8c374e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cfca31cb-14a9-4e95-a9b7-f905ab23db3c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-03T04:01:25.5862636Z","updatedOn":"2020-02-03T04:01:25.5862636Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c9fd36d4-1cfe-48c2-bbfc-1ff34a1d1f1f","type":"Microsoft.Authorization/roleAssignments","name":"c9fd36d4-1cfe-48c2-bbfc-1ff34a1d1f1f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d04239cd-f0db-4151-91e9-df98af92d231","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-15T05:29:57.8724060Z","updatedOn":"2020-06-15T05:29:57.8724060Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8bfc3a45-0214-4e85-bd1a-e4ab3c3bdb92","type":"Microsoft.Authorization/roleAssignments","name":"8bfc3a45-0214-4e85-bd1a-e4ab3c3bdb92"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d22a37ff-94a3-46b9-a549-e16b8b71a43c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T04:51:28.2854740Z","updatedOn":"2019-11-13T04:51:28.2854740Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b362e66e-bf5f-4ba5-adaf-88034544377b","type":"Microsoft.Authorization/roleAssignments","name":"b362e66e-bf5f-4ba5-adaf-88034544377b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d80964f8-f04a-4e50-8803-35e571cfb2d9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-07T10:01:41.1345273Z","updatedOn":"2020-02-07T10:01:41.1345273Z","createdBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","updatedBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f1ef5acb-1958-4cd3-a981-0aa430cb0fbd","type":"Microsoft.Authorization/roleAssignments","name":"f1ef5acb-1958-4cd3-a981-0aa430cb0fbd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d8422fc6-cc80-4990-b5d9-15dfc33bd4ce","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-28T05:13:52.5233941Z","updatedOn":"2019-11-28T05:13:52.5233941Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a2e5207-3e10-4ca2-9784-6e7bb8050194","type":"Microsoft.Authorization/roleAssignments","name":"9a2e5207-3e10-4ca2-9784-6e7bb8050194"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"db65a597-9bd4-4259-9632-ffcbfd208b04","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-01-31T18:43:41.6069289Z","updatedOn":"2019-01-31T18:43:41.6069289Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa2a3117-6ca4-4ddf-83c7-511b370735dd","type":"Microsoft.Authorization/roleAssignments","name":"aa2a3117-6ca4-4ddf-83c7-511b370735dd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dc1a3549-229c-4971-93d1-dd2a12439b19","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-18T02:46:17.6374569Z","updatedOn":"2019-09-18T02:46:17.6374569Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79ee6058-9515-427b-a19d-f9a245e4172b","type":"Microsoft.Authorization/roleAssignments","name":"79ee6058-9515-427b-a19d-f9a245e4172b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ddab67ba-ea88-4673-9802-b5393ef85c81","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-13T09:32:56.5200842Z","updatedOn":"2020-03-13T09:32:56.5200842Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/60066209-df2b-4102-bf3a-6a405afe485c","type":"Microsoft.Authorization/roleAssignments","name":"60066209-df2b-4102-bf3a-6a405afe485c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e12f87e2-42fe-4081-a272-85eee50a8062","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T04:19:32.2862854Z","updatedOn":"2019-12-05T04:19:32.2862854Z","createdBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","updatedBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3076ac0b-96c1-40da-b47c-cc8b1a6f60d7","type":"Microsoft.Authorization/roleAssignments","name":"3076ac0b-96c1-40da-b47c-cc8b1a6f60d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f19e5031-d73d-4d9a-86b7-d540f1bc6cd7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T11:59:35.4100543Z","updatedOn":"2020-05-26T11:59:35.4100543Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a156d12a-0595-4273-870e-26b43b10eefb","type":"Microsoft.Authorization/roleAssignments","name":"a156d12a-0595-4273-870e-26b43b10eefb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f22c2b35-e81d-4fa5-afa4-e6178a257deb","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T13:25:32.1208963Z","updatedOn":"2020-05-12T13:25:32.1208963Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a898ad94-406c-429f-8221-1d2e7b9cd5bb","type":"Microsoft.Authorization/roleAssignments","name":"a898ad94-406c-429f-8221-1d2e7b9cd5bb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f6c2f6f7-1bbf-4c17-87c6-28c02d7c0637","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-11-08T18:01:59.1260407Z","updatedOn":"2018-11-08T18:01:59.1260407Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c4b79dcb-c95a-44c2-82cd-e550faad8ac5","type":"Microsoft.Authorization/roleAssignments","name":"c4b79dcb-c95a-44c2-82cd-e550faad8ac5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f757bcca-02d6-4279-8f2d-61a7dcdbccd6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-21T05:32:27.2840541Z","updatedOn":"2020-01-21T05:32:27.2840541Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da4d3dfe-5384-4144-a9c2-5bd2124ddc51","type":"Microsoft.Authorization/roleAssignments","name":"da4d3dfe-5384-4144-a9c2-5bd2124ddc51"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f77592c5-1eb8-4ed3-8615-ddbb75adb4fe","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-19T05:03:29.3633566Z","updatedOn":"2020-06-19T05:03:29.3633566Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2194737b-2f80-4b24-bcd1-45b4c72bce84","type":"Microsoft.Authorization/roleAssignments","name":"2194737b-2f80-4b24-bcd1-45b4c72bce84"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f802089b-0ae0-4e9b-984a-4e37eef96b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-19T05:51:35.7314750Z","updatedOn":"2020-01-19T05:51:35.7314750Z","createdBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","updatedBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3cc61a45-01f3-45df-8661-e7bdd3cf0ef5","type":"Microsoft.Authorization/roleAssignments","name":"3cc61a45-01f3-45df-8661-e7bdd3cf0ef5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-11T08:57:15.2589033Z","updatedOn":"2020-06-11T08:57:15.2589033Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f14cf4c3-66bb-4cb4-aa88-de46c43a5235","type":"Microsoft.Authorization/roleAssignments","name":"f14cf4c3-66bb-4cb4-aa88-de46c43a5235"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"838439dc-f0fa-4a37-ba56-daa13ff730ed","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T09:19:13.9288977Z","updatedOn":"2019-09-11T09:19:13.9288977Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b02d8e07-7398-4236-bf13-6293699c6862","type":"Microsoft.Authorization/roleAssignments","name":"b02d8e07-7398-4236-bf13-6293699c6862"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-10-25T19:47:09.8058411Z","updatedOn":"2018-10-25T19:47:09.8058411Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/abd19ae1-8e0c-4e31-b1ab-25e85d987378","type":"Microsoft.Authorization/roleAssignments","name":"abd19ae1-8e0c-4e31-b1ab-25e85d987378"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/cdda3590-29a3-44f6-95f2-9f980659eb04","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-25T02:29:00.1905156Z","updatedOn":"2019-11-25T02:29:00.1905156Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/774d0387-22b2-41fb-9025-c689ab821fb0","type":"Microsoft.Authorization/roleAssignments","name":"774d0387-22b2-41fb-9025-c689ab821fb0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3e587269-2f98-4906-8e35-7c6af32219d1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-23T03:47:43.1586800Z","updatedOn":"2020-06-23T03:47:43.1586800Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8fcf9b86-69ae-4033-bb78-7f21b15375c4","type":"Microsoft.Authorization/roleAssignments","name":"8fcf9b86-69ae-4033-bb78-7f21b15375c4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"8adc2845-bd5a-4a35-b00f-b83f0640facd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-24T04:56:37.2992825Z","updatedOn":"2020-06-24T04:56:37.2992825Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3921853b-f10d-4c32-9f3c-4ba978198495","type":"Microsoft.Authorization/roleAssignments","name":"3921853b-f10d-4c32-9f3c-4ba978198495"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"8adc2845-bd5a-4a35-b00f-b83f0640facd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-24T05:56:50.0401266Z","updatedOn":"2020-06-24T05:56:50.0401266Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3620fe85-c1cb-46f3-a138-f96236bc1bb0","type":"Microsoft.Authorization/roleAssignments","name":"3620fe85-c1cb-46f3-a138-f96236bc1bb0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1952a856-3972-421d-b257-ae7d8d62e244","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-30T10:09:32.8969837Z","updatedOn":"2020-06-30T10:09:32.8969837Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3274beac-a4e5-43e2-86cc-2247a4e81e45","type":"Microsoft.Authorization/roleAssignments","name":"3274beac-a4e5-43e2-86cc-2247a4e81e45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T02:08:52.2449294Z","updatedOn":"2020-07-01T02:08:52.2449294Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/72cedbfc-50c9-44fa-ad63-d9d32f5215f9","type":"Microsoft.Authorization/roleAssignments","name":"72cedbfc-50c9-44fa-ad63-d9d32f5215f9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9bc33702-a011-4e3b-80f7-927356668049","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T03:00:59.1715198Z","updatedOn":"2020-07-01T03:00:59.1715198Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/89304b85-648a-403d-ab10-f246b2db26b6","type":"Microsoft.Authorization/roleAssignments","name":"89304b85-648a-403d-ab10-f246b2db26b6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9bc33702-a011-4e3b-80f7-927356668049","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T03:27:54.5201710Z","updatedOn":"2020-07-01T03:27:54.5201710Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e5367e0d-da08-4a30-819c-f496ccaa4bfa","type":"Microsoft.Authorization/roleAssignments","name":"e5367e0d-da08-4a30-819c-f496ccaa4bfa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ee38ef12-23d7-4595-8f6f-b4aaa15933f9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T04:46:10.4023148Z","updatedOn":"2020-07-01T04:46:10.4023148Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d3f0718-3404-4f68-b88f-01d3852d40c2","type":"Microsoft.Authorization/roleAssignments","name":"6d3f0718-3404-4f68-b88f-01d3852d40c2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T06:40:44.5009970Z","updatedOn":"2020-07-01T06:40:44.5009970Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/beed1228-2a59-415d-b3c1-7cde7e454ffb","type":"Microsoft.Authorization/roleAssignments","name":"beed1228-2a59-415d-b3c1-7cde7e454ffb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9ec9777a-d786-409e-91c4-da25125576e4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-07T03:23:39.3280578Z","updatedOn":"2020-08-07T03:23:39.3280578Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a7d71d52-c222-4e2f-8ee3-a8ebbfbd8305","type":"Microsoft.Authorization/roleAssignments","name":"a7d71d52-c222-4e2f-8ee3-a8ebbfbd8305"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f013c31e-6903-492d-9f8f-8a2b0097a737","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:25:12.2160705Z","updatedOn":"2020-08-10T05:25:12.2160705Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/218b7750-72ff-4972-8251-0dd31c91c0f5","type":"Microsoft.Authorization/roleAssignments","name":"218b7750-72ff-4972-8251-0dd31c91c0f5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2bb241ba-8f4e-4d58-9812-1f730a9bb04f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:26:33.0105360Z","updatedOn":"2020-08-10T05:26:33.0105360Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e140f43a-4943-4839-a7ad-3c88eda426a3","type":"Microsoft.Authorization/roleAssignments","name":"e140f43a-4943-4839-a7ad-3c88eda426a3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"497a3fb5-4a8b-4fdb-a358-b1c7384d1297","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:39:03.3686314Z","updatedOn":"2020-08-10T05:39:03.3686314Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0ced53d7-64d1-45c2-b08b-7fbdb293d299","type":"Microsoft.Authorization/roleAssignments","name":"0ced53d7-64d1-45c2-b08b-7fbdb293d299"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T06:07:40.7376298Z","updatedOn":"2020-08-10T06:07:40.7376298Z","createdBy":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","updatedBy":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8e606ca9-ad53-4135-837b-c2cde19b8a8e","type":"Microsoft.Authorization/roleAssignments","name":"8e606ca9-ad53-4135-837b-c2cde19b8a8e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b98fae7f-2c20-443f-ab5c-ef3a7be6eae1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T09:03:55.9162129Z","updatedOn":"2020-08-10T09:03:55.9162129Z","createdBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","updatedBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f2241eaf-def8-425f-83ea-6afc474524ae","type":"Microsoft.Authorization/roleAssignments","name":"f2241eaf-def8-425f-83ea-6afc474524ae"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3aca7341-bda7-4fd7-b5e9-c2b97e0de8a7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:10:41.9755999Z","updatedOn":"2020-08-14T14:10:41.9755999Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cb5d9b2a-326e-49b9-8b8e-73b207413e7a","type":"Microsoft.Authorization/roleAssignments","name":"cb5d9b2a-326e-49b9-8b8e-73b207413e7a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e0e3d203-4502-40cb-a021-639bafd28ad5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:23:15.5278986Z","updatedOn":"2020-08-14T14:23:15.5278986Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/91acbf07-9cbd-4f4e-b1d8-cc7828058ec9","type":"Microsoft.Authorization/roleAssignments","name":"91acbf07-9cbd-4f4e-b1d8-cc7828058ec9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5da9b62e-db61-48df-b7cb-983d777e2ff2","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:28:46.5840210Z","updatedOn":"2020-08-14T14:28:46.5840210Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6efa18b8-42bc-47ca-8813-d30e73cf53db","type":"Microsoft.Authorization/roleAssignments","name":"6efa18b8-42bc-47ca-8813-d30e73cf53db"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7b6eac7a-88af-454f-b145-c76749e9a29b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T19:29:47.4188577Z","updatedOn":"2020-08-14T19:29:47.4188577Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d001d53-d8f4-4fff-b679-d80a7040eac7","type":"Microsoft.Authorization/roleAssignments","name":"6d001d53-d8f4-4fff-b679-d80a7040eac7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8ac0350b-22e2-4160-a726-34c6caa4184f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T19:48:28.7252041Z","updatedOn":"2020-08-14T19:48:28.7252041Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e0d4187d-1ee3-4056-8250-14f5e12ec79a","type":"Microsoft.Authorization/roleAssignments","name":"e0d4187d-1ee3-4056-8250-14f5e12ec79a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1141514b-1bef-48de-b565-d44152e1062b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:27:12.9790197Z","updatedOn":"2020-08-17T07:27:12.9790197Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3ab310ca-f5aa-4cfe-aac7-1cd7bb778936","type":"Microsoft.Authorization/roleAssignments","name":"3ab310ca-f5aa-4cfe-aac7-1cd7bb778936"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"06f8821b-7fbf-4980-886d-665d9db57b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:40:08.6067489Z","updatedOn":"2020-08-17T07:40:08.6067489Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1cabdfaf-a394-44c3-affc-81aff3ba6ae2","type":"Microsoft.Authorization/roleAssignments","name":"1cabdfaf-a394-44c3-affc-81aff3ba6ae2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cf2a17da-9812-4844-9ae0-3ae15ec76cad","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:46:00.6157836Z","updatedOn":"2020-08-17T07:46:00.6157836Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4fd3d281-3cc9-40e7-9b52-583f1dd816ee","type":"Microsoft.Authorization/roleAssignments","name":"4fd3d281-3cc9-40e7-9b52-583f1dd816ee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60f762f9-4b9d-4819-8447-b96770d393f7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":"@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:Name]
-        stringEquals ''foo''","conditionVersion":"2.0","createdOn":"2020-08-18T07:10:10.3636738Z","updatedOn":"2020-08-18T07:10:10.3636738Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":"Role
-        assignment foo to check on bar"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6da08c78-7567-4c5c-88a4-880a2ace7352","type":"Microsoft.Authorization/roleAssignments","name":"6da08c78-7567-4c5c-88a4-880a2ace7352"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"16aec3a5-3759-4e41-a69e-7e2b2680eafd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T09:52:17.6795896Z","updatedOn":"2020-08-18T09:52:17.6795896Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/75161d12-2bb2-42ae-a4e7-582440b6c4f4","type":"Microsoft.Authorization/roleAssignments","name":"75161d12-2bb2-42ae-a4e7-582440b6c4f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"acb2e9d2-2452-4577-a05e-d21a637a10fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T11:06:21.1901058Z","updatedOn":"2020-08-18T11:06:21.1901058Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/14218d21-a768-490e-8618-c15affc6937c","type":"Microsoft.Authorization/roleAssignments","name":"14218d21-a768-490e-8618-c15affc6937c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"79fe61e0-fd04-47f9-82e9-dba4d7d21b2e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T11:07:15.5617349Z","updatedOn":"2020-08-18T11:07:15.5617349Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/589f009b-6553-4743-972a-4ce54c29a635","type":"Microsoft.Authorization/roleAssignments","name":"589f009b-6553-4743-972a-4ce54c29a635"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a9dc1ee2-52a6-4092-868a-816237d2e662","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:29.9317048Z","updatedOn":"2020-08-19T07:03:29.9317048Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a3cde6c2-db59-403b-815b-f599d2575d08","type":"Microsoft.Authorization/roleAssignments","name":"a3cde6c2-db59-403b-815b-f599d2575d08"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"119ba358-4192-473a-b06d-181459705162","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:29.7818867Z","updatedOn":"2020-08-19T07:03:29.7818867Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/133bdd44-fcf5-49b5-878a-87416f8ae60d","type":"Microsoft.Authorization/roleAssignments","name":"133bdd44-fcf5-49b5-878a-87416f8ae60d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"34ea07e2-7262-40a9-aadc-afdf3a92fe21","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:45.6787321Z","updatedOn":"2020-08-19T07:03:45.6787321Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09848f3b-57c3-4f72-a8f4-df0aaa3270f1","type":"Microsoft.Authorization/roleAssignments","name":"09848f3b-57c3-4f72-a8f4-df0aaa3270f1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf3ceccf-4953-42e1-b3df-edcabdd83461","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:04:52.1212465Z","updatedOn":"2020-08-19T07:04:52.1212465Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a47f705e-40ad-4dbb-ac53-4493a0b44991","type":"Microsoft.Authorization/roleAssignments","name":"a47f705e-40ad-4dbb-ac53-4493a0b44991"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b8bec651-22e5-4a25-be13-6b1f9df8a00a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:05:25.2684558Z","updatedOn":"2020-08-19T07:05:25.2684558Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/93e123a2-8f6a-450a-aa0d-e4dc04de68d6","type":"Microsoft.Authorization/roleAssignments","name":"93e123a2-8f6a-450a-aa0d-e4dc04de68d6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c8b802a4-9966-4de2-b39b-6d4266c6bfff","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:57:35.2037157Z","updatedOn":"2020-08-19T07:57:35.2037157Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/549e00ed-6b04-4930-b359-4d0f43f4950d","type":"Microsoft.Authorization/roleAssignments","name":"549e00ed-6b04-4930-b359-4d0f43f4950d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6d97229a-391f-473a-893f-f0608b592d7b","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:38:20.3090190Z","updatedOn":"2020-08-19T08:38:20.3090190Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a7686d39-2951-4c27-8cbf-c3c36d701d24","type":"Microsoft.Authorization/roleAssignments","name":"a7686d39-2951-4c27-8cbf-c3c36d701d24"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7bbbac61-5311-40e7-a9e2-2dd92c54144b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:40:47.6961897Z","updatedOn":"2020-08-19T08:40:47.6961897Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f13a2128-645b-4b42-be6a-7b8a174d6dda","type":"Microsoft.Authorization/roleAssignments","name":"f13a2128-645b-4b42-be6a-7b8a174d6dda"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"10741bcb-37eb-4b5d-b73d-b22e72e4c7dd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:45:43.8141578Z","updatedOn":"2020-08-19T08:45:43.8141578Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d4366a87-a683-4232-8270-8475b5105a7b","type":"Microsoft.Authorization/roleAssignments","name":"d4366a87-a683-4232-8270-8475b5105a7b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"667a932e-e24b-4684-aa4a-1db1fd704cc3","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:47:19.3260541Z","updatedOn":"2020-08-19T08:47:19.3260541Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e430a73b-7548-4fee-a45d-25c71c70d8b3","type":"Microsoft.Authorization/roleAssignments","name":"e430a73b-7548-4fee-a45d-25c71c70d8b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a9111493-85b7-43f0-b388-333c160780c6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T05:05:29.5232338Z","updatedOn":"2020-08-21T05:05:29.5232338Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/417d7e21-636b-441a-90ae-106afe45fab1","type":"Microsoft.Authorization/roleAssignments","name":"417d7e21-636b-441a-90ae-106afe45fab1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a0192903-a3ce-47e2-b3d0-ae831e62a518","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T06:29:50.5909137Z","updatedOn":"2020-08-21T06:29:50.5909137Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cc5e851d-a6f5-45f2-82f5-3e8e2638814c","type":"Microsoft.Authorization/roleAssignments","name":"cc5e851d-a6f5-45f2-82f5-3e8e2638814c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"63c25c04-362b-42d9-9e3f-83af045d0a3c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T07:14:04.1824643Z","updatedOn":"2020-08-21T07:14:04.1824643Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bf019dd5-58f4-4fbc-9206-845cf65a7d07","type":"Microsoft.Authorization/roleAssignments","name":"bf019dd5-58f4-4fbc-9206-845cf65a7d07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8e510330-6da3-437c-9d16-b6875c47b73b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:10:19.9912043Z","updatedOn":"2020-08-21T19:10:19.9912043Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/14e6ffd6-9879-4134-9ae2-6e2b8d528ad3","type":"Microsoft.Authorization/roleAssignments","name":"14e6ffd6-9879-4134-9ae2-6e2b8d528ad3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1c60843c-84f3-4dfc-8b47-ede4ead019a9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:29:23.4218009Z","updatedOn":"2020-08-21T19:29:23.4218009Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/411c5f77-af95-4f2f-9e27-9b0c3a5c3a8a","type":"Microsoft.Authorization/roleAssignments","name":"411c5f77-af95-4f2f-9e27-9b0c3a5c3a8a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6d94ee65-e779-469a-a4b5-d56a0b07c685","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:34:28.1634489Z","updatedOn":"2020-08-21T19:34:28.1634489Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e76d93b3-6b01-4778-84e7-799c8b676e9c","type":"Microsoft.Authorization/roleAssignments","name":"e76d93b3-6b01-4778-84e7-799c8b676e9c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2b6f181-9d6c-4e10-876f-b995612db461","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:09:42.7361350Z","updatedOn":"2020-08-24T14:09:42.7361350Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c46c851d-b430-4494-a15c-a07fb87a90ae","type":"Microsoft.Authorization/roleAssignments","name":"c46c851d-b430-4494-a15c-a07fb87a90ae"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b3d54681-34f2-47b8-a790-97ed4c5a7a8d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:23:13.0411929Z","updatedOn":"2020-08-24T14:23:13.0411929Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9f100957-31b1-468b-b2d9-58574bc56a9d","type":"Microsoft.Authorization/roleAssignments","name":"9f100957-31b1-468b-b2d9-58574bc56a9d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a7c9a5c2-8e7a-4f42-abb7-018d3b8e845f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:27:43.7812740Z","updatedOn":"2020-08-24T14:27:43.7812740Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/de3f15f5-edcb-4bcd-81b2-1140597849ac","type":"Microsoft.Authorization/roleAssignments","name":"de3f15f5-edcb-4bcd-81b2-1140597849ac"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-26T06:39:56.9154641Z","updatedOn":"2020-08-26T06:39:56.9154641Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/52185ca9-744e-443f-8d95-5ddb2c963891","type":"Microsoft.Authorization/roleAssignments","name":"52185ca9-744e-443f-8d95-5ddb2c963891"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8cf96a92-f77b-4f11-b378-bc65f571dd97","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-28T19:11:18.2902598Z","updatedOn":"2020-08-28T19:11:18.2902598Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aaa8ba85-b7e1-4267-9120-44c9bb88d6cf","type":"Microsoft.Authorization/roleAssignments","name":"aaa8ba85-b7e1-4267-9120-44c9bb88d6cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"aceba178-3429-4628-a918-9c2d07605ce4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-28T19:34:05.2521949Z","updatedOn":"2020-08-28T19:34:05.2521949Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/db744c26-387e-450c-af33-9f650d3e081a","type":"Microsoft.Authorization/roleAssignments","name":"db744c26-387e-450c-af33-9f650d3e081a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T02:18:54.8314918Z","updatedOn":"2020-08-31T02:18:54.8314918Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0c5c20de-7830-4420-b9a8-319bc24fd068","type":"Microsoft.Authorization/roleAssignments","name":"0c5c20de-7830-4420-b9a8-319bc24fd068"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"63a25eaf-4d6f-491e-9ee6-c1583073b797","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T03:56:52.4047017Z","updatedOn":"2020-08-31T03:56:52.4047017Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e5b45c0c-0568-48f2-b3e6-8f2a7c8a7480","type":"Microsoft.Authorization/roleAssignments","name":"e5b45c0c-0568-48f2-b3e6-8f2a7c8a7480"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bb6ddbae-c27c-4d59-8f74-7f3ae86b09cf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T08:13:57.1050454Z","updatedOn":"2020-08-31T08:13:57.1050454Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e19bab66-9aa8-4185-8022-4f12d711bd41","type":"Microsoft.Authorization/roleAssignments","name":"e19bab66-9aa8-4185-8022-4f12d711bd41"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b3e8f037-9df3-48d7-a200-ea26adbec31b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T16:38:12.9366042Z","updatedOn":"2020-08-31T16:38:12.9366042Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7a52c17e-ffcb-4fda-a6ec-00ce6ce0ec00","type":"Microsoft.Authorization/roleAssignments","name":"7a52c17e-ffcb-4fda-a6ec-00ce6ce0ec00"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f24c1379-3bff-4ef9-a12c-f2144e606f70","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-02T07:08:09.2474084Z","updatedOn":"2020-09-02T07:08:09.2474084Z","createdBy":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","updatedBy":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/617ef96e-12a4-4c5a-8d31-57d08a7a3d7a","type":"Microsoft.Authorization/roleAssignments","name":"617ef96e-12a4-4c5a-8d31-57d08a7a3d7a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2c830430-942c-49f3-85d5-47b113077c10","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-04T19:09:41.0321006Z","updatedOn":"2020-09-04T19:09:41.0321006Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b6663c97-f1e1-43b7-a4e6-48fab343ba41","type":"Microsoft.Authorization/roleAssignments","name":"b6663c97-f1e1-43b7-a4e6-48fab343ba41"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"82b73c5f-d0b6-4922-bee4-d4c15c6de7df","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-04T19:31:27.3400870Z","updatedOn":"2020-09-04T19:31:27.3400870Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff7c33ab-2fad-456e-a3cc-7b229b5368d5","type":"Microsoft.Authorization/roleAssignments","name":"ff7c33ab-2fad-456e-a3cc-7b229b5368d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2e888925-16dd-4a44-b8b1-ba406c26f5d7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:24:37.4713613Z","updatedOn":"2020-09-07T06:24:37.4713613Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/44f8b319-a262-4d13-b71f-333447b5a805","type":"Microsoft.Authorization/roleAssignments","name":"44f8b319-a262-4d13-b71f-333447b5a805"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9df1aedd-86b5-4ed0-b8ff-a88acb8650fb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:25:06.2141876Z","updatedOn":"2020-09-07T06:25:06.2141876Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/85e919b7-5319-413e-a542-afa0b9beeb62","type":"Microsoft.Authorization/roleAssignments","name":"85e919b7-5319-413e-a542-afa0b9beeb62"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"43ef2449-ad33-4be0-8ed0-5c683286f37a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:36:55.7776057Z","updatedOn":"2020-09-07T06:36:55.7776057Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/76ac0e9c-d79b-42f2-bd51-4cbc37748e64","type":"Microsoft.Authorization/roleAssignments","name":"76ac0e9c-d79b-42f2-bd51-4cbc37748e64"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f7365134-0464-4e1f-9b14-d7eec002fcf5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T07:05:11.6942078Z","updatedOn":"2020-09-07T07:05:11.6942078Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fbf2c497-545e-4588-8684-7b9ee6da6b1e","type":"Microsoft.Authorization/roleAssignments","name":"fbf2c497-545e-4588-8684-7b9ee6da6b1e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"93d51f04-4891-476a-8c64-06d57c749216","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T07:08:02.2196156Z","updatedOn":"2020-09-07T07:08:02.2196156Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2f30eec3-4fb4-4703-b46d-e4477070136f","type":"Microsoft.Authorization/roleAssignments","name":"2f30eec3-4fb4-4703-b46d-e4477070136f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d7715695-4665-4845-a99e-9893013479f9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T08:02:32.0378468Z","updatedOn":"2020-09-07T08:02:32.0378468Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7cf24871-6fd5-487e-a65e-c1ebfd911403","type":"Microsoft.Authorization/roleAssignments","name":"7cf24871-6fd5-487e-a65e-c1ebfd911403"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"18082f29-fabc-4d67-bc7e-d83a98f5df1e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T08:11:12.8568998Z","updatedOn":"2020-09-07T08:11:12.8568998Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6ebb62b0-b2cf-4db0-a7bf-9c7ff68a646f","type":"Microsoft.Authorization/roleAssignments","name":"6ebb62b0-b2cf-4db0-a7bf-9c7ff68a646f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"af994901-af8c-453d-947f-f35bd0f3762c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-04T01:15:27.8872966Z","updatedOn":"2020-07-04T01:15:27.8872966Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18b767b4-51f8-4bdc-8da9-98296b1cde8e","type":"Microsoft.Authorization/roleAssignments","name":"18b767b4-51f8-4bdc-8da9-98296b1cde8e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"68cc3003-9653-4bb3-a7c8-97d773f3ad69","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-06T02:38:51.7937810Z","updatedOn":"2020-07-06T02:38:51.7937810Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5235eab1-3e36-4012-b4a2-5f158ef93897","type":"Microsoft.Authorization/roleAssignments","name":"5235eab1-3e36-4012-b4a2-5f158ef93897"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"7402cbf1-d2ef-41cd-8fb4-d1dbee1fa54f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-06T04:08:01.5967452Z","updatedOn":"2020-07-06T04:08:01.5967452Z","createdBy":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","updatedBy":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b6cae0d1-4e24-42fa-8d89-341128d64407","type":"Microsoft.Authorization/roleAssignments","name":"b6cae0d1-4e24-42fa-8d89-341128d64407"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8328816a-0c23-48d8-bb6a-ed9dcf5691b0","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T03:14:22.0872359Z","updatedOn":"2020-07-07T03:14:22.0872359Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61fd3f76-16c6-4482-8193-ccf22532b437","type":"Microsoft.Authorization/roleAssignments","name":"61fd3f76-16c6-4482-8193-ccf22532b437"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:07.9267881Z","updatedOn":"2020-07-07T07:53:07.9267881Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cb1f995e-258c-4174-9f1f-b21038b6fe15","type":"Microsoft.Authorization/roleAssignments","name":"cb1f995e-258c-4174-9f1f-b21038b6fe15"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:53.3178813Z","updatedOn":"2020-07-07T07:53:53.3178813Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/300179b3-b4bc-4d43-a800-14a538c341f2","type":"Microsoft.Authorization/roleAssignments","name":"300179b3-b4bc-4d43-a800-14a538c341f2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:53.3373852Z","updatedOn":"2020-07-07T07:53:53.3373852Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6a385b91-b1ce-4f5b-800d-6b449bb808f4","type":"Microsoft.Authorization/roleAssignments","name":"6a385b91-b1ce-4f5b-800d-6b449bb808f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"038ceaf0-2c3a-4a46-b572-cf9c7c444bd2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-08T15:15:49.6291826Z","updatedOn":"2020-07-08T15:15:49.6291826Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/719a4419-b972-4af8-95e8-741c53fb6c52","type":"Microsoft.Authorization/roleAssignments","name":"719a4419-b972-4af8-95e8-741c53fb6c52"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1422d4db-8270-4ae7-8437-8cccba2922f2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T06:00:40.8283738Z","updatedOn":"2020-07-09T06:00:40.8283738Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/92636771-3b6d-420b-9f6f-31070fbf0b28","type":"Microsoft.Authorization/roleAssignments","name":"92636771-3b6d-420b-9f6f-31070fbf0b28"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"08cae1fd-4869-4440-b9ff-a97cd9c00e6e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T12:14:15.9609308Z","updatedOn":"2020-07-09T12:14:15.9609308Z","createdBy":"182c8534-f413-487c-91a3-7addc80e35d5","updatedBy":"182c8534-f413-487c-91a3-7addc80e35d5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dbc76c65-b271-4f11-b84b-0b41e3c13f04","type":"Microsoft.Authorization/roleAssignments","name":"dbc76c65-b271-4f11-b84b-0b41e3c13f04"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2fbc569b-038b-456d-b496-168b4d2647b3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T12:20:45.2035119Z","updatedOn":"2020-07-09T12:20:45.2035119Z","createdBy":"182c8534-f413-487c-91a3-7addc80e35d5","updatedBy":"182c8534-f413-487c-91a3-7addc80e35d5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/49e83287-ab00-4c77-8e75-0c44324555d7","type":"Microsoft.Authorization/roleAssignments","name":"49e83287-ab00-4c77-8e75-0c44324555d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a5928636-70a5-4dc6-9a39-83f4261ab739","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-11T01:21:44.1115337Z","updatedOn":"2020-07-11T01:21:44.1115337Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1ec24764-f578-4712-82d0-4cf303f8cd94","type":"Microsoft.Authorization/roleAssignments","name":"1ec24764-f578-4712-82d0-4cf303f8cd94"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1a0bac8e-d2d2-40d0-af60-3821fc4aad21","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T03:55:34.9995817Z","updatedOn":"2020-07-13T03:55:34.9995817Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79904528-b82f-426b-ba34-911b9b9d9bb1","type":"Microsoft.Authorization/roleAssignments","name":"79904528-b82f-426b-ba34-911b9b9d9bb1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"aa1452f8-438b-4993-a853-211244f65fd4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T06:08:09.4651196Z","updatedOn":"2020-07-13T06:08:09.4651196Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9f12bf7c-fb56-401f-8358-b1bb205a79c1","type":"Microsoft.Authorization/roleAssignments","name":"9f12bf7c-fb56-401f-8358-b1bb205a79c1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4bc2639f-4b4d-4507-9e1e-5560658dadcf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T06:11:38.7509627Z","updatedOn":"2020-07-13T06:11:38.7509627Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/80221d18-b98c-4114-b192-94febf5cdad1","type":"Microsoft.Authorization/roleAssignments","name":"80221d18-b98c-4114-b192-94febf5cdad1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6c7c1341-56f8-4dea-9015-ddeae7fcdc18","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T11:41:59.7653882Z","updatedOn":"2020-07-13T11:41:59.7653882Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/215ec308-e62e-409f-a0cf-6f7b18257cd3","type":"Microsoft.Authorization/roleAssignments","name":"215ec308-e62e-409f-a0cf-6f7b18257cd3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"76b9eb22-0091-49d2-847f-dc4831337de8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T03:06:52.4968477Z","updatedOn":"2020-07-14T03:06:52.4968477Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/876a1623-fed3-4ac9-9bd3-6373f166eb91","type":"Microsoft.Authorization/roleAssignments","name":"876a1623-fed3-4ac9-9bd3-6373f166eb91"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f0ec8449-0089-40c0-a539-430080dd51d5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T05:09:22.8572441Z","updatedOn":"2020-07-14T05:09:22.8572441Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/81c82fd2-ee9b-4636-a13c-c2fc290b1339","type":"Microsoft.Authorization/roleAssignments","name":"81c82fd2-ee9b-4636-a13c-c2fc290b1339"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3a62feb4-dd11-437d-8bf5-324bbcf2ca71","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T08:34:11.1314930Z","updatedOn":"2020-07-14T08:34:11.1314930Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10166085-8319-44c1-b39e-7c2e8a859606","type":"Microsoft.Authorization/roleAssignments","name":"10166085-8319-44c1-b39e-7c2e8a859606"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1768ac75-eb78-4760-904b-bf1daf362ed8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T13:24:26.4777748Z","updatedOn":"2020-07-14T13:24:26.4777748Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/89b22e91-fbe1-4519-9c28-55116cb4b449","type":"Microsoft.Authorization/roleAssignments","name":"89b22e91-fbe1-4519-9c28-55116cb4b449"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0c8ec4af-1f95-43d0-abdc-e98c7c377093","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T02:27:50.9285382Z","updatedOn":"2020-07-15T02:27:50.9285382Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6aa196a2-0d57-4ced-a7c4-e4309e305930","type":"Microsoft.Authorization/roleAssignments","name":"6aa196a2-0d57-4ced-a7c4-e4309e305930"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2f394b98-15c2-4a67-b5e4-59524a559fbe","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T06:04:05.5602990Z","updatedOn":"2020-07-15T06:04:05.5602990Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/29b52c6e-ef41-4228-be25-062bb7c962b2","type":"Microsoft.Authorization/roleAssignments","name":"29b52c6e-ef41-4228-be25-062bb7c962b2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d3ee15d8-bfc2-40e3-91ce-38f84f29b4fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:37:38.4755184Z","updatedOn":"2020-07-15T07:37:38.4755184Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/94971c0b-9b3c-4014-a9f3-0283d64c1b29","type":"Microsoft.Authorization/roleAssignments","name":"94971c0b-9b3c-4014-a9f3-0283d64c1b29"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"243b9ed2-a31b-4b74-abb7-fce2fa7b7d85","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:46:59.5663841Z","updatedOn":"2020-07-15T07:46:59.5663841Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0d8d5363-48b8-4bea-895a-0ca92c1737aa","type":"Microsoft.Authorization/roleAssignments","name":"0d8d5363-48b8-4bea-895a-0ca92c1737aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"936679b1-be85-401f-906b-1338954018e1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T08:01:13.4164296Z","updatedOn":"2020-07-15T08:01:13.4164296Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/56a43ec4-3148-4c7e-b526-817d25a836da","type":"Microsoft.Authorization/roleAssignments","name":"56a43ec4-3148-4c7e-b526-817d25a836da"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ee082e62-485a-4e27-8cbe-c3effae3cd9c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T08:49:06.7210416Z","updatedOn":"2020-07-15T08:49:06.7210416Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a78fc2bf-58e2-4e37-bc92-b7195a03fbee","type":"Microsoft.Authorization/roleAssignments","name":"a78fc2bf-58e2-4e37-bc92-b7195a03fbee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"28c339aa-6a69-4038-9085-b9de491ab4e8","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T02:40:49.7073175Z","updatedOn":"2020-07-16T02:40:49.7073175Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/47d4f9d6-ef56-4d94-9dcb-f79e11ed5e50","type":"Microsoft.Authorization/roleAssignments","name":"47d4f9d6-ef56-4d94-9dcb-f79e11ed5e50"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"59a64430-12a8-4f39-be98-d1dd2614aeea","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T07:46:36.5695565Z","updatedOn":"2020-07-16T07:46:36.5695565Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d5232861-40f7-44e1-b5dc-230787ad1927","type":"Microsoft.Authorization/roleAssignments","name":"d5232861-40f7-44e1-b5dc-230787ad1927"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a55ceb34-c21b-4a68-96c6-88eb4cc5e099","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T11:38:50.4745508Z","updatedOn":"2020-07-16T11:38:50.4745508Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/74d051bd-1538-486e-954d-12ba05d58a90","type":"Microsoft.Authorization/roleAssignments","name":"74d051bd-1538-486e-954d-12ba05d58a90"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e5e99afa-9231-46fd-acfc-92c8a8ff4489","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-17T07:29:54.2160514Z","updatedOn":"2020-07-17T07:29:54.2160514Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ceb853a2-799d-4948-990d-e0650efe5d4a","type":"Microsoft.Authorization/roleAssignments","name":"ceb853a2-799d-4948-990d-e0650efe5d4a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f1f3476e-5aa5-4e0e-8632-a6f8728860b8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-18T01:17:47.1042571Z","updatedOn":"2020-07-18T01:17:47.1042571Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3b69d82b-e9f6-432e-b75c-f93b2d88efd7","type":"Microsoft.Authorization/roleAssignments","name":"3b69d82b-e9f6-432e-b75c-f93b2d88efd7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9431860d-6e2d-4227-9829-7b00afbdfb64","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:19:08.9724715Z","updatedOn":"2020-07-21T08:19:08.9724715Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7a335959-fbd8-42b5-9e34-dfa0cf86dedb","type":"Microsoft.Authorization/roleAssignments","name":"7a335959-fbd8-42b5-9e34-dfa0cf86dedb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6e931f32-10eb-43f4-883d-86a7991108f7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:21:22.6590948Z","updatedOn":"2020-07-21T08:21:22.6590948Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a92bcbb4-ef43-43db-a151-2b11cb2131a3","type":"Microsoft.Authorization/roleAssignments","name":"a92bcbb4-ef43-43db-a151-2b11cb2131a3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8b26643c-1bce-4669-ba85-48403e88103d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:28:00.4744129Z","updatedOn":"2020-07-21T08:28:00.4744129Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3939f612-6d79-496c-bf5d-4f92e1d1b5e5","type":"Microsoft.Authorization/roleAssignments","name":"3939f612-6d79-496c-bf5d-4f92e1d1b5e5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"af02e2c0-437c-4fbf-8769-fe6b43600a11","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T12:39:54.0428636Z","updatedOn":"2020-07-21T12:39:54.0428636Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff44e8d6-b72d-43fc-91b6-ead0de501f65","type":"Microsoft.Authorization/roleAssignments","name":"ff44e8d6-b72d-43fc-91b6-ead0de501f65"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5eef490b-41df-460b-ab98-7e8d3f8a1559","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T03:20:01.9422980Z","updatedOn":"2020-07-22T03:20:01.9422980Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e3d03863-6d79-4535-b692-15ca1e2ec3be","type":"Microsoft.Authorization/roleAssignments","name":"e3d03863-6d79-4535-b692-15ca1e2ec3be"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"86609d61-9b24-4e62-8c38-8361f202f09f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T04:26:09.1052343Z","updatedOn":"2020-07-22T04:26:09.1052343Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a78eda47-9ef1-4c22-bfa4-0d996c5d599c","type":"Microsoft.Authorization/roleAssignments","name":"a78eda47-9ef1-4c22-bfa4-0d996c5d599c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ed0ebe06-e932-4087-8ba8-03478368e7c6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:23.4466032Z","updatedOn":"2020-07-22T06:09:23.4466032Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f03258ee-4f5a-48cd-a003-d23a60a3a014","type":"Microsoft.Authorization/roleAssignments","name":"f03258ee-4f5a-48cd-a003-d23a60a3a014"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d126d0bb-79bb-472f-8b80-a9a346f6f100","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:45.2929087Z","updatedOn":"2020-07-22T06:09:45.2929087Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3581753e-74ab-4e9d-b79d-0799442862b3","type":"Microsoft.Authorization/roleAssignments","name":"3581753e-74ab-4e9d-b79d-0799442862b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2d627045-009d-4074-8bcd-52d7eeabb18c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:54.6260798Z","updatedOn":"2020-07-22T06:09:54.6260798Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cf80890b-2e9e-424a-a8ab-1795078643d2","type":"Microsoft.Authorization/roleAssignments","name":"cf80890b-2e9e-424a-a8ab-1795078643d2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"535b5697-6115-4f18-92f3-20fc9a07cce7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:18:56.2452865Z","updatedOn":"2020-07-22T06:18:56.2452865Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6b91e17e-56de-4229-8453-5338337d3c6f","type":"Microsoft.Authorization/roleAssignments","name":"6b91e17e-56de-4229-8453-5338337d3c6f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d048d4f7-7edb-4712-aeca-af4fb5c61b5a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:19:12.0666094Z","updatedOn":"2020-07-22T06:19:12.0666094Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/051d8d7e-2bf8-400c-af8e-4cdea07dedf0","type":"Microsoft.Authorization/roleAssignments","name":"051d8d7e-2bf8-400c-af8e-4cdea07dedf0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b45b251f-c8a2-4d3a-af7f-a9739cbe0d68","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:15.0908010Z","updatedOn":"2020-07-22T06:20:15.0908010Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bcb6a1f9-fd6e-441b-aaf7-09cf14414872","type":"Microsoft.Authorization/roleAssignments","name":"bcb6a1f9-fd6e-441b-aaf7-09cf14414872"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5c709f8c-397c-40d2-a147-1040fb282e24","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:26.8312576Z","updatedOn":"2020-07-22T06:20:26.8312576Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ceb67739-0cce-4a0e-9d2a-bd8a1ea65485","type":"Microsoft.Authorization/roleAssignments","name":"ceb67739-0cce-4a0e-9d2a-bd8a1ea65485"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a3d2b5a7-f9ce-4ab2-9155-e47bc8121b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:31.6051855Z","updatedOn":"2020-07-22T06:20:31.6051855Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b151b8cc-8569-4dd6-97a3-a0652015d9ab","type":"Microsoft.Authorization/roleAssignments","name":"b151b8cc-8569-4dd6-97a3-a0652015d9ab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b56fdd17-ee35-4381-9aea-00dfa70a3872","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:24:16.5402929Z","updatedOn":"2020-07-22T06:24:16.5402929Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7d078199-8ce2-44ed-8eb3-c7aca7590bee","type":"Microsoft.Authorization/roleAssignments","name":"7d078199-8ce2-44ed-8eb3-c7aca7590bee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0ef05f56-75da-4e69-8886-cf7eb25921bf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:28:20.2615489Z","updatedOn":"2020-07-22T06:28:20.2615489Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f126b61c-58bb-40d5-90b5-035320097c81","type":"Microsoft.Authorization/roleAssignments","name":"f126b61c-58bb-40d5-90b5-035320097c81"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2b7f66f5-e2b4-4e90-a6c0-48fd09c6941c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:31:13.8352773Z","updatedOn":"2020-07-22T06:31:13.8352773Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a3fb647-a48a-4fb2-b9be-5c0ec0c1dd9f","type":"Microsoft.Authorization/roleAssignments","name":"9a3fb647-a48a-4fb2-b9be-5c0ec0c1dd9f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-24T03:54:19.5994989Z","updatedOn":"2020-07-24T03:54:19.5994989Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dc91700c-9959-4179-80b7-f2bfb957d4ec","type":"Microsoft.Authorization/roleAssignments","name":"dc91700c-9959-4179-80b7-f2bfb957d4ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d0daf77e-df2b-4f08-93a9-53bc40d2b65e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-25T01:20:25.7612859Z","updatedOn":"2020-07-25T01:20:25.7612859Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/01c4a64d-636d-4f02-8b51-1e52794b0065","type":"Microsoft.Authorization/roleAssignments","name":"01c4a64d-636d-4f02-8b51-1e52794b0065"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"75e0401f-c382-49bc-9681-5891889d6090","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-25T01:20:48.2269442Z","updatedOn":"2020-07-25T01:20:48.2269442Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d14294b-2a12-4034-98ed-d79fc8967004","type":"Microsoft.Authorization/roleAssignments","name":"8d14294b-2a12-4034-98ed-d79fc8967004"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cfa73ec2-e91c-4de2-9b7f-3886f1b1a7e9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-01T01:15:28.6134386Z","updatedOn":"2020-08-01T01:15:28.6134386Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2880df4d-a219-4208-8f53-11ba91fe5ee6","type":"Microsoft.Authorization/roleAssignments","name":"2880df4d-a219-4208-8f53-11ba91fe5ee6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4ffca8c7-2d31-4f24-9e03-a1a836f60ba8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-01T01:34:29.3212794Z","updatedOn":"2020-08-01T01:34:29.3212794Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/39e1d3ed-13fb-432e-a0cb-8b294fddc63a","type":"Microsoft.Authorization/roleAssignments","name":"39e1d3ed-13fb-432e-a0cb-8b294fddc63a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"26e698cd-9d87-41f6-9a7e-06b3627e6ca5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-04T05:20:53.6187620Z","updatedOn":"2020-08-04T05:20:53.6187620Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97f68035-e05b-4e7f-aa80-a3799725076a","type":"Microsoft.Authorization/roleAssignments","name":"97f68035-e05b-4e7f-aa80-a3799725076a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5fcaa3b3-d5b2-44ce-92e2-28a4241f1e6b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-04T05:29:27.6127065Z","updatedOn":"2020-08-04T05:29:27.6127065Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ae95584d-6d28-4372-872b-b96e6a1f9c1f","type":"Microsoft.Authorization/roleAssignments","name":"ae95584d-6d28-4372-872b-b96e6a1f9c1f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-05T03:43:59.8598863Z","updatedOn":"2020-08-05T03:43:59.8598863Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/254a30cf-3bdd-4e6c-aa9e-9d96397bf63a","type":"Microsoft.Authorization/roleAssignments","name":"254a30cf-3bdd-4e6c-aa9e-9d96397bf63a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"800eadcf-0a23-4298-939b-6cf9f3dbceef","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-05T05:51:54.9501785Z","updatedOn":"2020-08-05T05:51:54.9501785Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8b806af6-57f8-45f4-849f-6d0d0f43d093","type":"Microsoft.Authorization/roleAssignments","name":"8b806af6-57f8-45f4-849f-6d0d0f43d093"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ef53cdce-e483-4aa2-8260-58249cc1e7b1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-02T16:57:34.4713679Z","updatedOn":"2020-07-02T16:57:34.4713679Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/54fe41af-b32f-43d4-aac4-9e9be5b142a7","type":"Microsoft.Authorization/roleAssignments","name":"54fe41af-b32f-43d4-aac4-9e9be5b142a7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/providers/Microsoft.Management/managementGroups/CliMgmtGroup","condition":null,"conditionVersion":null,"createdOn":"2019-12-26T10:45:42.1154685Z","updatedOn":"2019-12-26T10:45:42.1154685Z","createdBy":"dfb7f346-f217-474e-ba6c-49895fd9cc13","updatedBy":"dfb7f346-f217-474e-ba6c-49895fd9cc13","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Management/managementGroups/CliMgmtGroup/providers/Microsoft.Authorization/roleAssignments/f0b07cf8-a079-446e-a391-c6fb1d115b59","type":"Microsoft.Authorization/roleAssignments","name":"f0b07cf8-a079-446e-a391-c6fb1d115b59"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"434760c4-8e4b-49e9-80be-3ed37b7a0aa3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T22:43:09.9154640Z","updatedOn":"2020-12-09T22:43:09.9154640Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.4824942Z","updatedOn":"2020-06-16T16:25:39.4824942Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e77058da-a7bf-4e89-8e48-7d9f61fa8246","type":"Microsoft.Authorization/roleAssignments","name":"e77058da-a7bf-4e89-8e48-7d9f61fa8246"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:12:52.8054393Z","updatedOn":"2020-11-25T05:12:52.8054393Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dea2d3a8-cf99-4169-b8dd-819b4c611a32","type":"Microsoft.Authorization/roleAssignments","name":"dea2d3a8-cf99-4169-b8dd-819b4c611a32"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:34:01.2642084Z","updatedOn":"2020-11-25T05:34:01.2642084Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bacc53c-9077-49ce-a14d-370bc09f72d8","type":"Microsoft.Authorization/roleAssignments","name":"4bacc53c-9077-49ce-a14d-370bc09f72d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6949b2a1-9b3e-42c8-b228-0b6c14927377","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-30T19:34:16.5100204Z","updatedOn":"2020-07-30T19:34:16.5100204Z","createdBy":"5bc13990-50e4-4898-835e-d026e066bba5","updatedBy":"5bc13990-50e4-4898-835e-d026e066bba5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/53b0d735-2402-41c6-9d6d-b2338a287741","type":"Microsoft.Authorization/roleAssignments","name":"53b0d735-2402-41c6-9d6d-b2338a287741"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4c480e6-1f29-4163-9a37-2b16a7e8e5c8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-16T13:48:13.9171700Z","updatedOn":"2020-09-16T13:48:13.9171700Z","createdBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","updatedBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8476200c-5011-42c4-9028-360ef1739a8d","type":"Microsoft.Authorization/roleAssignments","name":"8476200c-5011-42c4-9028-360ef1739a8d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '238289'
+      - '26722'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:27 GMT
+      - Wed, 09 Dec 2020 22:43:10 GMT
       expires:
       - '-1'
       pragma:
@@ -1847,8 +1874,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
-      "principalId": "3e675290-31e1-49f6-a3cd-03df3d7d6e2e", "principalType": "ServicePrincipal"}}'
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+      "principalId": "b9bc1545-a684-4e50-9a4d-2e2ee90bed6a", "principalType": "ServicePrincipal"}}'
     headers:
       Accept:
       - application/json
@@ -1862,20 +1889,19 @@ interactions:
       - '270'
       Content-Type:
       - application/json; charset=utf-8
-      Cookie:
-      - x-ms-gateway-slice=Production
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3e675290-31e1-49f6-a3cd-03df3d7d6e2e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-09-08T07:00:27.8589726Z","updatedOn":"2020-09-08T07:00:27.8589726Z","createdBy":null,"updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T22:43:11.5840476Z","updatedOn":"2020-12-09T22:43:12.1669408Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
     headers:
       cache-control:
       - no-cache
@@ -1884,7 +1910,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:29 GMT
+      - Wed, 09 Dec 2020 22:43:12 GMT
       expires:
       - '-1'
       pragma:
@@ -1901,136 +1927,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"d9d55412-3bf4-482c-83d2-c6d41039a082\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.81.194.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
-        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:29 GMT
-      etag:
-      - W/"d9d55412-3bf4-482c-83d2-c6d41039a082"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 6ba4015d-8c9d-4269-8bba-997ed41995a2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n  \"etag\": \"W/\\\"d9d55412-3bf4-482c-83d2-c6d41039a082\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.110.118.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:29 GMT
-      etag:
-      - W/"d9d55412-3bf4-482c-83d2-c6d41039a082"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - b1329527-0fd8-4594-8fe2-2ace665fcd49
-    status:
-      code: 200
-      message: OK
-- request:
     body: '{"tags": {"test": "create"}, "location": "eastus", "properties": {"clusterProfile":
-      {"pullSecret": "", "domain": "bcw4l0nr", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-bcw4l0nr"},
-      "servicePrincipalProfile": {"clientId": "2f1b33cc-af5a-4633-aeee-875b15c50c71",
-      "clientSecret": "7d56f3ea-420b-4932-a066-8dcf4be428a7"}, "networkProfile": {"podCidr":
+      {"pullSecret": "", "domain": "nb25qvuk", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-nb25qvuk"},
+      "servicePrincipalProfile": {"clientId": "4bdcbdbe-b405-4ffd-b8dc-696176de4f62",
+      "clientSecret": "500653c1-a586-46e7-9064-46db4d29bfb6"}, "networkProfile": {"podCidr":
       "10.128.0.0/14", "serviceCidr": "172.30.0.0/16"}, "masterProfile": {"vmSize":
       "Standard_D8s_v3", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002"},
       "workerProfiles": [{"name": "worker", "vmSize": "Standard_D4s_v3", "diskSizeGB":
@@ -2053,8 +1953,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -2065,11 +1966,11 @@ interactions:
         ,\n    \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\"\
         ,\n    \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"create\"\
         \n    },\n    \"properties\": {\n        \"provisioningState\": \"Creating\"\
-        ,\n        \"clusterProfile\": {\n            \"domain\": \"bcw4l0nr\",\n\
-        \            \"version\": \"4.4.17\",\n            \"resourceGroupId\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-bcw4l0nr\"\
+        ,\n        \"clusterProfile\": {\n            \"domain\": \"nb25qvuk\",\n\
+        \            \"version\": \"4.5.16\",\n            \"resourceGroupId\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-nb25qvuk\"\
         \n        },\n        \"consoleProfile\": {},\n        \"servicePrincipalProfile\"\
-        : {\n            \"clientId\": \"2f1b33cc-af5a-4633-aeee-875b15c50c71\"\n\
+        : {\n            \"clientId\": \"4bdcbdbe-b405-4ffd-b8dc-696176de4f62\"\n\
         \        },\n        \"networkProfile\": {\n            \"podCidr\": \"10.128.0.0/14\"\
         ,\n            \"serviceCidr\": \"172.30.0.0/16\"\n        },\n        \"\
         masterProfile\": {\n            \"vmSize\": \"Standard_D8s_v3\",\n       \
@@ -2084,7 +1985,7 @@ interactions:
         \   \"visibility\": \"Public\"\n            }\n        ]\n    }\n}\n"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -2092,7 +1993,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:00:33 GMT
+      - Wed, 09 Dec 2020 22:43:14 GMT
       expires:
       - '-1'
       pragma:
@@ -2120,15 +2021,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2137,7 +2039,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:01:04 GMT
+      - Wed, 09 Dec 2020 22:43:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2167,15 +2069,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2184,7 +2087,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:01:34 GMT
+      - Wed, 09 Dec 2020 22:44:15 GMT
       expires:
       - '-1'
       pragma:
@@ -2214,15 +2117,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2231,7 +2135,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:02:04 GMT
+      - Wed, 09 Dec 2020 22:44:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2261,15 +2165,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2278,7 +2183,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:02:34 GMT
+      - Wed, 09 Dec 2020 22:45:15 GMT
       expires:
       - '-1'
       pragma:
@@ -2308,15 +2213,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2325,7 +2231,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:03:04 GMT
+      - Wed, 09 Dec 2020 22:45:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2355,15 +2261,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2372,7 +2279,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:03:34 GMT
+      - Wed, 09 Dec 2020 22:46:16 GMT
       expires:
       - '-1'
       pragma:
@@ -2402,15 +2309,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2419,7 +2327,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:04:04 GMT
+      - Wed, 09 Dec 2020 22:46:46 GMT
       expires:
       - '-1'
       pragma:
@@ -2449,15 +2357,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2466,7 +2375,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:04:35 GMT
+      - Wed, 09 Dec 2020 22:47:16 GMT
       expires:
       - '-1'
       pragma:
@@ -2496,15 +2405,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2513,7 +2423,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:05:05 GMT
+      - Wed, 09 Dec 2020 22:47:46 GMT
       expires:
       - '-1'
       pragma:
@@ -2543,15 +2453,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2560,7 +2471,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:05:35 GMT
+      - Wed, 09 Dec 2020 22:48:16 GMT
       expires:
       - '-1'
       pragma:
@@ -2590,15 +2501,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2607,7 +2519,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:06:06 GMT
+      - Wed, 09 Dec 2020 22:48:46 GMT
       expires:
       - '-1'
       pragma:
@@ -2637,15 +2549,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2654,7 +2567,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:06:36 GMT
+      - Wed, 09 Dec 2020 22:49:16 GMT
       expires:
       - '-1'
       pragma:
@@ -2684,15 +2597,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2701,7 +2615,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:07:06 GMT
+      - Wed, 09 Dec 2020 22:49:46 GMT
       expires:
       - '-1'
       pragma:
@@ -2731,15 +2645,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2748,7 +2663,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:07:36 GMT
+      - Wed, 09 Dec 2020 22:50:17 GMT
       expires:
       - '-1'
       pragma:
@@ -2778,15 +2693,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2795,7 +2711,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:08:06 GMT
+      - Wed, 09 Dec 2020 22:50:47 GMT
       expires:
       - '-1'
       pragma:
@@ -2825,15 +2741,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2842,7 +2759,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:08:36 GMT
+      - Wed, 09 Dec 2020 22:51:17 GMT
       expires:
       - '-1'
       pragma:
@@ -2872,15 +2789,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2889,7 +2807,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:09:06 GMT
+      - Wed, 09 Dec 2020 22:51:47 GMT
       expires:
       - '-1'
       pragma:
@@ -2919,15 +2837,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2936,7 +2855,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:09:37 GMT
+      - Wed, 09 Dec 2020 22:52:17 GMT
       expires:
       - '-1'
       pragma:
@@ -2966,15 +2885,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2983,7 +2903,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:10:07 GMT
+      - Wed, 09 Dec 2020 22:52:47 GMT
       expires:
       - '-1'
       pragma:
@@ -3013,15 +2933,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3030,7 +2951,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:10:37 GMT
+      - Wed, 09 Dec 2020 22:53:17 GMT
       expires:
       - '-1'
       pragma:
@@ -3060,15 +2981,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3077,7 +2999,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:11:07 GMT
+      - Wed, 09 Dec 2020 22:53:48 GMT
       expires:
       - '-1'
       pragma:
@@ -3107,15 +3029,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3124,7 +3047,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:11:37 GMT
+      - Wed, 09 Dec 2020 22:54:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3154,15 +3077,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3171,7 +3095,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:12:07 GMT
+      - Wed, 09 Dec 2020 22:54:49 GMT
       expires:
       - '-1'
       pragma:
@@ -3201,15 +3125,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3218,7 +3143,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:12:38 GMT
+      - Wed, 09 Dec 2020 22:55:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3248,15 +3173,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3265,7 +3191,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:13:08 GMT
+      - Wed, 09 Dec 2020 22:55:49 GMT
       expires:
       - '-1'
       pragma:
@@ -3295,15 +3221,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3312,7 +3239,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:13:38 GMT
+      - Wed, 09 Dec 2020 22:56:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3342,15 +3269,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3359,7 +3287,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:14:08 GMT
+      - Wed, 09 Dec 2020 22:56:49 GMT
       expires:
       - '-1'
       pragma:
@@ -3389,15 +3317,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3406,7 +3335,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:14:38 GMT
+      - Wed, 09 Dec 2020 22:57:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3436,15 +3365,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3453,7 +3383,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:15:09 GMT
+      - Wed, 09 Dec 2020 22:57:50 GMT
       expires:
       - '-1'
       pragma:
@@ -3483,15 +3413,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3500,7 +3431,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:15:39 GMT
+      - Wed, 09 Dec 2020 22:58:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3530,15 +3461,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3547,7 +3479,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:16:09 GMT
+      - Wed, 09 Dec 2020 22:58:50 GMT
       expires:
       - '-1'
       pragma:
@@ -3577,15 +3509,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3594,7 +3527,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:16:39 GMT
+      - Wed, 09 Dec 2020 22:59:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3624,15 +3557,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3641,7 +3575,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:17:08 GMT
+      - Wed, 09 Dec 2020 22:59:50 GMT
       expires:
       - '-1'
       pragma:
@@ -3671,15 +3605,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3688,7 +3623,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:17:39 GMT
+      - Wed, 09 Dec 2020 23:00:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3718,15 +3653,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3735,7 +3671,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:18:09 GMT
+      - Wed, 09 Dec 2020 23:00:51 GMT
       expires:
       - '-1'
       pragma:
@@ -3765,15 +3701,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3782,7 +3719,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:18:39 GMT
+      - Wed, 09 Dec 2020 23:01:21 GMT
       expires:
       - '-1'
       pragma:
@@ -3812,15 +3749,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3829,7 +3767,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:19:09 GMT
+      - Wed, 09 Dec 2020 23:01:51 GMT
       expires:
       - '-1'
       pragma:
@@ -3859,15 +3797,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3876,7 +3815,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:19:39 GMT
+      - Wed, 09 Dec 2020 23:02:21 GMT
       expires:
       - '-1'
       pragma:
@@ -3906,15 +3845,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3923,7 +3863,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:20:10 GMT
+      - Wed, 09 Dec 2020 23:02:51 GMT
       expires:
       - '-1'
       pragma:
@@ -3953,15 +3893,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3970,7 +3911,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:20:40 GMT
+      - Wed, 09 Dec 2020 23:03:21 GMT
       expires:
       - '-1'
       pragma:
@@ -4000,15 +3941,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4017,7 +3959,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:21:10 GMT
+      - Wed, 09 Dec 2020 23:03:52 GMT
       expires:
       - '-1'
       pragma:
@@ -4047,15 +3989,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4064,7 +4007,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:21:40 GMT
+      - Wed, 09 Dec 2020 23:04:22 GMT
       expires:
       - '-1'
       pragma:
@@ -4094,15 +4037,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4111,7 +4055,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:22:10 GMT
+      - Wed, 09 Dec 2020 23:04:53 GMT
       expires:
       - '-1'
       pragma:
@@ -4141,15 +4085,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4158,7 +4103,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:22:41 GMT
+      - Wed, 09 Dec 2020 23:05:23 GMT
       expires:
       - '-1'
       pragma:
@@ -4188,15 +4133,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4205,7 +4151,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:23:11 GMT
+      - Wed, 09 Dec 2020 23:05:53 GMT
       expires:
       - '-1'
       pragma:
@@ -4235,15 +4181,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4252,7 +4199,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:23:41 GMT
+      - Wed, 09 Dec 2020 23:06:23 GMT
       expires:
       - '-1'
       pragma:
@@ -4282,15 +4229,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4299,7 +4247,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:24:11 GMT
+      - Wed, 09 Dec 2020 23:06:53 GMT
       expires:
       - '-1'
       pragma:
@@ -4329,15 +4277,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4346,7 +4295,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:24:42 GMT
+      - Wed, 09 Dec 2020 23:07:23 GMT
       expires:
       - '-1'
       pragma:
@@ -4376,15 +4325,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4393,7 +4343,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:25:11 GMT
+      - Wed, 09 Dec 2020 23:07:53 GMT
       expires:
       - '-1'
       pragma:
@@ -4423,15 +4373,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4440,7 +4391,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:25:41 GMT
+      - Wed, 09 Dec 2020 23:08:23 GMT
       expires:
       - '-1'
       pragma:
@@ -4470,15 +4421,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4487,7 +4439,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:26:11 GMT
+      - Wed, 09 Dec 2020 23:08:54 GMT
       expires:
       - '-1'
       pragma:
@@ -4517,15 +4469,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4534,7 +4487,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:26:41 GMT
+      - Wed, 09 Dec 2020 23:09:24 GMT
       expires:
       - '-1'
       pragma:
@@ -4564,15 +4517,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4581,7 +4535,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:27:12 GMT
+      - Wed, 09 Dec 2020 23:09:54 GMT
       expires:
       - '-1'
       pragma:
@@ -4611,15 +4565,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4628,7 +4583,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:27:42 GMT
+      - Wed, 09 Dec 2020 23:10:24 GMT
       expires:
       - '-1'
       pragma:
@@ -4658,15 +4613,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4675,7 +4631,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:28:12 GMT
+      - Wed, 09 Dec 2020 23:10:54 GMT
       expires:
       - '-1'
       pragma:
@@ -4705,15 +4661,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4722,7 +4679,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:28:42 GMT
+      - Wed, 09 Dec 2020 23:11:24 GMT
       expires:
       - '-1'
       pragma:
@@ -4752,15 +4709,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4769,7 +4727,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:29:13 GMT
+      - Wed, 09 Dec 2020 23:11:55 GMT
       expires:
       - '-1'
       pragma:
@@ -4799,15 +4757,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4816,7 +4775,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:29:42 GMT
+      - Wed, 09 Dec 2020 23:12:25 GMT
       expires:
       - '-1'
       pragma:
@@ -4846,15 +4805,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4863,7 +4823,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:30:13 GMT
+      - Wed, 09 Dec 2020 23:12:55 GMT
       expires:
       - '-1'
       pragma:
@@ -4893,15 +4853,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4910,7 +4871,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:30:43 GMT
+      - Wed, 09 Dec 2020 23:13:25 GMT
       expires:
       - '-1'
       pragma:
@@ -4940,15 +4901,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4957,7 +4919,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:31:13 GMT
+      - Wed, 09 Dec 2020 23:13:55 GMT
       expires:
       - '-1'
       pragma:
@@ -4987,15 +4949,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5004,7 +4967,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:31:43 GMT
+      - Wed, 09 Dec 2020 23:14:25 GMT
       expires:
       - '-1'
       pragma:
@@ -5034,15 +4997,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5051,7 +5015,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:32:13 GMT
+      - Wed, 09 Dec 2020 23:14:56 GMT
       expires:
       - '-1'
       pragma:
@@ -5081,15 +5045,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5098,7 +5063,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:32:44 GMT
+      - Wed, 09 Dec 2020 23:15:27 GMT
       expires:
       - '-1'
       pragma:
@@ -5128,15 +5093,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5145,7 +5111,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:33:14 GMT
+      - Wed, 09 Dec 2020 23:15:57 GMT
       expires:
       - '-1'
       pragma:
@@ -5175,15 +5141,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5192,7 +5159,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:33:44 GMT
+      - Wed, 09 Dec 2020 23:16:27 GMT
       expires:
       - '-1'
       pragma:
@@ -5222,16 +5189,65 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"endTime\": \"2020-09-08T07:34:08.425288899Z\",\n    \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/1e4259e2-9267-480d-a6b8-fd48df11b251\"\
-        ,\n    \"name\": \"1e4259e2-9267-480d-a6b8-fd48df11b251\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.755332706Z\",\n    \"status\": \"Succeeded\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 23:16:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9120d2ba-d027-42b9-8c2d-8716bd9158ff\"\
+        ,\n    \"name\": \"9120d2ba-d027-42b9-8c2d-8716bd9158ff\",\n    \"status\"\
+        : \"Succeeded\",\n    \"startTime\": \"2020-12-09T22:43:14.389864474Z\",\n\
+        \    \"endTime\": \"2020-12-09T23:17:27.413125618Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5240,7 +5256,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:34:14 GMT
+      - Wed, 09 Dec 2020 23:17:28 GMT
       expires:
       - '-1'
       pragma:
@@ -5270,8 +5286,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
   response:
@@ -5280,32 +5297,32 @@ interactions:
         ,\n    \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\"\
         ,\n    \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"create\"\
         \n    },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\"\
-        ,\n        \"clusterProfile\": {\n            \"domain\": \"bcw4l0nr\",\n\
-        \            \"version\": \"4.4.17\",\n            \"resourceGroupId\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-bcw4l0nr\"\
-        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.bcw4l0nr.eastus.aroapp.io/\"\
+        ,\n        \"clusterProfile\": {\n            \"domain\": \"nb25qvuk\",\n\
+        \            \"version\": \"4.5.16\",\n            \"resourceGroupId\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-nb25qvuk\"\
+        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.nb25qvuk.eastus.aroapp.io/\"\
         \n        },\n        \"servicePrincipalProfile\": {\n            \"clientId\"\
-        : \"2f1b33cc-af5a-4633-aeee-875b15c50c71\"\n        },\n        \"networkProfile\"\
+        : \"4bdcbdbe-b405-4ffd-b8dc-696176de4f62\"\n        },\n        \"networkProfile\"\
         : {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\"\
         : \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n          \
         \  \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
         \n        },\n        \"workerProfiles\": [\n            {\n             \
-        \   \"name\": \"aro000004-6wg28-worker-eastus1\",\n                \"vmSize\"\
+        \   \"name\": \"aro000004-v9ckn-worker-eastus1\",\n                \"vmSize\"\
         : \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n           \
         \     \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-6wg28-worker-eastus2\",\n                \"\
+        \       \"name\": \"aro000004-v9ckn-worker-eastus2\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-6wg28-worker-eastus3\",\n                \"\
+        \       \"name\": \"aro000004-v9ckn-worker-eastus3\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            }\n        ],\n        \"apiserverProfile\"\
-        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.bcw4l0nr.eastus.aroapp.io:6443/\"\
-        ,\n            \"ip\": \"52.186.36.89\"\n        },\n        \"ingressProfiles\"\
+        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.nb25qvuk.eastus.aroapp.io:6443/\"\
+        ,\n            \"ip\": \"52.151.247.71\"\n        },\n        \"ingressProfiles\"\
         : [\n            {\n                \"name\": \"default\",\n             \
-        \   \"visibility\": \"Public\",\n                \"ip\": \"52.226.101.173\"\
+        \   \"visibility\": \"Public\",\n                \"ip\": \"20.72.169.198\"\
         \n            }\n        ]\n    }\n}\n"
     headers:
       cache-control:
@@ -5315,7 +5332,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:34:14 GMT
+      - Wed, 09 Dec 2020 23:17:28 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_delete.yaml
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_delete.yaml
@@ -13,15 +13,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-resource/10.3.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_delete000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001","name":"cli_test_aro_delete000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-01T20:28:26Z","createdAt":"2020-12-01T20:28:26.9816675Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001","name":"cli_test_aro_delete000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-09T16:12:23Z","createdAt":"2020-12-09T16:12:24.7856306Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:27 GMT
+      - Wed, 09 Dec 2020 16:12:24 GMT
       expires:
       - '-1'
       pragma:
@@ -63,8 +64,9 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -72,10 +74,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"b729d47b-7880-4cf4-b2c4-c7d3ea5c1bf4\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"ac99a810-7740-449d-8f2d-9639d94fc657\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"48b28697-d257-4ca8-ba0f-ed8ca711842f\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"88b97458-5f24-4581-9541-9b8608123d8f\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -85,7 +87,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/60a09922-225a-4576-8e47-e754e493c027?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e69c63d8-e1ba-4859-8a09-5deb8adebd83?api-version=2020-07-01
       cache-control:
       - no-cache
       content-length:
@@ -93,7 +95,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:29 GMT
+      - Wed, 09 Dec 2020 16:12:27 GMT
       expires:
       - '-1'
       pragma:
@@ -106,7 +108,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 2e9edb44-6c85-4d2d-9df6-8bbaabcc16b7
+      - d2935619-982d-409e-b459-b7103f334c9c
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -126,10 +128,11 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/60a09922-225a-4576-8e47-e754e493c027?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e69c63d8-e1ba-4859-8a09-5deb8adebd83?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -141,7 +144,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:32 GMT
+      - Wed, 09 Dec 2020 16:12:29 GMT
       expires:
       - '-1'
       pragma:
@@ -158,7 +161,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - b7202628-f4df-483c-9349-34de7fa9a577
+      - f73a9ff2-5760-4704-b933-a683d02586e2
     status:
       code: 200
       message: OK
@@ -176,17 +179,18 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"4fdd3c85-02ba-48eb-a2f4-418cdffaea7b\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"24ae388b-4e0f-40c2-a959-c4420f5f05d3\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"48b28697-d257-4ca8-ba0f-ed8ca711842f\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"88b97458-5f24-4581-9541-9b8608123d8f\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -200,9 +204,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:32 GMT
+      - Wed, 09 Dec 2020 16:12:30 GMT
       etag:
-      - W/"4fdd3c85-02ba-48eb-a2f4-418cdffaea7b"
+      - W/"24ae388b-4e0f-40c2-a959-c4420f5f05d3"
       expires:
       - '-1'
       pragma:
@@ -219,7 +223,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 5009a568-f159-4ef7-a487-cba0103be5bb
+      - 2560c116-a105-4e75-860d-371ad6f6b0cb
     status:
       code: 200
       message: OK
@@ -237,8 +241,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -246,10 +251,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"4fdd3c85-02ba-48eb-a2f4-418cdffaea7b\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"24ae388b-4e0f-40c2-a959-c4420f5f05d3\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"48b28697-d257-4ca8-ba0f-ed8ca711842f\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"88b97458-5f24-4581-9541-9b8608123d8f\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -263,9 +268,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:33 GMT
+      - Wed, 09 Dec 2020 16:12:30 GMT
       etag:
-      - W/"4fdd3c85-02ba-48eb-a2f4-418cdffaea7b"
+      - W/"24ae388b-4e0f-40c2-a959-c4420f5f05d3"
       expires:
       - '-1'
       pragma:
@@ -282,7 +287,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 80807c73-baf1-410f-8981-8b2815ef832f
+      - ba0deecf-2e19-4c6f-832c-12b702bd1c7e
     status:
       code: 200
       message: OK
@@ -290,7 +295,7 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"properties":
-      {"addressPrefix": "10.122.225.0/24", "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]},
+      {"addressPrefix": "10.114.76.0/24", "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]},
       "name": "dev_master000002"}], "virtualNetworkPeerings": [], "enableDdosProtection":
       false, "enableVmProtection": false}}'
     headers:
@@ -303,14 +308,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '545'
+      - '544'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -318,17 +324,17 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"f3107554-9154-4b22-9c36-1fac76115638\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"433a4773-72eb-4d8a-9e51-02807e1379d8\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"48b28697-d257-4ca8-ba0f-ed8ca711842f\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"88b97458-5f24-4581-9541-9b8608123d8f\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"f3107554-9154-4b22-9c36-1fac76115638\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"433a4773-72eb-4d8a-9e51-02807e1379d8\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"addressPrefix\": \"10.122.225.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.114.76.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Updating\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -339,15 +345,15 @@ interactions:
         : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6a9d0b55-ea96-4a91-8eaa-745f8da46842?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6afab030-40eb-4111-90e2-3eee298fe180?api-version=2020-07-01
       cache-control:
       - no-cache
       content-length:
-      - '1619'
+      - '1618'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:33 GMT
+      - Wed, 09 Dec 2020 16:12:31 GMT
       expires:
       - '-1'
       pragma:
@@ -364,9 +370,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 7f4be222-7a90-42a6-b5b5-4fe98ab102b2
+      - 009f8ba0-5c3d-46c0-a248-09d22dae78dd
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 200
       message: OK
@@ -384,10 +390,11 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6a9d0b55-ea96-4a91-8eaa-745f8da46842?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6afab030-40eb-4111-90e2-3eee298fe180?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -399,7 +406,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:37 GMT
+      - Wed, 09 Dec 2020 16:12:35 GMT
       expires:
       - '-1'
       pragma:
@@ -416,7 +423,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 502f1295-118a-4075-a19e-20a129e8a9b5
+      - c62a6711-e2a3-4db0-b937-d35eca87e0f0
     status:
       code: 200
       message: OK
@@ -434,24 +441,25 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"b5485561-b6a4-49e6-9765-d881a5fc36e3\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"79f4bdbc-7c9f-43c0-9cb4-c22815700611\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"48b28697-d257-4ca8-ba0f-ed8ca711842f\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"88b97458-5f24-4581-9541-9b8608123d8f\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"b5485561-b6a4-49e6-9765-d881a5fc36e3\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"79f4bdbc-7c9f-43c0-9cb4-c22815700611\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.122.225.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.114.76.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -464,13 +472,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1622'
+      - '1621'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:37 GMT
+      - Wed, 09 Dec 2020 16:12:35 GMT
       etag:
-      - W/"b5485561-b6a4-49e6-9765-d881a5fc36e3"
+      - W/"79f4bdbc-7c9f-43c0-9cb4-c22815700611"
       expires:
       - '-1'
       pragma:
@@ -487,7 +495,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 074ea58a-a766-4fed-ade4-4cc1205a5e8a
+      - 9bc3cc1f-33ca-42f4-96e3-2a6f12f74ae3
     status:
       code: 200
       message: OK
@@ -505,8 +513,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -514,17 +523,17 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"b5485561-b6a4-49e6-9765-d881a5fc36e3\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"79f4bdbc-7c9f-43c0-9cb4-c22815700611\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"48b28697-d257-4ca8-ba0f-ed8ca711842f\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"88b97458-5f24-4581-9541-9b8608123d8f\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"b5485561-b6a4-49e6-9765-d881a5fc36e3\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"79f4bdbc-7c9f-43c0-9cb4-c22815700611\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.122.225.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.114.76.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -537,13 +546,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1622'
+      - '1621'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:38 GMT
+      - Wed, 09 Dec 2020 16:12:35 GMT
       etag:
-      - W/"b5485561-b6a4-49e6-9765-d881a5fc36e3"
+      - W/"79f4bdbc-7c9f-43c0-9cb4-c22815700611"
       expires:
       - '-1'
       pragma:
@@ -560,7 +569,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 95f5d31e-2043-48f7-9825-03a4aab795d9
+      - 7d68847b-8df6-48aa-ba2b-39934bad1cb6
     status:
       code: 200
       message: OK
@@ -568,10 +577,10 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "properties": {"addressPrefix": "10.122.225.0/24", "serviceEndpoints": [{"service":
+      "properties": {"addressPrefix": "10.114.76.0/24", "serviceEndpoints": [{"service":
       "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
       "Enabled", "privateLinkServiceNetworkPolicies": "Enabled"}, "name": "dev_master000002"},
-      {"properties": {"addressPrefix": "10.127.108.0/24", "serviceEndpoints": [{"service":
+      {"properties": {"addressPrefix": "10.4.242.0/24", "serviceEndpoints": [{"service":
       "Microsoft.ContainerRegistry"}]}, "name": "dev_worker000003"}], "virtualNetworkPeerings":
       [], "enableDdosProtection": false, "enableVmProtection": false}}'
     headers:
@@ -584,14 +593,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1004'
+      - '1001'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -599,17 +609,17 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"d28e72ab-bfe1-4777-b3b6-98e0e0f0af69\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"77a72575-e452-46bc-85cf-f843c9528fa8\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"48b28697-d257-4ca8-ba0f-ed8ca711842f\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"88b97458-5f24-4581-9541-9b8608123d8f\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"d28e72ab-bfe1-4777-b3b6-98e0e0f0af69\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"77a72575-e452-46bc-85cf-f843c9528fa8\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"addressPrefix\": \"10.122.225.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.114.76.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -618,9 +628,9 @@ interactions:
         : \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
         \r\n      },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n   \
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n        \"etag\": \"W/\\\"d28e72ab-bfe1-4777-b3b6-98e0e0f0af69\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"77a72575-e452-46bc-85cf-f843c9528fa8\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"addressPrefix\": \"10.127.108.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.4.242.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Updating\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -631,15 +641,15 @@ interactions:
         : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/5ce00ecd-309a-4acc-b790-823444e210eb?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/ca005fb6-9085-4c58-8106-ef137d49c20e?api-version=2020-07-01
       cache-control:
       - no-cache
       content-length:
-      - '2510'
+      - '2507'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:39 GMT
+      - Wed, 09 Dec 2020 16:12:36 GMT
       expires:
       - '-1'
       pragma:
@@ -656,9 +666,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 77c7fb77-6431-4c26-8d98-a211e88b13cd
+      - e935a563-b6fa-4018-8d15-fbe181cf3ec5
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 200
       message: OK
@@ -676,10 +686,11 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/5ce00ecd-309a-4acc-b790-823444e210eb?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/ca005fb6-9085-4c58-8106-ef137d49c20e?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -691,7 +702,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:42 GMT
+      - Wed, 09 Dec 2020 16:12:40 GMT
       expires:
       - '-1'
       pragma:
@@ -708,7 +719,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - c60efce3-55dd-4ce6-b3e0-a3c3d7870d03
+      - 9d5666cd-a0d9-4b6d-ba73-0a9e8c171dfd
     status:
       code: 200
       message: OK
@@ -726,24 +737,25 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"1b3fdba3-7991-4ea9-981f-eacbceb9d2c6\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"d5b51aa7-dfe2-4f9d-8220-c0e1506a2408\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"48b28697-d257-4ca8-ba0f-ed8ca711842f\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"88b97458-5f24-4581-9541-9b8608123d8f\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"1b3fdba3-7991-4ea9-981f-eacbceb9d2c6\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"d5b51aa7-dfe2-4f9d-8220-c0e1506a2408\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.122.225.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.114.76.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -752,9 +764,9 @@ interactions:
         : \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
         \r\n      },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n   \
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n        \"etag\": \"W/\\\"1b3fdba3-7991-4ea9-981f-eacbceb9d2c6\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"d5b51aa7-dfe2-4f9d-8220-c0e1506a2408\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.127.108.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.4.242.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -767,13 +779,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2514'
+      - '2511'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:42 GMT
+      - Wed, 09 Dec 2020 16:12:40 GMT
       etag:
-      - W/"1b3fdba3-7991-4ea9-981f-eacbceb9d2c6"
+      - W/"d5b51aa7-dfe2-4f9d-8220-c0e1506a2408"
       expires:
       - '-1'
       pragma:
@@ -790,7 +802,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 8f34a087-b259-4e32-b229-2cea80d03dd6
+      - b6dc3007-ab53-4fd5-ad4c-d2cee16ae328
     status:
       code: 200
       message: OK
@@ -808,8 +820,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -817,10 +830,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"1b3fdba3-7991-4ea9-981f-eacbceb9d2c6\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"d5b51aa7-dfe2-4f9d-8220-c0e1506a2408\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.122.225.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        addressPrefix\": \"10.114.76.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
         : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
         \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
         \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
@@ -830,13 +843,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '757'
+      - '756'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:43 GMT
+      - Wed, 09 Dec 2020 16:12:40 GMT
       etag:
-      - W/"1b3fdba3-7991-4ea9-981f-eacbceb9d2c6"
+      - W/"d5b51aa7-dfe2-4f9d-8220-c0e1506a2408"
       expires:
       - '-1'
       pragma:
@@ -853,13 +866,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 85b7d2bc-62de-4c9b-9260-43420e5bfa2b
+      - 335b5117-66f7-45c2-8c7d-cbeaafc49380
     status:
       code: 200
       message: OK
 - request:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "properties": {"addressPrefix": "10.122.225.0/24", "serviceEndpoints": [{"service":
+      "properties": {"addressPrefix": "10.114.76.0/24", "serviceEndpoints": [{"service":
       "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
       "Enabled", "privateLinkServiceNetworkPolicies": "Disabled"}, "name": "dev_master000002"}'
     headers:
@@ -872,14 +885,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '458'
+      - '457'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -887,10 +901,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"e33b6a18-900f-470b-8499-8617af5ade16\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"c4e13387-c216-4ae5-89fc-29b3b0d48cde\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
-        addressPrefix\": \"10.122.225.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        addressPrefix\": \"10.114.76.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
         : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
         \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
         \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
@@ -898,15 +912,15 @@ interactions:
         \r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/cb720f16-1cf3-4c94-b6bd-b62f848f6dbb?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/b9c13c9b-51b0-438b-84b3-acfff0c6ecd8?api-version=2020-07-01
       cache-control:
       - no-cache
       content-length:
-      - '757'
+      - '756'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:44 GMT
+      - Wed, 09 Dec 2020 16:12:40 GMT
       expires:
       - '-1'
       pragma:
@@ -916,10 +930,14 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - a1b3b48f-7a56-4a60-b540-1601a4d9673b
+      - ea028a5d-1458-4689-a44b-27ba83b9ace2
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -939,10 +957,11 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/cb720f16-1cf3-4c94-b6bd-b62f848f6dbb?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/b9c13c9b-51b0-438b-84b3-acfff0c6ecd8?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -954,7 +973,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:47 GMT
+      - Wed, 09 Dec 2020 16:12:44 GMT
       expires:
       - '-1'
       pragma:
@@ -971,7 +990,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e8a80e77-2626-45ed-9523-6a80e9db1145
+      - b7b88b7c-7fd7-487c-b2c4-60f079f01893
     status:
       code: 200
       message: OK
@@ -989,147 +1008,22 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"14abe618-4368-4375-a33a-c5770c3a66bf\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"4391a13a-89cb-424e-9f48-d4a5a06045f5\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.122.225.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        addressPrefix\": \"10.114.76.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
         : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
         \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
         \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
         : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '758'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 01 Dec 2020 20:28:47 GMT
-      etag:
-      - W/"14abe618-4368-4375-a33a-c5770c3a66bf"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 5c5059c3-5358-4fab-b2d9-b41f44f929db
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"14abe618-4368-4375-a33a-c5770c3a66bf\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.122.225.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '758'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 01 Dec 2020 20:28:47 GMT
-      etag:
-      - W/"14abe618-4368-4375-a33a-c5770c3a66bf"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - eb76b418-df9c-44c5-9c7b-6fcf0ccfe122
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n  \"etag\": \"W/\\\"14abe618-4368-4375-a33a-c5770c3a66bf\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.127.108.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
         \r\n}"
     headers:
       cache-control:
@@ -1139,9 +1033,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:48 GMT
+      - Wed, 09 Dec 2020 16:12:44 GMT
       etag:
-      - W/"14abe618-4368-4375-a33a-c5770c3a66bf"
+      - W/"4391a13a-89cb-424e-9f48-d4a5a06045f5"
       expires:
       - '-1'
       pragma:
@@ -1158,7 +1052,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 3a81a93a-08a6-4350-8de7-f531f980f58a
+      - 4d975e66-da1e-4eba-a8ba-1c3673e34a5e
     status:
       code: 200
       message: OK
@@ -1176,15 +1070,144 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
+        ,\r\n  \"etag\": \"W/\\\"4391a13a-89cb-424e-9f48-d4a5a06045f5\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.114.76.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '757'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 16:12:45 GMT
+      etag:
+      - W/"4391a13a-89cb-424e-9f48-d4a5a06045f5"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 40207f30-4201-4969-8325-66f1b93ce0dd
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\r\n  \"etag\": \"W/\\\"4391a13a-89cb-424e-9f48-d4a5a06045f5\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.4.242.0/24\",\r\n    \"serviceEndpoints\": [\r\n   \
+        \   {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '755'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 16:12:45 GMT
+      etag:
+      - W/"4391a13a-89cb-424e-9f48-d4a5a06045f5"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 92bbb673-b007-411c-9b31-a1ab5dbe86fa
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-resource/10.3.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_delete000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001","name":"cli_test_aro_delete000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-01T20:28:26Z","createdAt":"2020-12-01T20:28:26.9816675Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001","name":"cli_test_aro_delete000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-09T16:12:23Z","createdAt":"2020-12-09T16:12:24.7856306Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1193,7 +1216,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:48 GMT
+      - Wed, 09 Dec 2020 16:12:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1221,8 +1244,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-resource/10.3.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -1257,7 +1281,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:49 GMT
+      - Wed, 09 Dec 2020 16:12:46 GMT
       expires:
       - '-1'
       pragma:
@@ -1272,9 +1296,137 @@ interactions:
       code: 200
       message: OK
 - request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
+        ,\r\n  \"etag\": \"W/\\\"4391a13a-89cb-424e-9f48-d4a5a06045f5\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.114.76.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '757'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 16:12:46 GMT
+      etag:
+      - W/"4391a13a-89cb-424e-9f48-d4a5a06045f5"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 70972a63-adf5-4436-8a15-1d5ac8d70ac8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\r\n  \"etag\": \"W/\\\"4391a13a-89cb-424e-9f48-d4a5a06045f5\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.4.242.0/24\",\r\n    \"serviceEndpoints\": [\r\n   \
+        \   {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '755'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 16:12:46 GMT
+      etag:
+      - W/"4391a13a-89cb-424e-9f48-d4a5a06045f5"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - ef588dbe-4e4c-4193-a61f-f2234ad5d02a
+    status:
+      code: 200
+      message: OK
+- request:
     body: '{"passwordCredentials": [{"endDate": "2299-12-31T00:00:00.000Z", "value":
-      "ReplacedSPPassword123*"}], "displayName": "aro-ln6xcp7m", "identifierUris":
-      ["https://az.aro.azure.com/5b11a668-4466-4ba8-a5c3-dc377453fb66"]}'
+      "ReplacedSPPassword123*"}], "displayName": "aro-igim53r9", "identifierUris":
+      ["https://az.aro.azure.com/63628933-81d4-4de4-a873-c66dcaed9767"]}'
     headers:
       Accept:
       - application/json
@@ -1291,8 +1443,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
@@ -1301,28 +1454,28 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "6c2ff3ef-046b-435b-8ad4-ace0495d7530", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "bdbfddbd-2b8d-44ac-a3e8-e2442ccc0ffe",
+        "objectId": "82a1d6c4-42bf-43d1-aee7-10402ab37e32", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "22de8809-eaa4-49d9-bb3d-591373b1e7f9",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
-        false, "displayName": "aro-ln6xcp7m", "errorUrl": null, "groupMembershipClaims":
-        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/5b11a668-4466-4ba8-a5c3-dc377453fb66"],
+        false, "displayName": "aro-igim53r9", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/63628933-81d4-4de4-a873-c66dcaed9767"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/6c2ff3ef-046b-435b-8ad4-ace0495d7530/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/82a1d6c4-42bf-43d1-aee7-10402ab37e32/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/6c2ff3ef-046b-435b-8ad4-ace0495d7530/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/82a1d6c4-42bf-43d1-aee7-10402ab37e32/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
-        "Allow the application to access aro-ln6xcp7m on behalf of the signed-in user.",
-        "adminConsentDisplayName": "Access aro-ln6xcp7m", "id": "61d2ffa0-7483-41f8-b89a-307cde9ac7be",
+        "Allow the application to access aro-igim53r9 on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Access aro-igim53r9", "id": "3e541b8d-b95a-4a03-b2a9-0cc21a2901de",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
-        to access aro-ln6xcp7m on your behalf.", "userConsentDisplayName": "Access
-        aro-ln6xcp7m", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        to access aro-igim53r9 on your behalf.", "userConsentDisplayName": "Access
+        aro-igim53r9", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
         [{"customKeyIdentifier": null, "endDate": "2299-12-31T00:00:00Z", "keyId":
-        "2360a2bd-804b-475f-aae1-47fad10be32e", "startDate": "2020-12-01T20:28:50.6721374Z",
+        "af94471c-f3a5-4eb6-807d-549fdfcb4acc", "startDate": "2020-12-09T16:12:47.452892Z",
         "value": "ReplacedSPPassword123*"}], "publicClient": null, "publisherDomain":
         "rhcuppettgmail.onmicrosoft.com", "recordConsentConditions": null, "replyUrls":
         [], "requiredResourceAccess": [], "samlMetadataUrl": null, "signInAudience":
@@ -1333,27 +1486,27 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2267'
+      - '2266'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 01 Dec 2020 20:28:50 GMT
+      - Wed, 09 Dec 2020 16:12:47 GMT
       duration:
-      - '4968293'
+      - '4502902'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/6c2ff3ef-046b-435b-8ad4-ace0495d7530/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/82a1d6c4-42bf-43d1-aee7-10402ab37e32/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - lOKrvQBOuGF6JSf6BDbhoIr2PbvV+s2vss/lHnlCwO0=
+      - RWhUwQfkA820UAXB2a3FFwKnhwy5jxkjwd2p+y88XOY=
       ocp-aad-session-key:
-      - Xk0I69Q_RQuX3ot6nm9eO93d_FjhwR_hf0wmBG8b7pfBMnYXwOTalkeOlnTdwiSsR7AIozfC1cCOdq__U4FdVGRZjp7VAV1RdOYi2k0qFS_TH2ewepBUZzOfUyqb7EDUlhe6sMNER0yDG0FY3WSdi8LMBIxj1wulcldGjMbfZQE.nrbDJLhBqpl9De-iegFzzcqRf04AXkUO50MfdDVr41Q
+      - dhOPmxHzk7CoBQYWUPLg2n4FHz7fC8o-xlaKT7L_qikJPkr3XVFy2WF1bo8LMnUYJLMQTVA7iS1QWWUIeS8c-2pl2pFKAeP_Qn1Ym7Ag86oYAcMUWiOY9Y8HiS_M-jSay2IFu0AZ2pw6xFjo54yUdwHIEv14J0Njv9wm9TvPzh4.dFl3mKkB0AgbYqh3_uWaHioDUhWNX2v1wdjG2ecnJ5E
       pragma:
       - no-cache
       request-id:
-      - 8cd67092-8981-476a-8195-395a429ee757
+      - b9b4af38-d7a3-4d2e-9bff-baf8571ad509
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1381,12 +1534,13 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27bdbfddbd-2b8d-44ac-a3e8-e2442ccc0ffe%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%2722de8809-eaa4-49d9-bb3d-591373b1e7f9%27&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -1402,19 +1556,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 01 Dec 2020 20:28:51 GMT
+      - Wed, 09 Dec 2020 16:12:48 GMT
       duration:
-      - '262787'
+      - '340918'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - TPSpK7YqTzvrS9H9FJhKGkEhC59E8/CAvWjnDkKbAHc=
+      - /Dg1JmXFItNDSWtIVC+w1eGVH0VZLOi3+C+UY0KLSLA=
       ocp-aad-session-key:
-      - pAZvmjdhFbrXaGfyyVq4gRNqdp6ydkO1mK85fx8NE4v2kawEy0Om-oHOADcOZl4zmoZe7tt5U8EKHdCcPwk_utp-qmEseGfaUbripap5jx1g11z6vo6UdAQMlB0LQhhrh9dYm7BdiMpOQEs6ZaAFwEUMaKtNqU0aPIOo8tjVWeA.CGCNJRRV3SMBA4o9La9JfqJ1-wWi-ZwKz71Rmg66Yec
+      - YJLjG2TTBgqMLT3z8_NoI-uj0YniJ4NLOJ_HaUMqqO9AZKim9KtNX7ZEUH354BfJGzFyViQrh__a9KP3hlB1ksTqy-BXiLHb6NBMUQ1SEsg7cTpPgoCKeng4pbUu4RBvpK_-5D4e-KOeeI-0PIKN_Vu0Px-ZoJaZBc5CNd-m6rc.Xb9VPbeUIJd3fi9QCjKgPMjQeqHDTtpwzuP2CIhEZxU
       pragma:
       - no-cache
       request-id:
-      - 88256467-bb96-4fea-aa9f-e1fbca25f776
+      - 5b15aae4-b893-4d54-a3b3-7676dc9c9d93
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1429,7 +1583,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"appId": "bdbfddbd-2b8d-44ac-a3e8-e2442ccc0ffe"}'
+    body: '{"appId": "22de8809-eaa4-49d9-bb3d-591373b1e7f9"}'
     headers:
       Accept:
       - application/json
@@ -1446,20 +1600,21 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"00e7c116-5b2f-4710-bf71-ff36aee2c10f","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-ln6xcp7m","appId":"bdbfddbd-2b8d-44ac-a3e8-e2442ccc0ffe","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-ln6xcp7m","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access aro-ln6xcp7m on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        aro-ln6xcp7m","id":"61d2ffa0-7483-41f8-b89a-307cde9ac7be","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access aro-ln6xcp7m on your behalf.","userConsentDisplayName":"Access
-        aro-ln6xcp7m","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
-        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["bdbfddbd-2b8d-44ac-a3e8-e2442ccc0ffe","https://az.aro.azure.com/5b11a668-4466-4ba8-a5c3-dc377453fb66"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"28b696b7-8453-429d-9169-dfcd281c016a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-igim53r9","appId":"22de8809-eaa4-49d9-bb3d-591373b1e7f9","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-igim53r9","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access aro-igim53r9 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        aro-igim53r9","id":"3e541b8d-b95a-4a03-b2a9-0cc21a2901de","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access aro-igim53r9 on your behalf.","userConsentDisplayName":"Access
+        aro-igim53r9","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
+        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["22de8809-eaa4-49d9-bb3d-591373b1e7f9","https://az.aro.azure.com/63628933-81d4-4de4-a873-c66dcaed9767"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1472,21 +1627,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 01 Dec 2020 20:28:51 GMT
+      - Wed, 09 Dec 2020 16:12:48 GMT
       duration:
-      - '1652189'
+      - '3487009'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/00e7c116-5b2f-4710-bf71-ff36aee2c10f/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/28b696b7-8453-429d-9169-dfcd281c016a/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - 4T/yOYQhGpOrInpxqOjT/TWdA4YNWkgrlvDYW3S6/zQ=
+      - jHDkJUPNKaKjxbhtTdt7BEAPlFEz9XCgTpFLDpmYcJc=
       ocp-aad-session-key:
-      - XEH-bD-9lmSUG3tnVn1yrYMy07Si1wAYds099gxXNNx5sNylk4IBCbmszehMK6Y5jJwbQvPbEC8s_oFGXbyrXdInN9TMQRabxqdvGtEgPRF6QGpvo_M7yi_QpclWdZX5-UNfCxVvPUOaq_oyUfC_HItPYrEH2CxH4snXZJW3Bx0.PpFTSCb-5ou7epgQtnbxif_wp7iNyRIroDbSq7Db1IQ
+      - qXpS4vVgRO3MHFAnK-GcPoKhTiXA5CjMHQE0uPt77KMyrujQwXD2z0t_XZm13Y6pANGk2uXH8q49Wykfa4TZTbYeb33rTgarurYBFfwycxeqAFG0qbyDbd0abZWzItfpLR31PE2gXK5KL8zwsnJ6ngmy5DMoMJUWZ-cRB5iglxs.b8yKIJzNrFjLiiPsB5T-vXP1z47NEoJPyu4um8nebBg
       pragma:
       - no-cache
       request-id:
-      - 2d81911e-03a6-438a-89fc-5660a6bcb6cd
+      - 10af2ec4-8150-4c11-b69a-1444281b08c4
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1514,8 +1669,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -1538,19 +1694,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 01 Dec 2020 20:28:51 GMT
+      - Wed, 09 Dec 2020 16:12:48 GMT
       duration:
-      - '328837'
+      - '847834'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 5kVIXkwNXttHETyxIO/1UNLAPOmKrPKEEC4jNkI8EIY=
+      - S49r+eBoSgNeYE71hxU6pIgvGCQ+owMLkESNUZQvFlo=
       ocp-aad-session-key:
-      - V3d6IfXou8RxtHNWtL3-QkBNg3ZuaD8jFWyiG7muRckMYwVIBMwYwHUxWVcDtvliQIhfYZM6R6H_L6u103NSBPaeSdSwkXIT5qB7qneI5LY5ogTm5_ujQVzEtZyVDqkyuilWcM2GyF_zE9ZOyzlYc5lWWXj-l4GIL8IqMoJKiSU.2eO_WzhtDtzjIHDr5VziI4iqd9x4sNVWARPLIDWQVdA
+      - JbP2YogfGVq6DK-X2GCYNMuvGYzfHlBkG9cNY8T1aAYvPsi8etYEXZ87OugVB-AAUsdgAjDi3fb_xrxhYoi430oLyQUsX8S-bPE-1yW7hTM_Gm56uu0FEt78I-HFYvNmBthV4HkdNkErLoBWpO7v8wA9zfnlyPu6xy47e81Qx48.6hyxzUq2U48Beyrgr5oDygJHf7EfbXHZOPgFi404Oqo
       pragma:
       - no-cache
       request-id:
-      - d234426d-711d-410c-bf26-ec29560fc5fc
+      - 57ffffb2-9194-47bd-a035-4a7b68ea8855
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1578,8 +1734,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -1595,7 +1752,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:52 GMT
+      - Wed, 09 Dec 2020 16:12:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1615,7 +1772,7 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
-      "principalId": "00e7c116-5b2f-4710-bf71-ff36aee2c10f", "principalType": "ServicePrincipal"}}'
+      "principalId": "28b696b7-8453-429d-9169-dfcd281c016a", "principalType": "ServicePrincipal"}}'
     headers:
       Accept:
       - application/json
@@ -1629,20 +1786,19 @@ interactions:
       - '270'
       Content-Type:
       - application/json; charset=utf-8
-      Cookie:
-      - x-ms-gateway-slice=Production
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"00e7c116-5b2f-4710-bf71-ff36aee2c10f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-01T20:28:52.9678345Z","updatedOn":"2020-12-01T20:28:52.9678345Z","createdBy":null,"updatedBy":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"28b696b7-8453-429d-9169-dfcd281c016a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T16:12:50.3908165Z","updatedOn":"2020-12-09T16:12:50.3908165Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
     headers:
       cache-control:
       - no-cache
@@ -1651,7 +1807,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:54 GMT
+      - Wed, 09 Dec 2020 16:12:51 GMT
       expires:
       - '-1'
       pragma:
@@ -1663,7 +1819,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -1681,141 +1837,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"14abe618-4368-4375-a33a-c5770c3a66bf\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.122.225.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '758'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 01 Dec 2020 20:28:54 GMT
-      etag:
-      - W/"14abe618-4368-4375-a33a-c5770c3a66bf"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 5e4ddaee-ec6a-48a3-b794-f0459a11395c
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n  \"etag\": \"W/\\\"14abe618-4368-4375-a33a-c5770c3a66bf\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.127.108.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 01 Dec 2020 20:28:54 GMT
-      etag:
-      - W/"14abe618-4368-4375-a33a-c5770c3a66bf"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - f50aff79-df28-4ec4-a7ad-829247cecd57
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"00e7c116-5b2f-4710-bf71-ff36aee2c10f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-01T20:28:53.5532351Z","updatedOn":"2020-12-01T20:28:53.5532351Z","createdBy":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","updatedBy":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.4824942Z","updatedOn":"2020-06-16T16:25:39.4824942Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e77058da-a7bf-4e89-8e48-7d9f61fa8246","type":"Microsoft.Authorization/roleAssignments","name":"e77058da-a7bf-4e89-8e48-7d9f61fa8246"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:12:52.8054393Z","updatedOn":"2020-11-25T05:12:52.8054393Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dea2d3a8-cf99-4169-b8dd-819b4c611a32","type":"Microsoft.Authorization/roleAssignments","name":"dea2d3a8-cf99-4169-b8dd-819b4c611a32"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:34:01.2642084Z","updatedOn":"2020-11-25T05:34:01.2642084Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bacc53c-9077-49ce-a14d-370bc09f72d8","type":"Microsoft.Authorization/roleAssignments","name":"4bacc53c-9077-49ce-a14d-370bc09f72d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6949b2a1-9b3e-42c8-b228-0b6c14927377","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-30T19:34:16.5100204Z","updatedOn":"2020-07-30T19:34:16.5100204Z","createdBy":"5bc13990-50e4-4898-835e-d026e066bba5","updatedBy":"5bc13990-50e4-4898-835e-d026e066bba5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/53b0d735-2402-41c6-9d6d-b2338a287741","type":"Microsoft.Authorization/roleAssignments","name":"53b0d735-2402-41c6-9d6d-b2338a287741"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4c480e6-1f29-4163-9a37-2b16a7e8e5c8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-16T13:48:13.9171700Z","updatedOn":"2020-09-16T13:48:13.9171700Z","createdBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","updatedBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8476200c-5011-42c4-9028-360ef1739a8d","type":"Microsoft.Authorization/roleAssignments","name":"8476200c-5011-42c4-9028-360ef1739a8d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"28b696b7-8453-429d-9169-dfcd281c016a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T16:12:51.1251975Z","updatedOn":"2020-12-09T16:12:51.1251975Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.4824942Z","updatedOn":"2020-06-16T16:25:39.4824942Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e77058da-a7bf-4e89-8e48-7d9f61fa8246","type":"Microsoft.Authorization/roleAssignments","name":"e77058da-a7bf-4e89-8e48-7d9f61fa8246"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:12:52.8054393Z","updatedOn":"2020-11-25T05:12:52.8054393Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dea2d3a8-cf99-4169-b8dd-819b4c611a32","type":"Microsoft.Authorization/roleAssignments","name":"dea2d3a8-cf99-4169-b8dd-819b4c611a32"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:34:01.2642084Z","updatedOn":"2020-11-25T05:34:01.2642084Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bacc53c-9077-49ce-a14d-370bc09f72d8","type":"Microsoft.Authorization/roleAssignments","name":"4bacc53c-9077-49ce-a14d-370bc09f72d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6949b2a1-9b3e-42c8-b228-0b6c14927377","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-30T19:34:16.5100204Z","updatedOn":"2020-07-30T19:34:16.5100204Z","createdBy":"5bc13990-50e4-4898-835e-d026e066bba5","updatedBy":"5bc13990-50e4-4898-835e-d026e066bba5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/53b0d735-2402-41c6-9d6d-b2338a287741","type":"Microsoft.Authorization/roleAssignments","name":"53b0d735-2402-41c6-9d6d-b2338a287741"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4c480e6-1f29-4163-9a37-2b16a7e8e5c8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-16T13:48:13.9171700Z","updatedOn":"2020-09-16T13:48:13.9171700Z","createdBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","updatedBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8476200c-5011-42c4-9028-360ef1739a8d","type":"Microsoft.Authorization/roleAssignments","name":"8476200c-5011-42c4-9028-360ef1739a8d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
     headers:
       cache-control:
       - no-cache
@@ -1824,7 +1855,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:54 GMT
+      - Wed, 09 Dec 2020 16:12:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1858,20 +1889,19 @@ interactions:
       - '270'
       Content-Type:
       - application/json; charset=utf-8
-      Cookie:
-      - x-ms-gateway-slice=Production
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-01T20:28:55.6592967Z","updatedOn":"2020-12-01T20:28:55.6592967Z","createdBy":null,"updatedBy":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T16:12:53.1269733Z","updatedOn":"2020-12-09T16:12:53.1269733Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
     headers:
       cache-control:
       - no-cache
@@ -1880,7 +1910,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 20:28:56 GMT
+      - Wed, 09 Dec 2020 16:12:54 GMT
       expires:
       - '-1'
       pragma:
@@ -1892,141 +1922,15 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"14abe618-4368-4375-a33a-c5770c3a66bf\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.122.225.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '758'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 01 Dec 2020 20:28:56 GMT
-      etag:
-      - W/"14abe618-4368-4375-a33a-c5770c3a66bf"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 8b87066f-3bea-44c0-933d-453ba6d3fb9c
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n  \"etag\": \"W/\\\"14abe618-4368-4375-a33a-c5770c3a66bf\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.127.108.0/24\",\r\n    \"serviceEndpoints\": [\r\n \
-        \     {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 01 Dec 2020 20:28:56 GMT
-      etag:
-      - W/"14abe618-4368-4375-a33a-c5770c3a66bf"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - d322b49f-8aed-47a2-9802-c91fb1c0d956
-    status:
-      code: 200
-      message: OK
-- request:
     body: '{"tags": {"test": "delete"}, "location": "eastus", "properties": {"clusterProfile":
-      {"pullSecret": "", "domain": "ln6xcp7m", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m"},
-      "servicePrincipalProfile": {"clientId": "bdbfddbd-2b8d-44ac-a3e8-e2442ccc0ffe",
-      "clientSecret": "9de28c1b-661d-4787-9bc8-24775e52bf20"}, "networkProfile": {"podCidr":
+      {"pullSecret": "", "domain": "igim53r9", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9"},
+      "servicePrincipalProfile": {"clientId": "22de8809-eaa4-49d9-bb3d-591373b1e7f9",
+      "clientSecret": "87c33a47-052e-41f3-9e80-422a922861bb"}, "networkProfile": {"podCidr":
       "10.128.0.0/14", "serviceCidr": "172.30.0.0/16"}, "masterProfile": {"vmSize":
       "Standard_D8s_v3", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002"},
       "workerProfiles": [{"name": "worker", "vmSize": "Standard_D4s_v3", "diskSizeGB":
@@ -2049,8 +1953,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -2061,11 +1966,11 @@ interactions:
         ,\n    \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\"\
         ,\n    \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"delete\"\
         \n    },\n    \"properties\": {\n        \"provisioningState\": \"Creating\"\
-        ,\n        \"clusterProfile\": {\n            \"domain\": \"ln6xcp7m\",\n\
+        ,\n        \"clusterProfile\": {\n            \"domain\": \"igim53r9\",\n\
         \            \"version\": \"4.5.16\",\n            \"resourceGroupId\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-ln6xcp7m\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-igim53r9\"\
         \n        },\n        \"consoleProfile\": {},\n        \"servicePrincipalProfile\"\
-        : {\n            \"clientId\": \"bdbfddbd-2b8d-44ac-a3e8-e2442ccc0ffe\"\n\
+        : {\n            \"clientId\": \"22de8809-eaa4-49d9-bb3d-591373b1e7f9\"\n\
         \        },\n        \"networkProfile\": {\n            \"podCidr\": \"10.128.0.0/14\"\
         ,\n            \"serviceCidr\": \"172.30.0.0/16\"\n        },\n        \"\
         masterProfile\": {\n            \"vmSize\": \"Standard_D8s_v3\",\n       \
@@ -2080,7 +1985,7 @@ interactions:
         \   \"visibility\": \"Public\"\n            }\n        ]\n    }\n}\n"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -2088,7 +1993,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:28:58 GMT
+      - Wed, 09 Dec 2020 16:12:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2098,7 +2003,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -2116,15 +2021,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2133,7 +2039,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:29:29 GMT
+      - Wed, 09 Dec 2020 16:13:26 GMT
       expires:
       - '-1'
       pragma:
@@ -2163,15 +2069,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2180,7 +2087,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:29:59 GMT
+      - Wed, 09 Dec 2020 16:13:56 GMT
       expires:
       - '-1'
       pragma:
@@ -2210,15 +2117,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2227,7 +2135,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:30:30 GMT
+      - Wed, 09 Dec 2020 16:14:26 GMT
       expires:
       - '-1'
       pragma:
@@ -2257,15 +2165,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2274,7 +2183,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:31:00 GMT
+      - Wed, 09 Dec 2020 16:14:56 GMT
       expires:
       - '-1'
       pragma:
@@ -2304,15 +2213,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2321,7 +2231,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:31:30 GMT
+      - Wed, 09 Dec 2020 16:15:27 GMT
       expires:
       - '-1'
       pragma:
@@ -2351,15 +2261,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2368,7 +2279,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:32:00 GMT
+      - Wed, 09 Dec 2020 16:15:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2398,15 +2309,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2415,7 +2327,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:32:30 GMT
+      - Wed, 09 Dec 2020 16:16:27 GMT
       expires:
       - '-1'
       pragma:
@@ -2445,15 +2357,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2462,7 +2375,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:33:01 GMT
+      - Wed, 09 Dec 2020 16:16:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2492,15 +2405,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2509,7 +2423,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:33:30 GMT
+      - Wed, 09 Dec 2020 16:17:27 GMT
       expires:
       - '-1'
       pragma:
@@ -2539,15 +2453,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2556,7 +2471,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:34:02 GMT
+      - Wed, 09 Dec 2020 16:17:58 GMT
       expires:
       - '-1'
       pragma:
@@ -2586,15 +2501,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2603,7 +2519,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:34:32 GMT
+      - Wed, 09 Dec 2020 16:18:28 GMT
       expires:
       - '-1'
       pragma:
@@ -2633,15 +2549,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2650,7 +2567,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:35:02 GMT
+      - Wed, 09 Dec 2020 16:18:58 GMT
       expires:
       - '-1'
       pragma:
@@ -2680,15 +2597,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2697,7 +2615,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:35:32 GMT
+      - Wed, 09 Dec 2020 16:19:28 GMT
       expires:
       - '-1'
       pragma:
@@ -2727,15 +2645,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2744,7 +2663,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:36:02 GMT
+      - Wed, 09 Dec 2020 16:19:58 GMT
       expires:
       - '-1'
       pragma:
@@ -2774,15 +2693,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2791,7 +2711,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:36:32 GMT
+      - Wed, 09 Dec 2020 16:20:29 GMT
       expires:
       - '-1'
       pragma:
@@ -2821,15 +2741,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2838,7 +2759,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:37:02 GMT
+      - Wed, 09 Dec 2020 16:20:59 GMT
       expires:
       - '-1'
       pragma:
@@ -2868,15 +2789,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2885,7 +2807,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:37:32 GMT
+      - Wed, 09 Dec 2020 16:21:29 GMT
       expires:
       - '-1'
       pragma:
@@ -2915,15 +2837,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2932,7 +2855,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:38:02 GMT
+      - Wed, 09 Dec 2020 16:21:59 GMT
       expires:
       - '-1'
       pragma:
@@ -2962,15 +2885,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2979,7 +2903,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:38:33 GMT
+      - Wed, 09 Dec 2020 16:22:29 GMT
       expires:
       - '-1'
       pragma:
@@ -3009,15 +2933,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3026,7 +2951,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:39:03 GMT
+      - Wed, 09 Dec 2020 16:22:59 GMT
       expires:
       - '-1'
       pragma:
@@ -3056,15 +2981,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3073,7 +2999,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:39:33 GMT
+      - Wed, 09 Dec 2020 16:23:29 GMT
       expires:
       - '-1'
       pragma:
@@ -3103,15 +3029,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3120,7 +3047,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:40:03 GMT
+      - Wed, 09 Dec 2020 16:24:00 GMT
       expires:
       - '-1'
       pragma:
@@ -3150,15 +3077,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3167,7 +3095,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:40:33 GMT
+      - Wed, 09 Dec 2020 16:24:31 GMT
       expires:
       - '-1'
       pragma:
@@ -3197,15 +3125,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3214,7 +3143,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:41:04 GMT
+      - Wed, 09 Dec 2020 16:25:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3244,15 +3173,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3261,7 +3191,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:41:34 GMT
+      - Wed, 09 Dec 2020 16:25:31 GMT
       expires:
       - '-1'
       pragma:
@@ -3291,15 +3221,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3308,7 +3239,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:42:04 GMT
+      - Wed, 09 Dec 2020 16:26:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3338,15 +3269,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3355,7 +3287,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:42:35 GMT
+      - Wed, 09 Dec 2020 16:26:31 GMT
       expires:
       - '-1'
       pragma:
@@ -3385,15 +3317,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3402,7 +3335,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:43:05 GMT
+      - Wed, 09 Dec 2020 16:27:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3432,15 +3365,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3449,7 +3383,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:43:35 GMT
+      - Wed, 09 Dec 2020 16:27:31 GMT
       expires:
       - '-1'
       pragma:
@@ -3479,15 +3413,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3496,7 +3431,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:44:05 GMT
+      - Wed, 09 Dec 2020 16:28:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3526,15 +3461,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3543,7 +3479,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:44:35 GMT
+      - Wed, 09 Dec 2020 16:28:33 GMT
       expires:
       - '-1'
       pragma:
@@ -3573,15 +3509,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3590,7 +3527,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:45:05 GMT
+      - Wed, 09 Dec 2020 16:29:03 GMT
       expires:
       - '-1'
       pragma:
@@ -3620,15 +3557,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3637,7 +3575,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:45:35 GMT
+      - Wed, 09 Dec 2020 16:29:33 GMT
       expires:
       - '-1'
       pragma:
@@ -3667,15 +3605,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3684,7 +3623,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:46:05 GMT
+      - Wed, 09 Dec 2020 16:30:03 GMT
       expires:
       - '-1'
       pragma:
@@ -3714,15 +3653,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3731,7 +3671,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:46:35 GMT
+      - Wed, 09 Dec 2020 16:30:33 GMT
       expires:
       - '-1'
       pragma:
@@ -3761,15 +3701,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3778,7 +3719,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:47:06 GMT
+      - Wed, 09 Dec 2020 16:31:03 GMT
       expires:
       - '-1'
       pragma:
@@ -3808,15 +3749,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3825,7 +3767,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:47:36 GMT
+      - Wed, 09 Dec 2020 16:31:33 GMT
       expires:
       - '-1'
       pragma:
@@ -3855,15 +3797,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3872,7 +3815,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:48:06 GMT
+      - Wed, 09 Dec 2020 16:32:03 GMT
       expires:
       - '-1'
       pragma:
@@ -3902,15 +3845,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3919,7 +3863,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:48:36 GMT
+      - Wed, 09 Dec 2020 16:32:33 GMT
       expires:
       - '-1'
       pragma:
@@ -3949,15 +3893,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3966,7 +3911,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:49:06 GMT
+      - Wed, 09 Dec 2020 16:33:03 GMT
       expires:
       - '-1'
       pragma:
@@ -3996,15 +3941,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4013,7 +3959,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:49:36 GMT
+      - Wed, 09 Dec 2020 16:33:34 GMT
       expires:
       - '-1'
       pragma:
@@ -4043,15 +3989,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4060,7 +4007,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:50:07 GMT
+      - Wed, 09 Dec 2020 16:34:04 GMT
       expires:
       - '-1'
       pragma:
@@ -4090,15 +4037,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4107,7 +4055,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:50:37 GMT
+      - Wed, 09 Dec 2020 16:34:35 GMT
       expires:
       - '-1'
       pragma:
@@ -4137,15 +4085,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4154,7 +4103,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:51:07 GMT
+      - Wed, 09 Dec 2020 16:35:05 GMT
       expires:
       - '-1'
       pragma:
@@ -4184,15 +4133,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4201,7 +4151,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:51:38 GMT
+      - Wed, 09 Dec 2020 16:35:35 GMT
       expires:
       - '-1'
       pragma:
@@ -4231,15 +4181,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4248,7 +4199,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:52:08 GMT
+      - Wed, 09 Dec 2020 16:36:05 GMT
       expires:
       - '-1'
       pragma:
@@ -4278,15 +4229,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4295,7 +4247,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:52:38 GMT
+      - Wed, 09 Dec 2020 16:36:35 GMT
       expires:
       - '-1'
       pragma:
@@ -4325,15 +4277,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4342,7 +4295,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:53:08 GMT
+      - Wed, 09 Dec 2020 16:37:05 GMT
       expires:
       - '-1'
       pragma:
@@ -4372,15 +4325,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4389,7 +4343,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:53:39 GMT
+      - Wed, 09 Dec 2020 16:37:35 GMT
       expires:
       - '-1'
       pragma:
@@ -4419,15 +4373,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4436,7 +4391,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:54:09 GMT
+      - Wed, 09 Dec 2020 16:38:06 GMT
       expires:
       - '-1'
       pragma:
@@ -4466,15 +4421,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4483,7 +4439,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:54:39 GMT
+      - Wed, 09 Dec 2020 16:38:36 GMT
       expires:
       - '-1'
       pragma:
@@ -4513,15 +4469,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4530,7 +4487,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:55:09 GMT
+      - Wed, 09 Dec 2020 16:39:06 GMT
       expires:
       - '-1'
       pragma:
@@ -4560,15 +4517,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4577,7 +4535,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:55:39 GMT
+      - Wed, 09 Dec 2020 16:39:36 GMT
       expires:
       - '-1'
       pragma:
@@ -4607,15 +4565,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4624,7 +4583,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:56:09 GMT
+      - Wed, 09 Dec 2020 16:40:07 GMT
       expires:
       - '-1'
       pragma:
@@ -4654,15 +4613,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4671,7 +4631,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:56:40 GMT
+      - Wed, 09 Dec 2020 16:40:37 GMT
       expires:
       - '-1'
       pragma:
@@ -4701,15 +4661,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4718,7 +4679,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:57:10 GMT
+      - Wed, 09 Dec 2020 16:41:07 GMT
       expires:
       - '-1'
       pragma:
@@ -4748,15 +4709,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4765,7 +4727,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:57:40 GMT
+      - Wed, 09 Dec 2020 16:41:37 GMT
       expires:
       - '-1'
       pragma:
@@ -4795,15 +4757,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4812,7 +4775,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:58:10 GMT
+      - Wed, 09 Dec 2020 16:42:07 GMT
       expires:
       - '-1'
       pragma:
@@ -4842,15 +4805,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4859,7 +4823,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:58:40 GMT
+      - Wed, 09 Dec 2020 16:42:38 GMT
       expires:
       - '-1'
       pragma:
@@ -4889,15 +4853,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4906,7 +4871,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:59:10 GMT
+      - Wed, 09 Dec 2020 16:43:08 GMT
       expires:
       - '-1'
       pragma:
@@ -4936,15 +4901,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4953,7 +4919,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 20:59:41 GMT
+      - Wed, 09 Dec 2020 16:43:38 GMT
       expires:
       - '-1'
       pragma:
@@ -4983,15 +4949,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5000,7 +4967,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:00:11 GMT
+      - Wed, 09 Dec 2020 16:44:08 GMT
       expires:
       - '-1'
       pragma:
@@ -5030,15 +4997,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5047,7 +5015,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:00:41 GMT
+      - Wed, 09 Dec 2020 16:44:39 GMT
       expires:
       - '-1'
       pragma:
@@ -5077,15 +5045,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5094,7 +5063,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:01:11 GMT
+      - Wed, 09 Dec 2020 16:45:09 GMT
       expires:
       - '-1'
       pragma:
@@ -5124,15 +5093,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5141,7 +5111,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:01:41 GMT
+      - Wed, 09 Dec 2020 16:45:39 GMT
       expires:
       - '-1'
       pragma:
@@ -5171,15 +5141,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5188,7 +5159,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:02:11 GMT
+      - Wed, 09 Dec 2020 16:46:09 GMT
       expires:
       - '-1'
       pragma:
@@ -5218,15 +5189,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5235,7 +5207,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:02:42 GMT
+      - Wed, 09 Dec 2020 16:46:39 GMT
       expires:
       - '-1'
       pragma:
@@ -5265,1849 +5237,17 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:03:12 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:03:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:05:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:06:17 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:06:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:07:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:07:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:08:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:08:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:09:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:09:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:10:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:10:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:11:19 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:11:50 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:12:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:12:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:13:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:13:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:14:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:14:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:15:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:15:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:16:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:16:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:17:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:17:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:18:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:18:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:19:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:19:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:20:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:20:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:21:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:21:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:22:25 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:22:55 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:23:26 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Creating\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:23:57 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/742a18a0-11f0-44f9-8cd7-6b1eb635f02c\"\
-        ,\n    \"name\": \"742a18a0-11f0-44f9-8cd7-6b1eb635f02c\",\n    \"status\"\
-        : \"Succeeded\",\n    \"startTime\": \"2020-12-01T20:28:58.960918276Z\",\n\
-        \    \"endTime\": \"2020-12-01T21:24:02.78461647Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/801d206c-6347-4eb7-83e4-1987746ba4d5\"\
+        ,\n    \"name\": \"801d206c-6347-4eb7-83e4-1987746ba4d5\",\n    \"status\"\
+        : \"Succeeded\",\n    \"startTime\": \"2020-12-09T16:12:55.909294887Z\",\n\
+        \    \"endTime\": \"2020-12-09T16:46:49.82169737Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -7116,7 +5256,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:24:27 GMT
+      - Wed, 09 Dec 2020 16:47:09 GMT
       expires:
       - '-1'
       pragma:
@@ -7146,8 +5286,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
   response:
@@ -7156,42 +5297,42 @@ interactions:
         ,\n    \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\"\
         ,\n    \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"delete\"\
         \n    },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\"\
-        ,\n        \"clusterProfile\": {\n            \"domain\": \"ln6xcp7m\",\n\
+        ,\n        \"clusterProfile\": {\n            \"domain\": \"igim53r9\",\n\
         \            \"version\": \"4.5.16\",\n            \"resourceGroupId\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-ln6xcp7m\"\
-        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.ln6xcp7m.eastus.aroapp.io/\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-igim53r9\"\
+        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.igim53r9.eastus.aroapp.io/\"\
         \n        },\n        \"servicePrincipalProfile\": {\n            \"clientId\"\
-        : \"bdbfddbd-2b8d-44ac-a3e8-e2442ccc0ffe\"\n        },\n        \"networkProfile\"\
+        : \"22de8809-eaa4-49d9-bb3d-591373b1e7f9\"\n        },\n        \"networkProfile\"\
         : {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\"\
         : \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n          \
         \  \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
         \n        },\n        \"workerProfiles\": [\n            {\n             \
-        \   \"name\": \"aro000004-t26rq-worker-eastus1\",\n                \"vmSize\"\
+        \   \"name\": \"aro000004-zg8mz-worker-eastus1\",\n                \"vmSize\"\
         : \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n           \
         \     \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-t26rq-worker-eastus2\",\n                \"\
+        \       \"name\": \"aro000004-zg8mz-worker-eastus2\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-t26rq-worker-eastus3\",\n                \"\
+        \       \"name\": \"aro000004-zg8mz-worker-eastus3\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            }\n        ],\n        \"apiserverProfile\"\
-        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.ln6xcp7m.eastus.aroapp.io:6443/\"\
-        ,\n            \"ip\": \"40.76.157.148\"\n        },\n        \"ingressProfiles\"\
+        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.igim53r9.eastus.aroapp.io:6443/\"\
+        ,\n            \"ip\": \"52.149.171.163\"\n        },\n        \"ingressProfiles\"\
         : [\n            {\n                \"name\": \"default\",\n             \
-        \   \"visibility\": \"Public\",\n                \"ip\": \"40.88.227.244\"\
+        \   \"visibility\": \"Public\",\n                \"ip\": \"20.72.160.134\"\
         \n            }\n        ]\n    }\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2867'
+      - '2868'
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:24:27 GMT
+      - Wed, 09 Dec 2020 16:47:09 GMT
       expires:
       - '-1'
       pragma:
@@ -7221,8 +5362,9 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -7233,42 +5375,42 @@ interactions:
         ,\n    \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\"\
         ,\n    \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"delete\"\
         \n    },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\"\
-        ,\n        \"clusterProfile\": {\n            \"domain\": \"ln6xcp7m\",\n\
+        ,\n        \"clusterProfile\": {\n            \"domain\": \"igim53r9\",\n\
         \            \"version\": \"4.5.16\",\n            \"resourceGroupId\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-ln6xcp7m\"\
-        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.ln6xcp7m.eastus.aroapp.io/\"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-igim53r9\"\
+        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.igim53r9.eastus.aroapp.io/\"\
         \n        },\n        \"servicePrincipalProfile\": {\n            \"clientId\"\
-        : \"bdbfddbd-2b8d-44ac-a3e8-e2442ccc0ffe\"\n        },\n        \"networkProfile\"\
+        : \"22de8809-eaa4-49d9-bb3d-591373b1e7f9\"\n        },\n        \"networkProfile\"\
         : {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\"\
         : \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n          \
         \  \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
         \n        },\n        \"workerProfiles\": [\n            {\n             \
-        \   \"name\": \"aro000004-t26rq-worker-eastus1\",\n                \"vmSize\"\
+        \   \"name\": \"aro000004-zg8mz-worker-eastus1\",\n                \"vmSize\"\
         : \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n           \
         \     \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-t26rq-worker-eastus2\",\n                \"\
+        \       \"name\": \"aro000004-zg8mz-worker-eastus2\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-t26rq-worker-eastus3\",\n                \"\
+        \       \"name\": \"aro000004-zg8mz-worker-eastus3\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            }\n        ],\n        \"apiserverProfile\"\
-        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.ln6xcp7m.eastus.aroapp.io:6443/\"\
-        ,\n            \"ip\": \"40.76.157.148\"\n        },\n        \"ingressProfiles\"\
+        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.igim53r9.eastus.aroapp.io:6443/\"\
+        ,\n            \"ip\": \"52.149.171.163\"\n        },\n        \"ingressProfiles\"\
         : [\n            {\n                \"name\": \"default\",\n             \
-        \   \"visibility\": \"Public\",\n                \"ip\": \"40.88.227.244\"\
+        \   \"visibility\": \"Public\",\n                \"ip\": \"20.72.160.134\"\
         \n            }\n        ]\n    }\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2867'
+      - '2868'
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:24:28 GMT
+      - Wed, 09 Dec 2020 16:47:11 GMT
       expires:
       - '-1'
       pragma:
@@ -7298,8 +5440,150 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\r\n  \"etag\": \"W/\\\"f3c61216-c027-4f3f-8375-f9c06e76e361\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.4.242.0/24\",\r\n    \"networkSecurityGroup\": {\r\n\
+        \      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9/providers/Microsoft.Network/networkSecurityGroups/aro000004-zg8mz-nsg\"\
+        \r\n    },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9/providers/Microsoft.Network/networkInterfaces/aro000004-zg8mz-worker-eastus3-zq667-nic/ipConfigurations/pipConfig\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9/providers/Microsoft.Network/networkInterfaces/aro000004-zg8mz-worker-eastus1-mfpzh-nic/ipConfigurations/pipConfig\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9/providers/Microsoft.Network/networkInterfaces/aro000004-zg8mz-worker-eastus2-ghf7w-nic/ipConfigurations/pipConfig\"\
+        \r\n      }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n      \
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\"\
+        ,\r\n        \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\
+        \n    ],\r\n    \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\"\
+        : \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\
+        \n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1703'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 16:47:11 GMT
+      etag:
+      - W/"f3c61216-c027-4f3f-8375-f9c06e76e361"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 92f197ff-e0cc-4818-ba45-c8f93bb11c6b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -y -g -n --subscription
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
+        ,\r\n  \"etag\": \"W/\\\"f3c61216-c027-4f3f-8375-f9c06e76e361\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.114.76.0/24\",\r\n    \"networkSecurityGroup\": {\r\n\
+        \      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9/providers/Microsoft.Network/networkSecurityGroups/aro000004-zg8mz-nsg\"\
+        \r\n    },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9/providers/Microsoft.Network/loadBalancers/aro000004-zg8mz-internal/frontendIPConfigurations/internal-lb-ip-v4\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9/providers/Microsoft.Network/networkInterfaces/aro000004-zg8mz-pls.nic.c79b199f-1492-4c3b-909e-667be3b79d80/ipConfigurations/aro000004-zg8mz-pls-nic\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9/providers/Microsoft.Network/privateLinkServices/aro000004-zg8mz-pls/ipConfigurations/aro000004-zg8mz-pls-nic\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9/providers/Microsoft.Network/networkInterfaces/aro000004-zg8mz-master1-nic/ipConfigurations/pipConfig\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9/providers/Microsoft.Network/networkInterfaces/aro000004-zg8mz-master2-nic/ipConfigurations/pipConfig\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-igim53r9/providers/Microsoft.Network/networkInterfaces/aro000004-zg8mz-master0-nic/ipConfigurations/pipConfig\"\
+        \r\n      }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n      \
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\"\
+        ,\r\n        \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\
+        \n    ],\r\n    \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\"\
+        : \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\": \"Disabled\"\r\
+        \n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2406'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 16:47:12 GMT
+      etag:
+      - W/"f3c61216-c027-4f3f-8375-f9c06e76e361"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 27e44130-e367-4d27-a865-bffc3ec49ff9
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -y -g -n --subscription
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -7322,19 +5606,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 01 Dec 2020 21:24:29 GMT
+      - Wed, 09 Dec 2020 16:47:12 GMT
       duration:
-      - '779420'
+      - '587673'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - Wy/FtAyYfQcxCxQgPok979YLvFOc5laJpya67QX+ZxA=
+      - xLH67B9SlvYNCaoQ/nIDWZhTHLBRgD3HU7lUzrEJZio=
       ocp-aad-session-key:
-      - a-hoaxu2AVOtlneIoDDVE4WohgLqFB8JvDsW4fuOGxxmhshNTdxw81DCCq2pULMDwg0abM7VolRxWsPU1KWbR9sOQImmBe1VOE_aIdF8hNyUfKidtjEgMvJs7mXkfly4.kQmkoioxw3JV2KUz8Uxv2Fq6aIvYv2QjLrqMgQZg1AE
+      - xurvMXhumydr3IIQlN2MdvLyhe5ZMGOKA7uiD8y7oLp3LqSKOwt64x9_V6ITC_esq3-sa9TQt3Ali7WqAqrtWRJOp_xNU8cqs-JFQ3HwJ3cFIubjTK2Qi79_StLrgduTLAs0YDwpN9UCdIKjPAJinbiCFGtndzEqdJqeJAI3uY4.4hGbf39VBlYf-9h2ZX2cmIKW0A6bT1XLoiHNbn7adqs
       pragma:
       - no-cache
       request-id:
-      - 6da94838-e01e-4ca9-9655-3b90727714d9
+      - 7e49b5b7-5698-48fd-b001-20da352ecb31
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -7362,15 +5646,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"00e7c116-5b2f-4710-bf71-ff36aee2c10f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-01T20:28:53.5532351Z","updatedOn":"2020-12-01T20:28:53.5532351Z","createdBy":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","updatedBy":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-01T20:28:56.3394876Z","updatedOn":"2020-12-01T20:28:56.3394876Z","createdBy":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","updatedBy":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.4824942Z","updatedOn":"2020-06-16T16:25:39.4824942Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e77058da-a7bf-4e89-8e48-7d9f61fa8246","type":"Microsoft.Authorization/roleAssignments","name":"e77058da-a7bf-4e89-8e48-7d9f61fa8246"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:12:52.8054393Z","updatedOn":"2020-11-25T05:12:52.8054393Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dea2d3a8-cf99-4169-b8dd-819b4c611a32","type":"Microsoft.Authorization/roleAssignments","name":"dea2d3a8-cf99-4169-b8dd-819b4c611a32"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:34:01.2642084Z","updatedOn":"2020-11-25T05:34:01.2642084Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bacc53c-9077-49ce-a14d-370bc09f72d8","type":"Microsoft.Authorization/roleAssignments","name":"4bacc53c-9077-49ce-a14d-370bc09f72d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6949b2a1-9b3e-42c8-b228-0b6c14927377","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-30T19:34:16.5100204Z","updatedOn":"2020-07-30T19:34:16.5100204Z","createdBy":"5bc13990-50e4-4898-835e-d026e066bba5","updatedBy":"5bc13990-50e4-4898-835e-d026e066bba5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/53b0d735-2402-41c6-9d6d-b2338a287741","type":"Microsoft.Authorization/roleAssignments","name":"53b0d735-2402-41c6-9d6d-b2338a287741"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4c480e6-1f29-4163-9a37-2b16a7e8e5c8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-16T13:48:13.9171700Z","updatedOn":"2020-09-16T13:48:13.9171700Z","createdBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","updatedBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8476200c-5011-42c4-9028-360ef1739a8d","type":"Microsoft.Authorization/roleAssignments","name":"8476200c-5011-42c4-9028-360ef1739a8d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"28b696b7-8453-429d-9169-dfcd281c016a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T16:12:51.1251975Z","updatedOn":"2020-12-09T16:12:51.1251975Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T16:12:53.3633935Z","updatedOn":"2020-12-09T16:12:53.3633935Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.4824942Z","updatedOn":"2020-06-16T16:25:39.4824942Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e77058da-a7bf-4e89-8e48-7d9f61fa8246","type":"Microsoft.Authorization/roleAssignments","name":"e77058da-a7bf-4e89-8e48-7d9f61fa8246"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:12:52.8054393Z","updatedOn":"2020-11-25T05:12:52.8054393Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dea2d3a8-cf99-4169-b8dd-819b4c611a32","type":"Microsoft.Authorization/roleAssignments","name":"dea2d3a8-cf99-4169-b8dd-819b4c611a32"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:34:01.2642084Z","updatedOn":"2020-11-25T05:34:01.2642084Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bacc53c-9077-49ce-a14d-370bc09f72d8","type":"Microsoft.Authorization/roleAssignments","name":"4bacc53c-9077-49ce-a14d-370bc09f72d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6949b2a1-9b3e-42c8-b228-0b6c14927377","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-30T19:34:16.5100204Z","updatedOn":"2020-07-30T19:34:16.5100204Z","createdBy":"5bc13990-50e4-4898-835e-d026e066bba5","updatedBy":"5bc13990-50e4-4898-835e-d026e066bba5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/53b0d735-2402-41c6-9d6d-b2338a287741","type":"Microsoft.Authorization/roleAssignments","name":"53b0d735-2402-41c6-9d6d-b2338a287741"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4c480e6-1f29-4163-9a37-2b16a7e8e5c8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-16T13:48:13.9171700Z","updatedOn":"2020-09-16T13:48:13.9171700Z","createdBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","updatedBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8476200c-5011-42c4-9028-360ef1739a8d","type":"Microsoft.Authorization/roleAssignments","name":"8476200c-5011-42c4-9028-360ef1739a8d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
     headers:
       cache-control:
       - no-cache
@@ -7379,7 +5664,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 01 Dec 2020 21:24:29 GMT
+      - Wed, 09 Dec 2020 16:47:13 GMT
       expires:
       - '-1'
       pragma:
@@ -7408,152 +5693,14 @@ interactions:
       - aro delete
       Connection:
       - keep-alive
-      ParameterSetName:
-      - -y -g -n --subscription
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-06-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"6828ea5e-5556-4c26-bf57-a84d699a54e0\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.122.225.0/24\",\r\n    \"networkSecurityGroup\": {\r\
-        \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m/providers/Microsoft.Network/networkSecurityGroups/aro000004-t26rq-nsg\"\
-        \r\n    },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m/providers/Microsoft.Network/loadBalancers/aro000004-t26rq-internal/frontendIPConfigurations/internal-lb-ip-v4\"\
-        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m/providers/Microsoft.Network/networkInterfaces/aro000004-t26rq-pls.nic.ae64787d-1c4f-464c-b6ef-ba9b393b2b6a/ipConfigurations/aro000004-t26rq-pls-nic\"\
-        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m/providers/Microsoft.Network/privateLinkServices/aro000004-t26rq-pls/ipConfigurations/aro000004-t26rq-pls-nic\"\
-        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m/providers/Microsoft.Network/networkInterfaces/aro000004-t26rq-master2-nic/ipConfigurations/pipConfig\"\
-        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m/providers/Microsoft.Network/networkInterfaces/aro000004-t26rq-master1-nic/ipConfigurations/pipConfig\"\
-        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m/providers/Microsoft.Network/networkInterfaces/aro000004-t26rq-master0-nic/ipConfigurations/pipConfig\"\
-        \r\n      }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\"\
-        ,\r\n        \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\
-        \n    ],\r\n    \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\"\
-        : \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\": \"Disabled\"\r\
-        \n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '2407'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 01 Dec 2020 21:24:30 GMT
-      etag:
-      - W/"6828ea5e-5556-4c26-bf57-a84d699a54e0"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - a4bffc72-70ae-4b75-992f-a9657551d263
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -y -g -n --subscription
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/12.0.0 Azure-SDK-For-Python AZURECLI/2.15.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-06-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n  \"etag\": \"W/\\\"6828ea5e-5556-4c26-bf57-a84d699a54e0\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.127.108.0/24\",\r\n    \"networkSecurityGroup\": {\r\
-        \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m/providers/Microsoft.Network/networkSecurityGroups/aro000004-t26rq-nsg\"\
-        \r\n    },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m/providers/Microsoft.Network/networkInterfaces/aro000004-t26rq-worker-eastus1-nld52-nic/ipConfigurations/pipConfig\"\
-        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m/providers/Microsoft.Network/networkInterfaces/aro000004-t26rq-worker-eastus2-gks4j-nic/ipConfigurations/pipConfig\"\
-        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ln6xcp7m/providers/Microsoft.Network/networkInterfaces/aro000004-t26rq-worker-eastus3-mfpxx-nic/ipConfigurations/pipConfig\"\
-        \r\n      }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n      \
-        \  \"provisioningState\": \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\"\
-        ,\r\n        \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\
-        \n    ],\r\n    \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\"\
-        : \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\
-        \n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1705'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 01 Dec 2020 21:24:30 GMT
-      etag:
-      - W/"6828ea5e-5556-4c26-bf57-a84d699a54e0"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 4308c9ec-a889-4a35-a519-eebfe19cf8d4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro delete
-      Connection:
-      - keep-alive
       Content-Length:
       - '0'
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: DELETE
@@ -7563,7 +5710,7 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -7571,11 +5718,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:24:30 GMT
+      - Wed, 09 Dec 2020 16:47:13 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationresults/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationresults/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
       pragma:
       - no-cache
       strict-transport-security:
@@ -7601,15 +5748,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -7618,7 +5766,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:25:01 GMT
+      - Wed, 09 Dec 2020 16:47:44 GMT
       expires:
       - '-1'
       pragma:
@@ -7648,15 +5796,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -7665,7 +5814,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:25:31 GMT
+      - Wed, 09 Dec 2020 16:48:14 GMT
       expires:
       - '-1'
       pragma:
@@ -7695,15 +5844,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -7712,7 +5862,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:26:01 GMT
+      - Wed, 09 Dec 2020 16:48:44 GMT
       expires:
       - '-1'
       pragma:
@@ -7742,15 +5892,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -7759,7 +5910,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:26:31 GMT
+      - Wed, 09 Dec 2020 16:49:14 GMT
       expires:
       - '-1'
       pragma:
@@ -7789,15 +5940,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -7806,7 +5958,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:27:02 GMT
+      - Wed, 09 Dec 2020 16:49:44 GMT
       expires:
       - '-1'
       pragma:
@@ -7836,15 +5988,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -7853,7 +6006,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:27:32 GMT
+      - Wed, 09 Dec 2020 16:50:15 GMT
       expires:
       - '-1'
       pragma:
@@ -7883,15 +6036,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -7900,7 +6054,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:28:02 GMT
+      - Wed, 09 Dec 2020 16:50:45 GMT
       expires:
       - '-1'
       pragma:
@@ -7930,15 +6084,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -7947,7 +6102,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:28:32 GMT
+      - Wed, 09 Dec 2020 16:51:15 GMT
       expires:
       - '-1'
       pragma:
@@ -7977,15 +6132,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -7994,7 +6150,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:29:02 GMT
+      - Wed, 09 Dec 2020 16:51:45 GMT
       expires:
       - '-1'
       pragma:
@@ -8024,15 +6180,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -8041,7 +6198,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:29:32 GMT
+      - Wed, 09 Dec 2020 16:52:15 GMT
       expires:
       - '-1'
       pragma:
@@ -8071,15 +6228,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -8088,7 +6246,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:30:03 GMT
+      - Wed, 09 Dec 2020 16:52:45 GMT
       expires:
       - '-1'
       pragma:
@@ -8118,15 +6276,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -8135,7 +6294,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:30:33 GMT
+      - Wed, 09 Dec 2020 16:53:16 GMT
       expires:
       - '-1'
       pragma:
@@ -8165,15 +6324,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -8182,7 +6342,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:31:04 GMT
+      - Wed, 09 Dec 2020 16:53:47 GMT
       expires:
       - '-1'
       pragma:
@@ -8212,15 +6372,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -8229,7 +6390,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:31:33 GMT
+      - Wed, 09 Dec 2020 16:54:17 GMT
       expires:
       - '-1'
       pragma:
@@ -8259,15 +6420,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -8276,7 +6438,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:32:04 GMT
+      - Wed, 09 Dec 2020 16:54:47 GMT
       expires:
       - '-1'
       pragma:
@@ -8306,15 +6468,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -8323,7 +6486,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:32:34 GMT
+      - Wed, 09 Dec 2020 16:55:17 GMT
       expires:
       - '-1'
       pragma:
@@ -8353,15 +6516,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -8370,7 +6534,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:33:04 GMT
+      - Wed, 09 Dec 2020 16:55:47 GMT
       expires:
       - '-1'
       pragma:
@@ -8400,15 +6564,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -8417,7 +6582,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:33:34 GMT
+      - Wed, 09 Dec 2020 16:56:17 GMT
       expires:
       - '-1'
       pragma:
@@ -8447,15 +6612,16 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Deleting\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -8464,7 +6630,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:34:04 GMT
+      - Wed, 09 Dec 2020 16:56:47 GMT
       expires:
       - '-1'
       pragma:
@@ -8494,110 +6660,17 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:34:35 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -y -g -n --subscription
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Deleting\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Tue, 01 Dec 2020 21:35:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -y -g -n --subscription
-      User-Agent:
-      - python/3.6.7 (Linux-4.15.0-124-generic-x86_64-with-LinuxMint-19-tara) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.15.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/4a62ed34-b372-4a92-b9a8-82c82a137022\"\
-        ,\n    \"name\": \"4a62ed34-b372-4a92-b9a8-82c82a137022\",\n    \"status\"\
-        : \"Succeeded\",\n    \"startTime\": \"2020-12-01T21:24:31.210290311Z\",\n\
-        \    \"endTime\": \"2020-12-01T21:35:07.133466694Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\"\
+        ,\n    \"name\": \"62c6730b-1f2f-4d4b-bc7c-d7bb889851fe\",\n    \"status\"\
+        : \"Succeeded\",\n    \"startTime\": \"2020-12-09T16:47:14.052511231Z\",\n\
+        \    \"endTime\": \"2020-12-09T16:57:11.356556401Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -8606,7 +6679,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 01 Dec 2020 21:35:35 GMT
+      - Wed, 09 Dec 2020 16:57:18 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_update.yaml
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_update.yaml
@@ -13,15 +13,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-resource/10.3.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_update000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001","name":"cli_test_aro_update000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-09-08T06:59:58Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001","name":"cli_test_aro_update000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-09T17:45:44Z","createdAt":"2020-12-09T17:45:45.3290124Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +31,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:00 GMT
+      - Wed, 09 Dec 2020 17:45:45 GMT
       expires:
       - '-1'
       pragma:
@@ -63,8 +64,9 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -72,10 +74,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"332d633d-4e2b-4435-8c33-382f48da1c51\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"fbbadf59-f70d-4aa9-af6e-200adf3988a7\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"5832e53a-9f43-4970-86ed-fcfcefe8ffed\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"1814c02a-0df6-4e4d-bd3f-5f8979d4989a\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -85,7 +87,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/9dab0c5b-610f-4356-a976-2e6b71ce58e4?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/bafed280-8c17-4569-aa0c-27a11b1e3aac?api-version=2020-07-01
       cache-control:
       - no-cache
       content-length:
@@ -93,7 +95,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:03 GMT
+      - Wed, 09 Dec 2020 17:45:48 GMT
       expires:
       - '-1'
       pragma:
@@ -106,7 +108,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 9811ad57-5ef0-437c-8794-c34e52935d52
+      - 3d18741c-44f5-4765-91ed-eb94b7158fca
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -126,10 +128,11 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/9dab0c5b-610f-4356-a976-2e6b71ce58e4?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/bafed280-8c17-4569-aa0c-27a11b1e3aac?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -141,7 +144,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:07 GMT
+      - Wed, 09 Dec 2020 17:45:51 GMT
       expires:
       - '-1'
       pragma:
@@ -158,7 +161,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 558097d8-b713-406c-ab06-ea5d9ddbcec2
+      - 8621022a-9d6d-45b7-baa7-440ab5be40f2
     status:
       code: 200
       message: OK
@@ -176,17 +179,18 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"6478480a-2fd4-41c2-8695-ebe695f0ec0b\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"a72b4e76-d1cd-4123-a9f2-724749b1c7f5\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"5832e53a-9f43-4970-86ed-fcfcefe8ffed\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"1814c02a-0df6-4e4d-bd3f-5f8979d4989a\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -200,9 +204,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:07 GMT
+      - Wed, 09 Dec 2020 17:45:52 GMT
       etag:
-      - W/"6478480a-2fd4-41c2-8695-ebe695f0ec0b"
+      - W/"a72b4e76-d1cd-4123-a9f2-724749b1c7f5"
       expires:
       - '-1'
       pragma:
@@ -219,7 +223,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - d4bcf803-f699-4a7e-bd1d-93e29058be6d
+      - b21a41ef-ceea-464a-8f77-66592def8a9d
     status:
       code: 200
       message: OK
@@ -237,8 +241,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -246,10 +251,10 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"6478480a-2fd4-41c2-8695-ebe695f0ec0b\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"a72b4e76-d1cd-4123-a9f2-724749b1c7f5\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"5832e53a-9f43-4970-86ed-fcfcefe8ffed\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"1814c02a-0df6-4e4d-bd3f-5f8979d4989a\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":\
@@ -263,9 +268,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:07 GMT
+      - Wed, 09 Dec 2020 17:45:51 GMT
       etag:
-      - W/"6478480a-2fd4-41c2-8695-ebe695f0ec0b"
+      - W/"a72b4e76-d1cd-4123-a9f2-724749b1c7f5"
       expires:
       - '-1'
       pragma:
@@ -282,7 +287,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - df73911d-79ba-41e9-975d-aa50c56a1130
+      - 785ebe5d-284d-4fca-bcdd-552aae94a1ae
     status:
       code: 200
       message: OK
@@ -290,7 +295,7 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"properties":
-      {"addressPrefix": "10.79.3.0/24", "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]},
+      {"addressPrefix": "10.12.161.0/24", "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]},
       "name": "dev_master000002"}], "virtualNetworkPeerings": [], "enableDdosProtection":
       false, "enableVmProtection": false}}'
     headers:
@@ -303,14 +308,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '542'
+      - '544'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -318,17 +324,17 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"7828da9b-eca0-4bb4-b268-ea0afa6079de\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"ded441eb-38fa-4b84-b020-16eb08cc961f\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"5832e53a-9f43-4970-86ed-fcfcefe8ffed\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"1814c02a-0df6-4e4d-bd3f-5f8979d4989a\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"7828da9b-eca0-4bb4-b268-ea0afa6079de\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"ded441eb-38fa-4b84-b020-16eb08cc961f\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"addressPrefix\": \"10.79.3.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.12.161.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Updating\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -339,15 +345,15 @@ interactions:
         : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/bd02a418-5e78-48d6-82cf-226ed3f5eb90?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/32051da6-db10-4bcb-aa6c-aaeaf11b5a4f?api-version=2020-07-01
       cache-control:
       - no-cache
       content-length:
-      - '1616'
+      - '1618'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:08 GMT
+      - Wed, 09 Dec 2020 17:45:52 GMT
       expires:
       - '-1'
       pragma:
@@ -364,7 +370,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 1abb6a40-dd3c-4ee7-87e7-9ed8fcc58081
+      - b44f25ff-d29b-4f0e-855e-27ae0077aa45
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -384,10 +390,11 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/bd02a418-5e78-48d6-82cf-226ed3f5eb90?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/32051da6-db10-4bcb-aa6c-aaeaf11b5a4f?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -399,7 +406,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:12 GMT
+      - Wed, 09 Dec 2020 17:45:56 GMT
       expires:
       - '-1'
       pragma:
@@ -416,7 +423,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - f4cee941-4220-49cb-a79d-9ff3c922a8a9
+      - 13de6384-d9b5-4037-814d-c5b3b58ed688
     status:
       code: 200
       message: OK
@@ -434,24 +441,25 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"abb18f3e-7ed4-4de7-8e86-64946207ee98\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"f967d234-08fc-4c7b-b596-266737093f1c\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"5832e53a-9f43-4970-86ed-fcfcefe8ffed\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"1814c02a-0df6-4e4d-bd3f-5f8979d4989a\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"abb18f3e-7ed4-4de7-8e86-64946207ee98\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"f967d234-08fc-4c7b-b596-266737093f1c\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.79.3.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.12.161.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -464,13 +472,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1619'
+      - '1621'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:13 GMT
+      - Wed, 09 Dec 2020 17:45:56 GMT
       etag:
-      - W/"abb18f3e-7ed4-4de7-8e86-64946207ee98"
+      - W/"f967d234-08fc-4c7b-b596-266737093f1c"
       expires:
       - '-1'
       pragma:
@@ -487,7 +495,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 620fec69-9b7c-42d8-becc-665b8ef24ce4
+      - 0e180cae-6407-4986-a498-393f71a7dd68
     status:
       code: 200
       message: OK
@@ -505,8 +513,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -514,17 +523,17 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"abb18f3e-7ed4-4de7-8e86-64946207ee98\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"f967d234-08fc-4c7b-b596-266737093f1c\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"5832e53a-9f43-4970-86ed-fcfcefe8ffed\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"1814c02a-0df6-4e4d-bd3f-5f8979d4989a\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"abb18f3e-7ed4-4de7-8e86-64946207ee98\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"f967d234-08fc-4c7b-b596-266737093f1c\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.79.3.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.12.161.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -537,13 +546,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1619'
+      - '1621'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:12 GMT
+      - Wed, 09 Dec 2020 17:45:56 GMT
       etag:
-      - W/"abb18f3e-7ed4-4de7-8e86-64946207ee98"
+      - W/"f967d234-08fc-4c7b-b596-266737093f1c"
       expires:
       - '-1'
       pragma:
@@ -560,7 +569,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 0f0e7010-a5a6-4ac4-b0c2-54a634f083db
+      - ec2324ba-ab57-4754-9e73-c437d92a4927
     status:
       code: 200
       message: OK
@@ -568,10 +577,10 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "properties": {"addressPrefix": "10.79.3.0/24", "serviceEndpoints": [{"service":
+      "properties": {"addressPrefix": "10.12.161.0/24", "serviceEndpoints": [{"service":
       "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
       "Enabled", "privateLinkServiceNetworkPolicies": "Enabled"}, "name": "dev_master000002"},
-      {"properties": {"addressPrefix": "10.122.58.0/24", "serviceEndpoints": [{"service":
+      {"properties": {"addressPrefix": "10.35.125.0/24", "serviceEndpoints": [{"service":
       "Microsoft.ContainerRegistry"}]}, "name": "dev_worker000003"}], "virtualNetworkPeerings":
       [], "enableDdosProtection": false, "enableVmProtection": false}}'
     headers:
@@ -584,14 +593,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1000'
+      - '1002'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -599,17 +609,17 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"ffac506d-01b9-43cc-8ddb-60fdfdce5694\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"06703b99-1a60-48a6-89f3-76d82bf1abc5\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Updating\",\r\n    \"resourceGuid\": \"5832e53a-9f43-4970-86ed-fcfcefe8ffed\"\
+        \ \"Updating\",\r\n    \"resourceGuid\": \"1814c02a-0df6-4e4d-bd3f-5f8979d4989a\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"ffac506d-01b9-43cc-8ddb-60fdfdce5694\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"06703b99-1a60-48a6-89f3-76d82bf1abc5\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"addressPrefix\": \"10.79.3.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.12.161.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -618,9 +628,9 @@ interactions:
         : \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
         \r\n      },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n   \
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n        \"etag\": \"W/\\\"ffac506d-01b9-43cc-8ddb-60fdfdce5694\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"06703b99-1a60-48a6-89f3-76d82bf1abc5\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\"\
-        ,\r\n          \"addressPrefix\": \"10.122.58.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.35.125.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Updating\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -631,15 +641,15 @@ interactions:
         : false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/368db0fc-76c5-4660-941f-a4eee799c979?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/227adcc5-ffc3-40f1-af68-60096b0da03a?api-version=2020-07-01
       cache-control:
       - no-cache
       content-length:
-      - '2506'
+      - '2508'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:13 GMT
+      - Wed, 09 Dec 2020 17:45:57 GMT
       expires:
       - '-1'
       pragma:
@@ -656,9 +666,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 2188495b-5d6a-4649-be01-98e491d792f7
+      - 0860fce2-98c1-43cf-b418-78caef1d6b51
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 200
       message: OK
@@ -676,10 +686,11 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/368db0fc-76c5-4660-941f-a4eee799c979?api-version=2020-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/227adcc5-ffc3-40f1-af68-60096b0da03a?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -691,7 +702,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:17 GMT
+      - Wed, 09 Dec 2020 17:46:00 GMT
       expires:
       - '-1'
       pragma:
@@ -708,7 +719,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 06e7ee78-3ce6-4ff3-80a9-c2a76484f961
+      - b780b748-6921-4d27-b8a1-a433cab8c630
     status:
       code: 200
       message: OK
@@ -726,24 +737,25 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2020-07-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\"\
-        ,\r\n  \"etag\": \"W/\\\"a0a72c2b-66a7-4d47-9cad-2aa8f2fc5c08\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"a7c538c8-00e4-4b8f-9433-e5f4a2f0b13f\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\"\
         ,\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":\
-        \ \"Succeeded\",\r\n    \"resourceGuid\": \"5832e53a-9f43-4970-86ed-fcfcefe8ffed\"\
+        \ \"Succeeded\",\r\n    \"resourceGuid\": \"1814c02a-0df6-4e4d-bd3f-5f8979d4989a\"\
         ,\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"\
         10.0.0.0/9\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\"\
         : []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\"\
         ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n        \"etag\": \"W/\\\"a0a72c2b-66a7-4d47-9cad-2aa8f2fc5c08\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"a7c538c8-00e4-4b8f-9433-e5f4a2f0b13f\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.79.3.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.12.161.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -752,9 +764,9 @@ interactions:
         : \"Enabled\"\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
         \r\n      },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n   \
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n        \"etag\": \"W/\\\"a0a72c2b-66a7-4d47-9cad-2aa8f2fc5c08\\\"\"\
+        ,\r\n        \"etag\": \"W/\\\"a7c538c8-00e4-4b8f-9433-e5f4a2f0b13f\\\"\"\
         ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
-        ,\r\n          \"addressPrefix\": \"10.122.58.0/24\",\r\n          \"serviceEndpoints\"\
+        ,\r\n          \"addressPrefix\": \"10.35.125.0/24\",\r\n          \"serviceEndpoints\"\
         : [\r\n            {\r\n              \"provisioningState\": \"Succeeded\"\
         ,\r\n              \"service\": \"Microsoft.ContainerRegistry\",\r\n     \
         \         \"locations\": [\r\n                \"*\"\r\n              ]\r\n\
@@ -767,13 +779,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2510'
+      - '2512'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:17 GMT
+      - Wed, 09 Dec 2020 17:46:00 GMT
       etag:
-      - W/"a0a72c2b-66a7-4d47-9cad-2aa8f2fc5c08"
+      - W/"a7c538c8-00e4-4b8f-9433-e5f4a2f0b13f"
       expires:
       - '-1'
       pragma:
@@ -790,7 +802,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 3d8c6c64-ae26-45c5-8d96-e8edba6516d4
+      - 394632ee-135c-4bd4-bbd1-c1027ea98725
     status:
       code: 200
       message: OK
@@ -808,8 +820,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -817,318 +830,9 @@ interactions:
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"a0a72c2b-66a7-4d47-9cad-2aa8f2fc5c08\\\"\",\r\n \
+        ,\r\n  \"etag\": \"W/\\\"a7c538c8-00e4-4b8f-9433-e5f4a2f0b13f\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.79.3.0/24\",\r\n    \"serviceEndpoints\": [\r\n    \
-        \  {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '754'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:17 GMT
-      etag:
-      - W/"a0a72c2b-66a7-4d47-9cad-2aa8f2fc5c08"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 3ad69a77-b46a-420e-89e0-64094774f5a9
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "properties": {"addressPrefix": "10.79.3.0/24", "serviceEndpoints": [{"service":
-      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
-      "Enabled", "privateLinkServiceNetworkPolicies": "Disabled"}, "name": "dev_master000002"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet update
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '455'
-      Content-Type:
-      - application/json; charset=utf-8
-      ParameterSetName:
-      - -g --vnet-name -n --disable-private-link-service-network-policies
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"7fea724a-f4f7-496a-ba9f-350ba095080e\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
-        addressPrefix\": \"10.79.3.0/24\",\r\n    \"serviceEndpoints\": [\r\n    \
-        \  {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/655d96cc-9fbe-4dda-b25c-2145359499fa?api-version=2020-06-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '754'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 242e4946-170f-4cef-a8dc-fb844c540475
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --disable-private-link-service-network-policies
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/655d96cc-9fbe-4dda-b25c-2145359499fa?api-version=2020-06-01
-  response:
-    body:
-      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '29'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 49e17c48-b79f-4c8c-9a46-b0511594fdae
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --disable-private-link-service-network-policies
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"08077b46-2ebd-4a4b-9b5b-65886e6456ba\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.79.3.0/24\",\r\n    \"serviceEndpoints\": [\r\n    \
-        \  {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '755'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:21 GMT
-      etag:
-      - W/"08077b46-2ebd-4a4b-9b5b-65886e6456ba"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 0e9c8268-0836-4707-b6de-7f3c7de225eb
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"08077b46-2ebd-4a4b-9b5b-65886e6456ba\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.79.3.0/24\",\r\n    \"serviceEndpoints\": [\r\n    \
-        \  {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '755'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:21 GMT
-      etag:
-      - W/"08077b46-2ebd-4a4b-9b5b-65886e6456ba"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 311021ce-8703-4233-8037-f1eeb13645f1
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n  \"etag\": \"W/\\\"08077b46-2ebd-4a4b-9b5b-65886e6456ba\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.122.58.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        addressPrefix\": \"10.12.161.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
         \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
         : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
         \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
@@ -1143,9 +847,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:21 GMT
+      - Wed, 09 Dec 2020 17:46:01 GMT
       etag:
-      - W/"08077b46-2ebd-4a4b-9b5b-65886e6456ba"
+      - W/"a7c538c8-00e4-4b8f-9433-e5f4a2f0b13f"
       expires:
       - '-1'
       pragma:
@@ -1162,7 +866,193 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e02256f0-3950-4132-a67a-5b49efd0e60b
+      - 2d1564c1-b6c1-41e9-aa07-dd259de9cd0d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
+      "properties": {"addressPrefix": "10.12.161.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Disabled"}, "name": "dev_master000002"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '457'
+      Content-Type:
+      - application/json; charset=utf-8
+      ParameterSetName:
+      - -g --vnet-name -n --disable-private-link-service-network-policies
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
+        ,\r\n  \"etag\": \"W/\\\"355dba95-fe20-4d2c-b786-ea861b7832a5\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
+        addressPrefix\": \"10.12.161.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/9aff0004-b022-4fba-9cf6-79476a4ce03c?api-version=2020-07-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '756'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 17:46:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 1709aa98-d0ed-40f5-84e1-f58281b8e96c
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --disable-private-link-service-network-policies
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/9aff0004-b022-4fba-9cf6-79476a4ce03c?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '29'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 17:46:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - fc9cd551-f278-4d61-a8fa-77d7c39bada4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --disable-private-link-service-network-policies
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
+        ,\r\n  \"etag\": \"W/\\\"230ad998-1798-4dc2-8288-16987a507e37\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.12.161.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '757'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 17:46:05 GMT
+      etag:
+      - W/"230ad998-1798-4dc2-8288-16987a507e37"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - ee0c46d0-3aec-4f00-8a2a-0f5bcc528948
     status:
       code: 200
       message: OK
@@ -1180,15 +1070,144 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
+        ,\r\n  \"etag\": \"W/\\\"230ad998-1798-4dc2-8288-16987a507e37\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.12.161.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '757'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 17:46:06 GMT
+      etag:
+      - W/"230ad998-1798-4dc2-8288-16987a507e37"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - bdbf5656-0dce-444d-919e-8a033c9a5e9e
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\r\n  \"etag\": \"W/\\\"230ad998-1798-4dc2-8288-16987a507e37\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.35.125.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '756'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 17:46:05 GMT
+      etag:
+      - W/"230ad998-1798-4dc2-8288-16987a507e37"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 6ed516c6-22bb-4bae-ab54-4cdc13e54120
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-resource/10.3.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_update000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001","name":"cli_test_aro_update000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-09-08T06:59:58Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001","name":"cli_test_aro_update000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2020-12-09T17:45:44Z","createdAt":"2020-12-09T17:45:45.3290124Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1197,7 +1216,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:22 GMT
+      - Wed, 09 Dec 2020 17:46:06 GMT
       expires:
       - '-1'
       pragma:
@@ -1225,8 +1244,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-resource/10.3.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
@@ -1234,31 +1254,34 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift","namespace":"Microsoft.RedHatOpenShift","authorizations":[{"applicationId":"f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875","roleDefinitionId":"640c5ac9-6f32-4891-94f4-d20f7aa9a7e6","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635","managedByAuthorization":{"allowManagedByInheritance":true}}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2020-04-30","2019-12-31-preview"],"capabilities":"None"},{"resourceType":"locations/operationresults","locations":["Australia
-        East","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East US","East US 2","France Central","Japan East","Japan West","Korea
-        Central","North Central US","North Europe","South Africa North","South Central
-        US","Southeast Asia","Switzerland North","UK South","UK West","West Europe","West
-        US 2","West US"],"apiVersions":["2020-04-30"],"capabilities":"None"},{"resourceType":"locations/operationsstatus","locations":["Australia
-        East","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East US","East US 2","France Central","Japan East","Japan West","Korea
-        Central","North Central US","North Europe","South Africa North","South Central
-        US","Southeast Asia","Switzerland North","UK South","UK West","West Europe","West
-        US 2","West US"],"apiVersions":["2020-04-30"],"capabilities":"None"},{"resourceType":"OpenShiftClusters","locations":["Australia
-        East","Brazil South","Canada Central","Canada East","Central India","Central
-        US","East US","East US 2","France Central","Japan East","Japan West","Korea
-        Central","North Central US","North Europe","South Africa North","South Central
-        US","Southeast Asia","Switzerland North","UK South","UK West","West Europe","West
-        US 2","West US"],"apiVersions":["2020-04-30"],"defaultApiVersion":"2020-04-30","capabilities":"SystemAssignedResourceIdentity,
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US 2","France Central","Germany West
+        Central","Japan East","Japan West","Korea Central","North Central US","North
+        Europe","Norway East","South Africa North","South Central US","Southeast Asia","Switzerland
+        North","Switzerland West","UAE North","UK South","UK West","West Europe","West
+        US 2","West US","East US"],"apiVersions":["2020-04-30"],"capabilities":"None"},{"resourceType":"locations/operationsstatus","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US 2","France Central","Germany West
+        Central","Japan East","Japan West","Korea Central","North Central US","North
+        Europe","Norway East","South Africa North","South Central US","Southeast Asia","Switzerland
+        North","Switzerland West","UAE North","UK South","UK West","West Europe","West
+        US 2","West US","East US"],"apiVersions":["2020-04-30"],"capabilities":"None"},{"resourceType":"OpenShiftClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US 2","France Central","Germany West
+        Central","Japan East","Japan West","Korea Central","North Central US","North
+        Europe","Norway East","South Africa North","South Central US","Southeast Asia","Switzerland
+        North","Switzerland West","UAE North","UK South","UK West","West Europe","West
+        US 2","West US","East US"],"apiVersions":["2020-04-30"],"defaultApiVersion":"2020-04-30","capabilities":"SystemAssignedResourceIdentity,
         SupportsTags, SupportsLocation"},{"resourceType":"operations","locations":[],"apiVersions":["2020-04-30","2019-12-31-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2163'
+      - '2469'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:21 GMT
+      - Wed, 09 Dec 2020 17:46:06 GMT
       expires:
       - '-1'
       pragma:
@@ -1273,9 +1296,137 @@ interactions:
       code: 200
       message: OK
 - request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
+        ,\r\n  \"etag\": \"W/\\\"230ad998-1798-4dc2-8288-16987a507e37\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.12.161.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '757'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 17:46:07 GMT
+      etag:
+      - W/"230ad998-1798-4dc2-8288-16987a507e37"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - cdfccff3-76a4-4f3e-be17-2e9ea50d8f40
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\r\n  \"etag\": \"W/\\\"230ad998-1798-4dc2-8288-16987a507e37\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.35.125.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
+        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
+        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
+        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
+        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
+        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '756'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 17:46:07 GMT
+      etag:
+      - W/"230ad998-1798-4dc2-8288-16987a507e37"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - b069009d-130e-4d34-9404-bd504f38a784
+    status:
+      code: 200
+      message: OK
+- request:
     body: '{"passwordCredentials": [{"endDate": "2299-12-31T00:00:00.000Z", "value":
-      "ReplacedSPPassword123*"}], "displayName": "aro-am0w6b6j", "identifierUris":
-      ["https://az.aro.azure.com/6385c403-74d1-49e6-b9a9-aa8b1aba47b5"]}'
+      "ReplacedSPPassword123*"}], "displayName": "aro-ai3zo4ud", "identifierUris":
+      ["https://az.aro.azure.com/dbc309c3-51fe-49b8-b3d9-8c96db186d92"]}'
     headers:
       Accept:
       - application/json
@@ -1292,8 +1443,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
@@ -1302,30 +1454,30 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "49440e84-5ced-4b14-aee4-3615e37caa94", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "ee6718bb-7aee-4149-875a-61adc505dff8",
+        "objectId": "c86132ea-c825-46f5-899d-5f11ab23ac0f", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "e957e8cd-1467-42a0-bda1-665276ee51bf",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
-        false, "displayName": "aro-am0w6b6j", "errorUrl": null, "groupMembershipClaims":
-        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/6385c403-74d1-49e6-b9a9-aa8b1aba47b5"],
+        false, "displayName": "aro-ai3zo4ud", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/dbc309c3-51fe-49b8-b3d9-8c96db186d92"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/49440e84-5ced-4b14-aee4-3615e37caa94/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/c86132ea-c825-46f5-899d-5f11ab23ac0f/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/49440e84-5ced-4b14-aee4-3615e37caa94/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/c86132ea-c825-46f5-899d-5f11ab23ac0f/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
-        "Allow the application to access aro-am0w6b6j on behalf of the signed-in user.",
-        "adminConsentDisplayName": "Access aro-am0w6b6j", "id": "61df6528-ae78-48c3-985a-a47b3ce2a711",
+        "Allow the application to access aro-ai3zo4ud on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Access aro-ai3zo4ud", "id": "3d06ffd5-bc7f-4cd0-9ae5-24499d46621e",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
-        to access aro-am0w6b6j on your behalf.", "userConsentDisplayName": "Access
-        aro-am0w6b6j", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        to access aro-ai3zo4ud on your behalf.", "userConsentDisplayName": "Access
+        aro-ai3zo4ud", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
         [{"customKeyIdentifier": null, "endDate": "2299-12-31T00:00:00Z", "keyId":
-        "86037df4-2c5e-43d7-a8ae-dc248159a153", "startDate": "2020-09-08T07:00:22.7739941Z",
+        "f23a0463-462b-4cb6-8641-63b6c5504641", "startDate": "2020-12-09T17:46:08.5416752Z",
         "value": "ReplacedSPPassword123*"}], "publicClient": null, "publisherDomain":
-        "AzureSDKTeam.onmicrosoft.com", "recordConsentConditions": null, "replyUrls":
+        "rhcuppettgmail.onmicrosoft.com", "recordConsentConditions": null, "replyUrls":
         [], "requiredResourceAccess": [], "samlMetadataUrl": null, "signInAudience":
         "AzureADMyOrg", "tokenEncryptionKeyId": null}'
     headers:
@@ -1334,27 +1486,27 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2265'
+      - '2267'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 08 Sep 2020 07:00:23 GMT
+      - Wed, 09 Dec 2020 17:46:08 GMT
       duration:
-      - '5198177'
+      - '4645890'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/49440e84-5ced-4b14-aee4-3615e37caa94/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/c86132ea-c825-46f5-899d-5f11ab23ac0f/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - hwn6uEtjHiiLa1+/G29HvIs5WOJFHYFOq64UHyjuGvY=
+      - QQ7HkBqBI/wx1z6h5Nool8hdVGTXxMTDn56s0shXqnA=
       ocp-aad-session-key:
-      - xp-_8C11Hf_R-YELrJ7VQfR5CyobiVy1FbKM3VF3qvxLrxHi1z8eG7inZ9e_C3OlBfbBwP8X1vnjT0Bxbp1Knj88q4mHE-mahn6PYwvy2BxtaCcSRt98Nu7EbFSpHBJ1tzHEqacr0i4bqpW3YwySL5k_yKtGB4wFsJE30Q2NodM.AENtE-FzM-LSngzmXlFXsJcfS5T05S5pnOFGbXsq60c
+      - mkLaRIeGnuyjOVLpnLzy_iPI2hCcLeryGC0-5VRquF6KITPua6PDSkjo3cHJWcEFjM5yYnz6GveerNOxaQIx4bHfZHn6ZgeflFr42H7MNTojYreE-9nKycyJZmtFzsCXk1Psh_cH7dEkOqIrj2LNwhYo13xCri4HVxdyFHCRlkc.JlSFq8CThdFw1FucxpEJ9H2nQEDIWNlYQa_MZuwGHv4
       pragma:
       - no-cache
       request-id:
-      - d386d3df-8ee7-4290-a213-66918cf4fc41
+      - b274e120-b6ff-417e-8ecc-6a1ef827ba74
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1382,12 +1534,13 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27ee6718bb-7aee-4149-875a-61adc505dff8%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27e957e8cd-1467-42a0-bda1-665276ee51bf%27&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -1403,19 +1556,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 08 Sep 2020 07:00:23 GMT
+      - Wed, 09 Dec 2020 17:46:09 GMT
       duration:
-      - '488354'
+      - '255278'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - EUDBWud1VROW0ktIsTUCHxtQAUX7GL4vIgKLOvk0d7c=
+      - cFKgl6RkZhqKrnurLL4ZIzkOaeSto8WhnrtDrbK/sBo=
       ocp-aad-session-key:
-      - -8hZ1r2J40GjZnchie2qhvJ586mPDOjCoxHkf4oosPb9Rtqv1jeUkxPbvT8D_vrZdKn7kobAVyOsNzrj4nZKs4NxfKD0MPKOVdZNKeKC8QTRyKMnZiz3pBPCqSO4OP5it3AW6I8f8Ne4cEX8z7RmGdUWA1aab7e2LKDmO13pC5s.BWWAv7NuMonYbUxkCcASPjyWL8R65QT0j7NLYuuIAOw
+      - 8bDgCFQg1icvNGPt-yYGcW1fi6fQEFpF8zpklviCqhqKUAy5IGPESo5oi3J0teVYEciwHsdaOhCmsdb2OZX1f7v6n_2DV65HWL4dv89PADNavUFVXrtVQG-N5EcqMuqgan5BhtGSctHpLYEpn3cbNnyAbPzCY9gveyf6hYBGjPI.bdy_kIeL9AwsoCksP92IGtoWoEwLYlVXbZutTUS0Pzk
       pragma:
       - no-cache
       request-id:
-      - 870b62dd-1dfa-411e-a690-29a3df395e68
+      - ad6ccd5e-fb3d-4f6a-b5f8-a7de6a9496dd
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1430,7 +1583,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"appId": "ee6718bb-7aee-4149-875a-61adc505dff8"}'
+    body: '{"appId": "e957e8cd-1467-42a0-bda1-665276ee51bf"}'
     headers:
       Accept:
       - application/json
@@ -1447,46 +1600,48 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"634b6a14-daa6-42a6-936f-86aa40fef181","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-am0w6b6j","appId":"ee6718bb-7aee-4149-875a-61adc505dff8","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-am0w6b6j","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access aro-am0w6b6j on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        aro-am0w6b6j","id":"61df6528-ae78-48c3-985a-a47b3ce2a711","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access aro-am0w6b6j on your behalf.","userConsentDisplayName":"Access
-        aro-am0w6b6j","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["ee6718bb-7aee-4149-875a-61adc505dff8","https://az.aro.azure.com/6385c403-74d1-49e6-b9a9-aa8b1aba47b5"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"6a770218-bb37-4a0f-a83c-6e6bc93ebbfa","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-ai3zo4ud","appId":"e957e8cd-1467-42a0-bda1-665276ee51bf","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-ai3zo4ud","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access aro-ai3zo4ud on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        aro-ai3zo4ud","id":"3d06ffd5-bc7f-4cd0-9ae5-24499d46621e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access aro-ai3zo4ud on your behalf.","userConsentDisplayName":"Access
+        aro-ai3zo4ud","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
+        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["e957e8cd-1467-42a0-bda1-665276ee51bf","https://az.aro.azure.com/dbc309c3-51fe-49b8-b3d9-8c96db186d92"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '1674'
+      - '1695'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 08 Sep 2020 07:00:23 GMT
+      - Wed, 09 Dec 2020 17:46:08 GMT
       duration:
-      - '2103119'
+      - '2652693'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/634b6a14-daa6-42a6-936f-86aa40fef181/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/6a770218-bb37-4a0f-a83c-6e6bc93ebbfa/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - wyZ2chLc7keUKHMJZ5WTQztb1eGl2liBganf3B36Fuk=
+      - I+fdMr3Y0vz3zqnTZVT+5PL6c/tQo0Y4a3fmzixMZgk=
       ocp-aad-session-key:
-      - vEjYJ_spIoaT7EP_lU9QH4PYi86O0idH_9bnI6Upnesec8elKPt8Wi7yuQg0m_F4EXp5GiX1_tI03rNH5ZqffjKPtPCyVRaWJgPX1oNWmRm0qStFjrXrxdDm8HhH6u7kPQJADmwIihAc4HCtquR7iQogqU0i25BB3nNodQyrp78.9v-aFAO3LsIb8EZBGC7pgttV8hjmosNw9st3T4p6b-M
+      - WErGEpWQyK90eRoLX6o98w5B-BNZesuLtVhGTCj_pzSvPNjYqOxlbZIjpGisI1UI8rMB0wl7LhMTNcvyXSY0YXZlMZtlVSJtwavWFq4e8y44m5vqdJUidDVVFwVt9ABqvz2JKHzKtt6WptsWBbaUfg38VXM-AIfNOnwAOPZg7KY.ywAGWldZVf7JEXXOx6ujF_Gp0KRXKFWMf7pTziIO-74
       pragma:
       - no-cache
       request-id:
-      - 4a08dae7-a839-4830-a30c-5cf5710fd26b
+      - 57f40ed5-5ac5-4b48-bd6a-abee2322b33c
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1514,15 +1669,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"3e675290-31e1-49f6-a3cd-03df3d7d6e2e","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Azure
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Azure
         Red Hat OpenShift RP","appId":"f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875","applicationTemplateId":null,"appOwnerTenantId":"f8cdef31-a31e-4b4a-93e4-5f571e91255a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Azure
         Red Hat OpenShift RP","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft
         Services","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
@@ -1538,19 +1694,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 08 Sep 2020 07:00:23 GMT
+      - Wed, 09 Dec 2020 17:46:08 GMT
       duration:
-      - '575748'
+      - '980848'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - DCwgcMwuvn5dT/ucjNeznetw31cm4TxBRx0ZUowtuLE=
+      - jkbx3mM6nMwyGmaXNhG05uinFhY0kdwSCHTlmEsZUkY=
       ocp-aad-session-key:
-      - gjpWsDBjL556bAkx9qs9tqOEI-mAp0ft1wJp9qQA3fBS86kiVjAOqdthEClUvpCaVeHvyB4Uo00lw149iMmUQV03Ua31waHcfqWQ1TkHUIINUm-4mv69wsVw7tpiglS3kX_JWgDiWyeiq49SliKKjw-EvwZ68An_nHEO0qUPy54.uoxgI72pCIw1bx728Q1SPhBRY_WFyPzMgNdGC9O9ElA
+      - r5sjxCJ3bW6woEmzp9qUMJbCmGiuep3gihahWgD8QyaNzGL8u7wTM_rNnGCbWm3aOkuZgenCTC1Mfhv8OHjCnCvuCty-bEPn1stqrLGmpzPmmtpUEXfCr8B3SdGU4ceRzP_2IWpbL1wlcsch8wLEJjD2ogE83Hb4SdByIIrDYu4.PwjFFWEzqZ6w6Dpan7LzTQ2UNMnxSrRC8Skpsd-zu7A
       pragma:
       - no-cache
       request-id:
-      - e6a68701-ea3a-47ca-9865-65545bf7f6d4
+      - 97bd240e-c5e3-441e-a427-3aa7983ecd15
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1578,26 +1734,25 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2019-09-04T08:09:42.0835929Z","updatedOn":"2019-09-04T08:09:42.0835929Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/9d0c9433-a2c8-403f-ba1c-6310772291a5","type":"Microsoft.Authorization/roleAssignments","name":"9d0c9433-a2c8-403f-ba1c-6310772291a5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-14T05:22:05.1776921Z","updatedOn":"2020-03-14T05:22:05.1776921Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/eed777be-eb1b-4af7-9ec2-e4a74afba39e","type":"Microsoft.Authorization/roleAssignments","name":"eed777be-eb1b-4af7-9ec2-e4a74afba39e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-04T08:35:06.1202192Z","updatedOn":"2020-03-04T08:35:06.1202192Z","createdBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","updatedBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/67f6c798-74b6-41f7-ba07-ae40134ce8c1","type":"Microsoft.Authorization/roleAssignments","name":"67f6c798-74b6-41f7-ba07-ae40134ce8c1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T03:47:15.1734978Z","updatedOn":"2020-03-19T03:47:15.1734978Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/888c7688-4ae3-406f-948b-fd569da173fc","type":"Microsoft.Authorization/roleAssignments","name":"888c7688-4ae3-406f-948b-fd569da173fc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T04:06:32.7642459Z","updatedOn":"2020-03-19T04:06:32.7642459Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/b4bdedde-4f10-4610-9201-2421bb032107","type":"Microsoft.Authorization/roleAssignments","name":"b4bdedde-4f10-4610-9201-2421bb032107"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"02d52e0b-1c85-4aa9-a229-bca89f5fc079","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:06:31.6888688Z","updatedOn":"2020-07-15T07:06:31.6888688Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/e2f3fd89-b1cc-42c7-ae59-1ef03b4e731a","type":"Microsoft.Authorization/roleAssignments","name":"e2f3fd89-b1cc-42c7-ae59-1ef03b4e731a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-01-29T13:27:35.7170489Z","updatedOn":"2020-01-29T13:27:35.7170489Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/b6899915-1e85-4406-aa1f-f346ec3ded50","type":"Microsoft.Authorization/roleAssignments","name":"b6899915-1e85-4406-aa1f-f346ec3ded50"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"22bd72d9-4e93-4a74-b5ad-679cabe53baf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:27:36.1276006Z","updatedOn":"2020-07-15T07:27:36.1276006Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/06f37651-eecf-4b6c-a0e7-b26822697224","type":"Microsoft.Authorization/roleAssignments","name":"06f37651-eecf-4b6c-a0e7-b26822697224"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b304d026-311a-4be0-9994-8c578fc3697f","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:14:11.6612918Z","updatedOn":"2020-07-15T07:14:11.6612918Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/a75bb3e5-3b36-488f-a1a4-32be0a44e1a1","type":"Microsoft.Authorization/roleAssignments","name":"a75bb3e5-3b36-488f-a1a4-32be0a44e1a1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3","principalId":"30601973-dcd6-4c4e-85e8-dc6e057238fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-14T15:35:54.7519315Z","updatedOn":"2020-06-14T15:35:54.7519315Z","createdBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","updatedBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/02d00457-a5a7-4da3-b12a-e944705f4170","type":"Microsoft.Authorization/roleAssignments","name":"02d00457-a5a7-4da3-b12a-e944705f4170"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab","principalId":"677a61e9-086e-4f13-986a-11aaedc31416","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T03:31:37.3848580Z","updatedOn":"2019-11-26T03:31:37.3848580Z","createdBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","updatedBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aac8538d-8226-4b91-9232-03d3f3a40214","type":"Microsoft.Authorization/roleAssignments","name":"aac8538d-8226-4b91-9232-03d3f3a40214"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-04T08:40:46.0862758Z","updatedOn":"2020-03-04T08:40:46.0862758Z","createdBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","updatedBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5f32c47e-50b5-4be3-8774-ea1467857752","type":"Microsoft.Authorization/roleAssignments","name":"5f32c47e-50b5-4be3-8774-ea1467857752"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-20T09:03:02.6644378Z","updatedOn":"2020-01-20T09:03:02.6644378Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dd2121da-11a7-4ff5-bab0-053cc344b0b0","type":"Microsoft.Authorization/roleAssignments","name":"dd2121da-11a7-4ff5-bab0-053cc344b0b0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0444ccf8-fddb-43c4-b42b-ea036211229f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-25T07:18:48.8610796Z","updatedOn":"2020-03-25T07:18:48.8610796Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4f7c6762-b335-43e7-9c13-d42ab9bc6884","type":"Microsoft.Authorization/roleAssignments","name":"4f7c6762-b335-43e7-9c13-d42ab9bc6884"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"05b1f982-1404-4e2d-b2e8-af3ee7a330b4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-22T14:58:56.7424484Z","updatedOn":"2019-09-22T14:58:56.7424484Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a5d758f5-4ec2-4dd5-ba95-cee5405e367c","type":"Microsoft.Authorization/roleAssignments","name":"a5d758f5-4ec2-4dd5-ba95-cee5405e367c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-21T03:37:35.1867759Z","updatedOn":"2019-11-21T03:37:35.1867759Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f93778f-00f5-4efb-a56f-6aff1d668df7","type":"Microsoft.Authorization/roleAssignments","name":"6f93778f-00f5-4efb-a56f-6aff1d668df7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0a592c45-613e-4f1b-9023-7c4414fd53bf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-08-08T01:47:13.5745250Z","updatedOn":"2019-08-08T01:47:13.5745250Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d320644f-c08b-47f4-ae3b-9df595a5c368","type":"Microsoft.Authorization/roleAssignments","name":"d320644f-c08b-47f4-ae3b-9df595a5c368"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-26T04:16:43.3784273Z","updatedOn":"2019-07-26T04:16:43.3784273Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a567d42-8a33-4cad-9f7b-5299a16dc269","type":"Microsoft.Authorization/roleAssignments","name":"9a567d42-8a33-4cad-9f7b-5299a16dc269"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0eae5543-750d-4b1a-89bc-7bfd80671fbd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T05:52:20.5117449Z","updatedOn":"2020-04-13T05:52:20.5117449Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b2a0bc46-da6a-4ca0-b518-81cc1f0a14d3","type":"Microsoft.Authorization/roleAssignments","name":"b2a0bc46-da6a-4ca0-b518-81cc1f0a14d3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"182c8534-f413-487c-91a3-7addc80e35d5","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-09-06T13:37:05.6480940Z","updatedOn":"2017-09-06T13:37:05.6480940Z","createdBy":"bed854bc-89d1-444b-914a-8984c7a9d73d","updatedBy":"bed854bc-89d1-444b-914a-8984c7a9d73d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d0560ab5-dd8d-4978-8c9b-84768b4a9467","type":"Microsoft.Authorization/roleAssignments","name":"d0560ab5-dd8d-4978-8c9b-84768b4a9467"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"18f53146-1f6c-462a-96a5-d50e1293b770","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-05-24T02:53:04.7484734Z","updatedOn":"2019-05-24T02:53:04.7484734Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/553a3d02-d0da-4b7c-a0f1-d1298f556001","type":"Microsoft.Authorization/roleAssignments","name":"553a3d02-d0da-4b7c-a0f1-d1298f556001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1aa92e15-ee4e-4dda-9e61-5b4dc35d280b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-29T06:05:52.7948049Z","updatedOn":"2020-04-29T06:05:52.7948049Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/039870e3-5852-4b2f-a3a9-9e172adfd72b","type":"Microsoft.Authorization/roleAssignments","name":"039870e3-5852-4b2f-a3a9-9e172adfd72b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1c93a1ad-59cf-42fc-b6ce-0f5ffd464a70","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-04-09T20:12:14.4602372Z","updatedOn":"2018-04-09T20:12:14.4602372Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d5397a6-f185-4b65-bcba-6b9f2248093a","type":"Microsoft.Authorization/roleAssignments","name":"8d5397a6-f185-4b65-bcba-6b9f2248093a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"2262dfe7-375f-4597-a47c-2766489ecbe7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-06-14T17:54:39.3919633Z","updatedOn":"2019-06-14T17:54:39.3919633Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3f58856e-c1e1-4269-9055-f9fbe4cb6506","type":"Microsoft.Authorization/roleAssignments","name":"3f58856e-c1e1-4269-9055-f9fbe4cb6506"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"2ed08755-e5b9-42ef-8638-38e95105e710","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-23T06:01:53.1357543Z","updatedOn":"2019-12-23T06:01:53.1357543Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1986d758-ee67-4fc7-9eb2-c0d52d4a075d","type":"Microsoft.Authorization/roleAssignments","name":"1986d758-ee67-4fc7-9eb2-c0d52d4a075d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1b1b6446-6585-4988-b9ab-a8cdf9035b8a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-11T09:21:11.3066024Z","updatedOn":"2020-02-11T09:21:11.3066024Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ae57b317-873d-4242-a539-32b3e934259d","type":"Microsoft.Authorization/roleAssignments","name":"ae57b317-873d-4242-a539-32b3e934259d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-17T08:29:55.3047288Z","updatedOn":"2019-09-17T08:29:55.3047288Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e3591e24-669e-475f-a315-7d581996b864","type":"Microsoft.Authorization/roleAssignments","name":"e3591e24-669e-475f-a315-7d581996b864"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"32fe2882-ca97-44f9-8e0d-dfe916b9dfee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-06T03:03:50.0740099Z","updatedOn":"2019-09-06T03:03:50.0740099Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/01c1fcc9-4df3-4107-832f-42f245309750","type":"Microsoft.Authorization/roleAssignments","name":"01c1fcc9-4df3-4107-832f-42f245309750"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"378df7ee-31fd-4c54-945e-a1ed4f025a28","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-08-10T19:00:33.4173527Z","updatedOn":"2017-08-10T19:00:33.4173527Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e0ddb7cd-de16-42ce-bab6-6a0d4d3903d8","type":"Microsoft.Authorization/roleAssignments","name":"e0ddb7cd-de16-42ce-bab6-6a0d4d3903d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"37aa63b3-0814-4c36-9641-d9c3120b1f1b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-25T22:21:28.6870688Z","updatedOn":"2019-02-25T22:21:28.6870688Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/185a89d4-23f9-4fb8-827c-6d7f8e26c49d","type":"Microsoft.Authorization/roleAssignments","name":"185a89d4-23f9-4fb8-827c-6d7f8e26c49d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"37e77055-3c53-4ae5-bf04-d2459236b6a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:25:07.0794530Z","updatedOn":"2020-01-09T06:25:07.0794530Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ec3d1379-1350-4894-98dc-4742280ba73b","type":"Microsoft.Authorization/roleAssignments","name":"ec3d1379-1350-4894-98dc-4742280ba73b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"39029da9-0fef-42a9-b478-2fe4e19b8c7b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-19T02:54:07.7981142Z","updatedOn":"2020-06-19T02:54:07.7981142Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/90fa5166-2ffa-44a8-ad5d-da4f3eaab642","type":"Microsoft.Authorization/roleAssignments","name":"90fa5166-2ffa-44a8-ad5d-da4f3eaab642"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-19T03:54:40.3617093Z","updatedOn":"2020-01-19T03:54:40.3617093Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c9b97fb4-3b05-49af-97de-2950204d9066","type":"Microsoft.Authorization/roleAssignments","name":"c9b97fb4-3b05-49af-97de-2950204d9066"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3e675290-31e1-49f6-a3cd-03df3d7d6e2e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-03T04:39:51.0517217Z","updatedOn":"2020-05-03T04:39:51.0517217Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/49eedfad-3250-441e-8a85-03026008e57c","type":"Microsoft.Authorization/roleAssignments","name":"49eedfad-3250-441e-8a85-03026008e57c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"4582e5fb-504d-4b21-89be-9e11352ac837","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-27T01:17:48.4170577Z","updatedOn":"2020-02-27T01:17:48.4170577Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/43cfb5ae-8271-433b-8799-85858d658f59","type":"Microsoft.Authorization/roleAssignments","name":"43cfb5ae-8271-433b-8799-85858d658f59"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"4c1e34fd-dcf5-4516-bb96-b8ac22e138da","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T08:54:40.6904887Z","updatedOn":"2020-06-08T08:54:40.6904887Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/386dc123-cb36-4f9f-ac58-7aaaf5d7ed58","type":"Microsoft.Authorization/roleAssignments","name":"386dc123-cb36-4f9f-ac58-7aaaf5d7ed58"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"56b6b563-1341-4632-96cd-06252b81665d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-05T08:50:50.2703536Z","updatedOn":"2019-09-05T08:50:50.2703536Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e17d3c8b-26f3-4cdd-bcc1-211c3e490299","type":"Microsoft.Authorization/roleAssignments","name":"e17d3c8b-26f3-4cdd-bcc1-211c3e490299"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"596c247a-9db0-4c20-8ddb-d944102067ac","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-25T08:06:17.3145960Z","updatedOn":"2019-10-25T08:06:17.3145960Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5383f6ae-0e25-43d5-a448-2fd0d2699d72","type":"Microsoft.Authorization/roleAssignments","name":"5383f6ae-0e25-43d5-a448-2fd0d2699d72"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5a7755a0-33cc-4bcc-9064-12f1bf05c991","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-11T05:55:15.7549140Z","updatedOn":"2020-05-11T05:55:15.7549140Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5584dc94-54e6-4a61-af7c-09934f06b4d1","type":"Microsoft.Authorization/roleAssignments","name":"5584dc94-54e6-4a61-af7c-09934f06b4d1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5accae2a-f109-44ba-8549-8c682acd4ad1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-11-06T23:33:48.6032970Z","updatedOn":"2017-11-06T23:33:48.6032970Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b35dfe77-4bb3-4956-b644-16d58904b1bf","type":"Microsoft.Authorization/roleAssignments","name":"b35dfe77-4bb3-4956-b644-16d58904b1bf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"669ef724-96ef-462e-b760-a398c8d49f12","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-10-16T00:01:10.8880293Z","updatedOn":"2018-10-16T00:01:10.8880293Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1fb698ad-cef0-442e-8fa0-c5c4609b12ec","type":"Microsoft.Authorization/roleAssignments","name":"1fb698ad-cef0-442e-8fa0-c5c4609b12ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6ba8d12f-faf3-4859-918b-80f93e471e38","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-05T07:42:22.6383489Z","updatedOn":"2019-09-05T07:42:22.6383489Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1b0df1c0-baf0-41ed-9560-6495d40dfa06","type":"Microsoft.Authorization/roleAssignments","name":"1b0df1c0-baf0-41ed-9560-6495d40dfa06"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T05:03:40.5214262Z","updatedOn":"2020-04-26T05:03:40.5214262Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73651752-e48b-47b6-8ce6-770e1bf56e80","type":"Microsoft.Authorization/roleAssignments","name":"73651752-e48b-47b6-8ce6-770e1bf56e80"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-24T09:14:30.5134753Z","updatedOn":"2020-04-24T09:14:30.5134753Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1ba14abb-5c95-4d45-be2c-5429d47ba9b3","type":"Microsoft.Authorization/roleAssignments","name":"1ba14abb-5c95-4d45-be2c-5429d47ba9b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-10T06:36:08.0241793Z","updatedOn":"2019-09-10T06:36:08.0241793Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10b1e634-f9af-4434-bd13-55eb43a57124","type":"Microsoft.Authorization/roleAssignments","name":"10b1e634-f9af-4434-bd13-55eb43a57124"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7b29ef09-268a-44a7-b1f8-094beba68028","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-04-05T17:27:17.7281001Z","updatedOn":"2018-04-05T17:27:17.7281001Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a5c8a26b-80ac-421d-a137-2951374bca62","type":"Microsoft.Authorization/roleAssignments","name":"a5c8a26b-80ac-421d-a137-2951374bca62"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T06:26:40.9453629Z","updatedOn":"2019-11-26T06:26:40.9453629Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2ba40e27-d44f-48e7-9462-1561128bed69","type":"Microsoft.Authorization/roleAssignments","name":"2ba40e27-d44f-48e7-9462-1561128bed69"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-23T08:57:03.4127112Z","updatedOn":"2019-10-23T08:57:03.4127112Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ec55b030-cffa-46ab-a296-78f606400df8","type":"Microsoft.Authorization/roleAssignments","name":"ec55b030-cffa-46ab-a296-78f606400df8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7e58ddef-4719-4c36-a485-4c2a0a843a46","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-25T05:07:15.7863485Z","updatedOn":"2019-12-25T05:07:15.7863485Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/999c61a0-361b-416f-91ee-68f515f910ec","type":"Microsoft.Authorization/roleAssignments","name":"999c61a0-361b-416f-91ee-68f515f910ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-15T08:49:50.8762611Z","updatedOn":"2019-11-15T08:49:50.8762611Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/233c612a-f4d8-41fb-bf58-8e2a587142df","type":"Microsoft.Authorization/roleAssignments","name":"233c612a-f4d8-41fb-bf58-8e2a587142df"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"864a275e-8c80-4efb-ad1c-0c0ab3081788","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-12T02:40:02.3180608Z","updatedOn":"2020-06-12T02:40:02.3180608Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7c5ea86e-a5a6-4750-b95f-5ba47a93ff60","type":"Microsoft.Authorization/roleAssignments","name":"7c5ea86e-a5a6-4750-b95f-5ba47a93ff60"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-23T05:48:03.4970209Z","updatedOn":"2019-12-23T05:48:03.4970209Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8cbac001-17ff-4ba4-ade1-cbbb4924e6d6","type":"Microsoft.Authorization/roleAssignments","name":"8cbac001-17ff-4ba4-ade1-cbbb4924e6d6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"8d594fee-5764-49c9-ad85-35d3ee728386","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-23T09:22:57.7278029Z","updatedOn":"2019-10-23T09:22:57.7278029Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/66da1b82-8f84-41cc-995f-867498db9ae3","type":"Microsoft.Authorization/roleAssignments","name":"66da1b82-8f84-41cc-995f-867498db9ae3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-10T06:47:24.5464704Z","updatedOn":"2019-07-10T06:47:24.5464704Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/83b44361-6e27-4ed1-923c-b10ce84b3926","type":"Microsoft.Authorization/roleAssignments","name":"83b44361-6e27-4ed1-923c-b10ce84b3926"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-21T06:37:44.9936263Z","updatedOn":"2019-10-21T06:37:44.9936263Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7e96cad1-9fe5-49d6-b754-cbe33ce49882","type":"Microsoft.Authorization/roleAssignments","name":"7e96cad1-9fe5-49d6-b754-cbe33ce49882"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-04T03:06:42.9265284Z","updatedOn":"2019-12-04T03:06:42.9265284Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fe0b9591-410f-4229-a288-98d8bfb7ffe5","type":"Microsoft.Authorization/roleAssignments","name":"fe0b9591-410f-4229-a288-98d8bfb7ffe5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a9668459-3905-4e76-a681-a1633c50f368","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-16T02:39:39.2120161Z","updatedOn":"2019-12-16T02:39:39.2120161Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/263dab0a-bf9f-4eec-9ff6-387f87ed056b","type":"Microsoft.Authorization/roleAssignments","name":"263dab0a-bf9f-4eec-9ff6-387f87ed056b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-14T02:32:43.7202100Z","updatedOn":"2020-01-14T02:32:43.7202100Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/93adfbfa-f811-47e3-8ff7-e3a4675b579f","type":"Microsoft.Authorization/roleAssignments","name":"93adfbfa-f811-47e3-8ff7-e3a4675b579f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"ac47bda7-ff61-4451-9bb5-ad30ebcc2863","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-20T02:31:32.7276952Z","updatedOn":"2019-09-20T02:31:32.7276952Z","createdBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","updatedBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bf29019-3c72-44c1-97d4-58ef4d1a540f","type":"Microsoft.Authorization/roleAssignments","name":"4bf29019-3c72-44c1-97d4-58ef4d1a540f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b1eb9d0b-6ca2-4c64-8c13-31e5aa59065f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T07:10:10.5329285Z","updatedOn":"2020-06-08T07:10:10.5329285Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3bb3e257-89a9-4168-ae8b-99807e3819f3","type":"Microsoft.Authorization/roleAssignments","name":"3bb3e257-89a9-4168-ae8b-99807e3819f3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"93a01e49-673a-4e15-8230-51214a737962","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-07-05T21:56:39.5905773Z","updatedOn":"2017-07-05T21:56:39.5905773Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d09787d-0a89-40a8-abf2-a7b60e95d24b","type":"Microsoft.Authorization/roleAssignments","name":"8d09787d-0a89-40a8-abf2-a7b60e95d24b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-03T09:04:20.9413623Z","updatedOn":"2019-12-03T09:04:20.9413623Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6e6cc759-072e-47b8-b35d-ca5b95266e59","type":"Microsoft.Authorization/roleAssignments","name":"6e6cc759-072e-47b8-b35d-ca5b95266e59"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c0526f76-a841-4a3a-bdee-59a5db599e34","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-11T19:18:19.9314682Z","updatedOn":"2018-12-11T19:18:19.9314682Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d9e73a14-4984-4d89-8048-04773fb32344","type":"Microsoft.Authorization/roleAssignments","name":"d9e73a14-4984-4d89-8048-04773fb32344"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c7cc3390-43d1-4a59-8ab8-190092db8184","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T09:49:01.2994155Z","updatedOn":"2020-06-08T09:49:01.2994155Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/184cdda7-d40a-4c78-b71d-9e947e48a488","type":"Microsoft.Authorization/roleAssignments","name":"184cdda7-d40a-4c78-b71d-9e947e48a488"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c87f79eb-8113-4168-83c8-3a0e99ac67be","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-20T09:31:14.0133249Z","updatedOn":"2020-01-20T09:31:14.0133249Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5465d5e4-7123-4cd3-b584-f51ea72c2b79","type":"Microsoft.Authorization/roleAssignments","name":"5465d5e4-7123-4cd3-b584-f51ea72c2b79"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"cdc7828e-c6c1-4822-9b0b-ca54f3d92bcd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-03-15T23:45:46.1042773Z","updatedOn":"2018-03-15T23:45:46.1042773Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d194606-3a10-428a-9ce5-876fec5096c8","type":"Microsoft.Authorization/roleAssignments","name":"8d194606-3a10-428a-9ce5-876fec5096c8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1178d20-4ca4-45f0-ba9a-5a08f588da8d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-05T11:26:44.9370825Z","updatedOn":"2020-05-05T11:26:44.9370825Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d7689797-3689-4c92-b472-a9aaa7c54570","type":"Microsoft.Authorization/roleAssignments","name":"d7689797-3689-4c92-b472-a9aaa7c54570"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d36e0017-aac8-4dd3-8ccf-0ab8a7049c35","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-18T11:38:03.9624602Z","updatedOn":"2020-01-18T11:38:03.9624602Z","createdBy":"dca37046-82cf-4fbb-8088-faa399010380","updatedBy":"dca37046-82cf-4fbb-8088-faa399010380","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/86ebcfe8-2caa-40b5-aebe-ac5a928368ef","type":"Microsoft.Authorization/roleAssignments","name":"86ebcfe8-2caa-40b5-aebe-ac5a928368ef"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"dabd5159-ba4a-42fb-9e4d-7d841445695d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-16T04:29:39.1910424Z","updatedOn":"2020-01-16T04:29:39.1910424Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8ae1af04-181f-418f-a55d-cbdfa2327b75","type":"Microsoft.Authorization/roleAssignments","name":"8ae1af04-181f-418f-a55d-cbdfa2327b75"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-10T02:54:02.2514605Z","updatedOn":"2019-11-10T02:54:02.2514605Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/de186952-0e06-4557-89b5-31257c33093b","type":"Microsoft.Authorization/roleAssignments","name":"de186952-0e06-4557-89b5-31257c33093b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-24T03:28:22.7145389Z","updatedOn":"2019-09-24T03:28:22.7145389Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/16b3fb1c-befa-4dfd-8fbc-9838444af841","type":"Microsoft.Authorization/roleAssignments","name":"16b3fb1c-befa-4dfd-8fbc-9838444af841"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f19e5031-d73d-4d9a-86b7-d540f1bc6cd7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-07T09:51:42.8397254Z","updatedOn":"2020-05-07T09:51:42.8397254Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da43c24c-31f6-47e5-b44f-e1852b61cde6","type":"Microsoft.Authorization/roleAssignments","name":"da43c24c-31f6-47e5-b44f-e1852b61cde6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f3ea48f6-a16e-4b37-8260-f69cf2200525","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T04:53:43.7428061Z","updatedOn":"2020-04-13T04:53:43.7428061Z","createdBy":"7e58ddef-4719-4c36-a485-4c2a0a843a46","updatedBy":"7e58ddef-4719-4c36-a485-4c2a0a843a46","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4d3c5439-0e6d-4dba-afd2-36d6aa289238","type":"Microsoft.Authorization/roleAssignments","name":"4d3c5439-0e6d-4dba-afd2-36d6aa289238"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f4ed124d-6acb-49a5-a6ac-bd96f35d8d16","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T06:25:17.5556287Z","updatedOn":"2020-04-26T06:25:17.5556287Z","createdBy":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","updatedBy":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fcef0c4c-0b40-423a-937e-fb6493374993","type":"Microsoft.Authorization/roleAssignments","name":"fcef0c4c-0b40-423a-937e-fb6493374993"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f802089b-0ae0-4e9b-984a-4e37eef96b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T07:52:39.3088894Z","updatedOn":"2020-04-13T07:52:39.3088894Z","createdBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","updatedBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/82a5d3eb-6393-4a30-9d62-93d9b272d628","type":"Microsoft.Authorization/roleAssignments","name":"82a5d3eb-6393-4a30-9d62-93d9b272d628"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"ffbb9ca1-43fc-498d-b8db-ca965f1684ef","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-12-18T23:20:41.1586895Z","updatedOn":"2017-12-18T23:20:41.1586895Z","createdBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","updatedBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7e012250-6450-4432-b6dd-9e148ab64455","type":"Microsoft.Authorization/roleAssignments","name":"7e012250-6450-4432-b6dd-9e148ab64455"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T04:01:23.9885462Z","updatedOn":"2020-03-19T04:01:23.9885462Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a96438a6-6252-499b-b391-710446ac8ddb","type":"Microsoft.Authorization/roleAssignments","name":"a96438a6-6252-499b-b391-710446ac8ddb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/abec5297-d72c-4fbc-acaf-868482d345c2","principalId":"7a938a30-4226-420e-996f-4d48bca6d537","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-06-14T22:25:43.4944951Z","updatedOn":"2018-06-14T22:25:43.4944951Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a3662714-8332-43d4-a2cf-836f9367c53d","type":"Microsoft.Authorization/roleAssignments","name":"a3662714-8332-43d4-a2cf-836f9367c53d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"27c363a5-7016-4ae0-8540-818ec05673f1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T15:34:53.2206231Z","updatedOn":"2020-04-26T15:34:53.2206231Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/88670ac0-08a0-40af-8cb3-cfecc39224a6","type":"Microsoft.Authorization/roleAssignments","name":"88670ac0-08a0-40af-8cb3-cfecc39224a6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"5963f50c-7c43-405c-af7e-53294de76abd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-11T01:35:58.0239576Z","updatedOn":"2020-01-11T01:35:58.0239576Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/332cf847-f85f-4e42-93c0-ac2d2269c9c6","type":"Microsoft.Authorization/roleAssignments","name":"332cf847-f85f-4e42-93c0-ac2d2269c9c6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"63bdf800-9003-4644-b23c-0caeabf62a42","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T09:34:30.7345716Z","updatedOn":"2020-04-26T09:34:30.7345716Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1f6b6d83-0880-477a-a232-5d15410b189f","type":"Microsoft.Authorization/roleAssignments","name":"1f6b6d83-0880-477a-a232-5d15410b189f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"9e6a992a-0530-43ad-bcd7-e9e0e84ae703","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-11T05:47:51.9435473Z","updatedOn":"2020-03-11T05:47:51.9435473Z","createdBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","updatedBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/07371d4e-e9de-4ef7-84c6-0694afc57163","type":"Microsoft.Authorization/roleAssignments","name":"07371d4e-e9de-4ef7-84c6-0694afc57163"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"d8422fc6-cc80-4990-b5d9-15dfc33bd4ce","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-16T07:05:29.5235140Z","updatedOn":"2020-01-16T07:13:20.5220097Z","createdBy":"9abd3759-d4a6-4297-a26e-19f728a9bc15","updatedBy":"9abd3759-d4a6-4297-a26e-19f728a9bc15","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/20cbf68b-1170-7660-526a-0ce148ad6b9f","type":"Microsoft.Authorization/roleAssignments","name":"20cbf68b-1170-7660-526a-0ce148ad6b9f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-28T02:17:47.3517737Z","updatedOn":"2019-10-28T02:17:47.3517737Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fa59db41-bdc7-4934-9105-138c49aa3b25","type":"Microsoft.Authorization/roleAssignments","name":"fa59db41-bdc7-4934-9105-138c49aa3b25"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0216022c-0a14-4682-b106-fe0de377fba8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-11T10:14:11.4652781Z","updatedOn":"2020-06-11T10:14:11.4652781Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0bdccc57-790d-47b5-ab25-3b25b2c383f5","type":"Microsoft.Authorization/roleAssignments","name":"0bdccc57-790d-47b5-ab25-3b25b2c383f5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"025742e3-96b0-462b-92b8-c6f8a2467315","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T02:30:48.9213321Z","updatedOn":"2019-11-13T02:30:48.9213321Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8e56fee5-34b2-4fda-94f5-4d16d0f316c9","type":"Microsoft.Authorization/roleAssignments","name":"8e56fee5-34b2-4fda-94f5-4d16d0f316c9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"048c9bb6-913e-4ce6-99c5-35198246627b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T08:20:44.1467077Z","updatedOn":"2019-11-13T08:20:44.1467077Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ee9a0273-478f-49c1-ab8b-c391f00ab24a","type":"Microsoft.Authorization/roleAssignments","name":"ee9a0273-478f-49c1-ab8b-c391f00ab24a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"05b1f982-1404-4e2d-b2e8-af3ee7a330b4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-16T02:20:33.6180302Z","updatedOn":"2019-09-16T02:20:33.6180302Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dd290ec1-928e-4be9-bf1a-5444db3c31a9","type":"Microsoft.Authorization/roleAssignments","name":"dd290ec1-928e-4be9-bf1a-5444db3c31a9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0b9debbf-74a2-4090-9e79-6f814c15c64f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-13T23:58:24.6590895Z","updatedOn":"2019-02-13T23:58:24.6590895Z","createdBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","updatedBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/84210bda-8759-422b-b6ea-f95ba2a645cc","type":"Microsoft.Authorization/roleAssignments","name":"84210bda-8759-422b-b6ea-f95ba2a645cc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d1408bc-e090-4bb3-b430-608cc2fb2a0c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T13:25:32.0800552Z","updatedOn":"2020-05-12T13:25:32.0800552Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/95c1ae5a-01de-4f0c-9c56-8e87c017cf36","type":"Microsoft.Authorization/roleAssignments","name":"95c1ae5a-01de-4f0c-9c56-8e87c017cf36"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0444ccf8-fddb-43c4-b42b-ea036211229f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-18T09:31:46.3880250Z","updatedOn":"2019-09-18T09:31:46.3880250Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e7e0e4be-da1c-4e63-8872-b2486e10fbaf","type":"Microsoft.Authorization/roleAssignments","name":"e7e0e4be-da1c-4e63-8872-b2486e10fbaf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-29T13:26:41.7796634Z","updatedOn":"2020-01-29T13:26:41.7796634Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/185c46f5-737c-4e7e-bdeb-5bafee91059d","type":"Microsoft.Authorization/roleAssignments","name":"185c46f5-737c-4e7e-bdeb-5bafee91059d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0dbbe202-a46d-4ade-8f74-0927ccff3bb6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T07:04:08.1661319Z","updatedOn":"2020-06-09T07:04:08.1661319Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3322b8ab-16df-464e-9b80-b555950e6d56","type":"Microsoft.Authorization/roleAssignments","name":"3322b8ab-16df-464e-9b80-b555950e6d56"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"16253a8a-cc24-475a-a5cf-e58491ffd350","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-30T10:22:53.8662664Z","updatedOn":"2019-10-30T10:22:53.8662664Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0d7cca1c-37d2-492a-92ed-c9ae8323e2e2","type":"Microsoft.Authorization/roleAssignments","name":"0d7cca1c-37d2-492a-92ed-c9ae8323e2e2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"182c8534-f413-487c-91a3-7addc80e35d5","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-08T08:26:11.9991435Z","updatedOn":"2020-04-08T08:26:11.9991435Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7ec462b1-f831-472f-8e1b-ff3a11068385","type":"Microsoft.Authorization/roleAssignments","name":"7ec462b1-f831-472f-8e1b-ff3a11068385"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"23304842-3c9b-46fb-9f34-ae0afe0e9a82","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:34:09.9873389Z","updatedOn":"2020-01-09T06:34:09.9873389Z","createdBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","updatedBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79d401d9-e585-43bf-a874-1ecc9685e823","type":"Microsoft.Authorization/roleAssignments","name":"79d401d9-e585-43bf-a874-1ecc9685e823"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-11T15:04:11.6940972Z","updatedOn":"2020-03-14T14:47:34.7417244Z","createdBy":"2c4ad291-088a-4833-9d12-65562168e61f","updatedBy":"f238ba61-2e60-495f-8044-5abc249758fe","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9b26c70e-48e6-9170-677d-d2e0c5c9304e","type":"Microsoft.Authorization/roleAssignments","name":"9b26c70e-48e6-9170-677d-d2e0c5c9304e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"34dd2730-0adb-4bb0-973b-d020e4ae4284","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T02:45:08.7641129Z","updatedOn":"2020-06-08T02:45:08.7641129Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/201a6827-570f-4c37-9e6f-f128e3cd5d85","type":"Microsoft.Authorization/roleAssignments","name":"201a6827-570f-4c37-9e6f-f128e3cd5d85"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"37aa63b3-0814-4c36-9641-d9c3120b1f1b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-01-08T18:58:20.9990189Z","updatedOn":"2019-01-08T18:58:20.9990189Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/54925852-e514-4e06-9023-14b82e9060e7","type":"Microsoft.Authorization/roleAssignments","name":"54925852-e514-4e06-9023-14b82e9060e7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"46b61f8c-9b9c-48e4-912e-243041a7c6c5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:34:13.1774942Z","updatedOn":"2020-01-09T06:34:13.1774942Z","createdBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","updatedBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10e987b4-b922-471c-994b-ccd01cf71780","type":"Microsoft.Authorization/roleAssignments","name":"10e987b4-b922-471c-994b-ccd01cf71780"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4759ce24-1955-4c57-bc53-357a69cc065f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T05:42:58.0364828Z","updatedOn":"2019-09-11T05:42:58.0364828Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/096db8b9-6da1-41d6-91fc-a44386feca3f","type":"Microsoft.Authorization/roleAssignments","name":"096db8b9-6da1-41d6-91fc-a44386feca3f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"478ac2b7-8882-45d7-b424-6d8339728ea9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-01T00:51:52.9057101Z","updatedOn":"2019-11-01T00:51:52.9057101Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9eb79b9d-a384-4d48-83b7-5b31896a4f92","type":"Microsoft.Authorization/roleAssignments","name":"9eb79b9d-a384-4d48-83b7-5b31896a4f92"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4b5f89be-be88-448d-90bd-1148b6c6deb2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-23T02:16:34.2523880Z","updatedOn":"2019-07-23T02:16:34.2523880Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1da14562-3dee-4c97-a071-1b2937796647","type":"Microsoft.Authorization/roleAssignments","name":"1da14562-3dee-4c97-a071-1b2937796647"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4559f5d9-0272-48bd-b6af-fde7f60744dc","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-05T02:39:11.3496688Z","updatedOn":"2020-02-05T02:39:11.3496688Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/108c3348-6445-49c8-8a02-1e9088373505","type":"Microsoft.Authorization/roleAssignments","name":"108c3348-6445-49c8-8a02-1e9088373505"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"50d1b7ca-6643-4aac-a7b6-aba7bffecb30","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-05-30T21:23:34.5623608Z","updatedOn":"2019-05-30T21:23:34.5623608Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff3f8887-b570-4cd2-80d9-31c3c0d780aa","type":"Microsoft.Authorization/roleAssignments","name":"ff3f8887-b570-4cd2-80d9-31c3c0d780aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5230081f-d9b5-4af6-8d26-c648d9cf8ddd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-25T12:43:47.6193708Z","updatedOn":"2020-03-25T12:43:47.6193708Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/13f1d803-4dbb-4cf7-b199-35653a04bf75","type":"Microsoft.Authorization/roleAssignments","name":"13f1d803-4dbb-4cf7-b199-35653a04bf75"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5a17d64a-7ad7-432b-8622-88e4897b4cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-17T08:29:12.7481081Z","updatedOn":"2020-06-17T08:29:12.7481081Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0a0e59b8-4570-4bbc-90c1-87cfdbb3d9b0","type":"Microsoft.Authorization/roleAssignments","name":"0a0e59b8-4570-4bbc-90c1-87cfdbb3d9b0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"60a5c23b-3773-41b6-b27f-74805f1d2d9c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-04T10:54:04.8614591Z","updatedOn":"2020-02-04T10:54:04.8614591Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/47ad8fd8-84be-48d1-8d7a-923163696cdd","type":"Microsoft.Authorization/roleAssignments","name":"47ad8fd8-84be-48d1-8d7a-923163696cdd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"69ed4898-0851-4ea4-9813-dfc9864cbaf6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-11T19:26:34.1746649Z","updatedOn":"2018-12-11T19:26:34.1746649Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/27564201-65a3-4a09-bdaf-70c08ecd1786","type":"Microsoft.Authorization/roleAssignments","name":"27564201-65a3-4a09-bdaf-70c08ecd1786"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6a0911c8-758b-458a-8a36-7d6a4c2d450b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-21T05:12:27.5158666Z","updatedOn":"2020-01-21T05:12:27.5158666Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3e8820a3-637f-4a61-922b-abdf163ea9d5","type":"Microsoft.Authorization/roleAssignments","name":"3e8820a3-637f-4a61-922b-abdf163ea9d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"12af389a-3835-46c4-abe9-39d62a64c8e4","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-15T07:17:19.3982425Z","updatedOn":"2020-05-15T07:17:19.3982425Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4944a8a7-76af-49ad-9951-9b4526e228b3","type":"Microsoft.Authorization/roleAssignments","name":"4944a8a7-76af-49ad-9951-9b4526e228b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6aef5178-c2d2-41f6-a180-a296155ddf40","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-21T05:12:34.7950106Z","updatedOn":"2019-11-21T05:12:34.7950106Z","createdBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","updatedBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b5c83b39-f8a1-425f-984b-79e74f9ea79a","type":"Microsoft.Authorization/roleAssignments","name":"b5c83b39-f8a1-425f-984b-79e74f9ea79a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6cc662e7-785f-4759-ae7d-faf16eae02ab","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-29T05:58:51.6260835Z","updatedOn":"2020-04-29T05:58:51.6260835Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c394d91b-6eb5-4ccb-8350-c53c391e98b2","type":"Microsoft.Authorization/roleAssignments","name":"c394d91b-6eb5-4ccb-8350-c53c391e98b2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6f1ee714-b0e7-4abf-aa1e-3457f3205f0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-08T08:17:55.0153562Z","updatedOn":"2020-05-08T08:17:55.0153562Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1af0247f-6055-4bb1-9ee6-e8ea37f5413d","type":"Microsoft.Authorization/roleAssignments","name":"1af0247f-6055-4bb1-9ee6-e8ea37f5413d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"76b6ea71-288a-4e62-b904-3f3013201fb7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-17T06:36:55.9940820Z","updatedOn":"2020-06-17T06:36:55.9940820Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/21364cd1-07fd-407d-b94f-c341679a1ad6","type":"Microsoft.Authorization/roleAssignments","name":"21364cd1-07fd-407d-b94f-c341679a1ad6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6d61a178-3216-4ba7-bdc3-0fbc62b65ac9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-18T14:13:16.1350734Z","updatedOn":"2019-11-18T14:13:16.1350734Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/951d7466-f489-49df-88a3-9790ad814153","type":"Microsoft.Authorization/roleAssignments","name":"951d7466-f489-49df-88a3-9790ad814153"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"76d7bb0b-b614-4497-a519-7a46689f537c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-13T05:59:17.2737425Z","updatedOn":"2020-05-13T05:59:17.2737425Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d34fdce-9cef-427a-bfa0-fb81ffba52f2","type":"Microsoft.Authorization/roleAssignments","name":"6d34fdce-9cef-427a-bfa0-fb81ffba52f2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T06:25:38.6656804Z","updatedOn":"2019-11-26T06:25:38.6656804Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/02287c55-f42c-4852-9b08-c20c8a3b7e3b","type":"Microsoft.Authorization/roleAssignments","name":"02287c55-f42c-4852-9b08-c20c8a3b7e3b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T11:44:45.7387983Z","updatedOn":"2020-05-26T11:44:45.7387983Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6a878581-11bf-4bd4-a7ab-b1fb64e555aa","type":"Microsoft.Authorization/roleAssignments","name":"6a878581-11bf-4bd4-a7ab-b1fb64e555aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"81e54268-6800-49d3-b90f-a2ea6e20c110","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-12T09:05:37.5222708Z","updatedOn":"2020-04-12T09:05:37.5222708Z","createdBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","updatedBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f6bb8b0d-7009-454a-a489-610c6e23b559","type":"Microsoft.Authorization/roleAssignments","name":"f6bb8b0d-7009-454a-a489-610c6e23b559"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"838439dc-f0fa-4a37-ba56-daa13ff730ed","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T09:15:50.5935627Z","updatedOn":"2019-09-11T09:15:50.5935627Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/253c1f18-9f2b-490d-961d-520ba222a9b3","type":"Microsoft.Authorization/roleAssignments","name":"253c1f18-9f2b-490d-961d-520ba222a9b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"864a275e-8c80-4efb-ad1c-0c0ab3081788","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T06:17:44.5858739Z","updatedOn":"2020-06-09T06:17:44.5858739Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0565f4e2-558c-40b3-860e-3e910285cae7","type":"Microsoft.Authorization/roleAssignments","name":"0565f4e2-558c-40b3-860e-3e910285cae7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"885ee9c5-df35-4d21-bd29-33d930ef4721","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-08-08T07:30:25.7405858Z","updatedOn":"2019-08-08T07:30:25.7405858Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9e1de6d0-412e-4425-8e11-897f4aa32d65","type":"Microsoft.Authorization/roleAssignments","name":"9e1de6d0-412e-4425-8e11-897f4aa32d65"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8ce13a5d-7120-4635-b792-8cc697798e81","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-03T05:23:07.9499351Z","updatedOn":"2019-10-03T05:23:07.9499351Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ca192630-0f9b-47ea-bc2a-0cc0f9dc27d7","type":"Microsoft.Authorization/roleAssignments","name":"ca192630-0f9b-47ea-bc2a-0cc0f9dc27d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"90c3d926-9c03-4d90-86f4-12866a6da212","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-02T20:57:30.6864609Z","updatedOn":"2019-04-02T20:57:30.6864609Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bf3be37-b85e-49f9-ace5-e14c018302b5","type":"Microsoft.Authorization/roleAssignments","name":"6bf3be37-b85e-49f9-ace5-e14c018302b5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-27T01:19:27.7003320Z","updatedOn":"2020-02-27T01:19:27.7003320Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/363f553a-f660-4bcc-9c18-855b870f7bc8","type":"Microsoft.Authorization/roleAssignments","name":"363f553a-f660-4bcc-9c18-855b870f7bc8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"973fdd79-4ab9-438e-87c3-954cca1889e1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-09-21T19:09:54.9071757Z","updatedOn":"2018-09-21T19:09:54.9071757Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a4890276-7fa1-47a7-9d82-f0a4ceff9bd6","type":"Microsoft.Authorization/roleAssignments","name":"a4890276-7fa1-47a7-9d82-f0a4ceff9bd6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"97885433-e8ee-463f-9db0-194661924999","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-05T09:50:17.9261390Z","updatedOn":"2020-03-05T09:50:17.9261390Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7934da9a-5ac8-4145-b917-d9e061fc10fc","type":"Microsoft.Authorization/roleAssignments","name":"7934da9a-5ac8-4145-b917-d9e061fc10fc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"99220f34-fe4d-4bb9-a54f-8cef2c114bec","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T02:24:15.1904918Z","updatedOn":"2019-11-13T02:24:15.1904918Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/35b39af0-258c-488a-91d0-a744d937d7d0","type":"Microsoft.Authorization/roleAssignments","name":"35b39af0-258c-488a-91d0-a744d937d7d0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4e6a3ef-370d-4b96-8484-0f0e7ae097cc","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-23T04:54:51.7233330Z","updatedOn":"2019-02-23T04:54:51.7233330Z","createdBy":"4a399fbb-7213-47d3-b6ad-59284286d50a","updatedBy":"4a399fbb-7213-47d3-b6ad-59284286d50a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/44a09d24-8afc-4e6f-8194-92c41bc03d2c","type":"Microsoft.Authorization/roleAssignments","name":"44a09d24-8afc-4e6f-8194-92c41bc03d2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ac49f0af-daf1-40c5-a7c5-976a80349806","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-25T19:29:43.0393638Z","updatedOn":"2019-02-25T19:29:43.0393638Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2990befc-9d32-467c-82e6-f6d4b9989731","type":"Microsoft.Authorization/roleAssignments","name":"2990befc-9d32-467c-82e6-f6d4b9989731"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9085a307-933c-452f-ae3a-9a8e13e68500","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-02T09:57:16.5579321Z","updatedOn":"2020-04-02T09:57:16.5579321Z","createdBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","updatedBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1e74faf5-14cb-443a-a960-986c993decbc","type":"Microsoft.Authorization/roleAssignments","name":"1e74faf5-14cb-443a-a960-986c993decbc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b0460b1a-d53a-42e8-a6a4-d9f43f0ccc73","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-28T04:23:35.8222484Z","updatedOn":"2020-05-28T04:23:35.8222484Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a8cb3f2a-31d8-4e9f-999a-ec8894bb13d5","type":"Microsoft.Authorization/roleAssignments","name":"a8cb3f2a-31d8-4e9f-999a-ec8894bb13d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-22T06:33:53.8936608Z","updatedOn":"2020-01-22T06:33:53.8936608Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a4075ce9-efa5-4df6-a196-2538407da770","type":"Microsoft.Authorization/roleAssignments","name":"a4075ce9-efa5-4df6-a196-2538407da770"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b95d1b0f-145c-480a-915a-3fb867fb598b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-07T05:49:02.0078574Z","updatedOn":"2020-04-07T05:49:02.0078574Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bd310d01-f783-4f08-8b88-948f0b348a11","type":"Microsoft.Authorization/roleAssignments","name":"bd310d01-f783-4f08-8b88-948f0b348a11"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"be76b331-83ac-423a-83de-a97b6a990735","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-22T10:26:36.6728187Z","updatedOn":"2020-05-22T10:26:36.6728187Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/12e50c31-99da-4248-a195-0ab7ac62c504","type":"Microsoft.Authorization/roleAssignments","name":"12e50c31-99da-4248-a195-0ab7ac62c504"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c11b39f7-26c3-4dfc-8d0f-20dde3187845","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-13T18:31:05.4586182Z","updatedOn":"2018-12-13T18:31:05.4586182Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4901f853-a3c6-47e4-9495-2aeb09fb4491","type":"Microsoft.Authorization/roleAssignments","name":"4901f853-a3c6-47e4-9495-2aeb09fb4491"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c87f79eb-8113-4168-83c8-3a0e99ac67be","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T08:20:56.3783272Z","updatedOn":"2020-06-09T08:20:56.3783272Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/60aed0e0-6e97-4ca9-90ac-1f604f8c374e","type":"Microsoft.Authorization/roleAssignments","name":"60aed0e0-6e97-4ca9-90ac-1f604f8c374e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cfca31cb-14a9-4e95-a9b7-f905ab23db3c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-03T04:01:25.5862636Z","updatedOn":"2020-02-03T04:01:25.5862636Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c9fd36d4-1cfe-48c2-bbfc-1ff34a1d1f1f","type":"Microsoft.Authorization/roleAssignments","name":"c9fd36d4-1cfe-48c2-bbfc-1ff34a1d1f1f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d04239cd-f0db-4151-91e9-df98af92d231","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-15T05:29:57.8724060Z","updatedOn":"2020-06-15T05:29:57.8724060Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8bfc3a45-0214-4e85-bd1a-e4ab3c3bdb92","type":"Microsoft.Authorization/roleAssignments","name":"8bfc3a45-0214-4e85-bd1a-e4ab3c3bdb92"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d22a37ff-94a3-46b9-a549-e16b8b71a43c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T04:51:28.2854740Z","updatedOn":"2019-11-13T04:51:28.2854740Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b362e66e-bf5f-4ba5-adaf-88034544377b","type":"Microsoft.Authorization/roleAssignments","name":"b362e66e-bf5f-4ba5-adaf-88034544377b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d80964f8-f04a-4e50-8803-35e571cfb2d9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-07T10:01:41.1345273Z","updatedOn":"2020-02-07T10:01:41.1345273Z","createdBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","updatedBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f1ef5acb-1958-4cd3-a981-0aa430cb0fbd","type":"Microsoft.Authorization/roleAssignments","name":"f1ef5acb-1958-4cd3-a981-0aa430cb0fbd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d8422fc6-cc80-4990-b5d9-15dfc33bd4ce","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-28T05:13:52.5233941Z","updatedOn":"2019-11-28T05:13:52.5233941Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a2e5207-3e10-4ca2-9784-6e7bb8050194","type":"Microsoft.Authorization/roleAssignments","name":"9a2e5207-3e10-4ca2-9784-6e7bb8050194"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"db65a597-9bd4-4259-9632-ffcbfd208b04","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-01-31T18:43:41.6069289Z","updatedOn":"2019-01-31T18:43:41.6069289Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa2a3117-6ca4-4ddf-83c7-511b370735dd","type":"Microsoft.Authorization/roleAssignments","name":"aa2a3117-6ca4-4ddf-83c7-511b370735dd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dc1a3549-229c-4971-93d1-dd2a12439b19","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-18T02:46:17.6374569Z","updatedOn":"2019-09-18T02:46:17.6374569Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79ee6058-9515-427b-a19d-f9a245e4172b","type":"Microsoft.Authorization/roleAssignments","name":"79ee6058-9515-427b-a19d-f9a245e4172b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ddab67ba-ea88-4673-9802-b5393ef85c81","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-13T09:32:56.5200842Z","updatedOn":"2020-03-13T09:32:56.5200842Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/60066209-df2b-4102-bf3a-6a405afe485c","type":"Microsoft.Authorization/roleAssignments","name":"60066209-df2b-4102-bf3a-6a405afe485c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e12f87e2-42fe-4081-a272-85eee50a8062","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T04:19:32.2862854Z","updatedOn":"2019-12-05T04:19:32.2862854Z","createdBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","updatedBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3076ac0b-96c1-40da-b47c-cc8b1a6f60d7","type":"Microsoft.Authorization/roleAssignments","name":"3076ac0b-96c1-40da-b47c-cc8b1a6f60d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f19e5031-d73d-4d9a-86b7-d540f1bc6cd7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T11:59:35.4100543Z","updatedOn":"2020-05-26T11:59:35.4100543Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a156d12a-0595-4273-870e-26b43b10eefb","type":"Microsoft.Authorization/roleAssignments","name":"a156d12a-0595-4273-870e-26b43b10eefb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f22c2b35-e81d-4fa5-afa4-e6178a257deb","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T13:25:32.1208963Z","updatedOn":"2020-05-12T13:25:32.1208963Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a898ad94-406c-429f-8221-1d2e7b9cd5bb","type":"Microsoft.Authorization/roleAssignments","name":"a898ad94-406c-429f-8221-1d2e7b9cd5bb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f6c2f6f7-1bbf-4c17-87c6-28c02d7c0637","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-11-08T18:01:59.1260407Z","updatedOn":"2018-11-08T18:01:59.1260407Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c4b79dcb-c95a-44c2-82cd-e550faad8ac5","type":"Microsoft.Authorization/roleAssignments","name":"c4b79dcb-c95a-44c2-82cd-e550faad8ac5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f757bcca-02d6-4279-8f2d-61a7dcdbccd6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-21T05:32:27.2840541Z","updatedOn":"2020-01-21T05:32:27.2840541Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da4d3dfe-5384-4144-a9c2-5bd2124ddc51","type":"Microsoft.Authorization/roleAssignments","name":"da4d3dfe-5384-4144-a9c2-5bd2124ddc51"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f77592c5-1eb8-4ed3-8615-ddbb75adb4fe","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-19T05:03:29.3633566Z","updatedOn":"2020-06-19T05:03:29.3633566Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2194737b-2f80-4b24-bcd1-45b4c72bce84","type":"Microsoft.Authorization/roleAssignments","name":"2194737b-2f80-4b24-bcd1-45b4c72bce84"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f802089b-0ae0-4e9b-984a-4e37eef96b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-19T05:51:35.7314750Z","updatedOn":"2020-01-19T05:51:35.7314750Z","createdBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","updatedBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3cc61a45-01f3-45df-8661-e7bdd3cf0ef5","type":"Microsoft.Authorization/roleAssignments","name":"3cc61a45-01f3-45df-8661-e7bdd3cf0ef5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-11T08:57:15.2589033Z","updatedOn":"2020-06-11T08:57:15.2589033Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f14cf4c3-66bb-4cb4-aa88-de46c43a5235","type":"Microsoft.Authorization/roleAssignments","name":"f14cf4c3-66bb-4cb4-aa88-de46c43a5235"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"838439dc-f0fa-4a37-ba56-daa13ff730ed","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T09:19:13.9288977Z","updatedOn":"2019-09-11T09:19:13.9288977Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b02d8e07-7398-4236-bf13-6293699c6862","type":"Microsoft.Authorization/roleAssignments","name":"b02d8e07-7398-4236-bf13-6293699c6862"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-10-25T19:47:09.8058411Z","updatedOn":"2018-10-25T19:47:09.8058411Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/abd19ae1-8e0c-4e31-b1ab-25e85d987378","type":"Microsoft.Authorization/roleAssignments","name":"abd19ae1-8e0c-4e31-b1ab-25e85d987378"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/cdda3590-29a3-44f6-95f2-9f980659eb04","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-25T02:29:00.1905156Z","updatedOn":"2019-11-25T02:29:00.1905156Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/774d0387-22b2-41fb-9025-c689ab821fb0","type":"Microsoft.Authorization/roleAssignments","name":"774d0387-22b2-41fb-9025-c689ab821fb0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3e587269-2f98-4906-8e35-7c6af32219d1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-23T03:47:43.1586800Z","updatedOn":"2020-06-23T03:47:43.1586800Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8fcf9b86-69ae-4033-bb78-7f21b15375c4","type":"Microsoft.Authorization/roleAssignments","name":"8fcf9b86-69ae-4033-bb78-7f21b15375c4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"8adc2845-bd5a-4a35-b00f-b83f0640facd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-24T04:56:37.2992825Z","updatedOn":"2020-06-24T04:56:37.2992825Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3921853b-f10d-4c32-9f3c-4ba978198495","type":"Microsoft.Authorization/roleAssignments","name":"3921853b-f10d-4c32-9f3c-4ba978198495"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"8adc2845-bd5a-4a35-b00f-b83f0640facd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-24T05:56:50.0401266Z","updatedOn":"2020-06-24T05:56:50.0401266Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3620fe85-c1cb-46f3-a138-f96236bc1bb0","type":"Microsoft.Authorization/roleAssignments","name":"3620fe85-c1cb-46f3-a138-f96236bc1bb0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1952a856-3972-421d-b257-ae7d8d62e244","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-30T10:09:32.8969837Z","updatedOn":"2020-06-30T10:09:32.8969837Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3274beac-a4e5-43e2-86cc-2247a4e81e45","type":"Microsoft.Authorization/roleAssignments","name":"3274beac-a4e5-43e2-86cc-2247a4e81e45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T02:08:52.2449294Z","updatedOn":"2020-07-01T02:08:52.2449294Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/72cedbfc-50c9-44fa-ad63-d9d32f5215f9","type":"Microsoft.Authorization/roleAssignments","name":"72cedbfc-50c9-44fa-ad63-d9d32f5215f9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9bc33702-a011-4e3b-80f7-927356668049","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T03:00:59.1715198Z","updatedOn":"2020-07-01T03:00:59.1715198Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/89304b85-648a-403d-ab10-f246b2db26b6","type":"Microsoft.Authorization/roleAssignments","name":"89304b85-648a-403d-ab10-f246b2db26b6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9bc33702-a011-4e3b-80f7-927356668049","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T03:27:54.5201710Z","updatedOn":"2020-07-01T03:27:54.5201710Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e5367e0d-da08-4a30-819c-f496ccaa4bfa","type":"Microsoft.Authorization/roleAssignments","name":"e5367e0d-da08-4a30-819c-f496ccaa4bfa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ee38ef12-23d7-4595-8f6f-b4aaa15933f9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T04:46:10.4023148Z","updatedOn":"2020-07-01T04:46:10.4023148Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d3f0718-3404-4f68-b88f-01d3852d40c2","type":"Microsoft.Authorization/roleAssignments","name":"6d3f0718-3404-4f68-b88f-01d3852d40c2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T06:40:44.5009970Z","updatedOn":"2020-07-01T06:40:44.5009970Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/beed1228-2a59-415d-b3c1-7cde7e454ffb","type":"Microsoft.Authorization/roleAssignments","name":"beed1228-2a59-415d-b3c1-7cde7e454ffb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9ec9777a-d786-409e-91c4-da25125576e4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-07T03:23:39.3280578Z","updatedOn":"2020-08-07T03:23:39.3280578Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a7d71d52-c222-4e2f-8ee3-a8ebbfbd8305","type":"Microsoft.Authorization/roleAssignments","name":"a7d71d52-c222-4e2f-8ee3-a8ebbfbd8305"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f013c31e-6903-492d-9f8f-8a2b0097a737","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:25:12.2160705Z","updatedOn":"2020-08-10T05:25:12.2160705Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/218b7750-72ff-4972-8251-0dd31c91c0f5","type":"Microsoft.Authorization/roleAssignments","name":"218b7750-72ff-4972-8251-0dd31c91c0f5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2bb241ba-8f4e-4d58-9812-1f730a9bb04f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:26:33.0105360Z","updatedOn":"2020-08-10T05:26:33.0105360Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e140f43a-4943-4839-a7ad-3c88eda426a3","type":"Microsoft.Authorization/roleAssignments","name":"e140f43a-4943-4839-a7ad-3c88eda426a3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"497a3fb5-4a8b-4fdb-a358-b1c7384d1297","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:39:03.3686314Z","updatedOn":"2020-08-10T05:39:03.3686314Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0ced53d7-64d1-45c2-b08b-7fbdb293d299","type":"Microsoft.Authorization/roleAssignments","name":"0ced53d7-64d1-45c2-b08b-7fbdb293d299"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T06:07:40.7376298Z","updatedOn":"2020-08-10T06:07:40.7376298Z","createdBy":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","updatedBy":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8e606ca9-ad53-4135-837b-c2cde19b8a8e","type":"Microsoft.Authorization/roleAssignments","name":"8e606ca9-ad53-4135-837b-c2cde19b8a8e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b98fae7f-2c20-443f-ab5c-ef3a7be6eae1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T09:03:55.9162129Z","updatedOn":"2020-08-10T09:03:55.9162129Z","createdBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","updatedBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f2241eaf-def8-425f-83ea-6afc474524ae","type":"Microsoft.Authorization/roleAssignments","name":"f2241eaf-def8-425f-83ea-6afc474524ae"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3aca7341-bda7-4fd7-b5e9-c2b97e0de8a7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:10:41.9755999Z","updatedOn":"2020-08-14T14:10:41.9755999Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cb5d9b2a-326e-49b9-8b8e-73b207413e7a","type":"Microsoft.Authorization/roleAssignments","name":"cb5d9b2a-326e-49b9-8b8e-73b207413e7a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e0e3d203-4502-40cb-a021-639bafd28ad5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:23:15.5278986Z","updatedOn":"2020-08-14T14:23:15.5278986Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/91acbf07-9cbd-4f4e-b1d8-cc7828058ec9","type":"Microsoft.Authorization/roleAssignments","name":"91acbf07-9cbd-4f4e-b1d8-cc7828058ec9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5da9b62e-db61-48df-b7cb-983d777e2ff2","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:28:46.5840210Z","updatedOn":"2020-08-14T14:28:46.5840210Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6efa18b8-42bc-47ca-8813-d30e73cf53db","type":"Microsoft.Authorization/roleAssignments","name":"6efa18b8-42bc-47ca-8813-d30e73cf53db"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7b6eac7a-88af-454f-b145-c76749e9a29b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T19:29:47.4188577Z","updatedOn":"2020-08-14T19:29:47.4188577Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d001d53-d8f4-4fff-b679-d80a7040eac7","type":"Microsoft.Authorization/roleAssignments","name":"6d001d53-d8f4-4fff-b679-d80a7040eac7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8ac0350b-22e2-4160-a726-34c6caa4184f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T19:48:28.7252041Z","updatedOn":"2020-08-14T19:48:28.7252041Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e0d4187d-1ee3-4056-8250-14f5e12ec79a","type":"Microsoft.Authorization/roleAssignments","name":"e0d4187d-1ee3-4056-8250-14f5e12ec79a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1141514b-1bef-48de-b565-d44152e1062b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:27:12.9790197Z","updatedOn":"2020-08-17T07:27:12.9790197Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3ab310ca-f5aa-4cfe-aac7-1cd7bb778936","type":"Microsoft.Authorization/roleAssignments","name":"3ab310ca-f5aa-4cfe-aac7-1cd7bb778936"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"06f8821b-7fbf-4980-886d-665d9db57b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:40:08.6067489Z","updatedOn":"2020-08-17T07:40:08.6067489Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1cabdfaf-a394-44c3-affc-81aff3ba6ae2","type":"Microsoft.Authorization/roleAssignments","name":"1cabdfaf-a394-44c3-affc-81aff3ba6ae2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cf2a17da-9812-4844-9ae0-3ae15ec76cad","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:46:00.6157836Z","updatedOn":"2020-08-17T07:46:00.6157836Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4fd3d281-3cc9-40e7-9b52-583f1dd816ee","type":"Microsoft.Authorization/roleAssignments","name":"4fd3d281-3cc9-40e7-9b52-583f1dd816ee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60f762f9-4b9d-4819-8447-b96770d393f7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":"@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:Name]
-        stringEquals ''foo''","conditionVersion":"2.0","createdOn":"2020-08-18T07:10:10.3636738Z","updatedOn":"2020-08-18T07:10:10.3636738Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":"Role
-        assignment foo to check on bar"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6da08c78-7567-4c5c-88a4-880a2ace7352","type":"Microsoft.Authorization/roleAssignments","name":"6da08c78-7567-4c5c-88a4-880a2ace7352"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"16aec3a5-3759-4e41-a69e-7e2b2680eafd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T09:52:17.6795896Z","updatedOn":"2020-08-18T09:52:17.6795896Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/75161d12-2bb2-42ae-a4e7-582440b6c4f4","type":"Microsoft.Authorization/roleAssignments","name":"75161d12-2bb2-42ae-a4e7-582440b6c4f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"acb2e9d2-2452-4577-a05e-d21a637a10fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T11:06:21.1901058Z","updatedOn":"2020-08-18T11:06:21.1901058Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/14218d21-a768-490e-8618-c15affc6937c","type":"Microsoft.Authorization/roleAssignments","name":"14218d21-a768-490e-8618-c15affc6937c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"79fe61e0-fd04-47f9-82e9-dba4d7d21b2e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T11:07:15.5617349Z","updatedOn":"2020-08-18T11:07:15.5617349Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/589f009b-6553-4743-972a-4ce54c29a635","type":"Microsoft.Authorization/roleAssignments","name":"589f009b-6553-4743-972a-4ce54c29a635"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a9dc1ee2-52a6-4092-868a-816237d2e662","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:29.9317048Z","updatedOn":"2020-08-19T07:03:29.9317048Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a3cde6c2-db59-403b-815b-f599d2575d08","type":"Microsoft.Authorization/roleAssignments","name":"a3cde6c2-db59-403b-815b-f599d2575d08"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"119ba358-4192-473a-b06d-181459705162","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:29.7818867Z","updatedOn":"2020-08-19T07:03:29.7818867Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/133bdd44-fcf5-49b5-878a-87416f8ae60d","type":"Microsoft.Authorization/roleAssignments","name":"133bdd44-fcf5-49b5-878a-87416f8ae60d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"34ea07e2-7262-40a9-aadc-afdf3a92fe21","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:45.6787321Z","updatedOn":"2020-08-19T07:03:45.6787321Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09848f3b-57c3-4f72-a8f4-df0aaa3270f1","type":"Microsoft.Authorization/roleAssignments","name":"09848f3b-57c3-4f72-a8f4-df0aaa3270f1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf3ceccf-4953-42e1-b3df-edcabdd83461","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:04:52.1212465Z","updatedOn":"2020-08-19T07:04:52.1212465Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a47f705e-40ad-4dbb-ac53-4493a0b44991","type":"Microsoft.Authorization/roleAssignments","name":"a47f705e-40ad-4dbb-ac53-4493a0b44991"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b8bec651-22e5-4a25-be13-6b1f9df8a00a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:05:25.2684558Z","updatedOn":"2020-08-19T07:05:25.2684558Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/93e123a2-8f6a-450a-aa0d-e4dc04de68d6","type":"Microsoft.Authorization/roleAssignments","name":"93e123a2-8f6a-450a-aa0d-e4dc04de68d6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c8b802a4-9966-4de2-b39b-6d4266c6bfff","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:57:35.2037157Z","updatedOn":"2020-08-19T07:57:35.2037157Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/549e00ed-6b04-4930-b359-4d0f43f4950d","type":"Microsoft.Authorization/roleAssignments","name":"549e00ed-6b04-4930-b359-4d0f43f4950d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6d97229a-391f-473a-893f-f0608b592d7b","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:38:20.3090190Z","updatedOn":"2020-08-19T08:38:20.3090190Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a7686d39-2951-4c27-8cbf-c3c36d701d24","type":"Microsoft.Authorization/roleAssignments","name":"a7686d39-2951-4c27-8cbf-c3c36d701d24"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7bbbac61-5311-40e7-a9e2-2dd92c54144b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:40:47.6961897Z","updatedOn":"2020-08-19T08:40:47.6961897Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f13a2128-645b-4b42-be6a-7b8a174d6dda","type":"Microsoft.Authorization/roleAssignments","name":"f13a2128-645b-4b42-be6a-7b8a174d6dda"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"10741bcb-37eb-4b5d-b73d-b22e72e4c7dd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:45:43.8141578Z","updatedOn":"2020-08-19T08:45:43.8141578Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d4366a87-a683-4232-8270-8475b5105a7b","type":"Microsoft.Authorization/roleAssignments","name":"d4366a87-a683-4232-8270-8475b5105a7b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"667a932e-e24b-4684-aa4a-1db1fd704cc3","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:47:19.3260541Z","updatedOn":"2020-08-19T08:47:19.3260541Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e430a73b-7548-4fee-a45d-25c71c70d8b3","type":"Microsoft.Authorization/roleAssignments","name":"e430a73b-7548-4fee-a45d-25c71c70d8b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a9111493-85b7-43f0-b388-333c160780c6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T05:05:29.5232338Z","updatedOn":"2020-08-21T05:05:29.5232338Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/417d7e21-636b-441a-90ae-106afe45fab1","type":"Microsoft.Authorization/roleAssignments","name":"417d7e21-636b-441a-90ae-106afe45fab1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a0192903-a3ce-47e2-b3d0-ae831e62a518","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T06:29:50.5909137Z","updatedOn":"2020-08-21T06:29:50.5909137Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cc5e851d-a6f5-45f2-82f5-3e8e2638814c","type":"Microsoft.Authorization/roleAssignments","name":"cc5e851d-a6f5-45f2-82f5-3e8e2638814c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"63c25c04-362b-42d9-9e3f-83af045d0a3c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T07:14:04.1824643Z","updatedOn":"2020-08-21T07:14:04.1824643Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bf019dd5-58f4-4fbc-9206-845cf65a7d07","type":"Microsoft.Authorization/roleAssignments","name":"bf019dd5-58f4-4fbc-9206-845cf65a7d07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8e510330-6da3-437c-9d16-b6875c47b73b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:10:19.9912043Z","updatedOn":"2020-08-21T19:10:19.9912043Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/14e6ffd6-9879-4134-9ae2-6e2b8d528ad3","type":"Microsoft.Authorization/roleAssignments","name":"14e6ffd6-9879-4134-9ae2-6e2b8d528ad3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1c60843c-84f3-4dfc-8b47-ede4ead019a9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:29:23.4218009Z","updatedOn":"2020-08-21T19:29:23.4218009Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/411c5f77-af95-4f2f-9e27-9b0c3a5c3a8a","type":"Microsoft.Authorization/roleAssignments","name":"411c5f77-af95-4f2f-9e27-9b0c3a5c3a8a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6d94ee65-e779-469a-a4b5-d56a0b07c685","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:34:28.1634489Z","updatedOn":"2020-08-21T19:34:28.1634489Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e76d93b3-6b01-4778-84e7-799c8b676e9c","type":"Microsoft.Authorization/roleAssignments","name":"e76d93b3-6b01-4778-84e7-799c8b676e9c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2b6f181-9d6c-4e10-876f-b995612db461","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:09:42.7361350Z","updatedOn":"2020-08-24T14:09:42.7361350Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c46c851d-b430-4494-a15c-a07fb87a90ae","type":"Microsoft.Authorization/roleAssignments","name":"c46c851d-b430-4494-a15c-a07fb87a90ae"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b3d54681-34f2-47b8-a790-97ed4c5a7a8d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:23:13.0411929Z","updatedOn":"2020-08-24T14:23:13.0411929Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9f100957-31b1-468b-b2d9-58574bc56a9d","type":"Microsoft.Authorization/roleAssignments","name":"9f100957-31b1-468b-b2d9-58574bc56a9d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a7c9a5c2-8e7a-4f42-abb7-018d3b8e845f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:27:43.7812740Z","updatedOn":"2020-08-24T14:27:43.7812740Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/de3f15f5-edcb-4bcd-81b2-1140597849ac","type":"Microsoft.Authorization/roleAssignments","name":"de3f15f5-edcb-4bcd-81b2-1140597849ac"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-26T06:39:56.9154641Z","updatedOn":"2020-08-26T06:39:56.9154641Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/52185ca9-744e-443f-8d95-5ddb2c963891","type":"Microsoft.Authorization/roleAssignments","name":"52185ca9-744e-443f-8d95-5ddb2c963891"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8cf96a92-f77b-4f11-b378-bc65f571dd97","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-28T19:11:18.2902598Z","updatedOn":"2020-08-28T19:11:18.2902598Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aaa8ba85-b7e1-4267-9120-44c9bb88d6cf","type":"Microsoft.Authorization/roleAssignments","name":"aaa8ba85-b7e1-4267-9120-44c9bb88d6cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"aceba178-3429-4628-a918-9c2d07605ce4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-28T19:34:05.2521949Z","updatedOn":"2020-08-28T19:34:05.2521949Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/db744c26-387e-450c-af33-9f650d3e081a","type":"Microsoft.Authorization/roleAssignments","name":"db744c26-387e-450c-af33-9f650d3e081a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T02:18:54.8314918Z","updatedOn":"2020-08-31T02:18:54.8314918Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0c5c20de-7830-4420-b9a8-319bc24fd068","type":"Microsoft.Authorization/roleAssignments","name":"0c5c20de-7830-4420-b9a8-319bc24fd068"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"63a25eaf-4d6f-491e-9ee6-c1583073b797","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T03:56:52.4047017Z","updatedOn":"2020-08-31T03:56:52.4047017Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e5b45c0c-0568-48f2-b3e6-8f2a7c8a7480","type":"Microsoft.Authorization/roleAssignments","name":"e5b45c0c-0568-48f2-b3e6-8f2a7c8a7480"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bb6ddbae-c27c-4d59-8f74-7f3ae86b09cf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T08:13:57.1050454Z","updatedOn":"2020-08-31T08:13:57.1050454Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e19bab66-9aa8-4185-8022-4f12d711bd41","type":"Microsoft.Authorization/roleAssignments","name":"e19bab66-9aa8-4185-8022-4f12d711bd41"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b3e8f037-9df3-48d7-a200-ea26adbec31b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T16:38:12.9366042Z","updatedOn":"2020-08-31T16:38:12.9366042Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7a52c17e-ffcb-4fda-a6ec-00ce6ce0ec00","type":"Microsoft.Authorization/roleAssignments","name":"7a52c17e-ffcb-4fda-a6ec-00ce6ce0ec00"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f24c1379-3bff-4ef9-a12c-f2144e606f70","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-02T07:08:09.2474084Z","updatedOn":"2020-09-02T07:08:09.2474084Z","createdBy":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","updatedBy":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/617ef96e-12a4-4c5a-8d31-57d08a7a3d7a","type":"Microsoft.Authorization/roleAssignments","name":"617ef96e-12a4-4c5a-8d31-57d08a7a3d7a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2c830430-942c-49f3-85d5-47b113077c10","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-04T19:09:41.0321006Z","updatedOn":"2020-09-04T19:09:41.0321006Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b6663c97-f1e1-43b7-a4e6-48fab343ba41","type":"Microsoft.Authorization/roleAssignments","name":"b6663c97-f1e1-43b7-a4e6-48fab343ba41"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"82b73c5f-d0b6-4922-bee4-d4c15c6de7df","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-04T19:31:27.3400870Z","updatedOn":"2020-09-04T19:31:27.3400870Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff7c33ab-2fad-456e-a3cc-7b229b5368d5","type":"Microsoft.Authorization/roleAssignments","name":"ff7c33ab-2fad-456e-a3cc-7b229b5368d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2e888925-16dd-4a44-b8b1-ba406c26f5d7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:24:37.4713613Z","updatedOn":"2020-09-07T06:24:37.4713613Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/44f8b319-a262-4d13-b71f-333447b5a805","type":"Microsoft.Authorization/roleAssignments","name":"44f8b319-a262-4d13-b71f-333447b5a805"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9df1aedd-86b5-4ed0-b8ff-a88acb8650fb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:25:06.2141876Z","updatedOn":"2020-09-07T06:25:06.2141876Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/85e919b7-5319-413e-a542-afa0b9beeb62","type":"Microsoft.Authorization/roleAssignments","name":"85e919b7-5319-413e-a542-afa0b9beeb62"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"43ef2449-ad33-4be0-8ed0-5c683286f37a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:36:55.7776057Z","updatedOn":"2020-09-07T06:36:55.7776057Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/76ac0e9c-d79b-42f2-bd51-4cbc37748e64","type":"Microsoft.Authorization/roleAssignments","name":"76ac0e9c-d79b-42f2-bd51-4cbc37748e64"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f7365134-0464-4e1f-9b14-d7eec002fcf5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T07:05:11.6942078Z","updatedOn":"2020-09-07T07:05:11.6942078Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fbf2c497-545e-4588-8684-7b9ee6da6b1e","type":"Microsoft.Authorization/roleAssignments","name":"fbf2c497-545e-4588-8684-7b9ee6da6b1e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"93d51f04-4891-476a-8c64-06d57c749216","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T07:08:02.2196156Z","updatedOn":"2020-09-07T07:08:02.2196156Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2f30eec3-4fb4-4703-b46d-e4477070136f","type":"Microsoft.Authorization/roleAssignments","name":"2f30eec3-4fb4-4703-b46d-e4477070136f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d7715695-4665-4845-a99e-9893013479f9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T08:02:32.0378468Z","updatedOn":"2020-09-07T08:02:32.0378468Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7cf24871-6fd5-487e-a65e-c1ebfd911403","type":"Microsoft.Authorization/roleAssignments","name":"7cf24871-6fd5-487e-a65e-c1ebfd911403"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"18082f29-fabc-4d67-bc7e-d83a98f5df1e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T08:11:12.8568998Z","updatedOn":"2020-09-07T08:11:12.8568998Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6ebb62b0-b2cf-4db0-a7bf-9c7ff68a646f","type":"Microsoft.Authorization/roleAssignments","name":"6ebb62b0-b2cf-4db0-a7bf-9c7ff68a646f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"af994901-af8c-453d-947f-f35bd0f3762c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-04T01:15:27.8872966Z","updatedOn":"2020-07-04T01:15:27.8872966Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18b767b4-51f8-4bdc-8da9-98296b1cde8e","type":"Microsoft.Authorization/roleAssignments","name":"18b767b4-51f8-4bdc-8da9-98296b1cde8e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"68cc3003-9653-4bb3-a7c8-97d773f3ad69","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-06T02:38:51.7937810Z","updatedOn":"2020-07-06T02:38:51.7937810Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5235eab1-3e36-4012-b4a2-5f158ef93897","type":"Microsoft.Authorization/roleAssignments","name":"5235eab1-3e36-4012-b4a2-5f158ef93897"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"7402cbf1-d2ef-41cd-8fb4-d1dbee1fa54f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-06T04:08:01.5967452Z","updatedOn":"2020-07-06T04:08:01.5967452Z","createdBy":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","updatedBy":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b6cae0d1-4e24-42fa-8d89-341128d64407","type":"Microsoft.Authorization/roleAssignments","name":"b6cae0d1-4e24-42fa-8d89-341128d64407"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8328816a-0c23-48d8-bb6a-ed9dcf5691b0","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T03:14:22.0872359Z","updatedOn":"2020-07-07T03:14:22.0872359Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61fd3f76-16c6-4482-8193-ccf22532b437","type":"Microsoft.Authorization/roleAssignments","name":"61fd3f76-16c6-4482-8193-ccf22532b437"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:07.9267881Z","updatedOn":"2020-07-07T07:53:07.9267881Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cb1f995e-258c-4174-9f1f-b21038b6fe15","type":"Microsoft.Authorization/roleAssignments","name":"cb1f995e-258c-4174-9f1f-b21038b6fe15"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:53.3178813Z","updatedOn":"2020-07-07T07:53:53.3178813Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/300179b3-b4bc-4d43-a800-14a538c341f2","type":"Microsoft.Authorization/roleAssignments","name":"300179b3-b4bc-4d43-a800-14a538c341f2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:53.3373852Z","updatedOn":"2020-07-07T07:53:53.3373852Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6a385b91-b1ce-4f5b-800d-6b449bb808f4","type":"Microsoft.Authorization/roleAssignments","name":"6a385b91-b1ce-4f5b-800d-6b449bb808f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"038ceaf0-2c3a-4a46-b572-cf9c7c444bd2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-08T15:15:49.6291826Z","updatedOn":"2020-07-08T15:15:49.6291826Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/719a4419-b972-4af8-95e8-741c53fb6c52","type":"Microsoft.Authorization/roleAssignments","name":"719a4419-b972-4af8-95e8-741c53fb6c52"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1422d4db-8270-4ae7-8437-8cccba2922f2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T06:00:40.8283738Z","updatedOn":"2020-07-09T06:00:40.8283738Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/92636771-3b6d-420b-9f6f-31070fbf0b28","type":"Microsoft.Authorization/roleAssignments","name":"92636771-3b6d-420b-9f6f-31070fbf0b28"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"08cae1fd-4869-4440-b9ff-a97cd9c00e6e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T12:14:15.9609308Z","updatedOn":"2020-07-09T12:14:15.9609308Z","createdBy":"182c8534-f413-487c-91a3-7addc80e35d5","updatedBy":"182c8534-f413-487c-91a3-7addc80e35d5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dbc76c65-b271-4f11-b84b-0b41e3c13f04","type":"Microsoft.Authorization/roleAssignments","name":"dbc76c65-b271-4f11-b84b-0b41e3c13f04"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2fbc569b-038b-456d-b496-168b4d2647b3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T12:20:45.2035119Z","updatedOn":"2020-07-09T12:20:45.2035119Z","createdBy":"182c8534-f413-487c-91a3-7addc80e35d5","updatedBy":"182c8534-f413-487c-91a3-7addc80e35d5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/49e83287-ab00-4c77-8e75-0c44324555d7","type":"Microsoft.Authorization/roleAssignments","name":"49e83287-ab00-4c77-8e75-0c44324555d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a5928636-70a5-4dc6-9a39-83f4261ab739","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-11T01:21:44.1115337Z","updatedOn":"2020-07-11T01:21:44.1115337Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1ec24764-f578-4712-82d0-4cf303f8cd94","type":"Microsoft.Authorization/roleAssignments","name":"1ec24764-f578-4712-82d0-4cf303f8cd94"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1a0bac8e-d2d2-40d0-af60-3821fc4aad21","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T03:55:34.9995817Z","updatedOn":"2020-07-13T03:55:34.9995817Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79904528-b82f-426b-ba34-911b9b9d9bb1","type":"Microsoft.Authorization/roleAssignments","name":"79904528-b82f-426b-ba34-911b9b9d9bb1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"aa1452f8-438b-4993-a853-211244f65fd4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T06:08:09.4651196Z","updatedOn":"2020-07-13T06:08:09.4651196Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9f12bf7c-fb56-401f-8358-b1bb205a79c1","type":"Microsoft.Authorization/roleAssignments","name":"9f12bf7c-fb56-401f-8358-b1bb205a79c1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4bc2639f-4b4d-4507-9e1e-5560658dadcf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T06:11:38.7509627Z","updatedOn":"2020-07-13T06:11:38.7509627Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/80221d18-b98c-4114-b192-94febf5cdad1","type":"Microsoft.Authorization/roleAssignments","name":"80221d18-b98c-4114-b192-94febf5cdad1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6c7c1341-56f8-4dea-9015-ddeae7fcdc18","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T11:41:59.7653882Z","updatedOn":"2020-07-13T11:41:59.7653882Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/215ec308-e62e-409f-a0cf-6f7b18257cd3","type":"Microsoft.Authorization/roleAssignments","name":"215ec308-e62e-409f-a0cf-6f7b18257cd3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"76b9eb22-0091-49d2-847f-dc4831337de8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T03:06:52.4968477Z","updatedOn":"2020-07-14T03:06:52.4968477Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/876a1623-fed3-4ac9-9bd3-6373f166eb91","type":"Microsoft.Authorization/roleAssignments","name":"876a1623-fed3-4ac9-9bd3-6373f166eb91"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f0ec8449-0089-40c0-a539-430080dd51d5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T05:09:22.8572441Z","updatedOn":"2020-07-14T05:09:22.8572441Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/81c82fd2-ee9b-4636-a13c-c2fc290b1339","type":"Microsoft.Authorization/roleAssignments","name":"81c82fd2-ee9b-4636-a13c-c2fc290b1339"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3a62feb4-dd11-437d-8bf5-324bbcf2ca71","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T08:34:11.1314930Z","updatedOn":"2020-07-14T08:34:11.1314930Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10166085-8319-44c1-b39e-7c2e8a859606","type":"Microsoft.Authorization/roleAssignments","name":"10166085-8319-44c1-b39e-7c2e8a859606"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1768ac75-eb78-4760-904b-bf1daf362ed8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T13:24:26.4777748Z","updatedOn":"2020-07-14T13:24:26.4777748Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/89b22e91-fbe1-4519-9c28-55116cb4b449","type":"Microsoft.Authorization/roleAssignments","name":"89b22e91-fbe1-4519-9c28-55116cb4b449"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0c8ec4af-1f95-43d0-abdc-e98c7c377093","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T02:27:50.9285382Z","updatedOn":"2020-07-15T02:27:50.9285382Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6aa196a2-0d57-4ced-a7c4-e4309e305930","type":"Microsoft.Authorization/roleAssignments","name":"6aa196a2-0d57-4ced-a7c4-e4309e305930"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2f394b98-15c2-4a67-b5e4-59524a559fbe","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T06:04:05.5602990Z","updatedOn":"2020-07-15T06:04:05.5602990Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/29b52c6e-ef41-4228-be25-062bb7c962b2","type":"Microsoft.Authorization/roleAssignments","name":"29b52c6e-ef41-4228-be25-062bb7c962b2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d3ee15d8-bfc2-40e3-91ce-38f84f29b4fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:37:38.4755184Z","updatedOn":"2020-07-15T07:37:38.4755184Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/94971c0b-9b3c-4014-a9f3-0283d64c1b29","type":"Microsoft.Authorization/roleAssignments","name":"94971c0b-9b3c-4014-a9f3-0283d64c1b29"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"243b9ed2-a31b-4b74-abb7-fce2fa7b7d85","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:46:59.5663841Z","updatedOn":"2020-07-15T07:46:59.5663841Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0d8d5363-48b8-4bea-895a-0ca92c1737aa","type":"Microsoft.Authorization/roleAssignments","name":"0d8d5363-48b8-4bea-895a-0ca92c1737aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"936679b1-be85-401f-906b-1338954018e1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T08:01:13.4164296Z","updatedOn":"2020-07-15T08:01:13.4164296Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/56a43ec4-3148-4c7e-b526-817d25a836da","type":"Microsoft.Authorization/roleAssignments","name":"56a43ec4-3148-4c7e-b526-817d25a836da"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ee082e62-485a-4e27-8cbe-c3effae3cd9c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T08:49:06.7210416Z","updatedOn":"2020-07-15T08:49:06.7210416Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a78fc2bf-58e2-4e37-bc92-b7195a03fbee","type":"Microsoft.Authorization/roleAssignments","name":"a78fc2bf-58e2-4e37-bc92-b7195a03fbee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"28c339aa-6a69-4038-9085-b9de491ab4e8","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T02:40:49.7073175Z","updatedOn":"2020-07-16T02:40:49.7073175Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/47d4f9d6-ef56-4d94-9dcb-f79e11ed5e50","type":"Microsoft.Authorization/roleAssignments","name":"47d4f9d6-ef56-4d94-9dcb-f79e11ed5e50"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"59a64430-12a8-4f39-be98-d1dd2614aeea","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T07:46:36.5695565Z","updatedOn":"2020-07-16T07:46:36.5695565Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d5232861-40f7-44e1-b5dc-230787ad1927","type":"Microsoft.Authorization/roleAssignments","name":"d5232861-40f7-44e1-b5dc-230787ad1927"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a55ceb34-c21b-4a68-96c6-88eb4cc5e099","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T11:38:50.4745508Z","updatedOn":"2020-07-16T11:38:50.4745508Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/74d051bd-1538-486e-954d-12ba05d58a90","type":"Microsoft.Authorization/roleAssignments","name":"74d051bd-1538-486e-954d-12ba05d58a90"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e5e99afa-9231-46fd-acfc-92c8a8ff4489","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-17T07:29:54.2160514Z","updatedOn":"2020-07-17T07:29:54.2160514Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ceb853a2-799d-4948-990d-e0650efe5d4a","type":"Microsoft.Authorization/roleAssignments","name":"ceb853a2-799d-4948-990d-e0650efe5d4a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f1f3476e-5aa5-4e0e-8632-a6f8728860b8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-18T01:17:47.1042571Z","updatedOn":"2020-07-18T01:17:47.1042571Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3b69d82b-e9f6-432e-b75c-f93b2d88efd7","type":"Microsoft.Authorization/roleAssignments","name":"3b69d82b-e9f6-432e-b75c-f93b2d88efd7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9431860d-6e2d-4227-9829-7b00afbdfb64","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:19:08.9724715Z","updatedOn":"2020-07-21T08:19:08.9724715Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7a335959-fbd8-42b5-9e34-dfa0cf86dedb","type":"Microsoft.Authorization/roleAssignments","name":"7a335959-fbd8-42b5-9e34-dfa0cf86dedb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6e931f32-10eb-43f4-883d-86a7991108f7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:21:22.6590948Z","updatedOn":"2020-07-21T08:21:22.6590948Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a92bcbb4-ef43-43db-a151-2b11cb2131a3","type":"Microsoft.Authorization/roleAssignments","name":"a92bcbb4-ef43-43db-a151-2b11cb2131a3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8b26643c-1bce-4669-ba85-48403e88103d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:28:00.4744129Z","updatedOn":"2020-07-21T08:28:00.4744129Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3939f612-6d79-496c-bf5d-4f92e1d1b5e5","type":"Microsoft.Authorization/roleAssignments","name":"3939f612-6d79-496c-bf5d-4f92e1d1b5e5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"af02e2c0-437c-4fbf-8769-fe6b43600a11","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T12:39:54.0428636Z","updatedOn":"2020-07-21T12:39:54.0428636Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff44e8d6-b72d-43fc-91b6-ead0de501f65","type":"Microsoft.Authorization/roleAssignments","name":"ff44e8d6-b72d-43fc-91b6-ead0de501f65"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5eef490b-41df-460b-ab98-7e8d3f8a1559","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T03:20:01.9422980Z","updatedOn":"2020-07-22T03:20:01.9422980Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e3d03863-6d79-4535-b692-15ca1e2ec3be","type":"Microsoft.Authorization/roleAssignments","name":"e3d03863-6d79-4535-b692-15ca1e2ec3be"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"86609d61-9b24-4e62-8c38-8361f202f09f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T04:26:09.1052343Z","updatedOn":"2020-07-22T04:26:09.1052343Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a78eda47-9ef1-4c22-bfa4-0d996c5d599c","type":"Microsoft.Authorization/roleAssignments","name":"a78eda47-9ef1-4c22-bfa4-0d996c5d599c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ed0ebe06-e932-4087-8ba8-03478368e7c6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:23.4466032Z","updatedOn":"2020-07-22T06:09:23.4466032Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f03258ee-4f5a-48cd-a003-d23a60a3a014","type":"Microsoft.Authorization/roleAssignments","name":"f03258ee-4f5a-48cd-a003-d23a60a3a014"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d126d0bb-79bb-472f-8b80-a9a346f6f100","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:45.2929087Z","updatedOn":"2020-07-22T06:09:45.2929087Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3581753e-74ab-4e9d-b79d-0799442862b3","type":"Microsoft.Authorization/roleAssignments","name":"3581753e-74ab-4e9d-b79d-0799442862b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2d627045-009d-4074-8bcd-52d7eeabb18c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:54.6260798Z","updatedOn":"2020-07-22T06:09:54.6260798Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cf80890b-2e9e-424a-a8ab-1795078643d2","type":"Microsoft.Authorization/roleAssignments","name":"cf80890b-2e9e-424a-a8ab-1795078643d2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"535b5697-6115-4f18-92f3-20fc9a07cce7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:18:56.2452865Z","updatedOn":"2020-07-22T06:18:56.2452865Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6b91e17e-56de-4229-8453-5338337d3c6f","type":"Microsoft.Authorization/roleAssignments","name":"6b91e17e-56de-4229-8453-5338337d3c6f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d048d4f7-7edb-4712-aeca-af4fb5c61b5a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:19:12.0666094Z","updatedOn":"2020-07-22T06:19:12.0666094Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/051d8d7e-2bf8-400c-af8e-4cdea07dedf0","type":"Microsoft.Authorization/roleAssignments","name":"051d8d7e-2bf8-400c-af8e-4cdea07dedf0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b45b251f-c8a2-4d3a-af7f-a9739cbe0d68","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:15.0908010Z","updatedOn":"2020-07-22T06:20:15.0908010Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bcb6a1f9-fd6e-441b-aaf7-09cf14414872","type":"Microsoft.Authorization/roleAssignments","name":"bcb6a1f9-fd6e-441b-aaf7-09cf14414872"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5c709f8c-397c-40d2-a147-1040fb282e24","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:26.8312576Z","updatedOn":"2020-07-22T06:20:26.8312576Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ceb67739-0cce-4a0e-9d2a-bd8a1ea65485","type":"Microsoft.Authorization/roleAssignments","name":"ceb67739-0cce-4a0e-9d2a-bd8a1ea65485"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a3d2b5a7-f9ce-4ab2-9155-e47bc8121b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:31.6051855Z","updatedOn":"2020-07-22T06:20:31.6051855Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b151b8cc-8569-4dd6-97a3-a0652015d9ab","type":"Microsoft.Authorization/roleAssignments","name":"b151b8cc-8569-4dd6-97a3-a0652015d9ab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b56fdd17-ee35-4381-9aea-00dfa70a3872","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:24:16.5402929Z","updatedOn":"2020-07-22T06:24:16.5402929Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7d078199-8ce2-44ed-8eb3-c7aca7590bee","type":"Microsoft.Authorization/roleAssignments","name":"7d078199-8ce2-44ed-8eb3-c7aca7590bee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0ef05f56-75da-4e69-8886-cf7eb25921bf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:28:20.2615489Z","updatedOn":"2020-07-22T06:28:20.2615489Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f126b61c-58bb-40d5-90b5-035320097c81","type":"Microsoft.Authorization/roleAssignments","name":"f126b61c-58bb-40d5-90b5-035320097c81"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2b7f66f5-e2b4-4e90-a6c0-48fd09c6941c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:31:13.8352773Z","updatedOn":"2020-07-22T06:31:13.8352773Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a3fb647-a48a-4fb2-b9be-5c0ec0c1dd9f","type":"Microsoft.Authorization/roleAssignments","name":"9a3fb647-a48a-4fb2-b9be-5c0ec0c1dd9f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-24T03:54:19.5994989Z","updatedOn":"2020-07-24T03:54:19.5994989Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dc91700c-9959-4179-80b7-f2bfb957d4ec","type":"Microsoft.Authorization/roleAssignments","name":"dc91700c-9959-4179-80b7-f2bfb957d4ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d0daf77e-df2b-4f08-93a9-53bc40d2b65e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-25T01:20:25.7612859Z","updatedOn":"2020-07-25T01:20:25.7612859Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/01c4a64d-636d-4f02-8b51-1e52794b0065","type":"Microsoft.Authorization/roleAssignments","name":"01c4a64d-636d-4f02-8b51-1e52794b0065"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"75e0401f-c382-49bc-9681-5891889d6090","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-25T01:20:48.2269442Z","updatedOn":"2020-07-25T01:20:48.2269442Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d14294b-2a12-4034-98ed-d79fc8967004","type":"Microsoft.Authorization/roleAssignments","name":"8d14294b-2a12-4034-98ed-d79fc8967004"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cfa73ec2-e91c-4de2-9b7f-3886f1b1a7e9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-01T01:15:28.6134386Z","updatedOn":"2020-08-01T01:15:28.6134386Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2880df4d-a219-4208-8f53-11ba91fe5ee6","type":"Microsoft.Authorization/roleAssignments","name":"2880df4d-a219-4208-8f53-11ba91fe5ee6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4ffca8c7-2d31-4f24-9e03-a1a836f60ba8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-01T01:34:29.3212794Z","updatedOn":"2020-08-01T01:34:29.3212794Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/39e1d3ed-13fb-432e-a0cb-8b294fddc63a","type":"Microsoft.Authorization/roleAssignments","name":"39e1d3ed-13fb-432e-a0cb-8b294fddc63a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"26e698cd-9d87-41f6-9a7e-06b3627e6ca5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-04T05:20:53.6187620Z","updatedOn":"2020-08-04T05:20:53.6187620Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97f68035-e05b-4e7f-aa80-a3799725076a","type":"Microsoft.Authorization/roleAssignments","name":"97f68035-e05b-4e7f-aa80-a3799725076a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5fcaa3b3-d5b2-44ce-92e2-28a4241f1e6b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-04T05:29:27.6127065Z","updatedOn":"2020-08-04T05:29:27.6127065Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ae95584d-6d28-4372-872b-b96e6a1f9c1f","type":"Microsoft.Authorization/roleAssignments","name":"ae95584d-6d28-4372-872b-b96e6a1f9c1f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-05T03:43:59.8598863Z","updatedOn":"2020-08-05T03:43:59.8598863Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/254a30cf-3bdd-4e6c-aa9e-9d96397bf63a","type":"Microsoft.Authorization/roleAssignments","name":"254a30cf-3bdd-4e6c-aa9e-9d96397bf63a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"800eadcf-0a23-4298-939b-6cf9f3dbceef","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-05T05:51:54.9501785Z","updatedOn":"2020-08-05T05:51:54.9501785Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8b806af6-57f8-45f4-849f-6d0d0f43d093","type":"Microsoft.Authorization/roleAssignments","name":"8b806af6-57f8-45f4-849f-6d0d0f43d093"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ef53cdce-e483-4aa2-8260-58249cc1e7b1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-02T16:57:34.4713679Z","updatedOn":"2020-07-02T16:57:34.4713679Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/54fe41af-b32f-43d4-aac4-9e9be5b142a7","type":"Microsoft.Authorization/roleAssignments","name":"54fe41af-b32f-43d4-aac4-9e9be5b142a7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/providers/Microsoft.Management/managementGroups/CliMgmtGroup","condition":null,"conditionVersion":null,"createdOn":"2019-12-26T10:45:42.1154685Z","updatedOn":"2019-12-26T10:45:42.1154685Z","createdBy":"dfb7f346-f217-474e-ba6c-49895fd9cc13","updatedBy":"dfb7f346-f217-474e-ba6c-49895fd9cc13","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Management/managementGroups/CliMgmtGroup/providers/Microsoft.Authorization/roleAssignments/f0b07cf8-a079-446e-a391-c6fb1d115b59","type":"Microsoft.Authorization/roleAssignments","name":"f0b07cf8-a079-446e-a391-c6fb1d115b59"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.4824942Z","updatedOn":"2020-06-16T16:25:39.4824942Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e77058da-a7bf-4e89-8e48-7d9f61fa8246","type":"Microsoft.Authorization/roleAssignments","name":"e77058da-a7bf-4e89-8e48-7d9f61fa8246"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:12:52.8054393Z","updatedOn":"2020-11-25T05:12:52.8054393Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dea2d3a8-cf99-4169-b8dd-819b4c611a32","type":"Microsoft.Authorization/roleAssignments","name":"dea2d3a8-cf99-4169-b8dd-819b4c611a32"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:34:01.2642084Z","updatedOn":"2020-11-25T05:34:01.2642084Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bacc53c-9077-49ce-a14d-370bc09f72d8","type":"Microsoft.Authorization/roleAssignments","name":"4bacc53c-9077-49ce-a14d-370bc09f72d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6949b2a1-9b3e-42c8-b228-0b6c14927377","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-30T19:34:16.5100204Z","updatedOn":"2020-07-30T19:34:16.5100204Z","createdBy":"5bc13990-50e4-4898-835e-d026e066bba5","updatedBy":"5bc13990-50e4-4898-835e-d026e066bba5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/53b0d735-2402-41c6-9d6d-b2338a287741","type":"Microsoft.Authorization/roleAssignments","name":"53b0d735-2402-41c6-9d6d-b2338a287741"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4c480e6-1f29-4163-9a37-2b16a7e8e5c8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-16T13:48:13.9171700Z","updatedOn":"2020-09-16T13:48:13.9171700Z","createdBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","updatedBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8476200c-5011-42c4-9028-360ef1739a8d","type":"Microsoft.Authorization/roleAssignments","name":"8476200c-5011-42c4-9028-360ef1739a8d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '237237'
+      - '25670'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:24 GMT
+      - Wed, 09 Dec 2020 17:46:09 GMT
       expires:
       - '-1'
       pragma:
@@ -1616,8 +1771,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
-      "principalId": "634b6a14-daa6-42a6-936f-86aa40fef181", "principalType": "ServicePrincipal"}}'
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+      "principalId": "6a770218-bb37-4a0f-a83c-6e6bc93ebbfa", "principalType": "ServicePrincipal"}}'
     headers:
       Accept:
       - application/json
@@ -1631,20 +1786,19 @@ interactions:
       - '270'
       Content-Type:
       - application/json; charset=utf-8
-      Cookie:
-      - x-ms-gateway-slice=Production
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"634b6a14-daa6-42a6-936f-86aa40fef181","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-09-08T07:00:24.6504452Z","updatedOn":"2020-09-08T07:00:24.6504452Z","createdBy":null,"updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"6a770218-bb37-4a0f-a83c-6e6bc93ebbfa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T17:46:10.6560638Z","updatedOn":"2020-12-09T17:46:10.6560638Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
     headers:
       cache-control:
       - no-cache
@@ -1653,7 +1807,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:26 GMT
+      - Wed, 09 Dec 2020 17:46:10 GMT
       expires:
       - '-1'
       pragma:
@@ -1683,152 +1837,25 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"08077b46-2ebd-4a4b-9b5b-65886e6456ba\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.79.3.0/24\",\r\n    \"serviceEndpoints\": [\r\n    \
-        \  {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '755'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:26 GMT
-      etag:
-      - W/"08077b46-2ebd-4a4b-9b5b-65886e6456ba"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 773ca901-5a6a-4881-8252-1a690cecd49e
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n  \"etag\": \"W/\\\"08077b46-2ebd-4a4b-9b5b-65886e6456ba\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.122.58.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
-        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '756'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:26 GMT
-      etag:
-      - W/"08077b46-2ebd-4a4b-9b5b-65886e6456ba"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 818859f0-66dd-4c52-9176-a528f6c74f0d
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"634b6a14-daa6-42a6-936f-86aa40fef181","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-09-08T07:00:24.8804440Z","updatedOn":"2020-09-08T07:00:24.8804440Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2019-09-04T08:09:42.0835929Z","updatedOn":"2019-09-04T08:09:42.0835929Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/9d0c9433-a2c8-403f-ba1c-6310772291a5","type":"Microsoft.Authorization/roleAssignments","name":"9d0c9433-a2c8-403f-ba1c-6310772291a5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-14T05:22:05.1776921Z","updatedOn":"2020-03-14T05:22:05.1776921Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/eed777be-eb1b-4af7-9ec2-e4a74afba39e","type":"Microsoft.Authorization/roleAssignments","name":"eed777be-eb1b-4af7-9ec2-e4a74afba39e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-04T08:35:06.1202192Z","updatedOn":"2020-03-04T08:35:06.1202192Z","createdBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","updatedBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/67f6c798-74b6-41f7-ba07-ae40134ce8c1","type":"Microsoft.Authorization/roleAssignments","name":"67f6c798-74b6-41f7-ba07-ae40134ce8c1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T03:47:15.1734978Z","updatedOn":"2020-03-19T03:47:15.1734978Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/888c7688-4ae3-406f-948b-fd569da173fc","type":"Microsoft.Authorization/roleAssignments","name":"888c7688-4ae3-406f-948b-fd569da173fc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T04:06:32.7642459Z","updatedOn":"2020-03-19T04:06:32.7642459Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/b4bdedde-4f10-4610-9201-2421bb032107","type":"Microsoft.Authorization/roleAssignments","name":"b4bdedde-4f10-4610-9201-2421bb032107"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"02d52e0b-1c85-4aa9-a229-bca89f5fc079","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:06:31.6888688Z","updatedOn":"2020-07-15T07:06:31.6888688Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/e2f3fd89-b1cc-42c7-ae59-1ef03b4e731a","type":"Microsoft.Authorization/roleAssignments","name":"e2f3fd89-b1cc-42c7-ae59-1ef03b4e731a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-01-29T13:27:35.7170489Z","updatedOn":"2020-01-29T13:27:35.7170489Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/b6899915-1e85-4406-aa1f-f346ec3ded50","type":"Microsoft.Authorization/roleAssignments","name":"b6899915-1e85-4406-aa1f-f346ec3ded50"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"22bd72d9-4e93-4a74-b5ad-679cabe53baf","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:27:36.1276006Z","updatedOn":"2020-07-15T07:27:36.1276006Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/06f37651-eecf-4b6c-a0e7-b26822697224","type":"Microsoft.Authorization/roleAssignments","name":"06f37651-eecf-4b6c-a0e7-b26822697224"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b304d026-311a-4be0-9994-8c578fc3697f","principalType":"User","scope":"/","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:14:11.6612918Z","updatedOn":"2020-07-15T07:14:11.6612918Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Authorization/roleAssignments/a75bb3e5-3b36-488f-a1a4-32be0a44e1a1","type":"Microsoft.Authorization/roleAssignments","name":"a75bb3e5-3b36-488f-a1a4-32be0a44e1a1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3","principalId":"30601973-dcd6-4c4e-85e8-dc6e057238fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-14T15:35:54.7519315Z","updatedOn":"2020-06-14T15:35:54.7519315Z","createdBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","updatedBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/02d00457-a5a7-4da3-b12a-e944705f4170","type":"Microsoft.Authorization/roleAssignments","name":"02d00457-a5a7-4da3-b12a-e944705f4170"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab","principalId":"677a61e9-086e-4f13-986a-11aaedc31416","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T03:31:37.3848580Z","updatedOn":"2019-11-26T03:31:37.3848580Z","createdBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","updatedBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aac8538d-8226-4b91-9232-03d3f3a40214","type":"Microsoft.Authorization/roleAssignments","name":"aac8538d-8226-4b91-9232-03d3f3a40214"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-04T08:40:46.0862758Z","updatedOn":"2020-03-04T08:40:46.0862758Z","createdBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","updatedBy":"97233d81-8d2d-4e63-8bd2-ae5707805489","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5f32c47e-50b5-4be3-8774-ea1467857752","type":"Microsoft.Authorization/roleAssignments","name":"5f32c47e-50b5-4be3-8774-ea1467857752"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-20T09:03:02.6644378Z","updatedOn":"2020-01-20T09:03:02.6644378Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dd2121da-11a7-4ff5-bab0-053cc344b0b0","type":"Microsoft.Authorization/roleAssignments","name":"dd2121da-11a7-4ff5-bab0-053cc344b0b0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0444ccf8-fddb-43c4-b42b-ea036211229f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-25T07:18:48.8610796Z","updatedOn":"2020-03-25T07:18:48.8610796Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4f7c6762-b335-43e7-9c13-d42ab9bc6884","type":"Microsoft.Authorization/roleAssignments","name":"4f7c6762-b335-43e7-9c13-d42ab9bc6884"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"05b1f982-1404-4e2d-b2e8-af3ee7a330b4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-22T14:58:56.7424484Z","updatedOn":"2019-09-22T14:58:56.7424484Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a5d758f5-4ec2-4dd5-ba95-cee5405e367c","type":"Microsoft.Authorization/roleAssignments","name":"a5d758f5-4ec2-4dd5-ba95-cee5405e367c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-21T03:37:35.1867759Z","updatedOn":"2019-11-21T03:37:35.1867759Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f93778f-00f5-4efb-a56f-6aff1d668df7","type":"Microsoft.Authorization/roleAssignments","name":"6f93778f-00f5-4efb-a56f-6aff1d668df7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0a592c45-613e-4f1b-9023-7c4414fd53bf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-08-08T01:47:13.5745250Z","updatedOn":"2019-08-08T01:47:13.5745250Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d320644f-c08b-47f4-ae3b-9df595a5c368","type":"Microsoft.Authorization/roleAssignments","name":"d320644f-c08b-47f4-ae3b-9df595a5c368"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-26T04:16:43.3784273Z","updatedOn":"2019-07-26T04:16:43.3784273Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a567d42-8a33-4cad-9f7b-5299a16dc269","type":"Microsoft.Authorization/roleAssignments","name":"9a567d42-8a33-4cad-9f7b-5299a16dc269"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"0eae5543-750d-4b1a-89bc-7bfd80671fbd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T05:52:20.5117449Z","updatedOn":"2020-04-13T05:52:20.5117449Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b2a0bc46-da6a-4ca0-b518-81cc1f0a14d3","type":"Microsoft.Authorization/roleAssignments","name":"b2a0bc46-da6a-4ca0-b518-81cc1f0a14d3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"182c8534-f413-487c-91a3-7addc80e35d5","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-09-06T13:37:05.6480940Z","updatedOn":"2017-09-06T13:37:05.6480940Z","createdBy":"bed854bc-89d1-444b-914a-8984c7a9d73d","updatedBy":"bed854bc-89d1-444b-914a-8984c7a9d73d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d0560ab5-dd8d-4978-8c9b-84768b4a9467","type":"Microsoft.Authorization/roleAssignments","name":"d0560ab5-dd8d-4978-8c9b-84768b4a9467"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"18f53146-1f6c-462a-96a5-d50e1293b770","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-05-24T02:53:04.7484734Z","updatedOn":"2019-05-24T02:53:04.7484734Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/553a3d02-d0da-4b7c-a0f1-d1298f556001","type":"Microsoft.Authorization/roleAssignments","name":"553a3d02-d0da-4b7c-a0f1-d1298f556001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1aa92e15-ee4e-4dda-9e61-5b4dc35d280b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-29T06:05:52.7948049Z","updatedOn":"2020-04-29T06:05:52.7948049Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/039870e3-5852-4b2f-a3a9-9e172adfd72b","type":"Microsoft.Authorization/roleAssignments","name":"039870e3-5852-4b2f-a3a9-9e172adfd72b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1c93a1ad-59cf-42fc-b6ce-0f5ffd464a70","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-04-09T20:12:14.4602372Z","updatedOn":"2018-04-09T20:12:14.4602372Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d5397a6-f185-4b65-bcba-6b9f2248093a","type":"Microsoft.Authorization/roleAssignments","name":"8d5397a6-f185-4b65-bcba-6b9f2248093a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"2262dfe7-375f-4597-a47c-2766489ecbe7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-06-14T17:54:39.3919633Z","updatedOn":"2019-06-14T17:54:39.3919633Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3f58856e-c1e1-4269-9055-f9fbe4cb6506","type":"Microsoft.Authorization/roleAssignments","name":"3f58856e-c1e1-4269-9055-f9fbe4cb6506"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"2ed08755-e5b9-42ef-8638-38e95105e710","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-23T06:01:53.1357543Z","updatedOn":"2019-12-23T06:01:53.1357543Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1986d758-ee67-4fc7-9eb2-c0d52d4a075d","type":"Microsoft.Authorization/roleAssignments","name":"1986d758-ee67-4fc7-9eb2-c0d52d4a075d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1b1b6446-6585-4988-b9ab-a8cdf9035b8a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-11T09:21:11.3066024Z","updatedOn":"2020-02-11T09:21:11.3066024Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ae57b317-873d-4242-a539-32b3e934259d","type":"Microsoft.Authorization/roleAssignments","name":"ae57b317-873d-4242-a539-32b3e934259d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-17T08:29:55.3047288Z","updatedOn":"2019-09-17T08:29:55.3047288Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e3591e24-669e-475f-a315-7d581996b864","type":"Microsoft.Authorization/roleAssignments","name":"e3591e24-669e-475f-a315-7d581996b864"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"32fe2882-ca97-44f9-8e0d-dfe916b9dfee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-06T03:03:50.0740099Z","updatedOn":"2019-09-06T03:03:50.0740099Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/01c1fcc9-4df3-4107-832f-42f245309750","type":"Microsoft.Authorization/roleAssignments","name":"01c1fcc9-4df3-4107-832f-42f245309750"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"378df7ee-31fd-4c54-945e-a1ed4f025a28","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-08-10T19:00:33.4173527Z","updatedOn":"2017-08-10T19:00:33.4173527Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e0ddb7cd-de16-42ce-bab6-6a0d4d3903d8","type":"Microsoft.Authorization/roleAssignments","name":"e0ddb7cd-de16-42ce-bab6-6a0d4d3903d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"37aa63b3-0814-4c36-9641-d9c3120b1f1b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-25T22:21:28.6870688Z","updatedOn":"2019-02-25T22:21:28.6870688Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/185a89d4-23f9-4fb8-827c-6d7f8e26c49d","type":"Microsoft.Authorization/roleAssignments","name":"185a89d4-23f9-4fb8-827c-6d7f8e26c49d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"37e77055-3c53-4ae5-bf04-d2459236b6a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:25:07.0794530Z","updatedOn":"2020-01-09T06:25:07.0794530Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ec3d1379-1350-4894-98dc-4742280ba73b","type":"Microsoft.Authorization/roleAssignments","name":"ec3d1379-1350-4894-98dc-4742280ba73b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"39029da9-0fef-42a9-b478-2fe4e19b8c7b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-19T02:54:07.7981142Z","updatedOn":"2020-06-19T02:54:07.7981142Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/90fa5166-2ffa-44a8-ad5d-da4f3eaab642","type":"Microsoft.Authorization/roleAssignments","name":"90fa5166-2ffa-44a8-ad5d-da4f3eaab642"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-19T03:54:40.3617093Z","updatedOn":"2020-01-19T03:54:40.3617093Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c9b97fb4-3b05-49af-97de-2950204d9066","type":"Microsoft.Authorization/roleAssignments","name":"c9b97fb4-3b05-49af-97de-2950204d9066"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3e675290-31e1-49f6-a3cd-03df3d7d6e2e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-03T04:39:51.0517217Z","updatedOn":"2020-05-03T04:39:51.0517217Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/49eedfad-3250-441e-8a85-03026008e57c","type":"Microsoft.Authorization/roleAssignments","name":"49eedfad-3250-441e-8a85-03026008e57c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"4582e5fb-504d-4b21-89be-9e11352ac837","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-27T01:17:48.4170577Z","updatedOn":"2020-02-27T01:17:48.4170577Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/43cfb5ae-8271-433b-8799-85858d658f59","type":"Microsoft.Authorization/roleAssignments","name":"43cfb5ae-8271-433b-8799-85858d658f59"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"4c1e34fd-dcf5-4516-bb96-b8ac22e138da","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T08:54:40.6904887Z","updatedOn":"2020-06-08T08:54:40.6904887Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/386dc123-cb36-4f9f-ac58-7aaaf5d7ed58","type":"Microsoft.Authorization/roleAssignments","name":"386dc123-cb36-4f9f-ac58-7aaaf5d7ed58"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"56b6b563-1341-4632-96cd-06252b81665d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-05T08:50:50.2703536Z","updatedOn":"2019-09-05T08:50:50.2703536Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e17d3c8b-26f3-4cdd-bcc1-211c3e490299","type":"Microsoft.Authorization/roleAssignments","name":"e17d3c8b-26f3-4cdd-bcc1-211c3e490299"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"596c247a-9db0-4c20-8ddb-d944102067ac","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-25T08:06:17.3145960Z","updatedOn":"2019-10-25T08:06:17.3145960Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5383f6ae-0e25-43d5-a448-2fd0d2699d72","type":"Microsoft.Authorization/roleAssignments","name":"5383f6ae-0e25-43d5-a448-2fd0d2699d72"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5a7755a0-33cc-4bcc-9064-12f1bf05c991","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-11T05:55:15.7549140Z","updatedOn":"2020-05-11T05:55:15.7549140Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5584dc94-54e6-4a61-af7c-09934f06b4d1","type":"Microsoft.Authorization/roleAssignments","name":"5584dc94-54e6-4a61-af7c-09934f06b4d1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5accae2a-f109-44ba-8549-8c682acd4ad1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-11-06T23:33:48.6032970Z","updatedOn":"2017-11-06T23:33:48.6032970Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b35dfe77-4bb3-4956-b644-16d58904b1bf","type":"Microsoft.Authorization/roleAssignments","name":"b35dfe77-4bb3-4956-b644-16d58904b1bf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"669ef724-96ef-462e-b760-a398c8d49f12","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-10-16T00:01:10.8880293Z","updatedOn":"2018-10-16T00:01:10.8880293Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1fb698ad-cef0-442e-8fa0-c5c4609b12ec","type":"Microsoft.Authorization/roleAssignments","name":"1fb698ad-cef0-442e-8fa0-c5c4609b12ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6ba8d12f-faf3-4859-918b-80f93e471e38","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-05T07:42:22.6383489Z","updatedOn":"2019-09-05T07:42:22.6383489Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1b0df1c0-baf0-41ed-9560-6495d40dfa06","type":"Microsoft.Authorization/roleAssignments","name":"1b0df1c0-baf0-41ed-9560-6495d40dfa06"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T05:03:40.5214262Z","updatedOn":"2020-04-26T05:03:40.5214262Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73651752-e48b-47b6-8ce6-770e1bf56e80","type":"Microsoft.Authorization/roleAssignments","name":"73651752-e48b-47b6-8ce6-770e1bf56e80"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-24T09:14:30.5134753Z","updatedOn":"2020-04-24T09:14:30.5134753Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1ba14abb-5c95-4d45-be2c-5429d47ba9b3","type":"Microsoft.Authorization/roleAssignments","name":"1ba14abb-5c95-4d45-be2c-5429d47ba9b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-10T06:36:08.0241793Z","updatedOn":"2019-09-10T06:36:08.0241793Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10b1e634-f9af-4434-bd13-55eb43a57124","type":"Microsoft.Authorization/roleAssignments","name":"10b1e634-f9af-4434-bd13-55eb43a57124"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7b29ef09-268a-44a7-b1f8-094beba68028","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-04-05T17:27:17.7281001Z","updatedOn":"2018-04-05T17:27:17.7281001Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a5c8a26b-80ac-421d-a137-2951374bca62","type":"Microsoft.Authorization/roleAssignments","name":"a5c8a26b-80ac-421d-a137-2951374bca62"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T06:26:40.9453629Z","updatedOn":"2019-11-26T06:26:40.9453629Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2ba40e27-d44f-48e7-9462-1561128bed69","type":"Microsoft.Authorization/roleAssignments","name":"2ba40e27-d44f-48e7-9462-1561128bed69"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-23T08:57:03.4127112Z","updatedOn":"2019-10-23T08:57:03.4127112Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ec55b030-cffa-46ab-a296-78f606400df8","type":"Microsoft.Authorization/roleAssignments","name":"ec55b030-cffa-46ab-a296-78f606400df8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7e58ddef-4719-4c36-a485-4c2a0a843a46","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-25T05:07:15.7863485Z","updatedOn":"2019-12-25T05:07:15.7863485Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/999c61a0-361b-416f-91ee-68f515f910ec","type":"Microsoft.Authorization/roleAssignments","name":"999c61a0-361b-416f-91ee-68f515f910ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-15T08:49:50.8762611Z","updatedOn":"2019-11-15T08:49:50.8762611Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/233c612a-f4d8-41fb-bf58-8e2a587142df","type":"Microsoft.Authorization/roleAssignments","name":"233c612a-f4d8-41fb-bf58-8e2a587142df"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"864a275e-8c80-4efb-ad1c-0c0ab3081788","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-12T02:40:02.3180608Z","updatedOn":"2020-06-12T02:40:02.3180608Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7c5ea86e-a5a6-4750-b95f-5ba47a93ff60","type":"Microsoft.Authorization/roleAssignments","name":"7c5ea86e-a5a6-4750-b95f-5ba47a93ff60"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-23T05:48:03.4970209Z","updatedOn":"2019-12-23T05:48:03.4970209Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8cbac001-17ff-4ba4-ade1-cbbb4924e6d6","type":"Microsoft.Authorization/roleAssignments","name":"8cbac001-17ff-4ba4-ade1-cbbb4924e6d6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"8d594fee-5764-49c9-ad85-35d3ee728386","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-23T09:22:57.7278029Z","updatedOn":"2019-10-23T09:22:57.7278029Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/66da1b82-8f84-41cc-995f-867498db9ae3","type":"Microsoft.Authorization/roleAssignments","name":"66da1b82-8f84-41cc-995f-867498db9ae3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-10T06:47:24.5464704Z","updatedOn":"2019-07-10T06:47:24.5464704Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/83b44361-6e27-4ed1-923c-b10ce84b3926","type":"Microsoft.Authorization/roleAssignments","name":"83b44361-6e27-4ed1-923c-b10ce84b3926"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-21T06:37:44.9936263Z","updatedOn":"2019-10-21T06:37:44.9936263Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7e96cad1-9fe5-49d6-b754-cbe33ce49882","type":"Microsoft.Authorization/roleAssignments","name":"7e96cad1-9fe5-49d6-b754-cbe33ce49882"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-04T03:06:42.9265284Z","updatedOn":"2019-12-04T03:06:42.9265284Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fe0b9591-410f-4229-a288-98d8bfb7ffe5","type":"Microsoft.Authorization/roleAssignments","name":"fe0b9591-410f-4229-a288-98d8bfb7ffe5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a9668459-3905-4e76-a681-a1633c50f368","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-16T02:39:39.2120161Z","updatedOn":"2019-12-16T02:39:39.2120161Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/263dab0a-bf9f-4eec-9ff6-387f87ed056b","type":"Microsoft.Authorization/roleAssignments","name":"263dab0a-bf9f-4eec-9ff6-387f87ed056b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-14T02:32:43.7202100Z","updatedOn":"2020-01-14T02:32:43.7202100Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/93adfbfa-f811-47e3-8ff7-e3a4675b579f","type":"Microsoft.Authorization/roleAssignments","name":"93adfbfa-f811-47e3-8ff7-e3a4675b579f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"ac47bda7-ff61-4451-9bb5-ad30ebcc2863","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-20T02:31:32.7276952Z","updatedOn":"2019-09-20T02:31:32.7276952Z","createdBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","updatedBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bf29019-3c72-44c1-97d4-58ef4d1a540f","type":"Microsoft.Authorization/roleAssignments","name":"4bf29019-3c72-44c1-97d4-58ef4d1a540f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b1eb9d0b-6ca2-4c64-8c13-31e5aa59065f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T07:10:10.5329285Z","updatedOn":"2020-06-08T07:10:10.5329285Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3bb3e257-89a9-4168-ae8b-99807e3819f3","type":"Microsoft.Authorization/roleAssignments","name":"3bb3e257-89a9-4168-ae8b-99807e3819f3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"93a01e49-673a-4e15-8230-51214a737962","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-07-05T21:56:39.5905773Z","updatedOn":"2017-07-05T21:56:39.5905773Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d09787d-0a89-40a8-abf2-a7b60e95d24b","type":"Microsoft.Authorization/roleAssignments","name":"8d09787d-0a89-40a8-abf2-a7b60e95d24b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-03T09:04:20.9413623Z","updatedOn":"2019-12-03T09:04:20.9413623Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6e6cc759-072e-47b8-b35d-ca5b95266e59","type":"Microsoft.Authorization/roleAssignments","name":"6e6cc759-072e-47b8-b35d-ca5b95266e59"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c0526f76-a841-4a3a-bdee-59a5db599e34","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-11T19:18:19.9314682Z","updatedOn":"2018-12-11T19:18:19.9314682Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d9e73a14-4984-4d89-8048-04773fb32344","type":"Microsoft.Authorization/roleAssignments","name":"d9e73a14-4984-4d89-8048-04773fb32344"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c7cc3390-43d1-4a59-8ab8-190092db8184","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T09:49:01.2994155Z","updatedOn":"2020-06-08T09:49:01.2994155Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/184cdda7-d40a-4c78-b71d-9e947e48a488","type":"Microsoft.Authorization/roleAssignments","name":"184cdda7-d40a-4c78-b71d-9e947e48a488"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"c87f79eb-8113-4168-83c8-3a0e99ac67be","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-20T09:31:14.0133249Z","updatedOn":"2020-01-20T09:31:14.0133249Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5465d5e4-7123-4cd3-b584-f51ea72c2b79","type":"Microsoft.Authorization/roleAssignments","name":"5465d5e4-7123-4cd3-b584-f51ea72c2b79"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"cdc7828e-c6c1-4822-9b0b-ca54f3d92bcd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-03-15T23:45:46.1042773Z","updatedOn":"2018-03-15T23:45:46.1042773Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d194606-3a10-428a-9ce5-876fec5096c8","type":"Microsoft.Authorization/roleAssignments","name":"8d194606-3a10-428a-9ce5-876fec5096c8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1178d20-4ca4-45f0-ba9a-5a08f588da8d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-05T11:26:44.9370825Z","updatedOn":"2020-05-05T11:26:44.9370825Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d7689797-3689-4c92-b472-a9aaa7c54570","type":"Microsoft.Authorization/roleAssignments","name":"d7689797-3689-4c92-b472-a9aaa7c54570"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d36e0017-aac8-4dd3-8ccf-0ab8a7049c35","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-18T11:38:03.9624602Z","updatedOn":"2020-01-18T11:38:03.9624602Z","createdBy":"dca37046-82cf-4fbb-8088-faa399010380","updatedBy":"dca37046-82cf-4fbb-8088-faa399010380","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/86ebcfe8-2caa-40b5-aebe-ac5a928368ef","type":"Microsoft.Authorization/roleAssignments","name":"86ebcfe8-2caa-40b5-aebe-ac5a928368ef"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"dabd5159-ba4a-42fb-9e4d-7d841445695d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-16T04:29:39.1910424Z","updatedOn":"2020-01-16T04:29:39.1910424Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8ae1af04-181f-418f-a55d-cbdfa2327b75","type":"Microsoft.Authorization/roleAssignments","name":"8ae1af04-181f-418f-a55d-cbdfa2327b75"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-10T02:54:02.2514605Z","updatedOn":"2019-11-10T02:54:02.2514605Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/de186952-0e06-4557-89b5-31257c33093b","type":"Microsoft.Authorization/roleAssignments","name":"de186952-0e06-4557-89b5-31257c33093b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-24T03:28:22.7145389Z","updatedOn":"2019-09-24T03:28:22.7145389Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/16b3fb1c-befa-4dfd-8fbc-9838444af841","type":"Microsoft.Authorization/roleAssignments","name":"16b3fb1c-befa-4dfd-8fbc-9838444af841"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f19e5031-d73d-4d9a-86b7-d540f1bc6cd7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-07T09:51:42.8397254Z","updatedOn":"2020-05-07T09:51:42.8397254Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da43c24c-31f6-47e5-b44f-e1852b61cde6","type":"Microsoft.Authorization/roleAssignments","name":"da43c24c-31f6-47e5-b44f-e1852b61cde6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f3ea48f6-a16e-4b37-8260-f69cf2200525","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T04:53:43.7428061Z","updatedOn":"2020-04-13T04:53:43.7428061Z","createdBy":"7e58ddef-4719-4c36-a485-4c2a0a843a46","updatedBy":"7e58ddef-4719-4c36-a485-4c2a0a843a46","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4d3c5439-0e6d-4dba-afd2-36d6aa289238","type":"Microsoft.Authorization/roleAssignments","name":"4d3c5439-0e6d-4dba-afd2-36d6aa289238"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f4ed124d-6acb-49a5-a6ac-bd96f35d8d16","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T06:25:17.5556287Z","updatedOn":"2020-04-26T06:25:17.5556287Z","createdBy":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","updatedBy":"794f8d45-6eb3-4e1e-bc62-c01317eaeac1","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fcef0c4c-0b40-423a-937e-fb6493374993","type":"Microsoft.Authorization/roleAssignments","name":"fcef0c4c-0b40-423a-937e-fb6493374993"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"f802089b-0ae0-4e9b-984a-4e37eef96b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-13T07:52:39.3088894Z","updatedOn":"2020-04-13T07:52:39.3088894Z","createdBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","updatedBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/82a5d3eb-6393-4a30-9d62-93d9b272d628","type":"Microsoft.Authorization/roleAssignments","name":"82a5d3eb-6393-4a30-9d62-93d9b272d628"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"ffbb9ca1-43fc-498d-b8db-ca965f1684ef","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2017-12-18T23:20:41.1586895Z","updatedOn":"2017-12-18T23:20:41.1586895Z","createdBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","updatedBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7e012250-6450-4432-b6dd-9e148ab64455","type":"Microsoft.Authorization/roleAssignments","name":"7e012250-6450-4432-b6dd-9e148ab64455"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade","principalId":"9ac534f1-d577-4034-a32d-48de400dacbf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-19T04:01:23.9885462Z","updatedOn":"2020-03-19T04:01:23.9885462Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a96438a6-6252-499b-b391-710446ac8ddb","type":"Microsoft.Authorization/roleAssignments","name":"a96438a6-6252-499b-b391-710446ac8ddb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/abec5297-d72c-4fbc-acaf-868482d345c2","principalId":"7a938a30-4226-420e-996f-4d48bca6d537","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-06-14T22:25:43.4944951Z","updatedOn":"2018-06-14T22:25:43.4944951Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a3662714-8332-43d4-a2cf-836f9367c53d","type":"Microsoft.Authorization/roleAssignments","name":"a3662714-8332-43d4-a2cf-836f9367c53d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"27c363a5-7016-4ae0-8540-818ec05673f1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T15:34:53.2206231Z","updatedOn":"2020-04-26T15:34:53.2206231Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/88670ac0-08a0-40af-8cb3-cfecc39224a6","type":"Microsoft.Authorization/roleAssignments","name":"88670ac0-08a0-40af-8cb3-cfecc39224a6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"5963f50c-7c43-405c-af7e-53294de76abd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-11T01:35:58.0239576Z","updatedOn":"2020-01-11T01:35:58.0239576Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/332cf847-f85f-4e42-93c0-ac2d2269c9c6","type":"Microsoft.Authorization/roleAssignments","name":"332cf847-f85f-4e42-93c0-ac2d2269c9c6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"63bdf800-9003-4644-b23c-0caeabf62a42","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-26T09:34:30.7345716Z","updatedOn":"2020-04-26T09:34:30.7345716Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1f6b6d83-0880-477a-a232-5d15410b189f","type":"Microsoft.Authorization/roleAssignments","name":"1f6b6d83-0880-477a-a232-5d15410b189f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"9e6a992a-0530-43ad-bcd7-e9e0e84ae703","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-11T05:47:51.9435473Z","updatedOn":"2020-03-11T05:47:51.9435473Z","createdBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","updatedBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/07371d4e-e9de-4ef7-84c6-0694afc57163","type":"Microsoft.Authorization/roleAssignments","name":"07371d4e-e9de-4ef7-84c6-0694afc57163"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"d8422fc6-cc80-4990-b5d9-15dfc33bd4ce","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-16T07:05:29.5235140Z","updatedOn":"2020-01-16T07:13:20.5220097Z","createdBy":"9abd3759-d4a6-4297-a26e-19f728a9bc15","updatedBy":"9abd3759-d4a6-4297-a26e-19f728a9bc15","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/20cbf68b-1170-7660-526a-0ce148ad6b9f","type":"Microsoft.Authorization/roleAssignments","name":"20cbf68b-1170-7660-526a-0ce148ad6b9f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-28T02:17:47.3517737Z","updatedOn":"2019-10-28T02:17:47.3517737Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fa59db41-bdc7-4934-9105-138c49aa3b25","type":"Microsoft.Authorization/roleAssignments","name":"fa59db41-bdc7-4934-9105-138c49aa3b25"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0216022c-0a14-4682-b106-fe0de377fba8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-11T10:14:11.4652781Z","updatedOn":"2020-06-11T10:14:11.4652781Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0bdccc57-790d-47b5-ab25-3b25b2c383f5","type":"Microsoft.Authorization/roleAssignments","name":"0bdccc57-790d-47b5-ab25-3b25b2c383f5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"025742e3-96b0-462b-92b8-c6f8a2467315","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T02:30:48.9213321Z","updatedOn":"2019-11-13T02:30:48.9213321Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8e56fee5-34b2-4fda-94f5-4d16d0f316c9","type":"Microsoft.Authorization/roleAssignments","name":"8e56fee5-34b2-4fda-94f5-4d16d0f316c9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"048c9bb6-913e-4ce6-99c5-35198246627b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T08:20:44.1467077Z","updatedOn":"2019-11-13T08:20:44.1467077Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ee9a0273-478f-49c1-ab8b-c391f00ab24a","type":"Microsoft.Authorization/roleAssignments","name":"ee9a0273-478f-49c1-ab8b-c391f00ab24a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"05b1f982-1404-4e2d-b2e8-af3ee7a330b4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-16T02:20:33.6180302Z","updatedOn":"2019-09-16T02:20:33.6180302Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dd290ec1-928e-4be9-bf1a-5444db3c31a9","type":"Microsoft.Authorization/roleAssignments","name":"dd290ec1-928e-4be9-bf1a-5444db3c31a9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0b9debbf-74a2-4090-9e79-6f814c15c64f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-13T23:58:24.6590895Z","updatedOn":"2019-02-13T23:58:24.6590895Z","createdBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","updatedBy":"378df7ee-31fd-4c54-945e-a1ed4f025a28","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/84210bda-8759-422b-b6ea-f95ba2a645cc","type":"Microsoft.Authorization/roleAssignments","name":"84210bda-8759-422b-b6ea-f95ba2a645cc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d1408bc-e090-4bb3-b430-608cc2fb2a0c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T13:25:32.0800552Z","updatedOn":"2020-05-12T13:25:32.0800552Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/95c1ae5a-01de-4f0c-9c56-8e87c017cf36","type":"Microsoft.Authorization/roleAssignments","name":"95c1ae5a-01de-4f0c-9c56-8e87c017cf36"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0444ccf8-fddb-43c4-b42b-ea036211229f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-18T09:31:46.3880250Z","updatedOn":"2019-09-18T09:31:46.3880250Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e7e0e4be-da1c-4e63-8872-b2486e10fbaf","type":"Microsoft.Authorization/roleAssignments","name":"e7e0e4be-da1c-4e63-8872-b2486e10fbaf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0d504196-1423-4569-9a6e-15149656f0ee","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-29T13:26:41.7796634Z","updatedOn":"2020-01-29T13:26:41.7796634Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/185c46f5-737c-4e7e-bdeb-5bafee91059d","type":"Microsoft.Authorization/roleAssignments","name":"185c46f5-737c-4e7e-bdeb-5bafee91059d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0dbbe202-a46d-4ade-8f74-0927ccff3bb6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T07:04:08.1661319Z","updatedOn":"2020-06-09T07:04:08.1661319Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3322b8ab-16df-464e-9b80-b555950e6d56","type":"Microsoft.Authorization/roleAssignments","name":"3322b8ab-16df-464e-9b80-b555950e6d56"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"16253a8a-cc24-475a-a5cf-e58491ffd350","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-30T10:22:53.8662664Z","updatedOn":"2019-10-30T10:22:53.8662664Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0d7cca1c-37d2-492a-92ed-c9ae8323e2e2","type":"Microsoft.Authorization/roleAssignments","name":"0d7cca1c-37d2-492a-92ed-c9ae8323e2e2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"182c8534-f413-487c-91a3-7addc80e35d5","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-08T08:26:11.9991435Z","updatedOn":"2020-04-08T08:26:11.9991435Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7ec462b1-f831-472f-8e1b-ff3a11068385","type":"Microsoft.Authorization/roleAssignments","name":"7ec462b1-f831-472f-8e1b-ff3a11068385"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"23304842-3c9b-46fb-9f34-ae0afe0e9a82","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:34:09.9873389Z","updatedOn":"2020-01-09T06:34:09.9873389Z","createdBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","updatedBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79d401d9-e585-43bf-a874-1ecc9685e823","type":"Microsoft.Authorization/roleAssignments","name":"79d401d9-e585-43bf-a874-1ecc9685e823"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-11T15:04:11.6940972Z","updatedOn":"2020-03-14T14:47:34.7417244Z","createdBy":"2c4ad291-088a-4833-9d12-65562168e61f","updatedBy":"f238ba61-2e60-495f-8044-5abc249758fe","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9b26c70e-48e6-9170-677d-d2e0c5c9304e","type":"Microsoft.Authorization/roleAssignments","name":"9b26c70e-48e6-9170-677d-d2e0c5c9304e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"34dd2730-0adb-4bb0-973b-d020e4ae4284","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-08T02:45:08.7641129Z","updatedOn":"2020-06-08T02:45:08.7641129Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/201a6827-570f-4c37-9e6f-f128e3cd5d85","type":"Microsoft.Authorization/roleAssignments","name":"201a6827-570f-4c37-9e6f-f128e3cd5d85"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"37aa63b3-0814-4c36-9641-d9c3120b1f1b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-01-08T18:58:20.9990189Z","updatedOn":"2019-01-08T18:58:20.9990189Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/54925852-e514-4e06-9023-14b82e9060e7","type":"Microsoft.Authorization/roleAssignments","name":"54925852-e514-4e06-9023-14b82e9060e7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"46b61f8c-9b9c-48e4-912e-243041a7c6c5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-09T06:34:13.1774942Z","updatedOn":"2020-01-09T06:34:13.1774942Z","createdBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","updatedBy":"37e77055-3c53-4ae5-bf04-d2459236b6a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10e987b4-b922-471c-994b-ccd01cf71780","type":"Microsoft.Authorization/roleAssignments","name":"10e987b4-b922-471c-994b-ccd01cf71780"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4759ce24-1955-4c57-bc53-357a69cc065f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T05:42:58.0364828Z","updatedOn":"2019-09-11T05:42:58.0364828Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/096db8b9-6da1-41d6-91fc-a44386feca3f","type":"Microsoft.Authorization/roleAssignments","name":"096db8b9-6da1-41d6-91fc-a44386feca3f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"478ac2b7-8882-45d7-b424-6d8339728ea9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-01T00:51:52.9057101Z","updatedOn":"2019-11-01T00:51:52.9057101Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9eb79b9d-a384-4d48-83b7-5b31896a4f92","type":"Microsoft.Authorization/roleAssignments","name":"9eb79b9d-a384-4d48-83b7-5b31896a4f92"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4b5f89be-be88-448d-90bd-1148b6c6deb2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-07-23T02:16:34.2523880Z","updatedOn":"2019-07-23T02:16:34.2523880Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1da14562-3dee-4c97-a071-1b2937796647","type":"Microsoft.Authorization/roleAssignments","name":"1da14562-3dee-4c97-a071-1b2937796647"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4559f5d9-0272-48bd-b6af-fde7f60744dc","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-05T02:39:11.3496688Z","updatedOn":"2020-02-05T02:39:11.3496688Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/108c3348-6445-49c8-8a02-1e9088373505","type":"Microsoft.Authorization/roleAssignments","name":"108c3348-6445-49c8-8a02-1e9088373505"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"50d1b7ca-6643-4aac-a7b6-aba7bffecb30","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-05-30T21:23:34.5623608Z","updatedOn":"2019-05-30T21:23:34.5623608Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff3f8887-b570-4cd2-80d9-31c3c0d780aa","type":"Microsoft.Authorization/roleAssignments","name":"ff3f8887-b570-4cd2-80d9-31c3c0d780aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5230081f-d9b5-4af6-8d26-c648d9cf8ddd","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-25T12:43:47.6193708Z","updatedOn":"2020-03-25T12:43:47.6193708Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/13f1d803-4dbb-4cf7-b199-35653a04bf75","type":"Microsoft.Authorization/roleAssignments","name":"13f1d803-4dbb-4cf7-b199-35653a04bf75"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5a17d64a-7ad7-432b-8622-88e4897b4cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-17T08:29:12.7481081Z","updatedOn":"2020-06-17T08:29:12.7481081Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0a0e59b8-4570-4bbc-90c1-87cfdbb3d9b0","type":"Microsoft.Authorization/roleAssignments","name":"0a0e59b8-4570-4bbc-90c1-87cfdbb3d9b0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"60a5c23b-3773-41b6-b27f-74805f1d2d9c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-04T10:54:04.8614591Z","updatedOn":"2020-02-04T10:54:04.8614591Z","createdBy":"596c247a-9db0-4c20-8ddb-d944102067ac","updatedBy":"596c247a-9db0-4c20-8ddb-d944102067ac","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/47ad8fd8-84be-48d1-8d7a-923163696cdd","type":"Microsoft.Authorization/roleAssignments","name":"47ad8fd8-84be-48d1-8d7a-923163696cdd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"69ed4898-0851-4ea4-9813-dfc9864cbaf6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-11T19:26:34.1746649Z","updatedOn":"2018-12-11T19:26:34.1746649Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/27564201-65a3-4a09-bdaf-70c08ecd1786","type":"Microsoft.Authorization/roleAssignments","name":"27564201-65a3-4a09-bdaf-70c08ecd1786"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6a0911c8-758b-458a-8a36-7d6a4c2d450b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-21T05:12:27.5158666Z","updatedOn":"2020-01-21T05:12:27.5158666Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3e8820a3-637f-4a61-922b-abdf163ea9d5","type":"Microsoft.Authorization/roleAssignments","name":"3e8820a3-637f-4a61-922b-abdf163ea9d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"12af389a-3835-46c4-abe9-39d62a64c8e4","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-15T07:17:19.3982425Z","updatedOn":"2020-05-15T07:17:19.3982425Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4944a8a7-76af-49ad-9951-9b4526e228b3","type":"Microsoft.Authorization/roleAssignments","name":"4944a8a7-76af-49ad-9951-9b4526e228b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6aef5178-c2d2-41f6-a180-a296155ddf40","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-21T05:12:34.7950106Z","updatedOn":"2019-11-21T05:12:34.7950106Z","createdBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","updatedBy":"08cee9d4-f1ee-46a2-9dd1-7462196c9ac6","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b5c83b39-f8a1-425f-984b-79e74f9ea79a","type":"Microsoft.Authorization/roleAssignments","name":"b5c83b39-f8a1-425f-984b-79e74f9ea79a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6cc662e7-785f-4759-ae7d-faf16eae02ab","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-29T05:58:51.6260835Z","updatedOn":"2020-04-29T05:58:51.6260835Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c394d91b-6eb5-4ccb-8350-c53c391e98b2","type":"Microsoft.Authorization/roleAssignments","name":"c394d91b-6eb5-4ccb-8350-c53c391e98b2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6f1ee714-b0e7-4abf-aa1e-3457f3205f0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-08T08:17:55.0153562Z","updatedOn":"2020-05-08T08:17:55.0153562Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1af0247f-6055-4bb1-9ee6-e8ea37f5413d","type":"Microsoft.Authorization/roleAssignments","name":"1af0247f-6055-4bb1-9ee6-e8ea37f5413d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"76b6ea71-288a-4e62-b904-3f3013201fb7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-17T06:36:55.9940820Z","updatedOn":"2020-06-17T06:36:55.9940820Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/21364cd1-07fd-407d-b94f-c341679a1ad6","type":"Microsoft.Authorization/roleAssignments","name":"21364cd1-07fd-407d-b94f-c341679a1ad6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6d61a178-3216-4ba7-bdc3-0fbc62b65ac9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-18T14:13:16.1350734Z","updatedOn":"2019-11-18T14:13:16.1350734Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/951d7466-f489-49df-88a3-9790ad814153","type":"Microsoft.Authorization/roleAssignments","name":"951d7466-f489-49df-88a3-9790ad814153"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"76d7bb0b-b614-4497-a519-7a46689f537c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-13T05:59:17.2737425Z","updatedOn":"2020-05-13T05:59:17.2737425Z","createdBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","updatedBy":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d34fdce-9cef-427a-bfa0-fb81ffba52f2","type":"Microsoft.Authorization/roleAssignments","name":"6d34fdce-9cef-427a-bfa0-fb81ffba52f2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-26T06:25:38.6656804Z","updatedOn":"2019-11-26T06:25:38.6656804Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/02287c55-f42c-4852-9b08-c20c8a3b7e3b","type":"Microsoft.Authorization/roleAssignments","name":"02287c55-f42c-4852-9b08-c20c8a3b7e3b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T11:44:45.7387983Z","updatedOn":"2020-05-26T11:44:45.7387983Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6a878581-11bf-4bd4-a7ab-b1fb64e555aa","type":"Microsoft.Authorization/roleAssignments","name":"6a878581-11bf-4bd4-a7ab-b1fb64e555aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"81e54268-6800-49d3-b90f-a2ea6e20c110","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-12T09:05:37.5222708Z","updatedOn":"2020-04-12T09:05:37.5222708Z","createdBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","updatedBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f6bb8b0d-7009-454a-a489-610c6e23b559","type":"Microsoft.Authorization/roleAssignments","name":"f6bb8b0d-7009-454a-a489-610c6e23b559"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"838439dc-f0fa-4a37-ba56-daa13ff730ed","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T09:15:50.5935627Z","updatedOn":"2019-09-11T09:15:50.5935627Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/253c1f18-9f2b-490d-961d-520ba222a9b3","type":"Microsoft.Authorization/roleAssignments","name":"253c1f18-9f2b-490d-961d-520ba222a9b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"864a275e-8c80-4efb-ad1c-0c0ab3081788","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T06:17:44.5858739Z","updatedOn":"2020-06-09T06:17:44.5858739Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0565f4e2-558c-40b3-860e-3e910285cae7","type":"Microsoft.Authorization/roleAssignments","name":"0565f4e2-558c-40b3-860e-3e910285cae7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"885ee9c5-df35-4d21-bd29-33d930ef4721","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-08-08T07:30:25.7405858Z","updatedOn":"2019-08-08T07:30:25.7405858Z","createdBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","updatedBy":"9a0f0a3f-b307-4ae3-bb6a-27a65244de7e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9e1de6d0-412e-4425-8e11-897f4aa32d65","type":"Microsoft.Authorization/roleAssignments","name":"9e1de6d0-412e-4425-8e11-897f4aa32d65"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8ce13a5d-7120-4635-b792-8cc697798e81","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-10-03T05:23:07.9499351Z","updatedOn":"2019-10-03T05:23:07.9499351Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ca192630-0f9b-47ea-bc2a-0cc0f9dc27d7","type":"Microsoft.Authorization/roleAssignments","name":"ca192630-0f9b-47ea-bc2a-0cc0f9dc27d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"90c3d926-9c03-4d90-86f4-12866a6da212","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-02T20:57:30.6864609Z","updatedOn":"2019-04-02T20:57:30.6864609Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bf3be37-b85e-49f9-ace5-e14c018302b5","type":"Microsoft.Authorization/roleAssignments","name":"6bf3be37-b85e-49f9-ace5-e14c018302b5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"97233d81-8d2d-4e63-8bd2-ae5707805489","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-27T01:19:27.7003320Z","updatedOn":"2020-02-27T01:19:27.7003320Z","createdBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","updatedBy":"6ba8d12f-faf3-4859-918b-80f93e471e38","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/363f553a-f660-4bcc-9c18-855b870f7bc8","type":"Microsoft.Authorization/roleAssignments","name":"363f553a-f660-4bcc-9c18-855b870f7bc8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"973fdd79-4ab9-438e-87c3-954cca1889e1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-09-21T19:09:54.9071757Z","updatedOn":"2018-09-21T19:09:54.9071757Z","createdBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","updatedBy":"3b0ef8fb-e5c7-43b6-a594-013788cbd952","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a4890276-7fa1-47a7-9d82-f0a4ceff9bd6","type":"Microsoft.Authorization/roleAssignments","name":"a4890276-7fa1-47a7-9d82-f0a4ceff9bd6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"97885433-e8ee-463f-9db0-194661924999","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-05T09:50:17.9261390Z","updatedOn":"2020-03-05T09:50:17.9261390Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7934da9a-5ac8-4145-b917-d9e061fc10fc","type":"Microsoft.Authorization/roleAssignments","name":"7934da9a-5ac8-4145-b917-d9e061fc10fc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"99220f34-fe4d-4bb9-a54f-8cef2c114bec","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T02:24:15.1904918Z","updatedOn":"2019-11-13T02:24:15.1904918Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/35b39af0-258c-488a-91d0-a744d937d7d0","type":"Microsoft.Authorization/roleAssignments","name":"35b39af0-258c-488a-91d0-a744d937d7d0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4e6a3ef-370d-4b96-8484-0f0e7ae097cc","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-23T04:54:51.7233330Z","updatedOn":"2019-02-23T04:54:51.7233330Z","createdBy":"4a399fbb-7213-47d3-b6ad-59284286d50a","updatedBy":"4a399fbb-7213-47d3-b6ad-59284286d50a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/44a09d24-8afc-4e6f-8194-92c41bc03d2c","type":"Microsoft.Authorization/roleAssignments","name":"44a09d24-8afc-4e6f-8194-92c41bc03d2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ac49f0af-daf1-40c5-a7c5-976a80349806","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-02-25T19:29:43.0393638Z","updatedOn":"2019-02-25T19:29:43.0393638Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2990befc-9d32-467c-82e6-f6d4b9989731","type":"Microsoft.Authorization/roleAssignments","name":"2990befc-9d32-467c-82e6-f6d4b9989731"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9085a307-933c-452f-ae3a-9a8e13e68500","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-02T09:57:16.5579321Z","updatedOn":"2020-04-02T09:57:16.5579321Z","createdBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","updatedBy":"7f2b9f1e-23ea-4ef8-a76b-d1ff0fe05120","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1e74faf5-14cb-443a-a960-986c993decbc","type":"Microsoft.Authorization/roleAssignments","name":"1e74faf5-14cb-443a-a960-986c993decbc"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b0460b1a-d53a-42e8-a6a4-d9f43f0ccc73","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-28T04:23:35.8222484Z","updatedOn":"2020-05-28T04:23:35.8222484Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a8cb3f2a-31d8-4e9f-999a-ec8894bb13d5","type":"Microsoft.Authorization/roleAssignments","name":"a8cb3f2a-31d8-4e9f-999a-ec8894bb13d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b5ed59e8-f00d-4396-af62-8297e36d8b52","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-22T06:33:53.8936608Z","updatedOn":"2020-01-22T06:33:53.8936608Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a4075ce9-efa5-4df6-a196-2538407da770","type":"Microsoft.Authorization/roleAssignments","name":"a4075ce9-efa5-4df6-a196-2538407da770"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b95d1b0f-145c-480a-915a-3fb867fb598b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-04-07T05:49:02.0078574Z","updatedOn":"2020-04-07T05:49:02.0078574Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bd310d01-f783-4f08-8b88-948f0b348a11","type":"Microsoft.Authorization/roleAssignments","name":"bd310d01-f783-4f08-8b88-948f0b348a11"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"be76b331-83ac-423a-83de-a97b6a990735","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-22T10:26:36.6728187Z","updatedOn":"2020-05-22T10:26:36.6728187Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/12e50c31-99da-4248-a195-0ab7ac62c504","type":"Microsoft.Authorization/roleAssignments","name":"12e50c31-99da-4248-a195-0ab7ac62c504"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c11b39f7-26c3-4dfc-8d0f-20dde3187845","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-12-13T18:31:05.4586182Z","updatedOn":"2018-12-13T18:31:05.4586182Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4901f853-a3c6-47e4-9495-2aeb09fb4491","type":"Microsoft.Authorization/roleAssignments","name":"4901f853-a3c6-47e4-9495-2aeb09fb4491"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c87f79eb-8113-4168-83c8-3a0e99ac67be","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-09T08:20:56.3783272Z","updatedOn":"2020-06-09T08:20:56.3783272Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/60aed0e0-6e97-4ca9-90ac-1f604f8c374e","type":"Microsoft.Authorization/roleAssignments","name":"60aed0e0-6e97-4ca9-90ac-1f604f8c374e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cfca31cb-14a9-4e95-a9b7-f905ab23db3c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-03T04:01:25.5862636Z","updatedOn":"2020-02-03T04:01:25.5862636Z","createdBy":"18f53146-1f6c-462a-96a5-d50e1293b770","updatedBy":"18f53146-1f6c-462a-96a5-d50e1293b770","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c9fd36d4-1cfe-48c2-bbfc-1ff34a1d1f1f","type":"Microsoft.Authorization/roleAssignments","name":"c9fd36d4-1cfe-48c2-bbfc-1ff34a1d1f1f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d04239cd-f0db-4151-91e9-df98af92d231","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-15T05:29:57.8724060Z","updatedOn":"2020-06-15T05:29:57.8724060Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8bfc3a45-0214-4e85-bd1a-e4ab3c3bdb92","type":"Microsoft.Authorization/roleAssignments","name":"8bfc3a45-0214-4e85-bd1a-e4ab3c3bdb92"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d22a37ff-94a3-46b9-a549-e16b8b71a43c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-13T04:51:28.2854740Z","updatedOn":"2019-11-13T04:51:28.2854740Z","createdBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","updatedBy":"0143ff25-68ad-44d7-80ed-7deaff6bf9de","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b362e66e-bf5f-4ba5-adaf-88034544377b","type":"Microsoft.Authorization/roleAssignments","name":"b362e66e-bf5f-4ba5-adaf-88034544377b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d80964f8-f04a-4e50-8803-35e571cfb2d9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-02-07T10:01:41.1345273Z","updatedOn":"2020-02-07T10:01:41.1345273Z","createdBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","updatedBy":"7b280dae-3c0b-48cf-ad89-c54f9181ba5a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f1ef5acb-1958-4cd3-a981-0aa430cb0fbd","type":"Microsoft.Authorization/roleAssignments","name":"f1ef5acb-1958-4cd3-a981-0aa430cb0fbd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d8422fc6-cc80-4990-b5d9-15dfc33bd4ce","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-28T05:13:52.5233941Z","updatedOn":"2019-11-28T05:13:52.5233941Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a2e5207-3e10-4ca2-9784-6e7bb8050194","type":"Microsoft.Authorization/roleAssignments","name":"9a2e5207-3e10-4ca2-9784-6e7bb8050194"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"db65a597-9bd4-4259-9632-ffcbfd208b04","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-01-31T18:43:41.6069289Z","updatedOn":"2019-01-31T18:43:41.6069289Z","createdBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","updatedBy":"c0526f76-a841-4a3a-bdee-59a5db599e34","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa2a3117-6ca4-4ddf-83c7-511b370735dd","type":"Microsoft.Authorization/roleAssignments","name":"aa2a3117-6ca4-4ddf-83c7-511b370735dd"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dc1a3549-229c-4971-93d1-dd2a12439b19","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-18T02:46:17.6374569Z","updatedOn":"2019-09-18T02:46:17.6374569Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79ee6058-9515-427b-a19d-f9a245e4172b","type":"Microsoft.Authorization/roleAssignments","name":"79ee6058-9515-427b-a19d-f9a245e4172b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ddab67ba-ea88-4673-9802-b5393ef85c81","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-03-13T09:32:56.5200842Z","updatedOn":"2020-03-13T09:32:56.5200842Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/60066209-df2b-4102-bf3a-6a405afe485c","type":"Microsoft.Authorization/roleAssignments","name":"60066209-df2b-4102-bf3a-6a405afe485c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e12f87e2-42fe-4081-a272-85eee50a8062","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T04:19:32.2862854Z","updatedOn":"2019-12-05T04:19:32.2862854Z","createdBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","updatedBy":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3076ac0b-96c1-40da-b47c-cc8b1a6f60d7","type":"Microsoft.Authorization/roleAssignments","name":"3076ac0b-96c1-40da-b47c-cc8b1a6f60d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f19e5031-d73d-4d9a-86b7-d540f1bc6cd7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T11:59:35.4100543Z","updatedOn":"2020-05-26T11:59:35.4100543Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a156d12a-0595-4273-870e-26b43b10eefb","type":"Microsoft.Authorization/roleAssignments","name":"a156d12a-0595-4273-870e-26b43b10eefb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f22c2b35-e81d-4fa5-afa4-e6178a257deb","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T13:25:32.1208963Z","updatedOn":"2020-05-12T13:25:32.1208963Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a898ad94-406c-429f-8221-1d2e7b9cd5bb","type":"Microsoft.Authorization/roleAssignments","name":"a898ad94-406c-429f-8221-1d2e7b9cd5bb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f6c2f6f7-1bbf-4c17-87c6-28c02d7c0637","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-11-08T18:01:59.1260407Z","updatedOn":"2018-11-08T18:01:59.1260407Z","createdBy":"5963f50c-7c43-405c-af7e-53294de76abd","updatedBy":"5963f50c-7c43-405c-af7e-53294de76abd","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c4b79dcb-c95a-44c2-82cd-e550faad8ac5","type":"Microsoft.Authorization/roleAssignments","name":"c4b79dcb-c95a-44c2-82cd-e550faad8ac5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f757bcca-02d6-4279-8f2d-61a7dcdbccd6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-21T05:32:27.2840541Z","updatedOn":"2020-01-21T05:32:27.2840541Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da4d3dfe-5384-4144-a9c2-5bd2124ddc51","type":"Microsoft.Authorization/roleAssignments","name":"da4d3dfe-5384-4144-a9c2-5bd2124ddc51"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f77592c5-1eb8-4ed3-8615-ddbb75adb4fe","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-19T05:03:29.3633566Z","updatedOn":"2020-06-19T05:03:29.3633566Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2194737b-2f80-4b24-bcd1-45b4c72bce84","type":"Microsoft.Authorization/roleAssignments","name":"2194737b-2f80-4b24-bcd1-45b4c72bce84"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f802089b-0ae0-4e9b-984a-4e37eef96b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-19T05:51:35.7314750Z","updatedOn":"2020-01-19T05:51:35.7314750Z","createdBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","updatedBy":"3a401b8a-1d42-43d2-a38f-7ecd4e471273","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3cc61a45-01f3-45df-8661-e7bdd3cf0ef5","type":"Microsoft.Authorization/roleAssignments","name":"3cc61a45-01f3-45df-8661-e7bdd3cf0ef5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-11T08:57:15.2589033Z","updatedOn":"2020-06-11T08:57:15.2589033Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f14cf4c3-66bb-4cb4-aa88-de46c43a5235","type":"Microsoft.Authorization/roleAssignments","name":"f14cf4c3-66bb-4cb4-aa88-de46c43a5235"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"838439dc-f0fa-4a37-ba56-daa13ff730ed","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-09-11T09:19:13.9288977Z","updatedOn":"2019-09-11T09:19:13.9288977Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b02d8e07-7398-4236-bf13-6293699c6862","type":"Microsoft.Authorization/roleAssignments","name":"b02d8e07-7398-4236-bf13-6293699c6862"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-10-25T19:47:09.8058411Z","updatedOn":"2018-10-25T19:47:09.8058411Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/abd19ae1-8e0c-4e31-b1ab-25e85d987378","type":"Microsoft.Authorization/roleAssignments","name":"abd19ae1-8e0c-4e31-b1ab-25e85d987378"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/cdda3590-29a3-44f6-95f2-9f980659eb04","principalId":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-11-25T02:29:00.1905156Z","updatedOn":"2019-11-25T02:29:00.1905156Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/774d0387-22b2-41fb-9025-c689ab821fb0","type":"Microsoft.Authorization/roleAssignments","name":"774d0387-22b2-41fb-9025-c689ab821fb0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"3e587269-2f98-4906-8e35-7c6af32219d1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-23T03:47:43.1586800Z","updatedOn":"2020-06-23T03:47:43.1586800Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8fcf9b86-69ae-4033-bb78-7f21b15375c4","type":"Microsoft.Authorization/roleAssignments","name":"8fcf9b86-69ae-4033-bb78-7f21b15375c4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"8adc2845-bd5a-4a35-b00f-b83f0640facd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-24T04:56:37.2992825Z","updatedOn":"2020-06-24T04:56:37.2992825Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3921853b-f10d-4c32-9f3c-4ba978198495","type":"Microsoft.Authorization/roleAssignments","name":"3921853b-f10d-4c32-9f3c-4ba978198495"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"8adc2845-bd5a-4a35-b00f-b83f0640facd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-24T05:56:50.0401266Z","updatedOn":"2020-06-24T05:56:50.0401266Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3620fe85-c1cb-46f3-a138-f96236bc1bb0","type":"Microsoft.Authorization/roleAssignments","name":"3620fe85-c1cb-46f3-a138-f96236bc1bb0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"1952a856-3972-421d-b257-ae7d8d62e244","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-30T10:09:32.8969837Z","updatedOn":"2020-06-30T10:09:32.8969837Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3274beac-a4e5-43e2-86cc-2247a4e81e45","type":"Microsoft.Authorization/roleAssignments","name":"3274beac-a4e5-43e2-86cc-2247a4e81e45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T02:08:52.2449294Z","updatedOn":"2020-07-01T02:08:52.2449294Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/72cedbfc-50c9-44fa-ad63-d9d32f5215f9","type":"Microsoft.Authorization/roleAssignments","name":"72cedbfc-50c9-44fa-ad63-d9d32f5215f9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"9bc33702-a011-4e3b-80f7-927356668049","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T03:00:59.1715198Z","updatedOn":"2020-07-01T03:00:59.1715198Z","createdBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","updatedBy":"7c1f8589-d62d-4dc2-afb0-e94b22edf558","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/89304b85-648a-403d-ab10-f246b2db26b6","type":"Microsoft.Authorization/roleAssignments","name":"89304b85-648a-403d-ab10-f246b2db26b6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9bc33702-a011-4e3b-80f7-927356668049","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T03:27:54.5201710Z","updatedOn":"2020-07-01T03:27:54.5201710Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e5367e0d-da08-4a30-819c-f496ccaa4bfa","type":"Microsoft.Authorization/roleAssignments","name":"e5367e0d-da08-4a30-819c-f496ccaa4bfa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ee38ef12-23d7-4595-8f6f-b4aaa15933f9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T04:46:10.4023148Z","updatedOn":"2020-07-01T04:46:10.4023148Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d3f0718-3404-4f68-b88f-01d3852d40c2","type":"Microsoft.Authorization/roleAssignments","name":"6d3f0718-3404-4f68-b88f-01d3852d40c2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T06:40:44.5009970Z","updatedOn":"2020-07-01T06:40:44.5009970Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/beed1228-2a59-415d-b3c1-7cde7e454ffb","type":"Microsoft.Authorization/roleAssignments","name":"beed1228-2a59-415d-b3c1-7cde7e454ffb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9ec9777a-d786-409e-91c4-da25125576e4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-07T03:23:39.3280578Z","updatedOn":"2020-08-07T03:23:39.3280578Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a7d71d52-c222-4e2f-8ee3-a8ebbfbd8305","type":"Microsoft.Authorization/roleAssignments","name":"a7d71d52-c222-4e2f-8ee3-a8ebbfbd8305"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f013c31e-6903-492d-9f8f-8a2b0097a737","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:25:12.2160705Z","updatedOn":"2020-08-10T05:25:12.2160705Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/218b7750-72ff-4972-8251-0dd31c91c0f5","type":"Microsoft.Authorization/roleAssignments","name":"218b7750-72ff-4972-8251-0dd31c91c0f5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2bb241ba-8f4e-4d58-9812-1f730a9bb04f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:26:33.0105360Z","updatedOn":"2020-08-10T05:26:33.0105360Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e140f43a-4943-4839-a7ad-3c88eda426a3","type":"Microsoft.Authorization/roleAssignments","name":"e140f43a-4943-4839-a7ad-3c88eda426a3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"497a3fb5-4a8b-4fdb-a358-b1c7384d1297","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T05:39:03.3686314Z","updatedOn":"2020-08-10T05:39:03.3686314Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0ced53d7-64d1-45c2-b08b-7fbdb293d299","type":"Microsoft.Authorization/roleAssignments","name":"0ced53d7-64d1-45c2-b08b-7fbdb293d299"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T06:07:40.7376298Z","updatedOn":"2020-08-10T06:07:40.7376298Z","createdBy":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","updatedBy":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8e606ca9-ad53-4135-837b-c2cde19b8a8e","type":"Microsoft.Authorization/roleAssignments","name":"8e606ca9-ad53-4135-837b-c2cde19b8a8e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b98fae7f-2c20-443f-ab5c-ef3a7be6eae1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-10T09:03:55.9162129Z","updatedOn":"2020-08-10T09:03:55.9162129Z","createdBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","updatedBy":"f0f844e0-d2fe-4aa3-8e2c-2e429618f305","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f2241eaf-def8-425f-83ea-6afc474524ae","type":"Microsoft.Authorization/roleAssignments","name":"f2241eaf-def8-425f-83ea-6afc474524ae"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3aca7341-bda7-4fd7-b5e9-c2b97e0de8a7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:10:41.9755999Z","updatedOn":"2020-08-14T14:10:41.9755999Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cb5d9b2a-326e-49b9-8b8e-73b207413e7a","type":"Microsoft.Authorization/roleAssignments","name":"cb5d9b2a-326e-49b9-8b8e-73b207413e7a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e0e3d203-4502-40cb-a021-639bafd28ad5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:23:15.5278986Z","updatedOn":"2020-08-14T14:23:15.5278986Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/91acbf07-9cbd-4f4e-b1d8-cc7828058ec9","type":"Microsoft.Authorization/roleAssignments","name":"91acbf07-9cbd-4f4e-b1d8-cc7828058ec9"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5da9b62e-db61-48df-b7cb-983d777e2ff2","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T14:28:46.5840210Z","updatedOn":"2020-08-14T14:28:46.5840210Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6efa18b8-42bc-47ca-8813-d30e73cf53db","type":"Microsoft.Authorization/roleAssignments","name":"6efa18b8-42bc-47ca-8813-d30e73cf53db"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7b6eac7a-88af-454f-b145-c76749e9a29b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T19:29:47.4188577Z","updatedOn":"2020-08-14T19:29:47.4188577Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6d001d53-d8f4-4fff-b679-d80a7040eac7","type":"Microsoft.Authorization/roleAssignments","name":"6d001d53-d8f4-4fff-b679-d80a7040eac7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8ac0350b-22e2-4160-a726-34c6caa4184f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-14T19:48:28.7252041Z","updatedOn":"2020-08-14T19:48:28.7252041Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e0d4187d-1ee3-4056-8250-14f5e12ec79a","type":"Microsoft.Authorization/roleAssignments","name":"e0d4187d-1ee3-4056-8250-14f5e12ec79a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1141514b-1bef-48de-b565-d44152e1062b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:27:12.9790197Z","updatedOn":"2020-08-17T07:27:12.9790197Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3ab310ca-f5aa-4cfe-aac7-1cd7bb778936","type":"Microsoft.Authorization/roleAssignments","name":"3ab310ca-f5aa-4cfe-aac7-1cd7bb778936"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"06f8821b-7fbf-4980-886d-665d9db57b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:40:08.6067489Z","updatedOn":"2020-08-17T07:40:08.6067489Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1cabdfaf-a394-44c3-affc-81aff3ba6ae2","type":"Microsoft.Authorization/roleAssignments","name":"1cabdfaf-a394-44c3-affc-81aff3ba6ae2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cf2a17da-9812-4844-9ae0-3ae15ec76cad","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-17T07:46:00.6157836Z","updatedOn":"2020-08-17T07:46:00.6157836Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4fd3d281-3cc9-40e7-9b52-583f1dd816ee","type":"Microsoft.Authorization/roleAssignments","name":"4fd3d281-3cc9-40e7-9b52-583f1dd816ee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60f762f9-4b9d-4819-8447-b96770d393f7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":"@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:Name]
-        stringEquals ''foo''","conditionVersion":"2.0","createdOn":"2020-08-18T07:10:10.3636738Z","updatedOn":"2020-08-18T07:10:10.3636738Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":"Role
-        assignment foo to check on bar"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6da08c78-7567-4c5c-88a4-880a2ace7352","type":"Microsoft.Authorization/roleAssignments","name":"6da08c78-7567-4c5c-88a4-880a2ace7352"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"16aec3a5-3759-4e41-a69e-7e2b2680eafd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T09:52:17.6795896Z","updatedOn":"2020-08-18T09:52:17.6795896Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/75161d12-2bb2-42ae-a4e7-582440b6c4f4","type":"Microsoft.Authorization/roleAssignments","name":"75161d12-2bb2-42ae-a4e7-582440b6c4f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"acb2e9d2-2452-4577-a05e-d21a637a10fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T11:06:21.1901058Z","updatedOn":"2020-08-18T11:06:21.1901058Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/14218d21-a768-490e-8618-c15affc6937c","type":"Microsoft.Authorization/roleAssignments","name":"14218d21-a768-490e-8618-c15affc6937c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"79fe61e0-fd04-47f9-82e9-dba4d7d21b2e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-18T11:07:15.5617349Z","updatedOn":"2020-08-18T11:07:15.5617349Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/589f009b-6553-4743-972a-4ce54c29a635","type":"Microsoft.Authorization/roleAssignments","name":"589f009b-6553-4743-972a-4ce54c29a635"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a9dc1ee2-52a6-4092-868a-816237d2e662","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:29.9317048Z","updatedOn":"2020-08-19T07:03:29.9317048Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a3cde6c2-db59-403b-815b-f599d2575d08","type":"Microsoft.Authorization/roleAssignments","name":"a3cde6c2-db59-403b-815b-f599d2575d08"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"119ba358-4192-473a-b06d-181459705162","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:29.7818867Z","updatedOn":"2020-08-19T07:03:29.7818867Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/133bdd44-fcf5-49b5-878a-87416f8ae60d","type":"Microsoft.Authorization/roleAssignments","name":"133bdd44-fcf5-49b5-878a-87416f8ae60d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"34ea07e2-7262-40a9-aadc-afdf3a92fe21","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:03:45.6787321Z","updatedOn":"2020-08-19T07:03:45.6787321Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09848f3b-57c3-4f72-a8f4-df0aaa3270f1","type":"Microsoft.Authorization/roleAssignments","name":"09848f3b-57c3-4f72-a8f4-df0aaa3270f1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf3ceccf-4953-42e1-b3df-edcabdd83461","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:04:52.1212465Z","updatedOn":"2020-08-19T07:04:52.1212465Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a47f705e-40ad-4dbb-ac53-4493a0b44991","type":"Microsoft.Authorization/roleAssignments","name":"a47f705e-40ad-4dbb-ac53-4493a0b44991"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b8bec651-22e5-4a25-be13-6b1f9df8a00a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:05:25.2684558Z","updatedOn":"2020-08-19T07:05:25.2684558Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/93e123a2-8f6a-450a-aa0d-e4dc04de68d6","type":"Microsoft.Authorization/roleAssignments","name":"93e123a2-8f6a-450a-aa0d-e4dc04de68d6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c8b802a4-9966-4de2-b39b-6d4266c6bfff","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T07:57:35.2037157Z","updatedOn":"2020-08-19T07:57:35.2037157Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/549e00ed-6b04-4930-b359-4d0f43f4950d","type":"Microsoft.Authorization/roleAssignments","name":"549e00ed-6b04-4930-b359-4d0f43f4950d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"6d97229a-391f-473a-893f-f0608b592d7b","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:38:20.3090190Z","updatedOn":"2020-08-19T08:38:20.3090190Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a7686d39-2951-4c27-8cbf-c3c36d701d24","type":"Microsoft.Authorization/roleAssignments","name":"a7686d39-2951-4c27-8cbf-c3c36d701d24"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"7bbbac61-5311-40e7-a9e2-2dd92c54144b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:40:47.6961897Z","updatedOn":"2020-08-19T08:40:47.6961897Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f13a2128-645b-4b42-be6a-7b8a174d6dda","type":"Microsoft.Authorization/roleAssignments","name":"f13a2128-645b-4b42-be6a-7b8a174d6dda"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"10741bcb-37eb-4b5d-b73d-b22e72e4c7dd","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:45:43.8141578Z","updatedOn":"2020-08-19T08:45:43.8141578Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d4366a87-a683-4232-8270-8475b5105a7b","type":"Microsoft.Authorization/roleAssignments","name":"d4366a87-a683-4232-8270-8475b5105a7b"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7","principalId":"667a932e-e24b-4684-aa4a-1db1fd704cc3","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-19T08:47:19.3260541Z","updatedOn":"2020-08-19T08:47:19.3260541Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e430a73b-7548-4fee-a45d-25c71c70d8b3","type":"Microsoft.Authorization/roleAssignments","name":"e430a73b-7548-4fee-a45d-25c71c70d8b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a9111493-85b7-43f0-b388-333c160780c6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T05:05:29.5232338Z","updatedOn":"2020-08-21T05:05:29.5232338Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/417d7e21-636b-441a-90ae-106afe45fab1","type":"Microsoft.Authorization/roleAssignments","name":"417d7e21-636b-441a-90ae-106afe45fab1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a0192903-a3ce-47e2-b3d0-ae831e62a518","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T06:29:50.5909137Z","updatedOn":"2020-08-21T06:29:50.5909137Z","createdBy":"6d97229a-391f-473a-893f-f0608b592d7b","updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cc5e851d-a6f5-45f2-82f5-3e8e2638814c","type":"Microsoft.Authorization/roleAssignments","name":"cc5e851d-a6f5-45f2-82f5-3e8e2638814c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"63c25c04-362b-42d9-9e3f-83af045d0a3c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T07:14:04.1824643Z","updatedOn":"2020-08-21T07:14:04.1824643Z","createdBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","updatedBy":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bf019dd5-58f4-4fbc-9206-845cf65a7d07","type":"Microsoft.Authorization/roleAssignments","name":"bf019dd5-58f4-4fbc-9206-845cf65a7d07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8e510330-6da3-437c-9d16-b6875c47b73b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:10:19.9912043Z","updatedOn":"2020-08-21T19:10:19.9912043Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/14e6ffd6-9879-4134-9ae2-6e2b8d528ad3","type":"Microsoft.Authorization/roleAssignments","name":"14e6ffd6-9879-4134-9ae2-6e2b8d528ad3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1c60843c-84f3-4dfc-8b47-ede4ead019a9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:29:23.4218009Z","updatedOn":"2020-08-21T19:29:23.4218009Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/411c5f77-af95-4f2f-9e27-9b0c3a5c3a8a","type":"Microsoft.Authorization/roleAssignments","name":"411c5f77-af95-4f2f-9e27-9b0c3a5c3a8a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6d94ee65-e779-469a-a4b5-d56a0b07c685","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-21T19:34:28.1634489Z","updatedOn":"2020-08-21T19:34:28.1634489Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e76d93b3-6b01-4778-84e7-799c8b676e9c","type":"Microsoft.Authorization/roleAssignments","name":"e76d93b3-6b01-4778-84e7-799c8b676e9c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2b6f181-9d6c-4e10-876f-b995612db461","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:09:42.7361350Z","updatedOn":"2020-08-24T14:09:42.7361350Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c46c851d-b430-4494-a15c-a07fb87a90ae","type":"Microsoft.Authorization/roleAssignments","name":"c46c851d-b430-4494-a15c-a07fb87a90ae"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b3d54681-34f2-47b8-a790-97ed4c5a7a8d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:23:13.0411929Z","updatedOn":"2020-08-24T14:23:13.0411929Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9f100957-31b1-468b-b2d9-58574bc56a9d","type":"Microsoft.Authorization/roleAssignments","name":"9f100957-31b1-468b-b2d9-58574bc56a9d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a7c9a5c2-8e7a-4f42-abb7-018d3b8e845f","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-24T14:27:43.7812740Z","updatedOn":"2020-08-24T14:27:43.7812740Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/de3f15f5-edcb-4bcd-81b2-1140597849ac","type":"Microsoft.Authorization/roleAssignments","name":"de3f15f5-edcb-4bcd-81b2-1140597849ac"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-26T06:39:56.9154641Z","updatedOn":"2020-08-26T06:39:56.9154641Z","createdBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","updatedBy":"89f8b9bb-7e1f-4026-a2f1-2397bc515cb3","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/52185ca9-744e-443f-8d95-5ddb2c963891","type":"Microsoft.Authorization/roleAssignments","name":"52185ca9-744e-443f-8d95-5ddb2c963891"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8cf96a92-f77b-4f11-b378-bc65f571dd97","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-28T19:11:18.2902598Z","updatedOn":"2020-08-28T19:11:18.2902598Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aaa8ba85-b7e1-4267-9120-44c9bb88d6cf","type":"Microsoft.Authorization/roleAssignments","name":"aaa8ba85-b7e1-4267-9120-44c9bb88d6cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"aceba178-3429-4628-a918-9c2d07605ce4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-28T19:34:05.2521949Z","updatedOn":"2020-08-28T19:34:05.2521949Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/db744c26-387e-450c-af33-9f650d3e081a","type":"Microsoft.Authorization/roleAssignments","name":"db744c26-387e-450c-af33-9f650d3e081a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T02:18:54.8314918Z","updatedOn":"2020-08-31T02:18:54.8314918Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0c5c20de-7830-4420-b9a8-319bc24fd068","type":"Microsoft.Authorization/roleAssignments","name":"0c5c20de-7830-4420-b9a8-319bc24fd068"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"63a25eaf-4d6f-491e-9ee6-c1583073b797","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T03:56:52.4047017Z","updatedOn":"2020-08-31T03:56:52.4047017Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e5b45c0c-0568-48f2-b3e6-8f2a7c8a7480","type":"Microsoft.Authorization/roleAssignments","name":"e5b45c0c-0568-48f2-b3e6-8f2a7c8a7480"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bb6ddbae-c27c-4d59-8f74-7f3ae86b09cf","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T08:13:57.1050454Z","updatedOn":"2020-08-31T08:13:57.1050454Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e19bab66-9aa8-4185-8022-4f12d711bd41","type":"Microsoft.Authorization/roleAssignments","name":"e19bab66-9aa8-4185-8022-4f12d711bd41"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b3e8f037-9df3-48d7-a200-ea26adbec31b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-31T16:38:12.9366042Z","updatedOn":"2020-08-31T16:38:12.9366042Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7a52c17e-ffcb-4fda-a6ec-00ce6ce0ec00","type":"Microsoft.Authorization/roleAssignments","name":"7a52c17e-ffcb-4fda-a6ec-00ce6ce0ec00"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f24c1379-3bff-4ef9-a12c-f2144e606f70","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-02T07:08:09.2474084Z","updatedOn":"2020-09-02T07:08:09.2474084Z","createdBy":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","updatedBy":"7ecfd123-73a8-4c5a-b57b-df502769b4e7","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/617ef96e-12a4-4c5a-8d31-57d08a7a3d7a","type":"Microsoft.Authorization/roleAssignments","name":"617ef96e-12a4-4c5a-8d31-57d08a7a3d7a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2c830430-942c-49f3-85d5-47b113077c10","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-04T19:09:41.0321006Z","updatedOn":"2020-09-04T19:09:41.0321006Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b6663c97-f1e1-43b7-a4e6-48fab343ba41","type":"Microsoft.Authorization/roleAssignments","name":"b6663c97-f1e1-43b7-a4e6-48fab343ba41"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"82b73c5f-d0b6-4922-bee4-d4c15c6de7df","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-04T19:31:27.3400870Z","updatedOn":"2020-09-04T19:31:27.3400870Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff7c33ab-2fad-456e-a3cc-7b229b5368d5","type":"Microsoft.Authorization/roleAssignments","name":"ff7c33ab-2fad-456e-a3cc-7b229b5368d5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2e888925-16dd-4a44-b8b1-ba406c26f5d7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:24:37.4713613Z","updatedOn":"2020-09-07T06:24:37.4713613Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/44f8b319-a262-4d13-b71f-333447b5a805","type":"Microsoft.Authorization/roleAssignments","name":"44f8b319-a262-4d13-b71f-333447b5a805"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9df1aedd-86b5-4ed0-b8ff-a88acb8650fb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:25:06.2141876Z","updatedOn":"2020-09-07T06:25:06.2141876Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/85e919b7-5319-413e-a542-afa0b9beeb62","type":"Microsoft.Authorization/roleAssignments","name":"85e919b7-5319-413e-a542-afa0b9beeb62"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"43ef2449-ad33-4be0-8ed0-5c683286f37a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T06:36:55.7776057Z","updatedOn":"2020-09-07T06:36:55.7776057Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/76ac0e9c-d79b-42f2-bd51-4cbc37748e64","type":"Microsoft.Authorization/roleAssignments","name":"76ac0e9c-d79b-42f2-bd51-4cbc37748e64"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f7365134-0464-4e1f-9b14-d7eec002fcf5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T07:05:11.6942078Z","updatedOn":"2020-09-07T07:05:11.6942078Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fbf2c497-545e-4588-8684-7b9ee6da6b1e","type":"Microsoft.Authorization/roleAssignments","name":"fbf2c497-545e-4588-8684-7b9ee6da6b1e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"93d51f04-4891-476a-8c64-06d57c749216","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T07:08:02.2196156Z","updatedOn":"2020-09-07T07:08:02.2196156Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2f30eec3-4fb4-4703-b46d-e4477070136f","type":"Microsoft.Authorization/roleAssignments","name":"2f30eec3-4fb4-4703-b46d-e4477070136f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d7715695-4665-4845-a99e-9893013479f9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T08:02:32.0378468Z","updatedOn":"2020-09-07T08:02:32.0378468Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7cf24871-6fd5-487e-a65e-c1ebfd911403","type":"Microsoft.Authorization/roleAssignments","name":"7cf24871-6fd5-487e-a65e-c1ebfd911403"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"18082f29-fabc-4d67-bc7e-d83a98f5df1e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-07T08:11:12.8568998Z","updatedOn":"2020-09-07T08:11:12.8568998Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6ebb62b0-b2cf-4db0-a7bf-9c7ff68a646f","type":"Microsoft.Authorization/roleAssignments","name":"6ebb62b0-b2cf-4db0-a7bf-9c7ff68a646f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"af994901-af8c-453d-947f-f35bd0f3762c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-04T01:15:27.8872966Z","updatedOn":"2020-07-04T01:15:27.8872966Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18b767b4-51f8-4bdc-8da9-98296b1cde8e","type":"Microsoft.Authorization/roleAssignments","name":"18b767b4-51f8-4bdc-8da9-98296b1cde8e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"68cc3003-9653-4bb3-a7c8-97d773f3ad69","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-06T02:38:51.7937810Z","updatedOn":"2020-07-06T02:38:51.7937810Z","createdBy":"9bc33702-a011-4e3b-80f7-927356668049","updatedBy":"9bc33702-a011-4e3b-80f7-927356668049","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5235eab1-3e36-4012-b4a2-5f158ef93897","type":"Microsoft.Authorization/roleAssignments","name":"5235eab1-3e36-4012-b4a2-5f158ef93897"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"7402cbf1-d2ef-41cd-8fb4-d1dbee1fa54f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-06T04:08:01.5967452Z","updatedOn":"2020-07-06T04:08:01.5967452Z","createdBy":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","updatedBy":"a60521ff-51d0-4058-86b3-ff2fc1e68ddf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b6cae0d1-4e24-42fa-8d89-341128d64407","type":"Microsoft.Authorization/roleAssignments","name":"b6cae0d1-4e24-42fa-8d89-341128d64407"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8328816a-0c23-48d8-bb6a-ed9dcf5691b0","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T03:14:22.0872359Z","updatedOn":"2020-07-07T03:14:22.0872359Z","createdBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61fd3f76-16c6-4482-8193-ccf22532b437","type":"Microsoft.Authorization/roleAssignments","name":"61fd3f76-16c6-4482-8193-ccf22532b437"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:07.9267881Z","updatedOn":"2020-07-07T07:53:07.9267881Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cb1f995e-258c-4174-9f1f-b21038b6fe15","type":"Microsoft.Authorization/roleAssignments","name":"cb1f995e-258c-4174-9f1f-b21038b6fe15"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:53.3178813Z","updatedOn":"2020-07-07T07:53:53.3178813Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/300179b3-b4bc-4d43-a800-14a538c341f2","type":"Microsoft.Authorization/roleAssignments","name":"300179b3-b4bc-4d43-a800-14a538c341f2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88","principalId":"21cd756e-e290-4a26-9547-93e8cc1a8923","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-07T07:53:53.3373852Z","updatedOn":"2020-07-07T07:53:53.3373852Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6a385b91-b1ce-4f5b-800d-6b449bb808f4","type":"Microsoft.Authorization/roleAssignments","name":"6a385b91-b1ce-4f5b-800d-6b449bb808f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"038ceaf0-2c3a-4a46-b572-cf9c7c444bd2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-08T15:15:49.6291826Z","updatedOn":"2020-07-08T15:15:49.6291826Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/719a4419-b972-4af8-95e8-741c53fb6c52","type":"Microsoft.Authorization/roleAssignments","name":"719a4419-b972-4af8-95e8-741c53fb6c52"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1422d4db-8270-4ae7-8437-8cccba2922f2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T06:00:40.8283738Z","updatedOn":"2020-07-09T06:00:40.8283738Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/92636771-3b6d-420b-9f6f-31070fbf0b28","type":"Microsoft.Authorization/roleAssignments","name":"92636771-3b6d-420b-9f6f-31070fbf0b28"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"08cae1fd-4869-4440-b9ff-a97cd9c00e6e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T12:14:15.9609308Z","updatedOn":"2020-07-09T12:14:15.9609308Z","createdBy":"182c8534-f413-487c-91a3-7addc80e35d5","updatedBy":"182c8534-f413-487c-91a3-7addc80e35d5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dbc76c65-b271-4f11-b84b-0b41e3c13f04","type":"Microsoft.Authorization/roleAssignments","name":"dbc76c65-b271-4f11-b84b-0b41e3c13f04"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2fbc569b-038b-456d-b496-168b4d2647b3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-09T12:20:45.2035119Z","updatedOn":"2020-07-09T12:20:45.2035119Z","createdBy":"182c8534-f413-487c-91a3-7addc80e35d5","updatedBy":"182c8534-f413-487c-91a3-7addc80e35d5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/49e83287-ab00-4c77-8e75-0c44324555d7","type":"Microsoft.Authorization/roleAssignments","name":"49e83287-ab00-4c77-8e75-0c44324555d7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a5928636-70a5-4dc6-9a39-83f4261ab739","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-11T01:21:44.1115337Z","updatedOn":"2020-07-11T01:21:44.1115337Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1ec24764-f578-4712-82d0-4cf303f8cd94","type":"Microsoft.Authorization/roleAssignments","name":"1ec24764-f578-4712-82d0-4cf303f8cd94"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1a0bac8e-d2d2-40d0-af60-3821fc4aad21","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T03:55:34.9995817Z","updatedOn":"2020-07-13T03:55:34.9995817Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/79904528-b82f-426b-ba34-911b9b9d9bb1","type":"Microsoft.Authorization/roleAssignments","name":"79904528-b82f-426b-ba34-911b9b9d9bb1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"aa1452f8-438b-4993-a853-211244f65fd4","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T06:08:09.4651196Z","updatedOn":"2020-07-13T06:08:09.4651196Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9f12bf7c-fb56-401f-8358-b1bb205a79c1","type":"Microsoft.Authorization/roleAssignments","name":"9f12bf7c-fb56-401f-8358-b1bb205a79c1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4bc2639f-4b4d-4507-9e1e-5560658dadcf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T06:11:38.7509627Z","updatedOn":"2020-07-13T06:11:38.7509627Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/80221d18-b98c-4114-b192-94febf5cdad1","type":"Microsoft.Authorization/roleAssignments","name":"80221d18-b98c-4114-b192-94febf5cdad1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6c7c1341-56f8-4dea-9015-ddeae7fcdc18","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-13T11:41:59.7653882Z","updatedOn":"2020-07-13T11:41:59.7653882Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/215ec308-e62e-409f-a0cf-6f7b18257cd3","type":"Microsoft.Authorization/roleAssignments","name":"215ec308-e62e-409f-a0cf-6f7b18257cd3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"76b9eb22-0091-49d2-847f-dc4831337de8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T03:06:52.4968477Z","updatedOn":"2020-07-14T03:06:52.4968477Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/876a1623-fed3-4ac9-9bd3-6373f166eb91","type":"Microsoft.Authorization/roleAssignments","name":"876a1623-fed3-4ac9-9bd3-6373f166eb91"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f0ec8449-0089-40c0-a539-430080dd51d5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T05:09:22.8572441Z","updatedOn":"2020-07-14T05:09:22.8572441Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/81c82fd2-ee9b-4636-a13c-c2fc290b1339","type":"Microsoft.Authorization/roleAssignments","name":"81c82fd2-ee9b-4636-a13c-c2fc290b1339"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3a62feb4-dd11-437d-8bf5-324bbcf2ca71","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T08:34:11.1314930Z","updatedOn":"2020-07-14T08:34:11.1314930Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10166085-8319-44c1-b39e-7c2e8a859606","type":"Microsoft.Authorization/roleAssignments","name":"10166085-8319-44c1-b39e-7c2e8a859606"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1768ac75-eb78-4760-904b-bf1daf362ed8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-14T13:24:26.4777748Z","updatedOn":"2020-07-14T13:24:26.4777748Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/89b22e91-fbe1-4519-9c28-55116cb4b449","type":"Microsoft.Authorization/roleAssignments","name":"89b22e91-fbe1-4519-9c28-55116cb4b449"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0c8ec4af-1f95-43d0-abdc-e98c7c377093","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T02:27:50.9285382Z","updatedOn":"2020-07-15T02:27:50.9285382Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6aa196a2-0d57-4ced-a7c4-e4309e305930","type":"Microsoft.Authorization/roleAssignments","name":"6aa196a2-0d57-4ced-a7c4-e4309e305930"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2f394b98-15c2-4a67-b5e4-59524a559fbe","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T06:04:05.5602990Z","updatedOn":"2020-07-15T06:04:05.5602990Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/29b52c6e-ef41-4228-be25-062bb7c962b2","type":"Microsoft.Authorization/roleAssignments","name":"29b52c6e-ef41-4228-be25-062bb7c962b2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d3ee15d8-bfc2-40e3-91ce-38f84f29b4fa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:37:38.4755184Z","updatedOn":"2020-07-15T07:37:38.4755184Z","createdBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","updatedBy":"0a592c45-613e-4f1b-9023-7c4414fd53bf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/94971c0b-9b3c-4014-a9f3-0283d64c1b29","type":"Microsoft.Authorization/roleAssignments","name":"94971c0b-9b3c-4014-a9f3-0283d64c1b29"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"243b9ed2-a31b-4b74-abb7-fce2fa7b7d85","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T07:46:59.5663841Z","updatedOn":"2020-07-15T07:46:59.5663841Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0d8d5363-48b8-4bea-895a-0ca92c1737aa","type":"Microsoft.Authorization/roleAssignments","name":"0d8d5363-48b8-4bea-895a-0ca92c1737aa"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"936679b1-be85-401f-906b-1338954018e1","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T08:01:13.4164296Z","updatedOn":"2020-07-15T08:01:13.4164296Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/56a43ec4-3148-4c7e-b526-817d25a836da","type":"Microsoft.Authorization/roleAssignments","name":"56a43ec4-3148-4c7e-b526-817d25a836da"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ee082e62-485a-4e27-8cbe-c3effae3cd9c","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-15T08:49:06.7210416Z","updatedOn":"2020-07-15T08:49:06.7210416Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a78fc2bf-58e2-4e37-bc92-b7195a03fbee","type":"Microsoft.Authorization/roleAssignments","name":"a78fc2bf-58e2-4e37-bc92-b7195a03fbee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"28c339aa-6a69-4038-9085-b9de491ab4e8","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T02:40:49.7073175Z","updatedOn":"2020-07-16T02:40:49.7073175Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/47d4f9d6-ef56-4d94-9dcb-f79e11ed5e50","type":"Microsoft.Authorization/roleAssignments","name":"47d4f9d6-ef56-4d94-9dcb-f79e11ed5e50"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"59a64430-12a8-4f39-be98-d1dd2614aeea","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T07:46:36.5695565Z","updatedOn":"2020-07-16T07:46:36.5695565Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d5232861-40f7-44e1-b5dc-230787ad1927","type":"Microsoft.Authorization/roleAssignments","name":"d5232861-40f7-44e1-b5dc-230787ad1927"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a55ceb34-c21b-4a68-96c6-88eb4cc5e099","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-16T11:38:50.4745508Z","updatedOn":"2020-07-16T11:38:50.4745508Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/74d051bd-1538-486e-954d-12ba05d58a90","type":"Microsoft.Authorization/roleAssignments","name":"74d051bd-1538-486e-954d-12ba05d58a90"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"e5e99afa-9231-46fd-acfc-92c8a8ff4489","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-17T07:29:54.2160514Z","updatedOn":"2020-07-17T07:29:54.2160514Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ceb853a2-799d-4948-990d-e0650efe5d4a","type":"Microsoft.Authorization/roleAssignments","name":"ceb853a2-799d-4948-990d-e0650efe5d4a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"f1f3476e-5aa5-4e0e-8632-a6f8728860b8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-18T01:17:47.1042571Z","updatedOn":"2020-07-18T01:17:47.1042571Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3b69d82b-e9f6-432e-b75c-f93b2d88efd7","type":"Microsoft.Authorization/roleAssignments","name":"3b69d82b-e9f6-432e-b75c-f93b2d88efd7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9431860d-6e2d-4227-9829-7b00afbdfb64","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:19:08.9724715Z","updatedOn":"2020-07-21T08:19:08.9724715Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7a335959-fbd8-42b5-9e34-dfa0cf86dedb","type":"Microsoft.Authorization/roleAssignments","name":"7a335959-fbd8-42b5-9e34-dfa0cf86dedb"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6e931f32-10eb-43f4-883d-86a7991108f7","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:21:22.6590948Z","updatedOn":"2020-07-21T08:21:22.6590948Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a92bcbb4-ef43-43db-a151-2b11cb2131a3","type":"Microsoft.Authorization/roleAssignments","name":"a92bcbb4-ef43-43db-a151-2b11cb2131a3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8b26643c-1bce-4669-ba85-48403e88103d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T08:28:00.4744129Z","updatedOn":"2020-07-21T08:28:00.4744129Z","createdBy":"9ac534f1-d577-4034-a32d-48de400dacbf","updatedBy":"9ac534f1-d577-4034-a32d-48de400dacbf","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3939f612-6d79-496c-bf5d-4f92e1d1b5e5","type":"Microsoft.Authorization/roleAssignments","name":"3939f612-6d79-496c-bf5d-4f92e1d1b5e5"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"af02e2c0-437c-4fbf-8769-fe6b43600a11","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-21T12:39:54.0428636Z","updatedOn":"2020-07-21T12:39:54.0428636Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ff44e8d6-b72d-43fc-91b6-ead0de501f65","type":"Microsoft.Authorization/roleAssignments","name":"ff44e8d6-b72d-43fc-91b6-ead0de501f65"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"5eef490b-41df-460b-ab98-7e8d3f8a1559","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T03:20:01.9422980Z","updatedOn":"2020-07-22T03:20:01.9422980Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e3d03863-6d79-4535-b692-15ca1e2ec3be","type":"Microsoft.Authorization/roleAssignments","name":"e3d03863-6d79-4535-b692-15ca1e2ec3be"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"86609d61-9b24-4e62-8c38-8361f202f09f","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T04:26:09.1052343Z","updatedOn":"2020-07-22T04:26:09.1052343Z","createdBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","updatedBy":"4a736eb4-0e8c-456d-a498-61fdeb66d94c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/a78eda47-9ef1-4c22-bfa4-0d996c5d599c","type":"Microsoft.Authorization/roleAssignments","name":"a78eda47-9ef1-4c22-bfa4-0d996c5d599c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ed0ebe06-e932-4087-8ba8-03478368e7c6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:23.4466032Z","updatedOn":"2020-07-22T06:09:23.4466032Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f03258ee-4f5a-48cd-a003-d23a60a3a014","type":"Microsoft.Authorization/roleAssignments","name":"f03258ee-4f5a-48cd-a003-d23a60a3a014"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d126d0bb-79bb-472f-8b80-a9a346f6f100","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:45.2929087Z","updatedOn":"2020-07-22T06:09:45.2929087Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3581753e-74ab-4e9d-b79d-0799442862b3","type":"Microsoft.Authorization/roleAssignments","name":"3581753e-74ab-4e9d-b79d-0799442862b3"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2d627045-009d-4074-8bcd-52d7eeabb18c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:09:54.6260798Z","updatedOn":"2020-07-22T06:09:54.6260798Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/cf80890b-2e9e-424a-a8ab-1795078643d2","type":"Microsoft.Authorization/roleAssignments","name":"cf80890b-2e9e-424a-a8ab-1795078643d2"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"535b5697-6115-4f18-92f3-20fc9a07cce7","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:18:56.2452865Z","updatedOn":"2020-07-22T06:18:56.2452865Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6b91e17e-56de-4229-8453-5338337d3c6f","type":"Microsoft.Authorization/roleAssignments","name":"6b91e17e-56de-4229-8453-5338337d3c6f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d048d4f7-7edb-4712-aeca-af4fb5c61b5a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:19:12.0666094Z","updatedOn":"2020-07-22T06:19:12.0666094Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/051d8d7e-2bf8-400c-af8e-4cdea07dedf0","type":"Microsoft.Authorization/roleAssignments","name":"051d8d7e-2bf8-400c-af8e-4cdea07dedf0"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b45b251f-c8a2-4d3a-af7f-a9739cbe0d68","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:15.0908010Z","updatedOn":"2020-07-22T06:20:15.0908010Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/bcb6a1f9-fd6e-441b-aaf7-09cf14414872","type":"Microsoft.Authorization/roleAssignments","name":"bcb6a1f9-fd6e-441b-aaf7-09cf14414872"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5c709f8c-397c-40d2-a147-1040fb282e24","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:26.8312576Z","updatedOn":"2020-07-22T06:20:26.8312576Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ceb67739-0cce-4a0e-9d2a-bd8a1ea65485","type":"Microsoft.Authorization/roleAssignments","name":"ceb67739-0cce-4a0e-9d2a-bd8a1ea65485"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a3d2b5a7-f9ce-4ab2-9155-e47bc8121b0d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:20:31.6051855Z","updatedOn":"2020-07-22T06:20:31.6051855Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b151b8cc-8569-4dd6-97a3-a0652015d9ab","type":"Microsoft.Authorization/roleAssignments","name":"b151b8cc-8569-4dd6-97a3-a0652015d9ab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"b56fdd17-ee35-4381-9aea-00dfa70a3872","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:24:16.5402929Z","updatedOn":"2020-07-22T06:24:16.5402929Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7d078199-8ce2-44ed-8eb3-c7aca7590bee","type":"Microsoft.Authorization/roleAssignments","name":"7d078199-8ce2-44ed-8eb3-c7aca7590bee"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0ef05f56-75da-4e69-8886-cf7eb25921bf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:28:20.2615489Z","updatedOn":"2020-07-22T06:28:20.2615489Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f126b61c-58bb-40d5-90b5-035320097c81","type":"Microsoft.Authorization/roleAssignments","name":"f126b61c-58bb-40d5-90b5-035320097c81"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"2b7f66f5-e2b4-4e90-a6c0-48fd09c6941c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-22T06:31:13.8352773Z","updatedOn":"2020-07-22T06:31:13.8352773Z","createdBy":"0d504196-1423-4569-9a6e-15149656f0ee","updatedBy":"0d504196-1423-4569-9a6e-15149656f0ee","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/9a3fb647-a48a-4fb2-b9be-5c0ec0c1dd9f","type":"Microsoft.Authorization/roleAssignments","name":"9a3fb647-a48a-4fb2-b9be-5c0ec0c1dd9f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b","principalId":"181c08fa-7ac8-48a6-a869-342ab74566a4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-24T03:54:19.5994989Z","updatedOn":"2020-07-24T03:54:19.5994989Z","createdBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","updatedBy":"21cd756e-e290-4a26-9547-93e8cc1a8923","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dc91700c-9959-4179-80b7-f2bfb957d4ec","type":"Microsoft.Authorization/roleAssignments","name":"dc91700c-9959-4179-80b7-f2bfb957d4ec"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d0daf77e-df2b-4f08-93a9-53bc40d2b65e","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-25T01:20:25.7612859Z","updatedOn":"2020-07-25T01:20:25.7612859Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/01c4a64d-636d-4f02-8b51-1e52794b0065","type":"Microsoft.Authorization/roleAssignments","name":"01c4a64d-636d-4f02-8b51-1e52794b0065"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"75e0401f-c382-49bc-9681-5891889d6090","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-25T01:20:48.2269442Z","updatedOn":"2020-07-25T01:20:48.2269442Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8d14294b-2a12-4034-98ed-d79fc8967004","type":"Microsoft.Authorization/roleAssignments","name":"8d14294b-2a12-4034-98ed-d79fc8967004"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cfa73ec2-e91c-4de2-9b7f-3886f1b1a7e9","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-01T01:15:28.6134386Z","updatedOn":"2020-08-01T01:15:28.6134386Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/2880df4d-a219-4208-8f53-11ba91fe5ee6","type":"Microsoft.Authorization/roleAssignments","name":"2880df4d-a219-4208-8f53-11ba91fe5ee6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"4ffca8c7-2d31-4f24-9e03-a1a836f60ba8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-01T01:34:29.3212794Z","updatedOn":"2020-08-01T01:34:29.3212794Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/39e1d3ed-13fb-432e-a0cb-8b294fddc63a","type":"Microsoft.Authorization/roleAssignments","name":"39e1d3ed-13fb-432e-a0cb-8b294fddc63a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"26e698cd-9d87-41f6-9a7e-06b3627e6ca5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-04T05:20:53.6187620Z","updatedOn":"2020-08-04T05:20:53.6187620Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97f68035-e05b-4e7f-aa80-a3799725076a","type":"Microsoft.Authorization/roleAssignments","name":"97f68035-e05b-4e7f-aa80-a3799725076a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5fcaa3b3-d5b2-44ce-92e2-28a4241f1e6b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-04T05:29:27.6127065Z","updatedOn":"2020-08-04T05:29:27.6127065Z","createdBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","updatedBy":"b5ed59e8-f00d-4396-af62-8297e36d8b52","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/ae95584d-6d28-4372-872b-b96e6a1f9c1f","type":"Microsoft.Authorization/roleAssignments","name":"ae95584d-6d28-4372-872b-b96e6a1f9c1f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d64e4618-a7a0-41ff-a20c-1594fdde8c87","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-05T03:43:59.8598863Z","updatedOn":"2020-08-05T03:43:59.8598863Z","createdBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","updatedBy":"a9aa6a31-a53e-4776-afab-8ba3ea5dd918","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/254a30cf-3bdd-4e6c-aa9e-9d96397bf63a","type":"Microsoft.Authorization/roleAssignments","name":"254a30cf-3bdd-4e6c-aa9e-9d96397bf63a"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"800eadcf-0a23-4298-939b-6cf9f3dbceef","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-08-05T05:51:54.9501785Z","updatedOn":"2020-08-05T05:51:54.9501785Z","createdBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","updatedBy":"31e600e0-d7ce-4e98-a927-19bb30042e44","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8b806af6-57f8-45f4-849f-6d0d0f43d093","type":"Microsoft.Authorization/roleAssignments","name":"8b806af6-57f8-45f4-849f-6d0d0f43d093"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"ef53cdce-e483-4aa2-8260-58249cc1e7b1","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-02T16:57:34.4713679Z","updatedOn":"2020-07-02T16:57:34.4713679Z","createdBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","updatedBy":"181c08fa-7ac8-48a6-a869-342ab74566a4","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/54fe41af-b32f-43d4-aac4-9e9be5b142a7","type":"Microsoft.Authorization/roleAssignments","name":"54fe41af-b32f-43d4-aac4-9e9be5b142a7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"31e600e0-d7ce-4e98-a927-19bb30042e44","principalType":"User","scope":"/providers/Microsoft.Management/managementGroups/CliMgmtGroup","condition":null,"conditionVersion":null,"createdOn":"2019-12-26T10:45:42.1154685Z","updatedOn":"2019-12-26T10:45:42.1154685Z","createdBy":"dfb7f346-f217-474e-ba6c-49895fd9cc13","updatedBy":"dfb7f346-f217-474e-ba6c-49895fd9cc13","delegatedManagedIdentityResourceId":null,"description":null},"id":"/providers/Microsoft.Management/managementGroups/CliMgmtGroup/providers/Microsoft.Authorization/roleAssignments/f0b07cf8-a079-446e-a391-c6fb1d115b59","type":"Microsoft.Authorization/roleAssignments","name":"f0b07cf8-a079-446e-a391-c6fb1d115b59"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"6a770218-bb37-4a0f-a83c-6e6bc93ebbfa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T17:46:11.2561534Z","updatedOn":"2020-12-09T17:46:11.2561534Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.4824942Z","updatedOn":"2020-06-16T16:25:39.4824942Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e77058da-a7bf-4e89-8e48-7d9f61fa8246","type":"Microsoft.Authorization/roleAssignments","name":"e77058da-a7bf-4e89-8e48-7d9f61fa8246"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:12:52.8054393Z","updatedOn":"2020-11-25T05:12:52.8054393Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dea2d3a8-cf99-4169-b8dd-819b4c611a32","type":"Microsoft.Authorization/roleAssignments","name":"dea2d3a8-cf99-4169-b8dd-819b4c611a32"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:34:01.2642084Z","updatedOn":"2020-11-25T05:34:01.2642084Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bacc53c-9077-49ce-a14d-370bc09f72d8","type":"Microsoft.Authorization/roleAssignments","name":"4bacc53c-9077-49ce-a14d-370bc09f72d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6949b2a1-9b3e-42c8-b228-0b6c14927377","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-30T19:34:16.5100204Z","updatedOn":"2020-07-30T19:34:16.5100204Z","createdBy":"5bc13990-50e4-4898-835e-d026e066bba5","updatedBy":"5bc13990-50e4-4898-835e-d026e066bba5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/53b0d735-2402-41c6-9d6d-b2338a287741","type":"Microsoft.Authorization/roleAssignments","name":"53b0d735-2402-41c6-9d6d-b2338a287741"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4c480e6-1f29-4163-9a37-2b16a7e8e5c8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-16T13:48:13.9171700Z","updatedOn":"2020-09-16T13:48:13.9171700Z","createdBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","updatedBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8476200c-5011-42c4-9028-360ef1739a8d","type":"Microsoft.Authorization/roleAssignments","name":"8476200c-5011-42c4-9028-360ef1739a8d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '238289'
+      - '26722'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:27 GMT
+      - Wed, 09 Dec 2020 17:46:11 GMT
       expires:
       - '-1'
       pragma:
@@ -1847,8 +1874,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
-      "principalId": "3e675290-31e1-49f6-a3cd-03df3d7d6e2e", "principalType": "ServicePrincipal"}}'
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+      "principalId": "b9bc1545-a684-4e50-9a4d-2e2ee90bed6a", "principalType": "ServicePrincipal"}}'
     headers:
       Accept:
       - application/json
@@ -1862,20 +1889,19 @@ interactions:
       - '270'
       Content-Type:
       - application/json; charset=utf-8
-      Cookie:
-      - x-ms-gateway-slice=Production
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"3e675290-31e1-49f6-a3cd-03df3d7d6e2e","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-09-08T07:00:27.8097888Z","updatedOn":"2020-09-08T07:00:27.8097888Z","createdBy":null,"updatedBy":"6d97229a-391f-473a-893f-f0608b592d7b","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T17:46:12.9953922Z","updatedOn":"2020-12-09T17:46:12.9953922Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
     headers:
       cache-control:
       - no-cache
@@ -1884,7 +1910,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 08 Sep 2020 07:00:29 GMT
+      - Wed, 09 Dec 2020 17:46:13 GMT
       expires:
       - '-1'
       pragma:
@@ -1901,136 +1927,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
-        ,\r\n  \"etag\": \"W/\\\"08077b46-2ebd-4a4b-9b5b-65886e6456ba\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.79.3.0/24\",\r\n    \"serviceEndpoints\": [\r\n    \
-        \  {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '755'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:29 GMT
-      etag:
-      - W/"08077b46-2ebd-4a4b-9b5b-65886e6456ba"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 93bd9234-6abf-4932-bb2e-caa3112e8499
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-network/11.0.0 Azure-SDK-For-Python AZURECLI/2.11.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
-        ,\r\n  \"etag\": \"W/\\\"08077b46-2ebd-4a4b-9b5b-65886e6456ba\\\"\",\r\n \
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        addressPrefix\": \"10.122.58.0/24\",\r\n    \"serviceEndpoints\": [\r\n  \
-        \    {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"service\"\
-        : \"Microsoft.ContainerRegistry\",\r\n        \"locations\": [\r\n       \
-        \   \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\": [],\r\n\
-        \    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\"\
-        : \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\
-        \r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '756'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 08 Sep 2020 07:00:30 GMT
-      etag:
-      - W/"08077b46-2ebd-4a4b-9b5b-65886e6456ba"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - ab555bd4-10cf-4f21-a39e-c2ee569987d6
-    status:
-      code: 200
-      message: OK
-- request:
     body: '{"tags": {"test": "update"}, "location": "eastus", "properties": {"clusterProfile":
-      {"pullSecret": "", "domain": "am0w6b6j", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-am0w6b6j"},
-      "servicePrincipalProfile": {"clientId": "ee6718bb-7aee-4149-875a-61adc505dff8",
-      "clientSecret": "4fe57fa1-eb49-4364-84ef-74a13b024e92"}, "networkProfile": {"podCidr":
+      {"pullSecret": "", "domain": "ai3zo4ud", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud"},
+      "servicePrincipalProfile": {"clientId": "e957e8cd-1467-42a0-bda1-665276ee51bf",
+      "clientSecret": "a5c65681-f91e-405b-b384-c024d5c0c267"}, "networkProfile": {"podCidr":
       "10.128.0.0/14", "serviceCidr": "172.30.0.0/16"}, "masterProfile": {"vmSize":
       "Standard_D8s_v3", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002"},
       "workerProfiles": [{"name": "worker", "vmSize": "Standard_D4s_v3", "diskSizeGB":
@@ -2053,8 +1953,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PUT
@@ -2065,11 +1966,11 @@ interactions:
         ,\n    \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\"\
         ,\n    \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"update\"\
         \n    },\n    \"properties\": {\n        \"provisioningState\": \"Creating\"\
-        ,\n        \"clusterProfile\": {\n            \"domain\": \"am0w6b6j\",\n\
-        \            \"version\": \"4.4.17\",\n            \"resourceGroupId\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-am0w6b6j\"\
+        ,\n        \"clusterProfile\": {\n            \"domain\": \"ai3zo4ud\",\n\
+        \            \"version\": \"4.5.16\",\n            \"resourceGroupId\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-ai3zo4ud\"\
         \n        },\n        \"consoleProfile\": {},\n        \"servicePrincipalProfile\"\
-        : {\n            \"clientId\": \"ee6718bb-7aee-4149-875a-61adc505dff8\"\n\
+        : {\n            \"clientId\": \"e957e8cd-1467-42a0-bda1-665276ee51bf\"\n\
         \        },\n        \"networkProfile\": {\n            \"podCidr\": \"10.128.0.0/14\"\
         ,\n            \"serviceCidr\": \"172.30.0.0/16\"\n        },\n        \"\
         masterProfile\": {\n            \"vmSize\": \"Standard_D8s_v3\",\n       \
@@ -2084,7 +1985,7 @@ interactions:
         \   \"visibility\": \"Public\"\n            }\n        ]\n    }\n}\n"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -2092,7 +1993,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:00:33 GMT
+      - Wed, 09 Dec 2020 17:46:14 GMT
       expires:
       - '-1'
       pragma:
@@ -2102,7 +2003,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -2120,15 +2021,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2137,7 +2039,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:01:04 GMT
+      - Wed, 09 Dec 2020 17:46:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2167,15 +2069,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2184,7 +2087,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:01:34 GMT
+      - Wed, 09 Dec 2020 17:47:15 GMT
       expires:
       - '-1'
       pragma:
@@ -2214,15 +2117,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2231,7 +2135,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:02:04 GMT
+      - Wed, 09 Dec 2020 17:47:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2261,15 +2165,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2278,7 +2183,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:02:34 GMT
+      - Wed, 09 Dec 2020 17:48:15 GMT
       expires:
       - '-1'
       pragma:
@@ -2308,15 +2213,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2325,7 +2231,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:03:05 GMT
+      - Wed, 09 Dec 2020 17:48:45 GMT
       expires:
       - '-1'
       pragma:
@@ -2355,15 +2261,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2372,7 +2279,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:03:35 GMT
+      - Wed, 09 Dec 2020 17:49:16 GMT
       expires:
       - '-1'
       pragma:
@@ -2402,15 +2309,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2419,7 +2327,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:04:05 GMT
+      - Wed, 09 Dec 2020 17:49:47 GMT
       expires:
       - '-1'
       pragma:
@@ -2449,15 +2357,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2466,7 +2375,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:04:35 GMT
+      - Wed, 09 Dec 2020 17:50:17 GMT
       expires:
       - '-1'
       pragma:
@@ -2496,15 +2405,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2513,7 +2423,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:05:05 GMT
+      - Wed, 09 Dec 2020 17:50:47 GMT
       expires:
       - '-1'
       pragma:
@@ -2543,15 +2453,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2560,7 +2471,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:05:36 GMT
+      - Wed, 09 Dec 2020 17:51:17 GMT
       expires:
       - '-1'
       pragma:
@@ -2590,15 +2501,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2607,7 +2519,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:06:05 GMT
+      - Wed, 09 Dec 2020 17:51:47 GMT
       expires:
       - '-1'
       pragma:
@@ -2637,15 +2549,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2654,7 +2567,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:06:35 GMT
+      - Wed, 09 Dec 2020 17:52:18 GMT
       expires:
       - '-1'
       pragma:
@@ -2684,15 +2597,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2701,7 +2615,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:07:05 GMT
+      - Wed, 09 Dec 2020 17:52:48 GMT
       expires:
       - '-1'
       pragma:
@@ -2731,15 +2645,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2748,7 +2663,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:07:35 GMT
+      - Wed, 09 Dec 2020 17:53:18 GMT
       expires:
       - '-1'
       pragma:
@@ -2778,15 +2693,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2795,7 +2711,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:08:06 GMT
+      - Wed, 09 Dec 2020 17:53:48 GMT
       expires:
       - '-1'
       pragma:
@@ -2825,15 +2741,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2842,7 +2759,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:08:36 GMT
+      - Wed, 09 Dec 2020 17:54:18 GMT
       expires:
       - '-1'
       pragma:
@@ -2872,15 +2789,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2889,7 +2807,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:09:06 GMT
+      - Wed, 09 Dec 2020 17:54:48 GMT
       expires:
       - '-1'
       pragma:
@@ -2919,15 +2837,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2936,7 +2855,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:09:36 GMT
+      - Wed, 09 Dec 2020 17:55:18 GMT
       expires:
       - '-1'
       pragma:
@@ -2966,15 +2885,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2983,7 +2903,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:10:06 GMT
+      - Wed, 09 Dec 2020 17:55:49 GMT
       expires:
       - '-1'
       pragma:
@@ -3013,15 +2933,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3030,7 +2951,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:10:36 GMT
+      - Wed, 09 Dec 2020 17:56:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3060,15 +2981,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3077,7 +2999,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:11:07 GMT
+      - Wed, 09 Dec 2020 17:56:49 GMT
       expires:
       - '-1'
       pragma:
@@ -3107,15 +3029,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3124,7 +3047,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:11:37 GMT
+      - Wed, 09 Dec 2020 17:57:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3154,15 +3077,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3171,7 +3095,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:12:07 GMT
+      - Wed, 09 Dec 2020 17:57:49 GMT
       expires:
       - '-1'
       pragma:
@@ -3201,15 +3125,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3218,7 +3143,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:12:37 GMT
+      - Wed, 09 Dec 2020 17:58:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3248,15 +3173,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3265,7 +3191,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:13:07 GMT
+      - Wed, 09 Dec 2020 17:58:50 GMT
       expires:
       - '-1'
       pragma:
@@ -3295,15 +3221,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3312,7 +3239,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:13:38 GMT
+      - Wed, 09 Dec 2020 17:59:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3342,15 +3269,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3359,7 +3287,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:14:08 GMT
+      - Wed, 09 Dec 2020 17:59:50 GMT
       expires:
       - '-1'
       pragma:
@@ -3389,15 +3317,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3406,7 +3335,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:14:38 GMT
+      - Wed, 09 Dec 2020 18:00:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3436,15 +3365,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3453,7 +3383,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:15:08 GMT
+      - Wed, 09 Dec 2020 18:00:50 GMT
       expires:
       - '-1'
       pragma:
@@ -3483,15 +3413,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3500,7 +3431,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:15:38 GMT
+      - Wed, 09 Dec 2020 18:01:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3530,15 +3461,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3547,7 +3479,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:16:08 GMT
+      - Wed, 09 Dec 2020 18:01:50 GMT
       expires:
       - '-1'
       pragma:
@@ -3577,15 +3509,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3594,7 +3527,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:16:39 GMT
+      - Wed, 09 Dec 2020 18:02:21 GMT
       expires:
       - '-1'
       pragma:
@@ -3624,15 +3557,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3641,7 +3575,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:17:09 GMT
+      - Wed, 09 Dec 2020 18:02:51 GMT
       expires:
       - '-1'
       pragma:
@@ -3671,15 +3605,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3688,7 +3623,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:17:39 GMT
+      - Wed, 09 Dec 2020 18:03:22 GMT
       expires:
       - '-1'
       pragma:
@@ -3718,15 +3653,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3735,7 +3671,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:18:09 GMT
+      - Wed, 09 Dec 2020 18:03:52 GMT
       expires:
       - '-1'
       pragma:
@@ -3765,15 +3701,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3782,7 +3719,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:18:39 GMT
+      - Wed, 09 Dec 2020 18:04:22 GMT
       expires:
       - '-1'
       pragma:
@@ -3812,15 +3749,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3829,7 +3767,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:19:09 GMT
+      - Wed, 09 Dec 2020 18:04:52 GMT
       expires:
       - '-1'
       pragma:
@@ -3859,15 +3797,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3876,7 +3815,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:19:40 GMT
+      - Wed, 09 Dec 2020 18:05:23 GMT
       expires:
       - '-1'
       pragma:
@@ -3906,15 +3845,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3923,7 +3863,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:20:10 GMT
+      - Wed, 09 Dec 2020 18:05:53 GMT
       expires:
       - '-1'
       pragma:
@@ -3953,15 +3893,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3970,7 +3911,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:20:40 GMT
+      - Wed, 09 Dec 2020 18:06:22 GMT
       expires:
       - '-1'
       pragma:
@@ -4000,15 +3941,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4017,7 +3959,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:21:10 GMT
+      - Wed, 09 Dec 2020 18:06:53 GMT
       expires:
       - '-1'
       pragma:
@@ -4047,15 +3989,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4064,7 +4007,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:21:40 GMT
+      - Wed, 09 Dec 2020 18:07:23 GMT
       expires:
       - '-1'
       pragma:
@@ -4094,15 +4037,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4111,7 +4055,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:22:11 GMT
+      - Wed, 09 Dec 2020 18:07:53 GMT
       expires:
       - '-1'
       pragma:
@@ -4141,15 +4085,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4158,7 +4103,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:22:41 GMT
+      - Wed, 09 Dec 2020 18:08:24 GMT
       expires:
       - '-1'
       pragma:
@@ -4188,15 +4133,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4205,7 +4151,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:23:12 GMT
+      - Wed, 09 Dec 2020 18:08:54 GMT
       expires:
       - '-1'
       pragma:
@@ -4235,15 +4181,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4252,7 +4199,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:23:42 GMT
+      - Wed, 09 Dec 2020 18:09:24 GMT
       expires:
       - '-1'
       pragma:
@@ -4282,15 +4229,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4299,7 +4247,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:24:12 GMT
+      - Wed, 09 Dec 2020 18:09:54 GMT
       expires:
       - '-1'
       pragma:
@@ -4329,15 +4277,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4346,7 +4295,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:24:42 GMT
+      - Wed, 09 Dec 2020 18:10:24 GMT
       expires:
       - '-1'
       pragma:
@@ -4376,15 +4325,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4393,7 +4343,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:25:12 GMT
+      - Wed, 09 Dec 2020 18:10:54 GMT
       expires:
       - '-1'
       pragma:
@@ -4423,15 +4373,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4440,7 +4391,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:25:43 GMT
+      - Wed, 09 Dec 2020 18:11:24 GMT
       expires:
       - '-1'
       pragma:
@@ -4470,15 +4421,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4487,7 +4439,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:26:13 GMT
+      - Wed, 09 Dec 2020 18:11:55 GMT
       expires:
       - '-1'
       pragma:
@@ -4517,15 +4469,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4534,7 +4487,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:26:43 GMT
+      - Wed, 09 Dec 2020 18:12:25 GMT
       expires:
       - '-1'
       pragma:
@@ -4564,15 +4517,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4581,7 +4535,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:27:13 GMT
+      - Wed, 09 Dec 2020 18:12:55 GMT
       expires:
       - '-1'
       pragma:
@@ -4611,15 +4565,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4628,7 +4583,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:27:43 GMT
+      - Wed, 09 Dec 2020 18:13:25 GMT
       expires:
       - '-1'
       pragma:
@@ -4658,15 +4613,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4675,7 +4631,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:28:13 GMT
+      - Wed, 09 Dec 2020 18:13:55 GMT
       expires:
       - '-1'
       pragma:
@@ -4705,15 +4661,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4722,7 +4679,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:28:43 GMT
+      - Wed, 09 Dec 2020 18:14:25 GMT
       expires:
       - '-1'
       pragma:
@@ -4752,15 +4709,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4769,7 +4727,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:29:14 GMT
+      - Wed, 09 Dec 2020 18:14:56 GMT
       expires:
       - '-1'
       pragma:
@@ -4799,15 +4757,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4816,7 +4775,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:29:44 GMT
+      - Wed, 09 Dec 2020 18:15:26 GMT
       expires:
       - '-1'
       pragma:
@@ -4846,15 +4805,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4863,7 +4823,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:30:14 GMT
+      - Wed, 09 Dec 2020 18:15:56 GMT
       expires:
       - '-1'
       pragma:
@@ -4893,15 +4853,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4910,7 +4871,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:30:44 GMT
+      - Wed, 09 Dec 2020 18:16:26 GMT
       expires:
       - '-1'
       pragma:
@@ -4940,15 +4901,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4957,7 +4919,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:31:14 GMT
+      - Wed, 09 Dec 2020 18:16:57 GMT
       expires:
       - '-1'
       pragma:
@@ -4987,15 +4949,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5004,7 +4967,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:31:44 GMT
+      - Wed, 09 Dec 2020 18:17:27 GMT
       expires:
       - '-1'
       pragma:
@@ -5034,15 +4997,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5051,7 +5015,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:32:14 GMT
+      - Wed, 09 Dec 2020 18:17:57 GMT
       expires:
       - '-1'
       pragma:
@@ -5081,15 +5045,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5098,7 +5063,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:32:45 GMT
+      - Wed, 09 Dec 2020 18:18:28 GMT
       expires:
       - '-1'
       pragma:
@@ -5128,15 +5093,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5145,7 +5111,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:33:15 GMT
+      - Wed, 09 Dec 2020 18:18:58 GMT
       expires:
       - '-1'
       pragma:
@@ -5175,15 +5141,16 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Creating\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5192,7 +5159,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:33:45 GMT
+      - Wed, 09 Dec 2020 18:19:28 GMT
       expires:
       - '-1'
       pragma:
@@ -5222,16 +5189,689 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"endTime\": \"2020-09-08T07:34:08.470847797Z\",\n    \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ff434bdd-7785-41dc-b67a-6a280c3e1550\"\
-        ,\n    \"name\": \"ff434bdd-7785-41dc-b67a-6a280c3e1550\",\n    \"startTime\"\
-        : \"2020-09-08T07:00:33.179673893Z\",\n    \"status\": \"Succeeded\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:19:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:20:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:20:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:21:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:21:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:22:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:22:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:23:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:23:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:24:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:25:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:25:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:26:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Creating\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:26:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/7c187795-49d7-4868-98b4-55a23e97c427\"\
+        ,\n    \"name\": \"7c187795-49d7-4868-98b4-55a23e97c427\",\n    \"status\"\
+        : \"Succeeded\",\n    \"startTime\": \"2020-12-09T17:46:15.211262884Z\",\n\
+        \    \"endTime\": \"2020-12-09T18:26:46.492043278Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5240,7 +5880,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:34:14 GMT
+      - Wed, 09 Dec 2020 18:27:00 GMT
       expires:
       - '-1'
       pragma:
@@ -5270,8 +5910,9 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
   response:
@@ -5280,33 +5921,33 @@ interactions:
         ,\n    \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\"\
         ,\n    \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"update\"\
         \n    },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\"\
-        ,\n        \"clusterProfile\": {\n            \"domain\": \"am0w6b6j\",\n\
-        \            \"version\": \"4.4.17\",\n            \"resourceGroupId\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-am0w6b6j\"\
-        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.am0w6b6j.eastus.aroapp.io/\"\
+        ,\n        \"clusterProfile\": {\n            \"domain\": \"ai3zo4ud\",\n\
+        \            \"version\": \"4.5.16\",\n            \"resourceGroupId\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-ai3zo4ud\"\
+        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.ai3zo4ud.eastus.aroapp.io/\"\
         \n        },\n        \"servicePrincipalProfile\": {\n            \"clientId\"\
-        : \"ee6718bb-7aee-4149-875a-61adc505dff8\"\n        },\n        \"networkProfile\"\
+        : \"e957e8cd-1467-42a0-bda1-665276ee51bf\"\n        },\n        \"networkProfile\"\
         : {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\"\
         : \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n          \
         \  \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
         \n        },\n        \"workerProfiles\": [\n            {\n             \
-        \   \"name\": \"aro000004-dfcrm-worker-eastus1\",\n                \"vmSize\"\
+        \   \"name\": \"aro000004-nsm64-worker-eastus1\",\n                \"vmSize\"\
         : \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n           \
         \     \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-dfcrm-worker-eastus2\",\n                \"\
+        \       \"name\": \"aro000004-nsm64-worker-eastus2\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-dfcrm-worker-eastus3\",\n                \"\
+        \       \"name\": \"aro000004-nsm64-worker-eastus3\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            }\n        ],\n        \"apiserverProfile\"\
-        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.am0w6b6j.eastus.aroapp.io:6443/\"\
-        ,\n            \"ip\": \"40.88.22.155\"\n        },\n        \"ingressProfiles\"\
+        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.ai3zo4ud.eastus.aroapp.io:6443/\"\
+        ,\n            \"ip\": \"52.149.171.35\"\n        },\n        \"ingressProfiles\"\
         : [\n            {\n                \"name\": \"default\",\n             \
-        \   \"visibility\": \"Public\",\n                \"ip\": \"52.188.181.57\"\
-        \n            }\n        ]\n    }\n}\n"
+        \   \"visibility\": \"Public\",\n                \"ip\": \"40.88.202.96\"\n\
+        \            }\n        ]\n    }\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5315,11 +5956,462 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:34:15 GMT
+      - Wed, 09 Dec 2020 18:27:00 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subscription
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004\"\
+        ,\n    \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\"\
+        ,\n    \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"update\"\
+        \n    },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\"\
+        ,\n        \"clusterProfile\": {\n            \"domain\": \"ai3zo4ud\",\n\
+        \            \"version\": \"4.5.16\",\n            \"resourceGroupId\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-ai3zo4ud\"\
+        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.ai3zo4ud.eastus.aroapp.io/\"\
+        \n        },\n        \"servicePrincipalProfile\": {\n            \"clientId\"\
+        : \"e957e8cd-1467-42a0-bda1-665276ee51bf\"\n        },\n        \"networkProfile\"\
+        : {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\"\
+        : \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n          \
+        \  \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
+        \n        },\n        \"workerProfiles\": [\n            {\n             \
+        \   \"name\": \"aro000004-nsm64-worker-eastus1\",\n                \"vmSize\"\
+        : \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n           \
+        \     \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\n                \"count\": 1\n            },\n            {\n         \
+        \       \"name\": \"aro000004-nsm64-worker-eastus2\",\n                \"\
+        vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
+        \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\n                \"count\": 1\n            },\n            {\n         \
+        \       \"name\": \"aro000004-nsm64-worker-eastus3\",\n                \"\
+        vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
+        \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\n                \"count\": 1\n            }\n        ],\n        \"apiserverProfile\"\
+        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.ai3zo4ud.eastus.aroapp.io:6443/\"\
+        ,\n            \"ip\": \"52.149.171.35\"\n        },\n        \"ingressProfiles\"\
+        : [\n            {\n                \"name\": \"default\",\n             \
+        \   \"visibility\": \"Public\",\n                \"ip\": \"40.88.202.96\"\n\
+        \            }\n        ]\n    }\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2866'
+      content-type:
+      - application/json
+      date:
+      - Wed, 09 Dec 2020 18:27:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subscription
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
+        ,\r\n  \"etag\": \"W/\\\"9b2dcbf8-2b01-429e-ae0e-dd7b85915ab2\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.35.125.0/24\",\r\n    \"networkSecurityGroup\": {\r\n\
+        \      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud/providers/Microsoft.Network/networkSecurityGroups/aro000004-nsm64-nsg\"\
+        \r\n    },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud/providers/Microsoft.Network/networkInterfaces/aro000004-nsm64-worker-eastus1-wfgg4-nic/ipConfigurations/pipConfig\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud/providers/Microsoft.Network/networkInterfaces/aro000004-nsm64-worker-eastus2-tftw6-nic/ipConfigurations/pipConfig\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud/providers/Microsoft.Network/networkInterfaces/aro000004-nsm64-worker-eastus3-mpb8h-nic/ipConfigurations/pipConfig\"\
+        \r\n      }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n      \
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\"\
+        ,\r\n        \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\
+        \n    ],\r\n    \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\"\
+        : \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\
+        \n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1704'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 18:27:03 GMT
+      etag:
+      - W/"9b2dcbf8-2b01-429e-ae0e-dd7b85915ab2"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 4b1b625b-bd8e-4272-bfa7-0ef910759bcf
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subscription
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-network/13.0.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2020-07-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
+        ,\r\n  \"etag\": \"W/\\\"9b2dcbf8-2b01-429e-ae0e-dd7b85915ab2\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        addressPrefix\": \"10.12.161.0/24\",\r\n    \"networkSecurityGroup\": {\r\n\
+        \      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud/providers/Microsoft.Network/networkSecurityGroups/aro000004-nsm64-nsg\"\
+        \r\n    },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud/providers/Microsoft.Network/loadBalancers/aro000004-nsm64-internal/frontendIPConfigurations/internal-lb-ip-v4\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud/providers/Microsoft.Network/networkInterfaces/aro000004-nsm64-master1-nic/ipConfigurations/pipConfig\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud/providers/Microsoft.Network/networkInterfaces/aro000004-nsm64-master2-nic/ipConfigurations/pipConfig\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud/providers/Microsoft.Network/networkInterfaces/aro000004-nsm64-master0-nic/ipConfigurations/pipConfig\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud/providers/Microsoft.Network/networkInterfaces/aro000004-nsm64-pls.nic.b5258867-18ec-4793-9040-d91bd33c9930/ipConfigurations/aro000004-nsm64-pls-nic\"\
+        \r\n      },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-ai3zo4ud/providers/Microsoft.Network/privateLinkServices/aro000004-nsm64-pls/ipConfigurations/aro000004-nsm64-pls-nic\"\
+        \r\n      }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n      \
+        \  \"provisioningState\": \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\"\
+        ,\r\n        \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\
+        \n    ],\r\n    \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\"\
+        : \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\": \"Disabled\"\r\
+        \n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2406'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 18:27:03 GMT
+      etag:
+      - W/"9b2dcbf8-2b01-429e-ae0e-dd7b85915ab2"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 5ab6d0fc-a72f-476b-bf75-d660a5888d77
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subscription
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875%27&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Azure
+        Red Hat OpenShift RP","appId":"f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875","applicationTemplateId":null,"appOwnerTenantId":"f8cdef31-a31e-4b4a-93e4-5f571e91255a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Azure
+        Red Hat OpenShift RP","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Microsoft
+        Services","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1260'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 09 Dec 2020 18:27:03 GMT
+      duration:
+      - '596728'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - bj9FMdn44i0gpnrR1778FonNgLkqsFjKak/gqrdHT0k=
+      ocp-aad-session-key:
+      - KrruWIeZ9cjStxDUMzeUpmJ-hBuwRtckkxYqZXRgIYRq5gFhTQj2aAlrZ6d8pCazzXiIjDjcoU3wrT1cdSzkrT1uRQgAz3gVyTPPczVnLDxuZb06OPWR6cVp5FgrAh6_eifzx7ltUeYwVrTt-X0yRTM4uQEttNYqVPbgDJ7Fo2c.9MCZZz4E0-LjZuJ0pm7pnPuWY1xHkn9TNRJb5FexmBY
+      pragma:
+      - no-cache
+      request-id:
+      - 325f797f-71b4-43c1-b4c9-26dc9322860a
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-ms-resource-unit:
+      - '1'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subscription
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27e957e8cd-1467-42a0-bda1-665276ee51bf%27&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"6a770218-bb37-4a0f-a83c-6e6bc93ebbfa","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-ai3zo4ud","appId":"e957e8cd-1467-42a0-bda1-665276ee51bf","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-ai3zo4ud","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access aro-ai3zo4ud on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        aro-ai3zo4ud","id":"3d06ffd5-bc7f-4cd0-9ae5-24499d46621e","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access aro-ai3zo4ud on your behalf.","userConsentDisplayName":"Access
+        aro-ai3zo4ud","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
+        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["https://az.aro.azure.com/dbc309c3-51fe-49b8-b3d9-8c96db186d92","e957e8cd-1467-42a0-bda1-665276ee51bf"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '1698'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Wed, 09 Dec 2020 18:27:03 GMT
+      duration:
+      - '439992'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - EbILG5dopXW3bK7YdQQylm8ffxdilDqIpGOZB/cKtG0=
+      ocp-aad-session-key:
+      - tsxXDbCZbFLf8r_F7cj8wAxZT4pdt927Gxc-1aD7IrY9t1YRGB-jIvT7iMV2oWh_CSkOH9LgvOY2EDqDR-nsPrJ41SjjDui0VR-AXwQ9fhOy8196malkDHBQU-7s7tA0B_jhwnzWS_IbJ_Batl736zhJnBp4veWxxpmw9Pi1KfA.d6VBtgu_VxUU22A3WuooqiZlYax5MeTwK2-Jedf4MtQ
+      pragma:
+      - no-cache
+      request-id:
+      - 9c6ca8b0-9864-49ac-8317-e80b36b383c7
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-ms-resource-unit:
+      - '1'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subscription
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
+  response:
+    body:
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"6a770218-bb37-4a0f-a83c-6e6bc93ebbfa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T17:46:11.2561534Z","updatedOn":"2020-12-09T17:46:11.2561534Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T17:46:13.3304340Z","updatedOn":"2020-12-09T17:46:13.3304340Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.4824942Z","updatedOn":"2020-06-16T16:25:39.4824942Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e77058da-a7bf-4e89-8e48-7d9f61fa8246","type":"Microsoft.Authorization/roleAssignments","name":"e77058da-a7bf-4e89-8e48-7d9f61fa8246"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:12:52.8054393Z","updatedOn":"2020-11-25T05:12:52.8054393Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dea2d3a8-cf99-4169-b8dd-819b4c611a32","type":"Microsoft.Authorization/roleAssignments","name":"dea2d3a8-cf99-4169-b8dd-819b4c611a32"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:34:01.2642084Z","updatedOn":"2020-11-25T05:34:01.2642084Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bacc53c-9077-49ce-a14d-370bc09f72d8","type":"Microsoft.Authorization/roleAssignments","name":"4bacc53c-9077-49ce-a14d-370bc09f72d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6949b2a1-9b3e-42c8-b228-0b6c14927377","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-30T19:34:16.5100204Z","updatedOn":"2020-07-30T19:34:16.5100204Z","createdBy":"5bc13990-50e4-4898-835e-d026e066bba5","updatedBy":"5bc13990-50e4-4898-835e-d026e066bba5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/53b0d735-2402-41c6-9d6d-b2338a287741","type":"Microsoft.Authorization/roleAssignments","name":"53b0d735-2402-41c6-9d6d-b2338a287741"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4c480e6-1f29-4163-9a37-2b16a7e8e5c8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-16T13:48:13.9171700Z","updatedOn":"2020-09-16T13:48:13.9171700Z","createdBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","updatedBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8476200c-5011-42c4-9028-360ef1739a8d","type":"Microsoft.Authorization/roleAssignments","name":"8476200c-5011-42c4-9028-360ef1739a8d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '27774'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 18:27:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      set-cookie:
+      - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subscription
+      User-Agent:
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
+  response:
+    body:
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"6a770218-bb37-4a0f-a83c-6e6bc93ebbfa","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T17:46:11.2561534Z","updatedOn":"2020-12-09T17:46:11.2561534Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2020-12-09T17:46:13.3304340Z","updatedOn":"2020-12-09T17:46:13.3304340Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"d1cf9d0b-82f0-4647-883d-31a71e65feb4","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.4824942Z","updatedOn":"2020-06-16T16:25:39.4824942Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/e77058da-a7bf-4e89-8e48-7d9f61fa8246","type":"Microsoft.Authorization/roleAssignments","name":"e77058da-a7bf-4e89-8e48-7d9f61fa8246"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:12:52.8054393Z","updatedOn":"2020-11-25T05:12:52.8054393Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/dea2d3a8-cf99-4169-b8dd-819b4c611a32","type":"Microsoft.Authorization/roleAssignments","name":"dea2d3a8-cf99-4169-b8dd-819b4c611a32"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"61181853-6888-432e-a851-419afb6cf8ae","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-25T05:34:01.2642084Z","updatedOn":"2020-11-25T05:34:01.2642084Z","createdBy":"b8726ba5-4a62-458c-801b-07c6343f200c","updatedBy":"b8726ba5-4a62-458c-801b-07c6343f200c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4bacc53c-9077-49ce-a14d-370bc09f72d8","type":"Microsoft.Authorization/roleAssignments","name":"4bacc53c-9077-49ce-a14d-370bc09f72d8"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"6949b2a1-9b3e-42c8-b228-0b6c14927377","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-30T19:34:16.5100204Z","updatedOn":"2020-07-30T19:34:16.5100204Z","createdBy":"5bc13990-50e4-4898-835e-d026e066bba5","updatedBy":"5bc13990-50e4-4898-835e-d026e066bba5","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/53b0d735-2402-41c6-9d6d-b2338a287741","type":"Microsoft.Authorization/roleAssignments","name":"53b0d735-2402-41c6-9d6d-b2338a287741"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"a4c480e6-1f29-4163-9a37-2b16a7e8e5c8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-16T13:48:13.9171700Z","updatedOn":"2020-09-16T13:48:13.9171700Z","createdBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","updatedBy":"037d517b-3868-4729-9b13-dfd8fff7f8f8","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8476200c-5011-42c4-9028-360ef1739a8d","type":"Microsoft.Authorization/roleAssignments","name":"8476200c-5011-42c4-9028-360ef1739a8d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '27774'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 09 Dec 2020 18:27:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      set-cookie:
+      - x-ms-gateway-slice=Production; path=/; secure; samesite=none; httponly
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       transfer-encoding:
@@ -5349,8 +6441,9 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
       accept-language:
       - en-US
     method: PATCH
@@ -5361,36 +6454,36 @@ interactions:
         ,\n    \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\"\
         ,\n    \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"update\"\
         \n    },\n    \"properties\": {\n        \"provisioningState\": \"Updating\"\
-        ,\n        \"clusterProfile\": {\n            \"domain\": \"am0w6b6j\",\n\
-        \            \"version\": \"4.4.17\",\n            \"resourceGroupId\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-am0w6b6j\"\
-        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.am0w6b6j.eastus.aroapp.io/\"\
+        ,\n        \"clusterProfile\": {\n            \"domain\": \"ai3zo4ud\",\n\
+        \            \"version\": \"4.5.16\",\n            \"resourceGroupId\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-ai3zo4ud\"\
+        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.ai3zo4ud.eastus.aroapp.io/\"\
         \n        },\n        \"servicePrincipalProfile\": {\n            \"clientId\"\
-        : \"ee6718bb-7aee-4149-875a-61adc505dff8\"\n        },\n        \"networkProfile\"\
+        : \"e957e8cd-1467-42a0-bda1-665276ee51bf\"\n        },\n        \"networkProfile\"\
         : {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\"\
         : \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n          \
         \  \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
         \n        },\n        \"workerProfiles\": [\n            {\n             \
-        \   \"name\": \"aro000004-dfcrm-worker-eastus1\",\n                \"vmSize\"\
+        \   \"name\": \"aro000004-nsm64-worker-eastus1\",\n                \"vmSize\"\
         : \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n           \
         \     \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-dfcrm-worker-eastus2\",\n                \"\
+        \       \"name\": \"aro000004-nsm64-worker-eastus2\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-dfcrm-worker-eastus3\",\n                \"\
+        \       \"name\": \"aro000004-nsm64-worker-eastus3\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            }\n        ],\n        \"apiserverProfile\"\
-        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.am0w6b6j.eastus.aroapp.io:6443/\"\
-        ,\n            \"ip\": \"40.88.22.155\"\n        },\n        \"ingressProfiles\"\
+        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.ai3zo4ud.eastus.aroapp.io:6443/\"\
+        ,\n            \"ip\": \"52.149.171.35\"\n        },\n        \"ingressProfiles\"\
         : [\n            {\n                \"name\": \"default\",\n             \
-        \   \"visibility\": \"Public\",\n                \"ip\": \"52.188.181.57\"\
-        \n            }\n        ]\n    }\n}\n"
+        \   \"visibility\": \"Public\",\n                \"ip\": \"40.88.202.96\"\n\
+        \            }\n        ]\n    }\n}\n"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9ed8f2f2-0f51-446d-b9cb-2989b28bcd53?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/b68ee79e-46a0-4397-aefb-e3be49f792a5?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -5398,7 +6491,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:34:17 GMT
+      - Wed, 09 Dec 2020 18:27:04 GMT
       expires:
       - '-1'
       pragma:
@@ -5412,7 +6505,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 200
       message: OK
@@ -5430,16 +6523,17 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9ed8f2f2-0f51-446d-b9cb-2989b28bcd53?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/b68ee79e-46a0-4397-aefb-e3be49f792a5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"endTime\": \"2020-09-08T07:34:20.039612094Z\",\n    \"id\"\
-        : \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9ed8f2f2-0f51-446d-b9cb-2989b28bcd53\"\
-        ,\n    \"name\": \"9ed8f2f2-0f51-446d-b9cb-2989b28bcd53\",\n    \"startTime\"\
-        : \"2020-09-08T07:34:17.653488853Z\",\n    \"status\": \"Succeeded\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/b68ee79e-46a0-4397-aefb-e3be49f792a5\"\
+        ,\n    \"name\": \"b68ee79e-46a0-4397-aefb-e3be49f792a5\",\n    \"status\"\
+        : \"Succeeded\",\n    \"startTime\": \"2020-12-09T18:27:05.426803116Z\",\n\
+        \    \"endTime\": \"2020-12-09T18:27:07.316406501Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5448,7 +6542,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:34:47 GMT
+      - Wed, 09 Dec 2020 18:27:36 GMT
       expires:
       - '-1'
       pragma:
@@ -5478,8 +6572,9 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.8.5 (Linux-5.4.0-1023-azure-x86_64-with-glibc2.27) msrest/0.6.18
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.11.1
+      - python/3.6.12 (Linux-5.9.8-200.fc33.x86_64-x86_64-with-fedora-33-Thirty_Three)
+        msrest/0.6.18 msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python
+        AZURECLI/2.16.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
   response:
@@ -5488,33 +6583,33 @@ interactions:
         ,\n    \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\"\
         ,\n    \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"update\"\
         \n    },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\"\
-        ,\n        \"clusterProfile\": {\n            \"domain\": \"am0w6b6j\",\n\
-        \            \"version\": \"4.4.17\",\n            \"resourceGroupId\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-am0w6b6j\"\
-        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.am0w6b6j.eastus.aroapp.io/\"\
+        ,\n        \"clusterProfile\": {\n            \"domain\": \"ai3zo4ud\",\n\
+        \            \"version\": \"4.5.16\",\n            \"resourceGroupId\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-ai3zo4ud\"\
+        \n        },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.ai3zo4ud.eastus.aroapp.io/\"\
         \n        },\n        \"servicePrincipalProfile\": {\n            \"clientId\"\
-        : \"ee6718bb-7aee-4149-875a-61adc505dff8\"\n        },\n        \"networkProfile\"\
+        : \"e957e8cd-1467-42a0-bda1-665276ee51bf\"\n        },\n        \"networkProfile\"\
         : {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\"\
         : \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n          \
         \  \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\
         \n        },\n        \"workerProfiles\": [\n            {\n             \
-        \   \"name\": \"aro000004-dfcrm-worker-eastus1\",\n                \"vmSize\"\
+        \   \"name\": \"aro000004-nsm64-worker-eastus1\",\n                \"vmSize\"\
         : \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n           \
         \     \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-dfcrm-worker-eastus2\",\n                \"\
+        \       \"name\": \"aro000004-nsm64-worker-eastus2\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            },\n            {\n         \
-        \       \"name\": \"aro000004-dfcrm-worker-eastus3\",\n                \"\
+        \       \"name\": \"aro000004-nsm64-worker-eastus3\",\n                \"\
         vmSize\": \"Standard_D4s_v3\",\n                \"diskSizeGB\": 128,\n   \
         \             \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\"\
         ,\n                \"count\": 1\n            }\n        ],\n        \"apiserverProfile\"\
-        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.am0w6b6j.eastus.aroapp.io:6443/\"\
-        ,\n            \"ip\": \"40.88.22.155\"\n        },\n        \"ingressProfiles\"\
+        : {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.ai3zo4ud.eastus.aroapp.io:6443/\"\
+        ,\n            \"ip\": \"52.149.171.35\"\n        },\n        \"ingressProfiles\"\
         : [\n            {\n                \"name\": \"default\",\n             \
-        \   \"visibility\": \"Public\",\n                \"ip\": \"52.188.181.57\"\
-        \n            }\n        ]\n    }\n}\n"
+        \   \"visibility\": \"Public\",\n                \"ip\": \"40.88.202.96\"\n\
+        \            }\n        ]\n    }\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5523,7 +6618,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 08 Sep 2020 07:34:47 GMT
+      - Wed, 09 Dec 2020 18:27:36 GMT
       expires:
       - '-1'
       pragma:


### PR DESCRIPTION
**Description**<!--Mandatory-->
Upstreams [Azure/ARO-RP#1159](https://github.com/Azure/ARO-RP/pull/1159) which adds RBAC validation on ARO cluster update, unblocking updates when customers remove SPN permissions.  

Upstreams [Azure/ARO-RP#1217](https://github.com/Azure/ARO-RP/pull/1159) which updates error handling in ARO to conform to the guidelines. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
