### PR TITLE
{Profile} Add CREDENTIAL_WARNING_MESSAGE for more commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -8,89 +8,96 @@
 from knack.help_files import helps  # pylint: disable=unused-import
 
 helps['login'] = """
-    type: command
-    short-summary: Log in to Azure.
-    examples:
-        - name: Log in interactively.
-          text: >
-            az login
-        - name: Log in with user name and password. This doesn't work with Microsoft accounts or accounts that have two-factor authentication enabled. Use -p=secret if the first character of the password is '-'.
-          text: >
-            az login -u johndoe@contoso.com -p VerySecret
-        - name: Log in with a service principal using client secret. Use -p=secret if the first character of the password is '-'.
-          text: >
-            az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
-        - name: Log in with a service principal using client certificate.
-          text: >
-            az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
-        - name: Log in using a VM's system assigned identity
-          text: >
-            az login --identity
-        - name: Log in using a VM's user assigned identity. Client or object ids of the service identity also work
-          text: >
-            az login --identity -u /subscriptions/<subscriptionId>/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
-    """
+type: command
+short-summary: Log in to Azure.
+examples:
+    - name: Log in interactively.
+      text: >
+        az login
+    - name: Log in with user name and password. This doesn't work with Microsoft accounts or accounts that have two-factor authentication enabled. Use -p=secret if the first character of the password is '-'.
+      text: >
+        az login -u johndoe@contoso.com -p VerySecret
+    - name: Log in with a service principal using client secret. Use -p=secret if the first character of the password is '-'.
+      text: >
+        az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
+    - name: Log in with a service principal using client certificate.
+      text: >
+        az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
+    - name: Log in using a VM's system assigned identity
+      text: >
+        az login --identity
+    - name: Log in using a VM's user assigned identity. Client or object ids of the service identity also work
+      text: >
+        az login --identity -u /subscriptions/<subscriptionId>/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
+"""
 
 helps['account'] = """
-    type: group
-    short-summary: Manage Azure subscription information.
+type: group
+short-summary: Manage Azure subscription information.
 """
 
 helps['account clear'] = """
-    type: command
-    short-summary: Clear all subscriptions from the CLI's local cache.
-    long-summary: To clear the current subscription, use 'az logout'.
+type: command
+short-summary: Clear all subscriptions from the CLI's local cache.
+long-summary: To clear the current subscription, use 'az logout'.
 """
 
 helps['account list'] = """
-    type: command
-    short-summary: Get a list of subscriptions for the logged in account.
+type: command
+short-summary: Get a list of subscriptions for the logged in account.
 """
 
 helps['account list-locations'] = """
-    type: command
-    short-summary: List supported regions for the current subscription.
+type: command
+short-summary: List supported regions for the current subscription.
 """
 
 helps['account show'] = """
-    type: command
-    short-summary: Get the details of a subscription.
-    long-summary: If no subscription is specified, shows the current subscription.
+type: command
+short-summary: Get the details of a subscription.
+long-summary: If no subscription is specified, shows the current subscription.
 """
 
 helps['account set'] = """
-    type: command
-    short-summary: Set a subscription to be the current active subscription.
+type: command
+short-summary: Set a subscription to be the current active subscription.
 """
 
 helps['account show'] = """
-    type: command
-    short-summary: Get the details of a subscription.
-    long-summary: If the subscription isn't specified, shows the details of the default subscription.
+type: command
+short-summary: Get the details of a subscription.
+long-summary: >-
+    If the subscription isn't specified, shows the details of the default subscription.
+
+
+    When --sdk-auth is used,
+    the output includes credentials that you must protect. Be sure that you do not include these credentials
+    in your code or check the credentials into your source control. As an alternative, consider using
+    [managed identities](https://aka.ms/azadsp-managed-identities) if available to avoid the need to use credentials.
 """
 
 helps['account get-access-token'] = """
-    type: command
-    short-summary: Get a token for utilities to access Azure.
-    long-summary: >
-        The token will be valid for at least 5 minutes with the maximum at 60 minutes.
-        If the subscription argument isn't specified, the current account is used.
-    examples:
-        - name: Get an access token for the current account
-          text: >
-            az account get-access-token
-        - name: Get an access token for a specific subscription
-          text: >
-            az account get-access-token --subscription 00000000-0000-0000-0000-000000000000
-        - name: Get an access token for a specific tenant
-          text: >
-            az account get-access-token --tenant 00000000-0000-0000-0000-000000000000
-        - name: Get an access token to use with MS Graph API
-          text: >
-            az account get-access-token --resource-type ms-graph
+type: command
+short-summary: Get a token for utilities to access Azure.
+long-summary: >
+    The token will be valid for at least 5 minutes with the maximum at 60 minutes.
+    If the subscription argument isn't specified, the current account is used.
+examples:
+    - name: Get an access token for the current account
+      text: >
+        az account get-access-token
+    - name: Get an access token for a specific subscription
+      text: >
+        az account get-access-token --subscription 00000000-0000-0000-0000-000000000000
+    - name: Get an access token for a specific tenant
+      text: >
+        az account get-access-token --tenant 00000000-0000-0000-0000-000000000000
+    - name: Get an access token to use with MS Graph API
+      text: >
+        az account get-access-token --resource-type ms-graph
 """
 
 helps['self-test'] = """
-    type: command
-    short-summary: Runs a self-test of the CLI.
+type: command
+short-summary: Runs a self-test of the CLI.
 """

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -52,11 +52,15 @@ def list_subscriptions(cmd, all=False, refresh=False):  # pylint: disable=redefi
 def show_subscription(cmd, subscription=None, show_auth_for_sdk=None):
     import json
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    if not show_auth_for_sdk:
-        return profile.get_subscription(subscription)
 
-    # sdk-auth file should be in json format all the time, hence the print
-    print(json.dumps(profile.get_sp_auth_info(subscription), indent=2))
+    if show_auth_for_sdk:
+        from azure.cli.command_modules.role.custom import CREDENTIAL_WARNING_MESSAGE
+        logger.warning(CREDENTIAL_WARNING_MESSAGE)
+        # sdk-auth file should be in json format all the time, hence the print
+        print(json.dumps(profile.get_sp_auth_info(subscription), indent=2))
+        return
+
+    return profile.get_subscription(subscription)
 
 
 def get_access_token(cmd, subscription=None, resource=None, resource_type=None, tenant=None):

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1506,6 +1506,8 @@ def create_service_principal_for_rbac(
                                            ex.response.headers)  # pylint: disable=no-member
                     raise
 
+    logger.warning(CREDENTIAL_WARNING_MESSAGE)
+
     if show_auth_for_sdk:
         from azure.cli.core._profile import Profile
         profile = Profile(cli_ctx=cmd.cli_ctx)
@@ -1527,8 +1529,6 @@ def create_service_principal_for_rbac(
             "Please copy %s to a safe place. When you run 'az login', provide the file path in the --password argument",
             cert_file)
         result['fileWithCertAndPrivateKey'] = cert_file
-
-    logger.warning(CREDENTIAL_WARNING_MESSAGE)
     return result
 
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
Refine #15825: Add long-summary/warning for commands generating credentials

This PR shows the `CREDENTIAL_WARNING_MESSAGE` for more commands:

- `az account show --help`
- `az account show --sdk-auth`
- `az ad sp create-for-rbac --sdk-auth`
