### PR TITLE
[Storage] Fix issue #9956: Trying to download a snapshot version of a file share fails with ResourceNotFound

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
@@ -158,7 +158,7 @@ def storage_file_download_batch(cmd, client, source, destination, pattern=None, 
 
     from azure.cli.command_modules.storage.util import glob_files_remotely, mkdir_p
 
-    source_files = glob_files_remotely(cmd, client, source, pattern)
+    source_files = glob_files_remotely(cmd, client, source, pattern, snapshot=snapshot)
 
     if dryrun:
         source_files_list = list(source_files)

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
@@ -117,7 +117,9 @@ class StorageBatchOperationScenarios(StorageScenarioMixin, LiveScenarioTest):
     @StorageTestFilesPreparer()
     def test_storage_file_batch_download_scenarios(self, test_dir, storage_account_info):
         src_share = self.create_share(storage_account_info)
-
+        # Prepare files
+        snapshot = self.storage_cmd('storage share snapshot -n {} ',
+                                    storage_account_info, src_share).get_output_in_json()["snapshot"]
         self.storage_cmd('storage file upload-batch -s "{}" -d {} --max-connections 3', storage_account_info,
                          test_dir, src_share)
 
@@ -145,6 +147,25 @@ class StorageBatchOperationScenarios(StorageScenarioMixin, LiveScenarioTest):
         self.storage_cmd('storage file download-batch -s {} -d "{}" --pattern nonexists/*', storage_account_info,
                          src_share, local_folder)
         self.assertEqual(0, sum(len(f) for r, d, f in os.walk(local_folder)))
+
+        # download with snapshot
+        local_folder = self.create_temp_dir()
+        self.storage_cmd('storage file download-batch -s {} -d "{}" --snapshot {}', storage_account_info,
+                         src_share, local_folder, snapshot)
+        self.assertEqual(0, sum(len(f) for r, d, f in os.walk(local_folder)))
+
+        snapshot = self.storage_cmd('storage share snapshot -n {} ',
+                                    storage_account_info, src_share).get_output_in_json()["snapshot"]
+        self.storage_cmd('storage file download-batch -s {} -d "{}" --snapshot {}', storage_account_info,
+                         src_share, local_folder, snapshot)
+        self.assertEqual(41, sum(len(f) for r, d, f in os.walk(local_folder)))
+
+        local_folder = self.create_temp_dir()
+        share_url = self.storage_cmd('storage file url -s {} -p \'\' -otsv', storage_account_info,
+                                     src_share).output.strip()[:-1]
+        self.storage_cmd('storage file download-batch -s {} -d "{}" --pattern apple/* --snapshot {} ',
+                         storage_account_info, share_url, local_folder, snapshot)
+        self.assertEqual(10, sum(len(f) for r, d, f in os.walk(local_folder)))
 
     @ResourceGroupPreparer()
     @StorageAccountPreparer()

--- a/src/azure-cli/azure/cli/command_modules/storage/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/util.py
@@ -87,7 +87,7 @@ def glob_files_locally(folder_path, pattern):
                 yield (full_path, full_path[len_folder_path:])
 
 
-def glob_files_remotely(cmd, client, share_name, pattern):
+def glob_files_remotely(cmd, client, share_name, pattern, snapshot=None):
     """glob the files in remote file share based on the given pattern"""
     from collections import deque
     t_dir, t_file = cmd.get_models('file.models#Directory', 'file.models#File')
@@ -95,7 +95,7 @@ def glob_files_remotely(cmd, client, share_name, pattern):
     queue = deque([""])
     while queue:
         current_dir = queue.pop()
-        for f in client.list_directories_and_files(share_name, current_dir):
+        for f in client.list_directories_and_files(share_name, current_dir, snapshot=snapshot):
             if isinstance(f, t_file):
                 if not pattern or _match_path(os.path.join(current_dir, f.name), pattern):
                     yield current_dir, f.name


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #9956

**Testing Guide**
<!--Example commands with explanations.-->
`az storage file download-batch` with `--snapshot`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
