### PR TITLE
[Storage] `az storage file download-batch`: Fix the bug for batch download of snapshot

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
@@ -158,7 +158,7 @@ def storage_file_download_batch(cmd, client, source, destination, pattern=None, 
 
     from azure.cli.command_modules.storage.util import glob_files_remotely, mkdir_p
 
-    source_files = glob_files_remotely(cmd, client, source, pattern)
+    source_files = glob_files_remotely(cmd, client, source, pattern, snapshot)
 
     if dryrun:
         source_files_list = list(source_files)

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/file_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/file_azure_stack.py
@@ -132,7 +132,7 @@ def storage_file_download_batch(cmd, client, source, destination, pattern=None, 
 
     from azure.cli.command_modules.storage.util import glob_files_remotely, mkdir_p
 
-    source_files = glob_files_remotely(cmd, client, source, pattern)
+    source_files = glob_files_remotely(cmd, client, source, pattern, snapshot)
 
     if dryrun:
         source_files_list = list(source_files)

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
@@ -146,6 +146,18 @@ class StorageBatchOperationScenarios(StorageScenarioMixin, LiveScenarioTest):
                          src_share, local_folder)
         self.assertEqual(0, sum(len(f) for r, d, f in os.walk(local_folder)))
 
+        # download the specified snapshot
+        snapshot = self.storage_cmd('storage share snapshot -n {}', storage_account_info, src_share).\
+            get_output_in_json()['snapshot']
+
+        # delete some files and check whether the files in the previous snapshot will be affected
+        self.storage_cmd('storage file delete-batch -s {} --pattern apple/*', storage_account_info, src_share)
+
+        local_folder = self.create_temp_dir()
+        self.storage_cmd('storage file download-batch -s {} -d "{}" --snapshot "{}" ', storage_account_info, src_share,
+                         local_folder, snapshot)
+        self.assertEqual(41, sum(len(f) for r, d, f in os.walk(local_folder)))
+
     @ResourceGroupPreparer()
     @StorageAccountPreparer()
     @StorageTestFilesPreparer()

--- a/src/azure-cli/azure/cli/command_modules/storage/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/util.py
@@ -87,7 +87,7 @@ def glob_files_locally(folder_path, pattern):
                 yield (full_path, full_path[len_folder_path:])
 
 
-def glob_files_remotely(cmd, client, share_name, pattern):
+def glob_files_remotely(cmd, client, share_name, pattern, snapshot=None):
     """glob the files in remote file share based on the given pattern"""
     from collections import deque
     t_dir, t_file = cmd.get_models('file.models#Directory', 'file.models#File')
@@ -95,7 +95,7 @@ def glob_files_remotely(cmd, client, share_name, pattern):
     queue = deque([""])
     while queue:
         current_dir = queue.pop()
-        for f in client.list_directories_and_files(share_name, current_dir):
+        for f in client.list_directories_and_files(share_name, current_dir, snapshot=snapshot):
             if isinstance(f, t_file):
                 if not pattern or _match_path(os.path.join(current_dir, f.name), pattern):
                     yield current_dir, f.name


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix: #9961

When downloading files in batch, `list_directories_and_files` is used to query the list of files to be downloaded.
However, since the snapshot parameters are not passed to `list_directories_and_files`, the query is not about the snapshot but about the share. So passing in snapshot parameter when calling `list_directories_and_files` to fix this problem.


**Testing Guide**
<!--Example commands with explanations.-->
Run `az storage file download-batch` with `--snapshot`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
