### PR TITLE
{Synapse} fix help file

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/synapse/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/_help.py
@@ -333,7 +333,7 @@ examples:
         --resource-group rg
 """
 
-helps['sql db classification recommendation enable'] = """
+helps['synapse sql pool classification recommendation enable'] = """
 type: command
 short-summary: Enable sensitivity recommendations for a given column(recommendations are enabled by default on all columns).
 examples:
@@ -343,7 +343,7 @@ examples:
         --resource-group rg --schema dbo --table mytable --column mycolumn
 """
 
-helps['sql db classification recommendation disable'] = """
+helps['synapse sql pool classification recommendation disable'] = """
 type: command
 short-summary: Disable sensitivity recommendations for a given column(recommendations are enabled by default on all columns).
 examples:


### PR DESCRIPTION
## Description ##
In previous pr #16095 
The help for `az synapse sql pool classification recommendation` was misdirected to `az sql db classification recommendation`.
This pr is to fix the help entry name and make CI pass for `sql` module.

## Testing Guide ##
`az synapse sql pool classification recommendation enable -h`
`az synapse sql pool classification recommendation disable -h`