### PR TITLE
[Keyvault] Fix #16318: az keyvault certificate download crash on Python 3.9 due to removed method call

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -1569,7 +1569,7 @@ def download_certificate(client, file_path, vault_base_url=None, certificate_nam
                 f.write(cert)
             else:
                 import base64
-                encoded = base64.encodestring(cert)  # pylint:disable=deprecated-method
+                encoded = base64.encodebytes(cert)
                 if isinstance(encoded, bytes):
                     encoded = encoded.decode("utf-8")
                 encoded = '-----BEGIN CERTIFICATE-----\n' + encoded + '-----END CERTIFICATE-----\n'


### PR DESCRIPTION
**Description**

The `base64.encodestring()` method has been deprecated since Python 3.1 and removed in Python 3.9
This fixes crash for `azure keyvault certificate download`, as described in #16318 

**Testing Guide**

Please verify that `az keyvault certificate download` works as intended.

**History Notes**

[Keyvault] az keyvault certificate download: Fix deprecated/removed method call

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
