### PR TITLE
[SQL] Hotfix: az sql dw update: fix update to not accept backup-storage-redundancy

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_params.py
@@ -371,9 +371,6 @@ def _configure_db_dw_params(arg_ctx):
     arg_ctx.argument('zone_redundant',
                      arg_type=zone_redundant_param_type)
 
-    arg_ctx.argument('storage_account_type',
-                     arg_type=backup_storage_redundancy_param_type)
-
 
 def _configure_db_dw_create_params(
         arg_ctx,
@@ -488,6 +485,9 @@ def _configure_db_dw_create_params(
     arg_ctx.argument('elastic_pool_id',
                      help='The name or resource id of the elastic pool to create the database in.')
 
+    arg_ctx.argument('storage_account_type',
+                     arg_type=backup_storage_redundancy_param_type)
+
     # *** Step 3: Ignore params that are not applicable (based on engine & create mode) ***
 
     # Only applicable to default create mode. Also only applicable to db.
@@ -588,9 +588,6 @@ def load_arguments(self, _):
     with self.argument_context('sql db create') as c:
         _configure_db_dw_create_params(c, Engine.db, CreateMode.default)
 
-        c.argument('storage_account_type',
-                   arg_type=backup_storage_redundancy_param_type)
-
         c.argument('yes',
                    options_list=['--yes', '-y'],
                    help='Do not prompt for confirmation.', action='store_true')
@@ -610,9 +607,6 @@ def load_arguments(self, _):
                    options_list=['--dest-server'],
                    help='Name of the server to create the copy in.'
                    ' If unspecified, defaults to the origin server.')
-
-        c.argument('storage_account_type',
-                   arg_type=backup_storage_redundancy_param_type)
 
     with self.argument_context('sql db rename') as c:
         c.argument('new_name',
@@ -641,9 +635,6 @@ def load_arguments(self, _):
                    ' Must match the deleted time of a deleted database in the same server.'
                    ' Either --time or --deleted-time (or both) must be specified. ' +
                    time_format_help)
-
-        c.argument('storage_account_type',
-                   arg_type=backup_storage_redundancy_param_type)
 
     with self.argument_context('sql db show') as c:
         # Service tier advisors and transparent data encryption are not included in the first batch
@@ -823,9 +814,6 @@ def load_arguments(self, _):
                    options_list=['--partner-database'],
                    help='Name of the new replica.'
                    ' If unspecified, defaults to the source database name.')
-
-        c.argument('storage_account_type',
-                   arg_type=backup_storage_redundancy_param_type)
 
     with self.argument_context('sql db replica set-primary') as c:
         c.argument('database_name',

--- a/src/azure-cli/azure/cli/command_modules/synapse/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/_help.py
@@ -333,7 +333,7 @@ examples:
         --resource-group rg
 """
 
-helps['sql db classification recommendation enable'] = """
+helps['synapse sql pool classification recommendation enable'] = """
 type: command
 short-summary: Enable sensitivity recommendations for a given column(recommendations are enabled by default on all columns).
 examples:
@@ -343,7 +343,7 @@ examples:
         --resource-group rg --schema dbo --table mytable --column mycolumn
 """
 
-helps['sql db classification recommendation disable'] = """
+helps['synapse sql pool classification recommendation disable'] = """
 type: command
 short-summary: Disable sensitivity recommendations for a given column(recommendations are enabled by default on all columns).
 examples:


### PR DESCRIPTION
**Description**<!--Mandatory-->
A previous [PR from earlier this year](https://github.com/Azure/azure-cli/pull/15341) added backup-storage-redundancy to all SQL create/update methods. This inadvertently added the functionality to SQL DW as well. However, this parameter should not be available during dw update (not supported in the backend), so this PR removes the customer's ability to update a DW's backup storage redundancy.

Additionally, this fixes an issue for az sql **db** update; where the update command was not updating backup storage redundancy values on existing databases.  

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[SQL] az sql dw update: do not accept backup-storage-redundancy argument
[SQL] az sql db update: update backup storage redundancy as requested from command

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
