### PR TITLE
[Monitor] az monitor metrics alert create: improve error message to give more actionable insight

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/monitor/actions.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/actions.py
@@ -137,10 +137,16 @@ class MetricAlertConditionAction(argparse._AppendAction):
 class MetricAlertAddAction(argparse._AppendAction):
 
     def __call__(self, parser, namespace, values, option_string=None):
+        action_group_id = values[0]
+        try:
+            webhook_property_candidates = dict(x.split('=', 1) for x in values[1:]) if len(values) > 1 else None
+        except ValueError:
+            raise InvalidArgumentValueError("value of " + option_string + " is invalid. Please refer to --help to get insight of correct format")
+
         from azure.mgmt.monitor.models import MetricAlertAction
         action = MetricAlertAction(
-            action_group_id=values[0],
-            web_hook_properties=dict(x.split('=', 1) for x in values[1:]) if len(values) > 1 else None
+            action_group_id=action_group_id,
+            web_hook_properties=webhook_property_candidates
         )
         action.odatatype = 'Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.' \
                            'DataContracts.Resources.ScheduledQueryRules.Action'

--- a/src/azure-cli/azure/cli/command_modules/monitor/actions.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/actions.py
@@ -141,7 +141,10 @@ class MetricAlertAddAction(argparse._AppendAction):
         try:
             webhook_property_candidates = dict(x.split('=', 1) for x in values[1:]) if len(values) > 1 else None
         except ValueError:
-            raise InvalidArgumentValueError("value of " + option_string + " is invalid. Please refer to --help to get insight of correct format")
+            err_msg = "value of {} is invalid. Please refer to --help to get insight of correct format".format(
+                option_string
+            )
+            raise InvalidArgumentValueError(err_msg)
 
         from azure.mgmt.monitor.models import MetricAlertAction
         action = MetricAlertAction(


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

One of fix for https://github.com/Azure/azure-cli/issues/14988

**Testing Guide**
To reproduce via run:
```
az monitor metrics alert create -n alert1 -g harold --scopes /subscriptions/0000-0000/resourceGroups/xxxxx/providers/Microsoft.Compute/virtualMachines/xxxx/extensions/MicrosoftMonitoringAgent --condition "avg Percentage CPU > 90" --window-size 5m --evaluation-frequency 1m --description "High CPU Usage"  --action /subscriptions/xxxx/resourceGroups/xxxx/providers/microsoft.insights/actionGroups/xxxx apiKe
```

And the subsequently error output would be like:
```
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1969, in _parse_known_args
    positionals_end_index = consume_positionals(start_index)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1946, in consume_positionals
    take_action(action, args)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1855, in take_action
    action(self, namespace, argument_values, option_string)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1152, in __call__
    subnamespace, arg_strings = parser.parse_known_args(arg_strings, None)
  File "/home/harold/Microsoft/azure-cli/src/azure-cli-core/azure/cli/core/parser.py", line 289, in parse_known_args
    self._namespace, self._raw_arguments = super().parse_known_args(args=args, namespace=namespace)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1781, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1969, in _parse_known_args
    positionals_end_index = consume_positionals(start_index)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1946, in consume_positionals
    take_action(action, args)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1855, in take_action
    action(self, namespace, argument_values, option_string)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1152, in __call__
    subnamespace, arg_strings = parser.parse_known_args(arg_strings, None)
  File "/home/harold/Microsoft/azure-cli/src/azure-cli-core/azure/cli/core/parser.py", line 289, in parse_known_args
    self._namespace, self._raw_arguments = super().parse_known_args(args=args, namespace=namespace)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1781, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1987, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1927, in consume_optional
    take_action(action, args, option_string)
  File "/home/harold/.pyenv/versions/3.7.4/lib/python3.7/argparse.py", line 1855, in take_action
    action(self, namespace, argument_values, option_string)
  File "/home/harold/Microsoft/azure-cli/src/azure-cli/azure/cli/command_modules/monitor/actions.py", line 152, in __call__
    web_hook_properties=dict(x.split('=', 1) for x in values[1:]) if len(values) > 1 else None
ValueError: dictionary update sequence element #0 has length 1; 2 is required
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
