### PR TITLE
[Profile] Fix "missing secret or certificate in order to authenticate through a service principal"

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -641,7 +641,7 @@ class Profile:
                 username_or_sp_id, account[_TENANT_ID], resource)
             return None, token_entry.get(_REFRESH_TOKEN), token_entry[_ACCESS_TOKEN], str(account[_TENANT_ID])
 
-        sp_secret = self._creds_cache.retrieve_secret_of_service_principal(username_or_sp_id)
+        sp_secret = self._creds_cache.retrieve_cred_for_service_principal(username_or_sp_id)
         return username_or_sp_id, sp_secret, None, str(account[_TENANT_ID])
 
     def get_raw_token(self, resource=None, subscription=None, tenant=None):
@@ -706,7 +706,7 @@ class Profile:
             subscriptions = []
             try:
                 if is_service_principal:
-                    sp_auth = ServicePrincipalAuth(self._creds_cache.retrieve_secret_of_service_principal(user_name))
+                    sp_auth = ServicePrincipalAuth(self._creds_cache.retrieve_cred_for_service_principal(user_name))
                     subscriptions = subscription_finder.find_from_service_principal_id(user_name, sp_auth, tenant,
                                                                                        self._ad_resource_uri)
                 else:
@@ -752,7 +752,7 @@ class Profile:
             user_type = account[_USER_ENTITY].get(_USER_TYPE)
             if user_type == _SERVICE_PRINCIPAL:
                 result['clientId'] = account[_USER_ENTITY][_USER_NAME]
-                sp_auth = ServicePrincipalAuth(self._creds_cache.retrieve_secret_of_service_principal(
+                sp_auth = ServicePrincipalAuth(self._creds_cache.retrieve_cred_for_service_principal(
                     account[_USER_ENTITY][_USER_NAME]))
                 secret = getattr(sp_auth, 'secret', None)
                 if secret:
@@ -1109,13 +1109,14 @@ class CredsCache:
         token_entry = sp_auth.acquire_token(context, resource, sp_id)
         return (token_entry[_TOKEN_ENTRY_TOKEN_TYPE], token_entry[_ACCESS_TOKEN], token_entry)
 
-    def retrieve_secret_of_service_principal(self, sp_id):
+    def retrieve_cred_for_service_principal(self, sp_id):
+        """Returns the secret or certificate of the specified service principal."""
         self.load_adal_token_cache()
         matched = [x for x in self._service_principal_creds if sp_id == x[_SERVICE_PRINCIPAL_ID]]
         if not matched:
             raise CLIError("No matched service principal found")
         cred = matched[0]
-        return cred.get(_ACCESS_TOKEN, None)
+        return cred.get(_ACCESS_TOKEN) or cred.get(_SERVICE_PRINCIPAL_CERT_FILE)
 
     @property
     def adal_token_cache(self):

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -1525,7 +1525,7 @@ class TestProfile(unittest.TestCase):
         mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
         mock_arm_client.subscriptions.list.side_effect = deepcopy([[self.subscription1], [self.subscription2, sp_subscription1]])
         finder = SubscriptionFinder(cli, lambda _, _1, _2: mock_auth_context, None, lambda _: mock_arm_client)
-        profile._creds_cache.retrieve_secret_of_service_principal = lambda _: 'verySecret'
+        profile._creds_cache.retrieve_cred_for_service_principal = lambda _: 'verySecret'
         profile._creds_cache.flush_to_disk = lambda _: ''
         # action
         profile.refresh_accounts(finder)
@@ -1594,21 +1594,29 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(creds_cache._service_principal_creds, [test_sp])
 
     @mock.patch('azure.cli.core._profile._load_tokens_from_file', autospec=True)
-    def test_credscache_retrieve_sp_secret_with_cert(self, mock_read_file):
+    def test_credscache_retrieve_sp_cred(self, mock_read_file):
         cli = DummyCli()
-        test_sp = {
-            "servicePrincipalId": "myapp",
-            "servicePrincipalTenant": "mytenant",
-            "certificateFile": 'junkcert.pem'
-        }
-        mock_read_file.return_value = [test_sp]
+        test_cache = [
+            {
+                "servicePrincipalId": "myapp",
+                "servicePrincipalTenant": "mytenant",
+                "accessToken": "Secret"
+            },
+            {
+                "servicePrincipalId": "myapp2",
+                "servicePrincipalTenant": "mytenant",
+                "certificateFile": 'junkcert.pem'
+            }
+        ]
+        mock_read_file.return_value = test_cache
 
         # action
         creds_cache = CredsCache(cli, async_persist=False)
         creds_cache.load_adal_token_cache()
 
         # assert
-        self.assertEqual(creds_cache.retrieve_secret_of_service_principal(test_sp['servicePrincipalId']), None)
+        self.assertEqual(creds_cache.retrieve_cred_for_service_principal('myapp'), 'Secret')
+        self.assertEqual(creds_cache.retrieve_cred_for_service_principal('myapp2'), 'junkcert.pem')
 
     @mock.patch('azure.cli.core._profile._load_tokens_from_file', autospec=True)
     @mock.patch('os.fdopen', autospec=True)

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile_v2016_06_01.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile_v2016_06_01.py
@@ -1379,7 +1379,7 @@ class TestProfile(unittest.TestCase):
         mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
         mock_arm_client.subscriptions.list.side_effect = deepcopy([[self.subscription1], [self.subscription2, sp_subscription1]])
         finder = SubscriptionFinder(cli, lambda _, _1, _2: mock_auth_context, None, lambda _: mock_arm_client)
-        profile._creds_cache.retrieve_secret_of_service_principal = lambda _: 'verySecret'
+        profile._creds_cache.retrieve_cred_for_service_principal = lambda _: 'verySecret'
         profile._creds_cache.flush_to_disk = lambda _: ''
         # action
         profile.refresh_accounts(finder)
@@ -1462,7 +1462,7 @@ class TestProfile(unittest.TestCase):
         creds_cache.load_adal_token_cache()
 
         # assert
-        self.assertEqual(creds_cache.retrieve_secret_of_service_principal(test_sp['servicePrincipalId']), None)
+        self.assertEqual(creds_cache.retrieve_cred_for_service_principal(test_sp['servicePrincipalId']), None)
 
     @mock.patch('azure.cli.core._profile._load_tokens_from_file', autospec=True)
     @mock.patch('os.fdopen', autospec=True)


### PR DESCRIPTION
**Description**

After logging in with a Service Principal using a certificate, 2 commands

- `az account show --sdk-auth`
- `az account list --refresh`

will fail with

```
missing secret or certificate in order to authenticate through a service principal
```

This is because `retrieve_secret_of_service_principal` can only return a `secret`, but `None` for `certificateFile`, causing subsequent `ServicePrincipalAuth` instantiation to fail due to the lack of `password_arg_value`.

This PR fixes these commands by:

- Rename `retrieve_secret_of_service_principal` to `retrieve_cred_for_service_principal` to reflect its actual functionality.
- Let `retrieve_cred_for_service_principal` return `secret` or `certificateFile` of the Service Principal so that `ServicePrincipalAuth` gets what it needs.

**Testing Guide**

To repro:

```sh
> az ad sp create-for-rbac --create-cert --skip-assignment --sdk-auth
{
    "clientId": "9bf154b1-c29b-4aeb-804a-0a1f8a9bac4c",
    "clientCertificate": "C:\\Users\\username\\tmp6yoosff6.pem",
    "subscriptionId": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "activeDirectoryEndpointUrl": "https://login.microsoftonline.com",
    "resourceManagerEndpointUrl": "https://management.azure.com/",
    "activeDirectoryGraphResourceId": "https://graph.windows.net/",
    "sqlManagementEndpointUrl": "https://management.core.windows.net:8443/",
    "galleryEndpointUrl": "https://gallery.azure.com/",
    "managementEndpointUrl": "https://management.core.windows.net/"
}

> az login --service-principal 
           --username "9bf154b1-c29b-4aeb-804a-0a1f8a9bac4c" 
           --password "C:\Users\username\tmp6yoosff6.pem"
           --tenant "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"
           --allow-no-subscriptions

> az account show --sdk-auth
missing secret or certificate in order to authenticate through a service principal

> az account list --refresh
Refreshing for '9bf154b1-c29b-4aeb-804a-0a1f8a9bac4c' failed with an error 'missing secret or certificate 
in order to authenticate through a service principal'. The existing accounts were not modified. You can run 
'az login' later to explicitly refresh them
```

After the fix:

```sh
> az account show --sdk-auth
{
  "clientId": "9bf154b1-c29b-4aeb-804a-0a1f8a9bac4c",
  "clientCertificate": "C:\\Users\\username\\tmp6yoosff6.pem",
  "subscriptionId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "activeDirectoryEndpointUrl": "https://login.microsoftonline.com",
  "resourceManagerEndpointUrl": "https://management.azure.com/",
  "activeDirectoryGraphResourceId": "https://graph.windows.net/",
  "sqlManagementEndpointUrl": "https://management.core.windows.net:8443/",
  "galleryEndpointUrl": "https://gallery.azure.com/",
  "managementEndpointUrl": "https://management.core.windows.net/"
}

> az account list --refresh
[
  {
    "cloudName": "AzureCloud",
    "id": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "isDefault": true,
    "name": "N/A(tenant level account)",
    "state": "Enabled",
    "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
    "user": {
      "name": "9bf154b1-c29b-4aeb-804a-0a1f8a9bac4c",
      "type": "servicePrincipal"
    }
  }
]
```