### PR TITLE
[ARO] Ensure worker_profile is not None before getting the subnets from

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/custom.py
@@ -292,7 +292,12 @@ def get_route_tables_from_subnets(cli_ctx, subnets):
 
 def get_cluster_network_resources(cli_ctx, oc):
     master_subnet = oc.master_profile.subnet_id
-    worker_subnets = {w.subnet_id for w in oc.worker_profiles}
+    worker_subnets = set()
+
+    # Ensure that worker_profiles exists
+    # it will not be returned if the cluster resources do not exist
+    if oc.worker_profiles is not None:
+        worker_subnets = {w.subnet_id for w in oc.worker_profiles if w}
 
     master_parts = parse_resource_id(master_subnet)
     vnet = resource_id(


### PR DESCRIPTION
**Description**<!--Mandatory-->
Upstreams [Azure/ARO-RP#1227](https://github.com/Azure/ARO-RP/pull/1227) to ensure that worker_profiles is not None before attempting to access it.  

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).