### PR TITLE
Update custom.py

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1899,7 +1899,8 @@ def delete_template_spec(cmd, resource_group_name=None, name=None, version=None,
             version = None
     if version:
         return rcf.template_specs.delete(resource_group_name=resource_group_name, template_spec_name=name, template_spec_version=version)
-    return rcf.template_specs.delete(resource_group_name=resource_group_name, template_spec_name=name)
+    else:
+        return rcf.template_specs.delete(resource_group_name=resource_group_name, template_spec_name=name)
 
 
 def list_template_specs(cmd, resource_group_name=None, name=None):


### PR DESCRIPTION
Fix rcf.template_specs.delete If VersionID presented

**Description**<!--Mandatory-->
CLI command for delete Template specs is deleting the template specs instead of the provided version alone, else statement adder

**Testing Guide**
az ts delete -g RGName --n TSName -v 1.0 
this was deleting the template specs resource and not the version needed, now will delete the version alone in case version ID provided 

**History Notes**
[Template Specs] az command Delete: Fix version parameter issue.