### PR TITLE
{Error Handling} Show explicit error messages for HttpOperationError

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -173,12 +173,12 @@ def extract_http_operation_error(ex):
         if isinstance(response, str):
             error = response
         else:
-            error = response['error']
+            error = response.get('error', response.get('Error', None))
         # ARM should use ODATA v4. So should try this first.
         # http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091
         if isinstance(error, dict):
-            status_code = error.get('code', 'Unknown Code')
-            message = error.get('message', ex)
+            status_code = error.get('code', error.get('Code', 'Unknown Code'))
+            message = error.get('message', error.get('Message', ex))
             error_msg = "{}: {}".format(status_code, message)
         else:
             error_msg = error


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR tries to fix the issue https://github.com/Azure/azure-cli-extensions/issues/2793.

For `HttpOperationError`, we can find its error message either in `HttpOperationError.response.text` and `HttpOperationError.message`.  E.g, for the case above, the error message in  `HttpOperationError.message` is
```
Operation returned an invalid status code 'Bad Request'
```

and the error message in `HttpOperationError.response.text` is like below, **which is more explicit**
```
{"Error":{"Code":"ValidationFailed","Message":"Updating immutable properties is not allowed."}}
```

Previously in AzureCLI core, the exception handler firstly tries to parse the `HttpOperationError.response.text` (usually a dict), and when that fails, it falls back to use `HttpOperationError.message`. 

While the problem is the  `HttpOperationError.response.text` is not a standard structure to parse, so we have to try to parse it according to the possible response structures. It means that we may also get a response like this

```
{"error":{"code":"ValidationFailed","message":"Updating immutable properties is not allowed."}}
```
**Testing Guide**
<!--Example commands with explanations.-->
For the issue above, follow the reproducing steps there

Previously, you'll get the error message
```
BadRequestError: Operation returned an invalid status code 'Bad Request'
```

Now, you will get the error messgae
```
BadRequestError: ValidationFailed: Updating immutable properties is not allowed.
```