### PR TITLE
[AppService] Fix #13907: az webapp config ssl import: Change command to also import App Service Certificate

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -1320,11 +1320,11 @@ examples:
 
 helps['webapp config ssl import'] = """
 type: command
-short-summary: Import an SSL certificate to a web app from Key Vault.
+short-summary: Import an SSL or App Service Certificate to a web app from Key Vault.
 examples:
-  - name: Import an SSL certificate to a web app from Key Vault.
+  - name: Import an SSL or App Service Certificate certificate to a web app from Key Vault.
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault MyKeyVault --key-vault-certificate-name MyCertificateName
-  - name: Import an SSL certificate to a web app from Key Vault using resource id (typically if Key Vault is in another subscription).
+  - name: Import an SSL or App Service Certificate to a web app from Key Vault using resource id (typically if Key Vault is in another subscription).
     text: az webapp config ssl import --resource-group MyResourceGroup --name MyWebapp --key-vault '/subscriptions/[sub id]/resourceGroups/[rg]/providers/Microsoft.KeyVault/vaults/[vault name]' --key-vault-certificate-name MyCertificateName
 """
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2431,6 +2431,20 @@ def import_ssl_cert(cmd, resource_group_name, name, key_vault, key_vault_certifi
     kv_name = kv_id_parts['name']
     kv_resource_group_name = kv_id_parts['resource_group']
     kv_subscription = kv_id_parts['subscription']
+
+    if kv_subscription.lower() != client.config.subscription_id.lower():
+        diff_subscription_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_APPSERVICE,
+                                                           subscription_id=kv_subscription)
+        ascs = diff_subscription_client.app_service_certificate_orders.list()
+    else:
+        ascs = client.app_service_certificate_orders.list()
+
+    for asc in ascs:
+        if asc.name == key_vault_certificate_name:
+            kv_secret_name = asc.certificates[key_vault_certificate_name].key_vault_secret_name
+    if not kv_secret_name:
+        kv_secret_name = key_vault_certificate_name
+
     cert_name = '{}-{}-{}'.format(resource_group_name, kv_name, key_vault_certificate_name)
     lnk = 'https://azure.github.io/AppService/2016/05/24/Deploying-Azure-Web-App-Certificate-through-Key-Vault.html'
     lnk_msg = 'Find more details here: {}'.format(lnk)
@@ -2440,7 +2454,7 @@ def import_ssl_cert(cmd, resource_group_name, name, key_vault, key_vault_certifi
         logger.warning(lnk_msg)
 
     kv_cert_def = Certificate(location=location, key_vault_id=kv_id, password='',
-                              key_vault_secret_name=key_vault_certificate_name, server_farm_id=server_farm_id)
+                              key_vault_secret_name=kv_secret_name, server_farm_id=server_farm_id)
 
     return client.certificates.create_or_update(name=cert_name, resource_group_name=resource_group_name,
                                                 certificate_envelope=kv_cert_def)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2439,6 +2439,7 @@ def import_ssl_cert(cmd, resource_group_name, name, key_vault, key_vault_certifi
     else:
         ascs = client.app_service_certificate_orders.list()
 
+    kv_secret_name = None
     for asc in ascs:
         if asc.name == key_vault_certificate_name:
             kv_secret_name = asc.certificates[key_vault_certificate_name].key_vault_secret_name

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import.yaml
@@ -13,24 +13,24 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2020-10-29T03:17:42Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2021-01-04T21:53:15Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '474'
+      - '431'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:17:47 GMT
+      - Mon, 04 Jan 2021 21:53:18 GMT
       expires:
       - '-1'
       pragma:
@@ -63,8 +63,8 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: POST
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:17:47 GMT
+      - Mon, 04 Jan 2021 21:53:19 GMT
       expires:
       - '-1'
       pragma:
@@ -118,24 +118,24 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2020-10-29T03:17:42Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2021-01-04T21:53:15Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '474'
+      - '431'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:17:48 GMT
+      - Mon, 04 Jan 2021 21:53:19 GMT
       expires:
       - '-1'
       pragma:
@@ -168,8 +168,8 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: PUT
@@ -177,17 +177,17 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"Japan
-        West","properties":{"serverFarmId":15244,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-JapanWestwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
-        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_15244","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        West","properties":{"serverFarmId":18607,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-JapanWestwebspace","subscription":"cd8e0c02-3a22-4a19-8a6a-46e9e4e5cb86","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
+        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_18607","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"azBalancing":false},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1533'
+      - '1553'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:18:00 GMT
+      - Mon, 04 Jan 2021 21:53:33 GMT
       expires:
       - '-1'
       pragma:
@@ -225,8 +225,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -234,17 +234,17 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"Japan
-        West","properties":{"serverFarmId":15244,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-JapanWestwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
-        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_15244","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        West","properties":{"serverFarmId":18607,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-JapanWestwebspace","subscription":"cd8e0c02-3a22-4a19-8a6a-46e9e4e5cb86","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
+        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_18607","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"azBalancing":false},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1533'
+      - '1553'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:18:01 GMT
+      - Mon, 04 Jan 2021 21:53:34 GMT
       expires:
       - '-1'
       pragma:
@@ -285,8 +285,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: POST
@@ -302,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:18:03 GMT
+      - Mon, 04 Jan 2021 21:53:35 GMT
       expires:
       - '-1'
       pragma:
@@ -340,8 +340,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -349,17 +349,17 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","name":"ssl-test-plan000002","type":"Microsoft.Web/serverfarms","kind":"app","location":"Japan
-        West","properties":{"serverFarmId":15244,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-JapanWestwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
-        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_15244","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        West","properties":{"serverFarmId":18607,"name":"ssl-test-plan000002","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000001-JapanWestwebspace","subscription":"cd8e0c02-3a22-4a19-8a6a-46e9e4e5cb86","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
+        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000001","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_18607","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"azBalancing":false},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1533'
+      - '1553'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:18:03 GMT
+      - Mon, 04 Jan 2021 21:53:36 GMT
       expires:
       - '-1'
       pragma:
@@ -399,8 +399,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: POST
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:18:05 GMT
+      - Mon, 04 Jan 2021 21:53:36 GMT
       expires:
       - '-1'
       pragma:
@@ -460,8 +460,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: PUT
@@ -469,20 +469,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:18:09.6533333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
+        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T21:53:45.4866667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
         all","description":"Allow all access"}],"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
-        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5838'
+      - '5867'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:18:28 GMT
+      - Mon, 04 Jan 2021 21:54:04 GMT
       etag:
-      - '"1D6ADA220F4DB35"'
+      - '"1D6E2E4139C3475"'
       expires:
       - '-1'
       pragma:
@@ -524,8 +524,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: POST
@@ -534,17 +534,22 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000003 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="pTKyCaj8uvBlXBEuaqvEHEC9SYojBGyN31xh88WkFivu4W5LLoQ9B1tNpX3z"
+        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="sfHtPZzA0fvlKQ8gkujXFzl4p3dTkZFy6qfJLRAPiAQJq1MscaS0XvMzBzaw"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
         - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="pTKyCaj8uvBlXBEuaqvEHEC9SYojBGyN31xh88WkFivu4W5LLoQ9B1tNpX3z"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="sfHtPZzA0fvlKQ8gkujXFzl4p3dTkZFy6qfJLRAPiAQJq1MscaS0XvMzBzaw"
+        destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
+        - Zip Deploy" publishMethod="ZipDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
+        userName="$web-ssl-test000003" userPWD="sfHtPZzA0fvlKQ8gkujXFzl4p3dTkZFy6qfJLRAPiAQJq1MscaS0XvMzBzaw"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
         - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-os1-013dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="pTKyCaj8uvBlXBEuaqvEHEC9SYojBGyN31xh88WkFivu4W5LLoQ9B1tNpX3z"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="sfHtPZzA0fvlKQ8gkujXFzl4p3dTkZFy6qfJLRAPiAQJq1MscaS0XvMzBzaw"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -552,11 +557,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1678'
+      - '2179'
       content-type:
       - application/xml
       date:
-      - Thu, 29 Oct 2020 03:18:30 GMT
+      - Mon, 04 Jan 2021 21:54:05 GMT
       expires:
       - '-1'
       pragma:
@@ -590,24 +595,24 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2020-10-29T03:17:42Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2021-01-04T21:53:15Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '474'
+      - '431'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:18:30 GMT
+      - Mon, 04 Jan 2021 21:54:06 GMT
       expires:
       - '-1'
       pragma:
@@ -631,7 +636,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-graphrbac/0.60.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -639,33 +644,43 @@ interactions:
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2019-10-21T06:37:42Z","creationType":"Invitation","department":null,"dirSyncEnabled":null,"displayName":"Bin
-        Ma","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":"bim@microsoft.com","mailNickname":"bim_microsoft.com#EXT#","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["bim@microsoft.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":["SMTP:bim@microsoft.com"],"refreshTokensValidFromDateTime":"2019-10-21T06:37:41Z","showInAddressList":false,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"bim_microsoft.com#EXT#@AzureSDKTeam.onmicrosoft.com","userState":"Accepted","userStateChangedOn":"2019-10-21T06:39:35Z","userType":"Guest"}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":["a413a9ff-720c-4822-98ef-2f37c2a21f4c","a6520331-d7d4-4276-95f5-15c0933bc757","ded3d325-1bdc-453e-8432-5bac26d7a014","afa73018-811e-46e9-988f-f75d2b1b8430","b21a6b06-1988-436e-a07b-51ec6d9f52ad","531ee2f8-b1cb-453b-9c21-d2180d014ca5","bf28f719-7844-4079-9c78-c1307898e192","28b0fa46-c39a-4188-89e2-58e979a6b014","199a5c09-e0ca-4e37-8f7c-b05d533e1ea2","65cc641f-cccd-4643-97e0-a17e3045e541","e26c2fcc-ab91-4a61-b35c-03cdc8dddf66","46129a58-a698-46f0-aa5b-17f6586297d9","6db1f1db-2b46-403f-be40-e39395f08dbb","6dc145d6-95dd-4191-b9c3-185575ee6f6b","41fcdd7d-4733-4863-9cf4-c65b83ce2df4","c4801e8a-cb58-4c35-aca6-f2dcc106f287","0898bdbb-73b0-471a-81e5-20f1fe4dd66e","617b097b-4b93-4ede-83de-5f075bb5fb2f","33c4f319-9bdd-48d6-9c4d-410b750a4a5a","8e0c0a52-6a6c-4d40-8370-dd62790dcd70","4828c8ec-dc2e-4779-b502-87ac9ce28ab7","3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"],"skuId":"c7df2760-2c81-4ef7-b578-5b5392b571df"},{"disabledPlans":[],"skuId":"3d957427-ecdc-4df2-aacd-01cc9d519da8"},{"disabledPlans":[],"skuId":"85aae730-b3d1-4f99-bb28-c9f81b05137c"},{"disabledPlans":[],"skuId":"9f3d9c1d-25a5-4aaa-8e59-23a1e6450a67"},{"disabledPlans":["39b5c996-467e-4e60-bd62-46066f572726"],"skuId":"90d8b3f8-712e-4f7b-aa1e-62e7ae6cbe96"},{"disabledPlans":["e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72"],"skuId":"09015f9f-377f-4538-bbb5-f75ceb09358a"},{"disabledPlans":[],"skuId":"c5928f49-12ba-48f7-ada3-0d743a3601d5"},{"disabledPlans":[],"skuId":"26a18e8f-4d14-46f8-835a-ed3ba424a961"},{"disabledPlans":[],"skuId":"412ce1a7-a499-41b3-8eb6-b38f2bbc5c3f"},{"disabledPlans":[],"skuId":"b05e124f-c7cc-45a0-a6aa-8cf78c946968"},{"disabledPlans":[],"skuId":"488ba24a-39a9-4473-8ee5-19291e71b002"},{"disabledPlans":["0b03f40b-c404-40c3-8651-2aceb74365fa","b650d915-9886-424b-a08d-633cede56f57","e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72","fe71d6c3-a2ea-4499-9778-da042bf08063","fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"],"skuId":"ea126fc5-a19e-42e2-a731-da9d437bffcf"}],"assignedPlans":[{"assignedTimestamp":"2020-12-23T16:01:41Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2020-12-23T16:01:41Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"199a5c09-e0ca-4e37-8f7c-b05d533e1ea2"},{"assignedTimestamp":"2020-12-23T16:01:41Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2020-12-23T16:01:41Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2020-12-23T16:01:41Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"},{"assignedTimestamp":"2020-12-23T10:56:14Z","capabilityStatus":"Enabled","service":"MIPExchangeSolutions","servicePlanId":"cd31b152-6326-4d1b-ae1b-997b625182e6"},{"assignedTimestamp":"2020-12-23T10:56:14Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"2f442157-a11c-46b9-ae5b-6e39ff4e5849"},{"assignedTimestamp":"2020-12-12T03:35:05Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"18fa3aba-b085-4105-87d7-55617b8585e6"},{"assignedTimestamp":"2020-12-12T03:35:05Z","capabilityStatus":"Enabled","service":"ERP","servicePlanId":"69f07c66-bee4-4222-b051-195095efee5b"},{"assignedTimestamp":"2020-12-12T03:35:05Z","capabilityStatus":"Enabled","service":"ProjectProgramsAndPortfolios","servicePlanId":"0a05d977-a21a-45b2-91ce-61c240dbafa2"},{"assignedTimestamp":"2020-11-03T21:28:57Z","capabilityStatus":"Deleted","service":"M365CommunicationCompliance","servicePlanId":"a413a9ff-720c-4822-98ef-2f37c2a21f4c"},{"assignedTimestamp":"2020-10-30T07:25:47Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"7e6d7d78-73de-46ba-83b1-6d25117334ba"},{"assignedTimestamp":"2020-10-17T06:20:29Z","capabilityStatus":"Enabled","service":"WorkplaceAnalytics","servicePlanId":"f477b0f0-3bb1-4890-940c-40fcee6ce05f"},{"assignedTimestamp":"2020-08-14T19:26:04Z","capabilityStatus":"Enabled","service":"YammerEnterprise","servicePlanId":"7547a3fe-08ee-4ccb-b430-5077c5041653"},{"assignedTimestamp":"2020-08-04T05:39:55Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"b622badb-1b45-48d5-920f-4b27a2c0996c"},{"assignedTimestamp":"2020-08-04T05:39:55Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"f3d5636e-ddc2-41bf-bba6-ca6fadece269"},{"assignedTimestamp":"2020-06-18T10:39:50Z","capabilityStatus":"Enabled","service":"MicrosoftPrint","servicePlanId":"795f6fe0-cc4d-4773-b050-5dde4dc704c9"},{"assignedTimestamp":"2019-11-04T22:49:18Z","capabilityStatus":"Enabled","service":"WhiteboardServices","servicePlanId":"4a51bca5-1eff-43f5-878c-177680f191af"},{"assignedTimestamp":"2019-10-14T23:17:04Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"5136a095-5cf0-4aff-bec3-e84448b38ea5"},{"assignedTimestamp":"2019-10-14T23:17:04Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb0351d-3b08-4503-993d-383af8de41e3"},{"assignedTimestamp":"2019-08-09T01:37:07Z","capabilityStatus":"Enabled","service":"MicrosoftFormsProTest","servicePlanId":"97f29a83-1a20-44ff-bf48-5e4ad11f3e51"},{"assignedTimestamp":"2019-05-24T17:22:49Z","capabilityStatus":"Enabled","service":"DYN365AISERVICEINSIGHTS","servicePlanId":"1412cdc1-d593-4ad1-9050-40c30ad0b023"},{"assignedTimestamp":"2019-04-07T07:24:32Z","capabilityStatus":"Enabled","service":"ProjectProgramsAndPortfolios","servicePlanId":"818523f5-016b-4355-9be8-ed6944946ea7"},{"assignedTimestamp":"2019-04-07T07:24:32Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"fa200448-008c-4acb-abd4-ea106ed2199d"},{"assignedTimestamp":"2019-04-07T07:24:32Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"50554c47-71d9-49fd-bc54-42a2765c555c"},{"assignedTimestamp":"2018-12-04T10:31:59Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"b1188c4c-1b36-4018-b48b-ee07604f6feb"},{"assignedTimestamp":"2018-09-06T19:21:02Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"e212cbc7-0961-4c40-9825-01117710dcb1"},{"assignedTimestamp":"2018-09-06T19:21:02Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2018-09-06T19:21:02Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"663a804f-1c30-4ff0-9915-9db84f0d1cea"},{"assignedTimestamp":"2018-09-06T19:21:02Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2018-08-22T20:29:37Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"018fb91e-cee3-418c-9063-d7562978bdaf"},{"assignedTimestamp":"2018-08-22T20:29:36Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"ca4be917-fbce-4b52-839e-6647467a1668"},{"assignedTimestamp":"2018-08-16T20:56:40Z","capabilityStatus":"Enabled","service":"Deskless","servicePlanId":"8c7d2df8-86f0-4902-b2ed-a0458298f3b3"},{"assignedTimestamp":"2018-08-16T20:56:40Z","capabilityStatus":"Enabled","service":"To-Do","servicePlanId":"3fb82609-8c27-4f7b-bd51-30634711ee67"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"9f431833-0334-42de-a7dc-70aa40db46db"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"0feaeb32-d00e-4d66-bd5a-43b5b83db82c"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"07699545-9485-468e-95b6-2fca3738be01"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"8c098270-9dd4-4350-9b30-ba4703f3b36b"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"MicrosoftStream","servicePlanId":"6c6042f5-6f01-4d67-b8c1-eb99d36eed3e"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"Sway","servicePlanId":"a23b959c-7ce8-4e57-9140-b90eb88a9e97"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"PowerBI","servicePlanId":"70d33638-9c74-4d01-bfd3-562de28bd4ba"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"ProjectWorkManagement","servicePlanId":"b737dad2-2f6c-4c65-90e3-ca563267e8b9"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb87545-963c-4e0d-99df-69c6916d9eb0"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"4de31727-a228-4ec3-a5bf-8e45b5ca48cc"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"TeamspaceAPI","servicePlanId":"57ff2da0-773e-42df-b2af-ffb7a2317929"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"9c0dab89-a30c-4117-86e7-97bda240acd2"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"34c0d7a0-a70f-4668-9238-47f9fc208882"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"43de0ff5-c92c-492b-9116-175376d08c38"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"41781fb2-bc02-4b7c-bd55-b576c07bb09d"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"bea4c11e-220a-4e6d-8eb8-8ea15d019f90"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"eec0eb4f-6444-4f95-aba0-50c24d67f998"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"SCO","servicePlanId":"c1ec4a95-1f05-45b3-a911-aa3fa01094f5"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"AzureAdvancedThreatAnalytics","servicePlanId":"14ab5db5-e6c4-4b20-b4bc-13e36fd2227f"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"6c57d4b6-3b23-47a5-9bc9-69f17b4947b3"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"MultiFactorService","servicePlanId":"8a256a2b-b617-496d-b51b-e76466e88db0"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"5689bec4-755d-4753-8b61-40975025187c"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"2e2ddb96-6af9-4b1d-a3f0-d6ecfd22edb2"},{"assignedTimestamp":"2018-08-14T22:39:05Z","capabilityStatus":"Enabled","service":"WindowsDefenderATP","servicePlanId":"871d91ec-ec1a-452b-a83f-bd76c7d770ef"},{"assignedTimestamp":"2018-08-14T22:39:05Z","capabilityStatus":"Enabled","service":"Windows","servicePlanId":"e7c91390-7625-45be-94e0-e16907e03118"},{"assignedTimestamp":"2018-08-14T22:39:03Z","capabilityStatus":"Enabled","service":"Netbreeze","servicePlanId":"03acaee3-9492-4f40-aed4-bcb6b32981b6"},{"assignedTimestamp":"2018-08-14T22:39:03Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"d56f3deb-50d8-465a-bedb-f079817ccac1"}],"city":"REDMOND","companyName":"MICROSOFT","consentProvidedForMinor":null,"country":null,"createdDateTime":"2018-08-14T22:20:31Z","creationType":null,"department":"App
+        Svcs_balam_OPEX 1010","dirSyncEnabled":true,"displayName":"Sofi Inglessis","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Sofi","immutableId":"1308897","isCompromised":null,"jobTitle":"SOFTWARE
+        ENGINEER","lastDirSyncTime":"2020-11-20T14:54:07Z","legalAgeGroupClassification":null,"mail":"Sofi.Inglessis@microsoft.com","mailNickname":"soingles","mobile":null,"onPremisesDistinguishedName":"CN=Sofi
+        Inglessis,OU=MSE,OU=Users,OU=CoreIdentity,DC=redmond,DC=corp,DC=microsoft,DC=com","onPremisesSecurityIdentifier":"S-1-5-21-2127521184-1604012920-1887927527-32814598","otherMails":[],"passwordPolicies":"DisablePasswordExpiration","passwordProfile":null,"physicalDeliveryOfficeName":"41/5A00","postalCode":null,"preferredLanguage":null,"provisionedPlans":[{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Netbreeze"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"}],"provisioningErrors":[],"proxyAddresses":["x500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=22590aa7de894926877b700eb193308d-Sofi
+        Ingles","X500:/o=microsoft/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=97f7bbfa849144d39b7423844fb56916-Sofi
+        Inglessis","X500:/o=MMS/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=aac473785c84411b85dc865c26812a73-Sofi
+        Inglessiee23cc5","X500:/o=microsoft/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=07e2db4d78de458a852334ad47ef3693-Sofi
+        Inglessis","smtp:soingles@microsoft.onmicrosoft.com","smtp:soingles@service.microsoft.com","smtp:soingles@microsoft.com","SMTP:Sofi.Inglessis@microsoft.com"],"refreshTokensValidFromDateTime":"2020-01-08T01:04:32Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":"soingles@microsoft.com","state":null,"streetAddress":null,"surname":"Inglessis","telephoneNumber":"+1
+        (425) 7041861","thumbnailPhoto@odata.mediaEditLink":"directoryObjects/99d1d831-0cdf-4a81-8a09-d1d75851b8d3/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":"US","userIdentities":[],"userPrincipalName":"soingles@microsoft.com","userState":null,"userStateChangedOn":null,"userType":"Member","extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10231243","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10231243","extension_18e31482d3fb4a8ea958aa96b662f508_SupervisorInd":"N","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToPersonnelNbr":"340857","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToFullName":"Panchagnula,
+        Sisira P","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToEmailName":"SISIRAP","extension_18e31482d3fb4a8ea958aa96b662f508_ZipCode":"98052","extension_18e31482d3fb4a8ea958aa96b662f508_StateProvinceCode":"WA","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"91419945","extension_18e31482d3fb4a8ea958aa96b662f508_LocationAreaCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_CountryShortCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1010","extension_18e31482d3fb4a8ea958aa96b662f508_CityName":"REDMOND","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"41","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"309","extension_18e31482d3fb4a8ea958aa96b662f508_AddressLine1":"1
+        Microsoft Way","extension_18e31482d3fb4a8ea958aa96b662f508_PersonnelNumber":"1308897"}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '1668'
+      - '17153'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 29 Oct 2020 03:18:31 GMT
+      - Mon, 04 Jan 2021 21:54:06 GMT
       duration:
-      - '2332111'
+      - '1037732'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - mJ6QF4GrKJGA7YcWacYUZXMYHkvaYiDvizVEZmVXKQM=
+      - FzJ2jBYKwtzeOMbecJZjYrXfMEvzWm/nSCSV6KL+WXQ=
       ocp-aad-session-key:
-      - fyyxQy6CM3DRphOO9iBw5zRq-TS36gs51K6tu_7HlNxGwvmjFLbDCWTkBpUmPyBcfBO9dOY_kC9wcf15z3iI9lDzmBaYsjJF-GDn-e_7ZaVXAU7NL9LvBiTo9udTQDN_.I7TiTxYxobwn6spuQWoGOL0DVJ2THTjHa7mD6gZEC_k
+      - UrqMgWRpFL4Eo6cP0v9YnP0R5KEy946-oGfvQogHz317QZzGO929gQk86RFHrvslQLcTONiVX7sQoMEXN9yWgxvpZMEvXYKtz3Y-c3wmTBsFId8TAZhHvlRJghzYYvlW.6cHUM_UG06xlxvjyujd9QYyyUpgsH3ZNcPCMeBYt-Bk
       pragma:
       - no-cache
       request-id:
-      - 790fe808-8d63-4613-ac97-92b0f90461ac
+      - 27041d90-619c-4809-9139-3d2af2570de8
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -680,9 +695,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": "japanwest", "properties": {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+    body: '{"location": "japanwest", "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
       "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa",
+      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "99d1d831-0cdf-4a81-8a09-d1d75851b8d3",
       "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
       "backup", "restore", "recover"], "secrets": ["get", "list", "set", "delete",
       "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
@@ -707,12 +722,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net","provisioningState":"RegisteringDns"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net","provisioningState":"RegisteringDns"}}'
     headers:
       cache-control:
       - no-cache
@@ -721,7 +736,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:18:38 GMT
+      - Mon, 04 Jan 2021 21:54:16 GMT
       expires:
       - '-1'
       pragma:
@@ -739,9 +754,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.112.0
+      - 1.1.163.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -761,12 +776,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -775,7 +790,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:19:08 GMT
+      - Mon, 04 Jan 2021 21:54:46 GMT
       expires:
       - '-1'
       pragma:
@@ -793,7 +808,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.112.0
+      - 1.1.163.0
       x-powered-by:
       - ASP.NET
     status:
@@ -809,7 +824,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-graphrbac/0.60.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -817,38 +832,37 @@ interactions:
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27Microsoft.Azure.WebSites%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"559f925e-c126-4b02-a759-f0b2f5d999fe","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
-        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":"f8cdef31-a31e-4b4a-93e4-5f571e91255a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft
-        Azure App Service","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
+        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft.Azure.WebSites","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access all the APIs registered with App Service","adminConsentDisplayName":"Access
         APIs registered with App Service","id":"e0ea806b-d128-49dc-ac08-2bf18f7874d8","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access all the APIs registered with App Service","userConsentDisplayName":"Access
-        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":["https://trywebsites.azurewebsites.net/","https://trywebsitesstaging.azurewebsites.net/","https://resources-staging.azure.com","https://resources.azure.com","https://deploy.azure.com","https://deploy-staging.azure.com","https://tryappservice.azure.com","https://tryappservice-staging.azure.com","https://functions.azure.com","https://functions-staging.azure.com","https://functions-next.azure.com","https://scratch.botframework.com/","https://ppe.botframework.com/","https://functions-release.azure.com","https://dev.botframework.com/"],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["abfa0a7c-a6b6-4736-8310-5855508787cd","Microsoft.Azure.WebSites","https://appservice.azure.com"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
+        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["Microsoft.Azure.WebSites","abfa0a7c-a6b6-4736-8310-5855508787cd"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2280'
+      - '1677'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 29 Oct 2020 03:19:10 GMT
+      - Mon, 04 Jan 2021 21:54:47 GMT
       duration:
-      - '2263398'
+      - '571745'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - UCqg51CRwbFSVSpQdd+0eu2pZyuBt7dvQmjs73sOGao=
+      - 5tXUu3y+ErO1/XND1tRuShyWMEydPW/DHrlAYL3nHdc=
       ocp-aad-session-key:
-      - Yj7XMfaC7Ecc-c7qxtEFj0_12m_MzwS3RS_zNFzy4Tu35xy0dqzhTHgx0XS8OO6F1tZTH54dwyimw-3WfXG9xun1vOHd7LpZ4xJdACBgoKF_OfCCZpSJ1jJmHXEaRFpT.qTos_MNUXRGXMEb6WGO8Rn9paov8RHVGm5vaf66pxzI
+      - P9A0LYjs2j8XXdJnnoLsbWJyvQzcpzF65ZtMI5DnIYDF1VZ7h-ffcTnQVDkIcuLk0sr3NFusZYi_mLHWPXE-jsMX9OibCQSO_wVPBDNuAF5VNDgebC9r8tpPi7TatT7-.G5hc_YasTlXFB0eWBYGHcKVlIHEem690XPmy79fVLG0
       pragma:
       - no-cache
       request-id:
-      - 00a724db-7464-4fc9-8cc3-c4a65b4fe3ac
+      - 0310abf7-b33b-4d07-9a14-173184f8bc93
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -876,12 +890,12 @@ interactions:
       ParameterSetName:
       - -g --name --spn --secret-permissions
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -890,7 +904,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:19:11 GMT
+      - Mon, 04 Jan 2021 21:54:47 GMT
       expires:
       - '-1'
       pragma:
@@ -908,23 +922,23 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.112.0
+      - 1.1.163.0
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"location": "japanwest", "tags": {}, "properties": {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+    body: '{"location": "japanwest", "tags": {}, "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
       "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa",
+      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "99d1d831-0cdf-4a81-8a09-d1d75851b8d3",
       "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
       "backup", "restore", "recover"], "secrets": ["get", "list", "set", "delete",
       "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
       "import", "update", "managecontacts", "getissuers", "listissuers", "setissuers",
       "deleteissuers", "manageissuers", "recover"], "storage": ["get", "list", "delete",
       "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}},
-      {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "559f925e-c126-4b02-a759-f0b2f5d999fe",
+      {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "f8daea97-62e7-4026-becf-13c2ea98e8b4",
       "permissions": {"secrets": ["get"]}}], "vaultUri": "https://kv-ssl-test000004.vault.azure.net/",
       "enabledForDeployment": false, "enableSoftDelete": true, "softDeleteRetentionInDays":
       90}}'
@@ -944,12 +958,12 @@ interactions:
       ParameterSetName:
       - -g --name --spn --secret-permissions
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"559f925e-c126-4b02-a759-f0b2f5d999fe","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -958,7 +972,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:19:12 GMT
+      - Mon, 04 Jan 2021 21:54:48 GMT
       expires:
       - '-1'
       pragma:
@@ -976,9 +990,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.112.0
+      - 1.1.163.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -998,7 +1012,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-keyvault/7.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -1016,7 +1030,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:19:13 GMT
+      - Mon, 04 Jan 2021 21:54:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1024,16 +1038,16 @@ interactions:
       strict-transport-security:
       - max-age=31536000;includeSubDomains
       www-authenticate:
-      - Bearer authorization="https://login.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
         resource="https://vault.azure.net"
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=167.220.255.120;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.2.58;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - japanwest
       x-ms-keyvault-service-version:
-      - 1.2.58.0
+      - 1.2.99.0
       x-powered-by:
       - ASP.NET
     status:
@@ -1055,7 +1069,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-keyvault/7.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -1063,7 +1077,7 @@ interactions:
     uri: https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/import?api-version=7.0
   response:
     body:
-      string: '{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/37490ee900f641c986e2acd4b822c44b","kid":"https://kv-ssl-test000004.vault.azure.net/keys/test-cert/37490ee900f641c986e2acd4b822c44b","sid":"https://kv-ssl-test000004.vault.azure.net/secrets/test-cert/37490ee900f641c986e2acd4b822c44b","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1603941556,"updated":1603941556,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1603941556,"updated":1603941556}}}'
+      string: '{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/d7a1b1426a4344feab6c03593922bb89","kid":"https://kv-ssl-test000004.vault.azure.net/keys/test-cert/d7a1b1426a4344feab6c03593922bb89","sid":"https://kv-ssl-test000004.vault.azure.net/secrets/test-cert/d7a1b1426a4344feab6c03593922bb89","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1609797290,"updated":1609797290,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000004.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1609797290,"updated":1609797290}}}'
     headers:
       cache-control:
       - no-cache
@@ -1072,7 +1086,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:19:16 GMT
+      - Mon, 04 Jan 2021 21:54:51 GMT
       expires:
       - '-1'
       pragma:
@@ -1082,11 +1096,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=167.220.255.120;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.2.58;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - japanwest
       x-ms-keyvault-service-version:
-      - 1.2.58.0
+      - 1.2.99.0
       x-powered-by:
       - ASP.NET
     status:
@@ -1106,8 +1120,8 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -1115,18 +1129,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:18:10.3233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T21:53:46.3433333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5638'
+      - '5667'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:17 GMT
+      - Mon, 04 Jan 2021 21:54:52 GMT
       etag:
-      - '"1D6ADA220F4DB35"'
+      - '"1D6E2E4139C3475"'
       expires:
       - '-1'
       pragma:
@@ -1162,21 +1176,21 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azps-test-group/providers/Microsoft.KeyVault/vaults/azps-test-kv2","name":"azps-test-kv2","type":"Microsoft.KeyVault/vaults","location":"eastus","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"6f4d4442-0894-47fe-a5e6-b84bfb47b944","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"63c25c04-362b-42d9-9e3f-83af045d0a3c","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"2927ba5f-2732-4a5e-bdb8-f5fc20b476c9","permissions":{"keys":["Get","List","UnwrapKey","WrapKey"],"secrets":[],"certificates":[]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"d1178d20-4ca4-45f0-ba9a-5a08f588da8d","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://azps-test-kv2.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yeming/providers/Microsoft.KeyVault/vaults/yeming","name":"yeming","type":"Microsoft.KeyVault/vaults","location":"eastasia","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"6cc662e7-785f-4759-ae7d-faf16eae02ab","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"8d594fee-5764-49c9-ad85-35d3ee728386","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":[]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableRbacAuthorization":false,"vaultUri":"https://yeming.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bim-rg/providers/Microsoft.KeyVault/vaults/bimkv2","name":"bimkv2","type":"Microsoft.KeyVault/vaults","location":"eastus2","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["restore","recover","delete","list","get","purge"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://bimkv2.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azps-test-group/providers/Microsoft.KeyVault/vaults/azps-test-kv4","name":"azps-test-kv4","type":"Microsoft.KeyVault/vaults","location":"southcentralus","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"d1178d20-4ca4-45f0-ba9a-5a08f588da8d","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://azps-test-kv4.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bim-rg/providers/Microsoft.KeyVault/vaults/bim-kv5","name":"bim-kv5","type":"Microsoft.KeyVault/vaults","location":"eastus2euap","tags":{"k1":"v1"},"properties":{"sku":{"family":"A","name":"premium"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","UnwrapKey","WrapKey","Purge","Encrypt","Decrypt"],"secrets":["Get","Set","Delete","Recover","Backup","Restore","Purge","List"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers","Purge"]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efb","permissions":{"keys":["get","wrapKey"]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"d58f9633-86c6-49a6-85eb-14d579744a4d","permissions":{"keys":[],"secrets":["Get","List"],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":60,"enableRbacAuthorization":false,"enablePurgeProtection":true,"vaultUri":"https://bim-kv5.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZZtb6M4FIX%2fS7TaT5MGQ%2bgolapVMgEnZEwaMHbwN%2fPSEt4bSAKM5r%2fPpVOtVju%2fIBJCsmRzdZ97zjE%2fJmXctd9PZdZMnn5MjKVLPXfyNEnatm6eZrNClvItLuKyfZDD5Rw%2fhFUxay5BE55PdXuqymamBOj1cf4VTVHwqkznUSSnMg61aRgs1K%2fqq7LQF8qsPlfXUxSfmxk5heeqqV7bh13cM3nJ29l1fDf%2fyPo0vcIW%2bOqzqqDFVIEH%2ff1Xk0GpKovLZzc%2bX09hvJJNHH2hxeIi3E7wzbLzVcQiTHqndFJHSxpqRm7I8qPN9RPJhOYrpJOo9jm1bGaYOvUcM%2fZ041C0ghnZDdYi9hbeIU2kg%2fyeFrUZKej9cExsmZsaz6Lf%2b%2bG8LFpt8uUD1dLdLu8KVs6QUHwWoqAQ2wB3J6Z2iJfh4uXw%2fPzZlOeqd9WTIGVyE0bE48JZ28dcxlmt8Tz5FrJqcKiVMs155NTGBNvvbhklAX%2fr%2fczhsmCtW7J9kGeDWFs7GxtDsDYlM61asOgWqIfe5ouUG%2fq7n4d6pJpHsV6lwXHZifUWRXntB3ixd3HXiiyREjvHeL0iTHWugiUyLuzWSc2UKHXlK8mZ%2fGbs7j26%2bWbY1Fl%2bvzev%2fYE6rzWa2o3N7U2wEZINORIcAQqj90qWOUalcJbgALPtITUzph5U8BKgNh%2fddCXj3NQF13GooBbQJtzwEaDHQV5fxAbOazBajOYxN4%2bRVu8BfS%2byaB%2bqpu8VXUqQVflqLaH%2bMcY6jOLQi7XNiKJvPLqSHlUWIGtu3F%2bs%2fYE6q880g5BT0MUtncTFTgWqbka0XgEqNetWmCGgsmAUuQx4OIDqXAkoA63OHbNueKFzOaIv84TkooVR7aKCDE5pJQ7yIEsBZcEuAid7Zujq%2f1D3lG67uABXbOpsHBFPrT24YHsoRfKJ2lq%2bLO2R951nSG41tEA7ibdDgNs9U5NOeNE8LkzfKVd7kukdTa0dCPPCjkBXW%2fWwHulvQ9zaQblSKLVYzElPS5aAkOcC1zxktR9uWB7kVe8XShdmSu9Sew%2fTG4C2QrLOp2V9OgzGDTJsT8x8rJeRAuqzUCHL%2f%2ba04S1f7otzwDuFmsluvH8%2bDdz71FLCt4%2b%2b%2fo3F%2b%2bts9Ctf226AyeAVAvwFUYYRJqAIWKfgr8Efowv8yUp2IkholNpXuCU2XmqDX%2b1Hn%2bs24azdr81TwMBfoADJsoEXi4SoSe1ncItAxNng03j8Pke3EFtHwvWEGdWooDEaKYHo48b8Br9BH4o6FB1h2rKHqNwF2Ny4oDAxQDT%2b%2fPkL"}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg_soingles/providers/Microsoft.KeyVault/vaults/testCertRotationKV","name":"testCertRotationKV","type":"Microsoft.KeyVault/vaults","location":"northcentralus","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"ed47c2a1-bd23-4341-b39c-f4fd69138dd3","permissions":{"secrets":["get","set","delete"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"vaultUri":"https://testcertrotationkv.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testKV/providers/Microsoft.KeyVault/vaults/testKVSofi","name":"testKVSofi","type":"Microsoft.KeyVault/vaults","location":"eastus","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://testkvsofi.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/keyvault_sofitest/providers/Microsoft.KeyVault/vaults/keyvaultSofiTest","name":"keyvaultSofiTest","type":"Microsoft.KeyVault/vaults","location":"westus","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["Get"],"keys":[],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableRbacAuthorization":false,"vaultUri":"https://keyvaultsofitest.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZLbbqMwEIbfBa32qgmHhCiJFK2SloXQmjQc7OA7A941wRgWTJJS9d3XrfZmHyHSaKTRP5rRN%2fO%2fa4Le5Espql5bv2vBIYy9RyeIw%2b1LEmlrjUnZ9mtdr4kgv2lNhZyScejoNG9qvR%2byPu%2fKVpaN6PW8WFIjN6zJjFjWZE7M1WRJFmQyX9AVnVM7z5YLve2aS1nQrtdBmXdN3%2fyS02f6BsnApX75zP0P0paTi2pRUzeWocYYKszv3%2fpKrWoqKjYR7S5lTnekp8VDXK8GHN3OGQrrdNzbuetL7AUEOfM5dgpE6%2fBnXCud%2b3F6DiLihl7m4ZLMwpP2oDnbKL4z1Co08QI70IAW3icKDZg%2bgPXtUPBWktHYKCzk3B0WAzw1sWu6APkKC5%2fBmcsUsihzwZic2f86D0vA2yusvj68e42%2fsP3t6zb4ZL8r72Ig2PWfV5%2bCEyeA%2b6Oqn3Pl1cJjFfJ2BuJFRGAzwrotqSJHkDW5Y%2b9RbfJwtlvEFXNpYoxHEQZZZQ%2bpaAmxoIxFGxDu2%2bjUHtRlh%2fjU4ixJbxjZPkDgLRaMQQNfcFUYoLqlqr88js4VcXYAjv0nET4LHVsiWDTBcbPRPj7%2bAg%3d%3d"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '9107'
+      - '4391'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:19:19 GMT
+      - Mon, 04 Jan 2021 21:54:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1188,14 +1202,10 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
-      - f795e797-5d1e-47f4-bfb2-08766d64d105
-      - 32be6ad6-611e-4510-abcf-d55b27eeb78a
-      - b9e3a3f8-d730-48e4-9bb0-0de3b30aad6c
-      - 72727f66-cf31-459c-bcc9-6d58ee27eb34
-      - beee70a5-1482-4534-ac42-b4975cd22e86
-      - 7c11b25f-2999-45dd-913f-695b9c13624b
-      - 593f4f9c-60ab-4f83-86fd-9d1b108f4e38
-      - bde97a0c-eed4-4e4d-87c2-ee6d41d52ed4
+      - f8e6d59c-a741-4de2-aaf9-e4a3aacacc3f
+      - a6742f9a-5f2d-4504-9e59-ae588219255b
+      - 3fa18539-7dd0-405a-a481-18258ccacee2
+      - bb97a45b-3a4b-48c7-9af4-2810dc88316c
     status:
       code: 200
       message: OK
@@ -1213,21 +1223,21 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZZtb6M4FIX%2FS7TaT5MGQ%2BgolapVMgEnZEwaMHbwN%2FPSEt4bSAKM5r%2FPpVOtVju%2FIBJCsmRzdZ97zjE%2FJmXctd9PZdZMnn5MjKVLPXfyNEnatm6eZrNClvItLuKyfZDD5Rw%2FhFUxay5BE55PdXuqymamBOj1cf4VTVHwqkznUSSnMg61aRgs1K%2Fqq7LQF8qsPlfXUxSfmxk5heeqqV7bh13cM3nJ29l1fDf%2FyPo0vcIW%2BOqzqqDFVIEH%2Ff1Xk0GpKovLZzc%2BX09hvJJNHH2hxeIi3E7wzbLzVcQiTHqndFJHSxpqRm7I8qPN9RPJhOYrpJOo9jm1bGaYOvUcM%2FZ041C0ghnZDdYi9hbeIU2kg%2FyeFrUZKej9cExsmZsaz6Lf%2B%2BG8LFpt8uUD1dLdLu8KVs6QUHwWoqAQ2wB3J6Z2iJfh4uXw%2FPzZlOeqd9WTIGVyE0bE48JZ28dcxlmt8Tz5FrJqcKiVMs155NTGBNvvbhklAX%2Fr%2FczhsmCtW7J9kGeDWFs7GxtDsDYlM61asOgWqIfe5ouUG%2Fq7n4d6pJpHsV6lwXHZifUWRXntB3ixd3HXiiyREjvHeL0iTHWugiUyLuzWSc2UKHXlK8mZ%2FGbs7j26%2BWbY1Fl%2Bvzev%2FYE6rzWa2o3N7U2wEZINORIcAQqj90qWOUalcJbgALPtITUzph5U8BKgNh%2FddCXj3NQF13GooBbQJtzwEaDHQV5fxAbOazBajOYxN4%2BRVu8BfS%2ByaB%2Bqpu8VXUqQVflqLaH%2BMcY6jOLQi7XNiKJvPLqSHlUWIGtu3F%2Bs%2FYE6q880g5BT0MUtncTFTgWqbka0XgEqNetWmCGgsmAUuQx4OIDqXAkoA63OHbNueKFzOaIv84TkooVR7aKCDE5pJQ7yIEsBZcEuAid7Zujq%2F1D3lG67uABXbOpsHBFPrT24YHsoRfKJ2lq%2BLO2R951nSG41tEA7ibdDgNs9U5NOeNE8LkzfKVd7kukdTa0dCPPCjkBXW%2FWwHulvQ9zaQblSKLVYzElPS5aAkOcC1zxktR9uWB7kVe8XShdmSu9Sew%2FTG4C2QrLOp2V9OgzGDTJsT8x8rJeRAuqzUCHL%2F%2Ba04S1f7otzwDuFmsluvH8%2BDdz71FLCt4%2B%2B%2Fo3F%2B%2Bts9Ctf226AyeAVAvwFUYYRJqAIWKfgr8Efowv8yUp2IkholNpXuCU2XmqDX%2B1Hn%2Bs24azdr81TwMBfoADJsoEXi4SoSe1ncItAxNng03j8Pke3EFtHwvWEGdWooDEaKYHo48b8Br9BH4o6FB1h2rKHqNwF2Ny4oDAxQDT%2B%2FPkL
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZLbbqMwEIbfBa32qgmHhCiJFK2SloXQmjQc7OA7A941wRgWTJJS9d3XrfZmHyHSaKTRP5rRN%2FO%2Fa4Le5Espql5bv2vBIYy9RyeIw%2B1LEmlrjUnZ9mtdr4kgv2lNhZyScejoNG9qvR%2ByPu%2FKVpaN6PW8WFIjN6zJjFjWZE7M1WRJFmQyX9AVnVM7z5YLve2aS1nQrtdBmXdN3%2FyS02f6BsnApX75zP0P0paTi2pRUzeWocYYKszv3%2FpKrWoqKjYR7S5lTnekp8VDXK8GHN3OGQrrdNzbuetL7AUEOfM5dgpE6%2FBnXCud%2B3F6DiLihl7m4ZLMwpP2oDnbKL4z1Co08QI70IAW3icKDZg%2BgPXtUPBWktHYKCzk3B0WAzw1sWu6APkKC5%2FBmcsUsihzwZic2f86D0vA2yusvj68e42%2FsP3t6zb4ZL8r72Ig2PWfV5%2BCEyeA%2B6Oqn3Pl1cJjFfJ2BuJFRGAzwrotqSJHkDW5Y%2B9RbfJwtlvEFXNpYoxHEQZZZQ%2BpaAmxoIxFGxDu2%2BjUHtRlh%2FjU4ixJbxjZPkDgLRaMQQNfcFUYoLqlqr88js4VcXYAjv0nET4LHVsiWDTBcbPRPj7%2BAg%3D%3D
   response:
     body:
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZXfbqM4FIffpVrt1WSCaegolapVMoEEZgxTY%2bzYd%2bZPB7BNnEAawmjefZ3uaC%2f6BpUQkqXjg%2fSd7%2fz4dddV4%2fC96WR%2f9%2fjrzl%2blOEvvHu%2fqYTD943yuRSd%2bVrrqhs9iOp%2bqz8VBz%2ftz3henxgzNoevnTg5eHhZfwAzkL85sUZZiJqriflbkS%2feL%2b%2bIsvaUzN6fDa1NWp34Om%2bJ06A8vw%2bdv1ZWIsxrmr7d3%2f48wzezVltiuT64DljPHPuDvv3ppP3WQVfeUVqfXpqjWoq%2fKT1gvzzwdOd2tRuYCUm7hFXWoRfd1j4MyLYjax9RroOT3zIGjAIZRPSbEIR4GqIWZc8VaxVDKC5UIQaCyrK0FAuxKFaLCB0cxxQnxvSOlJhGZt8vwOoEyu9x9%2boPK%2fVisYFdfuF%2fSSqNNvFeiUuyCqWmhv7gWm3Wb03rAbXiB6jDRjktbD5hrEKQoSzskkL9wqfZkRaMd6cqGBrynpFzkOmYZjoSQh5Hh%2bGvuhtd4jxLYrY%2bYgqnS%2flXs4iSXzshlLcQW7avNGhIQTVgbmusgtP049T17Bk758%2bnJMk6TDO%2b%2b%2bjFGq%2b8fTcv3qK02I1N1Cn3vIdV1kmfc4QSJXIfTc8d5pYw9Fw60KDJtRwL4iclSQAnOYqvq%2fDYqDS4iMCztjEy36J5lhVdZ7fmON9SPLhZ9AnWUYT20uVIel2VSuAHL9Gj7RUesSqdQxqc4bu39K8tqZEdp%2by9Fhp2lRU79j5cA71FXyqLTJoE02OGOC%2bgYl8r6IFxyJN1a5SoE1FoJHc%2biGnmO5fhWr6MjadcJmeSFTaGX240ne2WRjgdGvW3pomOqTQzd8oFvQpDTcOIbkiC3foc6dLEs09yNd%2fG%2bTPL9ekHbcCyAGdIuEs%2f%2foY5WP1bxjfcHzxCNBgZqu8wmo13dosCc2RR%2fEy4KxWbd5MRc7ZnmRDErvkAuctkUHUpKdpDWEgUHl7UhEBrt4R6pNIiON0ErHbBiQ1rohFe8N0mRgQeyN7FdnBttB9qh4c40z5N%2foapO4DbY57uoRr55uC1avHrLkP%2fjw89WPz4eabqJ03wLp0zzGioG%2bBZsIY1sRPAWAX5mN6%2bVGog2NXSstxkSwqav2BGJJvLKnJIK66FNV0kD%2f8qo4%2bUSHNNONXYSRyxthOhgsBFjPUYL63laWq%2fFDjUoiMyfCMEQrwX1Fxf7Z30j%2f6xHSH0DGClARZSdvOJ8shHy%2b%2fe%2f"}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=FY3bboJAGITfhTS9KnKoEjUhjUakYqEtUha5W5e%2fsu4BwiKKxncvTSaTTPLNzF2TcG0%2fqGRKm9%2b1YPG1iJC3S7S5VrZtreaGIbDERxAg2xG%2bnRsYkUoY6nxQpKF1SyupDFJMwSSmrb9i29bH2JrpU%2bxgfezADMYwIYepY9RN1dECGmWElDSVqn7b0Rb6FJ95a3T%2frt5wTfVuQIZV1zaHGXOQ9fyk2HBVMZDuDpqOElhiBcVLImbnfHfNQ1lecq9AIOJVlHEcmptrwso0REFb%2bJwib2PtT9EWiyBDojwNfJfwOAVeO7k%2fwZiZlwRZPgjv9iOX7CBUn6CJImidkVXAkV86%2bTrGgIINeU%2f5bl1fECsksHEfrQJ2yOIqZ4UZsus%2bkTX9vnkXxMvP0A%2bGPPQ463MvxuToutrj8Qc%3d"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1508'
+      - '1908'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:19:20 GMT
+      - Mon, 04 Jan 2021 21:54:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1239,14 +1249,10 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
-      - f638c3cf-e601-4310-9ae1-dbb3b8a81b17
-      - efb39dae-98ed-4db9-bf44-803b0bea1224
-      - 5f122c42-b33b-4431-a33e-ff28b6e26ba5
-      - 95cd964f-060d-47e0-8f0e-632e62d24080
-      - e77ee3fd-36a3-4876-a4a7-69d2826d559d
-      - a8f4644d-9451-4d18-856b-d38171587fc7
-      - 2495de49-7f06-40d4-8356-ca073c5021b3
-      - 9967579f-f9b2-442c-ac7a-2349a88d288c
+      - 0dc670b6-f652-4886-8a8f-e0cf6949ec1b
+      - 38d1512a-a53a-4a0f-a201-bde2e43402cf
+      - 386556ef-bab2-4573-a4fe-f026ef257782
+      - 60cf001b-4a22-41e8-9244-fd0b861755fa
     status:
       code: 200
       message: OK
@@ -1264,38 +1270,78 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
+      accept-language:
+      - en-US
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZXfbqM4FIffpVrt1WSCaegolapVMoEEZgxTY%2BzYd%2BZPB7BNnEAawmjefZ3uaC%2F6BpUQkqXjg%2FSd7%2Fz4dddV4%2FC96WR%2F9%2Fjrzl%2BlOEvvHu%2FqYTD943yuRSd%2BVrrqhs9iOp%2Bqz8VBz%2Ftz3henxgzNoevnTg5eHhZfwAzkL85sUZZiJqriflbkS%2FeL%2B%2BIsvaUzN6fDa1NWp34Om%2BJ06A8vw%2Bdv1ZWIsxrmr7d3%2F48wzezVltiuT64DljPHPuDvv3ppP3WQVfeUVqfXpqjWoq%2FKT1gvzzwdOd2tRuYCUm7hFXWoRfd1j4MyLYjax9RroOT3zIGjAIZRPSbEIR4GqIWZc8VaxVDKC5UIQaCyrK0FAuxKFaLCB0cxxQnxvSOlJhGZt8vwOoEyu9x9%2BoPK%2FVisYFdfuF%2FSSqNNvFeiUuyCqWmhv7gWm3Wb03rAbXiB6jDRjktbD5hrEKQoSzskkL9wqfZkRaMd6cqGBrynpFzkOmYZjoSQh5Hh%2BGvuhtd4jxLYrY%2BYgqnS%2FlXs4iSXzshlLcQW7avNGhIQTVgbmusgtP049T17Bk758%2BnJMk6TDO%2B%2B%2BjFGq%2B8fTcv3qK02I1N1Cn3vIdV1kmfc4QSJXIfTc8d5pYw9Fw60KDJtRwL4iclSQAnOYqvq%2FDYqDS4iMCztjEy36J5lhVdZ7fmON9SPLhZ9AnWUYT20uVIel2VSuAHL9Gj7RUesSqdQxqc4bu39K8tqZEdp%2By9Fhp2lRU79j5cA71FXyqLTJoE02OGOC%2BgYl8r6IFxyJN1a5SoE1FoJHc%2BiGnmO5fhWr6MjadcJmeSFTaGX240ne2WRjgdGvW3pomOqTQzd8oFvQpDTcOIbkiC3foc6dLEs09yNd%2FG%2BTPL9ekHbcCyAGdIuEs%2F%2FoY5WP1bxjfcHzxCNBgZqu8wmo13dosCc2RR%2FEy4KxWbd5MRc7ZnmRDErvkAuctkUHUpKdpDWEgUHl7UhEBrt4R6pNIiON0ErHbBiQ1rohFe8N0mRgQeyN7FdnBttB9qh4c40z5N%2FoapO4DbY57uoRr55uC1avHrLkP%2Fjw89WPz4eabqJ03wLp0zzGioG%2BBZsIY1sRPAWAX5mN6%2BVGog2NXSstxkSwqav2BGJJvLKnJIK66FNV0kD%2F8qo4%2BUSHNNONXYSRyxthOhgsBFjPUYL63laWq%2FFDjUoiMyfCMEQrwX1Fxf7Z30j%2F6xHSH0DGClARZSdvOJ8shHy%2B%2Fe%2F
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CertificateRegistration/certificateOrders?api-version=2019-08-01
   response:
     body:
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZRRj6I4AID%2fy%2bRyT%2btKGXXjJJOL3gDKbOtaSiu8FcpsoQWroCCb%2fe9X5zb7cPcLJiEQ0qbAx9fvx0NTDN3XslHtw9OPB28VkTh6eHqQXWfap%2bm05g3%2fXtRF033m4%2bVcfM6P9bS9ZG1%2bLk1XHpt26mTgbTH7AiYge3MmMyH4hBf54yTPlu4X981ZzpfO1JyP11IU53YKy%2fx8bI9v3efX4kb5RXfT6%2f3c%2fsVNObnaKXbVZ9cBy4ljD%2fDnH62yjzqqonmOivO1zIs1bwvxidTLSxoNKdushsQFVATwhhtc4UfZEj8HQpsNrQHiKjyRGAfcA11cDyl14p5p3GZUx%2ftKcgySG6tNKIBe7A8ypZ45My3s%2fPmGEsqzmD4%2bfPqFxv1YbGAj%2b9QTrKjxCzpoDnV6tqzaIggXrPF3dMSLRIlZ5usTa3QJ3d4lVfiaec4Y10sV%2bebKGoMKarZxo1FWyzZRsoHB%2frZ7WaOM3FmKqmD0lG5Cy8rcEkdEPKB2PaMzJp1USc4DfChe1tCyvRCCrtD1T5SgErvSECWvcP%2f8bBlHu5hs%2fvYQwauvH03D%2f6Fu1k5yMAxqk0RVyu2nn1Jf9jDwO1ybqtBpn1CLhtGDRS6xN2%2fTlzDiVkOLTll0Y%2brJVx74W75ZSzrue6YwLli4iauwxKNyEioi6NpfQajM4qNFLXa56ydW8wqCsE990QsFLrgKq4yGgCmphIu6IlhWMXGWFjnzPt6O%2fy%2fqQlvrXNALN1zEDVZ2fLCoeE5NBw%2b4hI2Y210QwRh0abCUdhyksUBQzRes8hV0xZxoueP1drRWKq6TgegcWIu3UYN21PduhBmVB%2fiUjEhCZ362Vu8yhi77A07v70N84UA1JPkG77Dn3Hfdqwi2Nx4Mav8v6nD1bYXuvD94Q9S8T8awhS46Rc26pKN%2fSTeGo%2bB%2b9XcZoWdSg6Co0ZYRJKnbW5FFnwfoICydjOHLvbeQ4QOrB27FvzdHQQec7vO5jkdGJbuP82CeQmB6K%2fY7XdKYcj96tjlyB31zyYOlwo5tmiNY%2fv29Ib%2fz4cWrbx%2bPNHtBURZAW99UQp2ANAABZOHW3lcYpC5hc5775oA2xiYgdhIH88wNL3xjUBbPF0ThCPn6QBqhs3pvvXWA8GZjZMlRkPbW8zbXxosaqWy9B6LEK6T6FDdCsWDofiWEQLLmzJv99npfD5A%2b4lli10P3pNTz8j0hP3%2f%2bAw%3d%3d"}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-Storage-EastUS/providers/Microsoft.CertificateRegistration/certificateOrders/testImportCert","name":"testImportCert","type":"certificateOrders","location":"global","properties":{"certificates":{"testImportCert":{"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/keyvault_sofitest/providers/microsoft.keyvault/vaults/keyvaultsofitest","keyVaultSecretName":"testimportcert2c72f30f-62d5-4acc-9a82-e14641877c59","provisioningState":"OperationNotPermittedOnKeyVault"}},"distinguishedName":"CN=soinglesTest.com","domainVerificationToken":"a2ccejppf2f11lgq9kqhs61918","validityInYears":1,"keySize":2048,"productType":"StandardDomainValidatedSsl","autoRenew":true,"status":"Issued","signedCertificate":{"version":3,"serialNumber":"67951DAE3499D4C2","thumbprint":"5DA6DD1F54D401B003292141C5F0B9426A8F9346","subject":"CN=soinglestest.com,
+        OU=Domain Control Validated","notBefore":"2020-09-17T20:13:10+00:00","notAfter":"2021-09-17T20:13:10+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Secure Certificate Authority - G2, OU=http://certs.godaddy.com/repository/,
+        O=\"GoDaddy.com, Inc.\", L=Scottsdale, S=Arizona, C=US","rawData":"-----BEGIN
+        CERTIFICATE-----\nMIIGRDCCBSygAwIBAgIIZ5UdrjSZ1MIwDQYJKoZIhvcNAQELBQAwgbQxCzAJBgNV\nBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQHEwpTY290dHNkYWxlMRow\nGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjEtMCsGA1UECxMkaHR0cDovL2NlcnRz\nLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvMTMwMQYDVQQDEypHbyBEYWRkeSBTZWN1\ncmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIwHhcNMjAwOTE3MjAxMzEwWhcN\nMjEwOTE3MjAxMzEwWjA+MSEwHwYDVQQLExhEb21haW4gQ29udHJvbCBWYWxpZGF0\nZWQxGTAXBgNVBAMTEHNvaW5nbGVzdGVzdC5jb20wggEiMA0GCSqGSIb3DQEBAQUA\nA4IBDwAwggEKAoIBAQDMNCUb+RR6T+e6A4s4ETJLpSbNjG2X8nYTtalHAO2U9HEe\nsW6yRdzuLGEvTcc8rcdSDISImqf6+RfB/GfBEamLj8EYxsMHbEhSWs3M/2N+XJty\ngwgJ/3hL4g2l8fw3XOV4GLz3pKrgki9jRneJ7zyUEajwu5JrybiFmCdidr1gFjtd\nNd5HYWVOurtF+FI6Uc83mbb8pWtZuvaF3t1fAKsSwCnLMYlQaClxOXcGqXcHLmU/\nL4TNx+ePHlDmVbT+jHkpzqgU3eOLz0XpVqAC+zVxr3OVD6PsFwoRyVaQy3CX1qH2\nJORgRC3nTw5r0MqVlGpn+XY5jIpg2hDfcu58t3BLAgMBAAGjggLNMIICyTAMBgNV\nHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAOBgNVHQ8B\nAf8EBAMCBaAwOAYDVR0fBDEwLzAtoCugKYYnaHR0cDovL2NybC5nb2RhZGR5LmNv\nbS9nZGlnMnMxLTIzMDguY3JsMF0GA1UdIARWMFQwSAYLYIZIAYb9bQEHFwEwOTA3\nBggrBgEFBQcCARYraHR0cDovL2NlcnRpZmljYXRlcy5nb2RhZGR5LmNvbS9yZXBv\nc2l0b3J5LzAIBgZngQwBAgEwdgYIKwYBBQUHAQEEajBoMCQGCCsGAQUFBzABhhho\ndHRwOi8vb2NzcC5nb2RhZGR5LmNvbS8wQAYIKwYBBQUHMAKGNGh0dHA6Ly9jZXJ0\naWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVwb3NpdG9yeS9nZGlnMi5jcnQwHwYDVR0j\nBBgwFoAUQMK9J47MNIMwojPX+2yz8LQsgM4wMQYDVR0RBCowKIIQc29pbmdsZXN0\nZXN0LmNvbYIUd3d3LnNvaW5nbGVzdGVzdC5jb20wHQYDVR0OBBYEFHSNO4Rlj7Vi\nOe7Ayy6uUQvWt2e3MIIBBAYKKwYBBAHWeQIEAgSB9QSB8gDwAHYA9lyUL9F3MCIU\nVBgIMJRWjuNNExkzv98MLyALzE7xZOMAAAF0nbMcYAAABAMARzBFAiBMuPqKPhsY\nEJt1j5fChonbEHAz4trqPAnVl/hK+aU0wQIhAOxNTNZl/0Im5wQB9aB+ERzXD6O9\ne0qN4YbGVV5+2+XxAHYAXNxDkv7mq0VEsV6a1FbmEDf71fpH3KFzlLJe5vbHDsoA\nAAF0nbMebQAABAMARzBFAiEAwkz88LrG5u3Rm6HbAC+Sepy+jkBC91ktkDBDGbO+\ntvcCID9ngauuspb1ytYZo5pf1ZOFi9fPUPHCBJt9CmBmcUjnMA0GCSqGSIb3DQEB\nCwUAA4IBAQBuDb8vsiScuSIgCOIhkP0d7s6+A6grmmdrCPmeCRUO52bflPXD+E/L\nKy4rzRIflz09MlB4tqOR+bao/hGxukuIJ3G7wPBX+IDjN0BcBLBIKvQNmbiopUQS\nIiKx/0EvHw8NgG/aDqADU1Qf/nVEuFidD5bYqW4aDp+oJurGigiEu8oQCdGRh16i\nA++YKfJQmgS+gJJ+LKv6DgILdaWAHvmEiYu7ooZiYsgCN16YHTFVhiunqW9BOMgr\nOmchwvfxLVkCVK44TUAc06/bg9LHk3Ra4MA9tfrcApecuBvbV/HSuB0Zms7SGBm5\nl0mm+zIN2s/jOeLDMTEw3aHEKjKvYNxP\n-----END
+        CERTIFICATE-----\n"},"csr":"-----BEGIN NEW CERTIFICATE REQUEST-----\r\nMIIEQzCCAysCAQAwGzEZMBcGA1UEAwwQc29pbmdsZXNUZXN0LmNvbTCCASIwDQYJ\r\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMw0JRv5FHpP57oDizgRMkulJs2MbZfy\r\ndhO1qUcA7ZT0cR6xbrJF3O4sYS9Nxzytx1IMhIiap/r5F8H8Z8ERqYuPwRjGwwds\r\nSFJazcz/Y35cm3KDCAn/eEviDaXx/Ddc5XgYvPekquCSL2NGd4nvPJQRqPC7kmvJ\r\nuIWYJ2J2vWAWO1013kdhZU66u0X4UjpRzzeZtvyla1m69oXe3V8AqxLAKcsxiVBo\r\nKXE5dwapdwcuZT8vhM3H548eUOZVtP6MeSnOqBTd44vPRelWoAL7NXGvc5UPo+wX\r\nChHJVpDLcJfWofYk5GBELedPDmvQypWUamf5djmMimDaEN9y7ny3cEsCAwEAAaCC\r\nAeEwHAYKKwYBBAGCNw0CAzEOFgwxMC4wLjE0MzkzLjIwTQYJKwYBBAGCNxUUMUAw\r\nPgIBBQwOUkQwMDE1NUQ0MUVFM0MMH0lJUyBBUFBQT09MXEdlb01hc3RlckFwcFBv\r\nb2xDc20MCHczd3AuZXhlMIGCBgorBgEEAYI3DQICMXQwcgIBAR5qAE0AaQBjAHIA\r\nbwBzAG8AZgB0ACAARQBuAGgAYQBuAGMAZQBkACAAUgBTAEEAIABhAG4AZAAgAEEA\r\nRQBTACAAQwByAHkAcAB0AG8AZwByAGEAcABoAGkAYwAgAFAAcgBvAHYAaQBkAGUA\r\ncgMBADCB7AYJKoZIhvcNAQkOMYHeMIHbMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\r\nDDAKBggrBgEFBQcDATCBlAYJKoZIhvcNAQkPBIGGMIGDMA4GCCqGSIb3DQMCAgIA\r\ngDAOBggqhkiG9w0DBAICAIAwBwYFKw4DAgcwCgYIKoZIhvcNAwcwCwYJYIZIAWUD\r\nBAEqMAsGCWCGSAFlAwQBLTALBglghkgBZQMEARYwCwYJYIZIAWUDBAEZMAsGCWCG\r\nSAFlAwQBAjALBglghkgBZQMEAQUwHQYDVR0OBBYEFHSNO4Rlj7ViOe7Ayy6uUQvW\r\nt2e3MA0GCSqGSIb3DQEBCwUAA4IBAQCSklCihgAuIslVtbpmglW4sFVDfy3x68i0\r\nJWR4r3/8lvCOYEb1I5r2u++6VUAdyOcryp6MbzTVPvE3hrnKnXQ5gH3TkXA6i1UC\r\ndnJj2yVrC4Bgm9XpQ+lKfMUV9rwz3lE2KdkWcWVPdmM6kZ6sDuwhsl5ho83fmOIo\r\n0CtK7vJ9juhgwoQK4XD9xA1hd6kMkhea9dzuv2fvAW7TkyYOt+Z7UrAslNhwLq/A\r\neAfRieWdcy/NdNuKGnIFtOXPMu0icKJCgSI0CUMxG92ZKKgCxhbTTlJg7bLdK96u\r\nfe94FOKTbVb5uLq7zJyzElsp6nZx4dlT8mCSBDi0TxLgihFYbGbp\r\n-----END
+        NEW CERTIFICATE REQUEST-----\r\n","intermediate":{"version":3,"serialNumber":"07","thumbprint":"27AC9369FAF25207BB2627CEFACCBE4EF9C319B8","subject":"CN=Go
+        Daddy Secure Certificate Authority - G2, OU=http://certs.godaddy.com/repository/,
+        O=\"GoDaddy.com, Inc.\", L=Scottsdale, S=Arizona, C=US","notBefore":"2011-05-03T07:00:00+00:00","notAfter":"2031-05-03T07:00:00+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","rawData":"-----BEGIN CERTIFICATE-----\nMIIE0DCCA7igAwIBAgIBBzANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\nEDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\nEUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\nZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTExMDUwMzA3MDAwMFoXDTMxMDUwMzA3\nMDAwMFowgbQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\nEwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjEtMCsGA1UE\nCxMkaHR0cDovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvMTMwMQYDVQQD\nEypHbyBEYWRkeSBTZWN1cmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIwggEi\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC54MsQ1K92vdSTYuswZLiBCGzD\nBNliF44v/z5lz4/OYuY8UhzaFkVLVat4a2ODYpDOD2lsmcgaFItMzEUz6ojcnqOv\nK/6AYZ15V8TPLvQ/MDxdR/yaFrzDN5ZBUY4RS1T4KL7QjL7wMDge87Am+GZHY23e\ncSZHjzhHU9FGHbTj3ADqRay9vHHZqm8A29vNMDp5T19MR/gd71vCxJ1gO7GyQ5HY\npDNO6rPWJ0+tJYqlxvTV0KaudAVkV4i1RFXULSo6Pvi4vekyCgKUZMQWOlDxSq7n\neTOvDCAHf+jfBDnCaQJsY1L6d8EbyHSHyLmTGFBUNUtpTrw700kuH9zB0lL7AgMB\nAAGjggEaMIIBFjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNV\nHQ4EFgQUQMK9J47MNIMwojPX+2yz8LQsgM4wHwYDVR0jBBgwFoAUOpqFBxBnKLbv\n9r0FQW4gwZTaD94wNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8v\nb2NzcC5nb2RhZGR5LmNvbS8wNQYDVR0fBC4wLDAqoCigJoYkaHR0cDovL2NybC5n\nb2RhZGR5LmNvbS9nZHJvb3QtZzIuY3JsMEYGA1UdIAQ/MD0wOwYEVR0gADAzMDEG\nCCsGAQUFBwIBFiVodHRwczovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkv\nMA0GCSqGSIb3DQEBCwUAA4IBAQAIfmyTEMg4uJapkEv/oV9PBO9sPpyIBslQj6Zz\n91cxG7685C/b+LrTW+C05+Z5Yg4MotdqY3MxtfWoSKQ7CC2iXZDXtHwlTxFWMMS2\nRJ17LJ3lXubvDGGqv+QqG+6EnriDfcFDzkSnE3ANkR/0yBOtg2DZ2HKocyQetawi\nDsoXiWJYRBuriSUBAA/NxBti21G00w9RKpv0vHP8ds42pM3Z2Czqrpv1KrKQ0U11\nGIo/ikGQI31bS/6kA1ibRrLDYGCD+H1QQc7CoZDDu+8CL9IVVO5EFdkKrqeKM+2x\nLXY2JtwE65/3YR8V3Idv7kaWKK2hJn0KCacuBKONvPi8BDAB\n-----END
+        CERTIFICATE-----"},"root":{"version":3,"serialNumber":"00","thumbprint":"47BEABC922EAE80E78783462A79F45C254FDE68B","subject":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","notBefore":"2009-09-01T00:00:00+00:00","notAfter":"2037-12-31T23:59:59+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","rawData":"-----BEGIN CERTIFICATE-----\nMIIDxTCCAq2gAwIBAgIBADANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\nEDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\nEUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\nZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTA5MDkwMTAwMDAwMFoXDTM3MTIzMTIz\nNTk1OVowgYMxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\nEwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjExMC8GA1UE\nAxMoR28gRGFkZHkgUm9vdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgLSBHMjCCASIw\nDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL9xYgjx+lk09xvJGKP3gElY6SKD\nE6bFIEMBO4Tx5oVJnyfq9oQbTqC023CYxzIBsQU+B07u9PpPL1kwIuerGVZr4oAH\n/PMWdYA5UXvl+TW2dE6pjYIT5LY/qQOD+qK+ihVqf94Lw7YZFAXK6sOoBJQ7Rnwy\nDfMAZiLIjWltNowRGLfTshxgtDj6AozO091GB94KPutdfMh8+7ArU6SSYmlRJQVh\nGkSBjCypQ5Yj36w6gZoOKcUcqeldHraenjAKOc7xiID7S13MMuyFYkMlNAJWJwGR\ntDtwKj9useiciAF9n9T521NtYJ2/LOdYq7hfRvzOxBsDPAnrSTFcaUaz4EcCAwEA\nAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYE\nFDqahQcQZyi27/a9BUFuIMGU2g/eMA0GCSqGSIb3DQEBCwUAA4IBAQCZ21151fmX\nWWcDYfF+OwYxdS2hII5PZYe096acvNjpL9DbWu7PdIxztDhC2gV7+AJ1uP2lsdeu\n9tfeE8tTEH6KRtGX+rcuKxGrkLAngPnon1rpN5+r5N9ss4UXnT3ZJE95kTXWXwTr\ngIOrmgIttRD02JDHBHNA7XIloKmf7J6raBKZV8aPEjoJpL1E/QYVN8Gb5DKj7Tjo\n2GTzLH4U/ALqn83/B2gX2yKQOC16jdFU8WnjXzPKej17CuPKf1855eJ1usV2GDPO\nLPAvTK33sefOT6jEm0pUBsV/fdUID+Ic/n4XuKxe9tQWskMJDE32p2u0mYRlynqI\n4uJEvlz36hz1\n-----END
+        CERTIFICATE-----"},"serialNumber":"7463904591480476866","lastCertificateIssuanceTime":"2020-09-17T20:13:41.746614","expirationTime":"2021-09-17T20:13:10","isPrivateKeyExternal":false,"appServiceCertificateNotRenewableReasons":["ExpirationNotInRenewalTimeRange"]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg_soingles/providers/Microsoft.CertificateRegistration/certificateOrders/exampleCert","name":"exampleCert","type":"certificateOrders","location":"global","properties":{"certificates":{"exampleCert":{"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/keyvault_sofitest/providers/microsoft.keyvault/vaults/keyvaultsofitest","keyVaultSecretName":"examplecert1ab3bd4e-25f1-42d9-9c38-d7677a93886b","provisioningState":"OperationNotPermittedOnKeyVault"}},"distinguishedName":"CN=soinglesTest.com","validityInYears":1,"keySize":2048,"productType":"StandardDomainValidatedSsl","autoRenew":true,"status":"Issued","signedCertificate":{"version":3,"serialNumber":"008F6895C0F5DD3C9A","thumbprint":"DDC4C1C4D62C52168CE298CE8DD7D6CC8B3F08D0","subject":"CN=soinglestest.com,
+        OU=Domain Control Validated","notBefore":"2020-12-07T03:56:54+00:00","notAfter":"2022-01-08T03:56:54+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Secure Certificate Authority - G2, OU=http://certs.godaddy.com/repository/,
+        O=\"GoDaddy.com, Inc.\", L=Scottsdale, S=Arizona, C=US","rawData":"-----BEGIN
+        CERTIFICATE-----\nMIIGRTCCBS2gAwIBAgIJAI9olcD13TyaMA0GCSqGSIb3DQEBCwUAMIG0MQswCQYD\nVQQGEwJVUzEQMA4GA1UECBMHQXJpem9uYTETMBEGA1UEBxMKU2NvdHRzZGFsZTEa\nMBgGA1UEChMRR29EYWRkeS5jb20sIEluYy4xLTArBgNVBAsTJGh0dHA6Ly9jZXJ0\ncy5nb2RhZGR5LmNvbS9yZXBvc2l0b3J5LzEzMDEGA1UEAxMqR28gRGFkZHkgU2Vj\ndXJlIENlcnRpZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTIwMTIwNzAzNTY1NFoX\nDTIyMDEwODAzNTY1NFowPjEhMB8GA1UECxMYRG9tYWluIENvbnRyb2wgVmFsaWRh\ndGVkMRkwFwYDVQQDExBzb2luZ2xlc3Rlc3QuY29tMIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAzPZACPhV6YP779cfDuMn4DuNGwGTxP8M9WEiDvTbCDTz\nP3YFfsyOCFtPF2o3Zh97BwkTPJtASkZU6EIhOVmKDB6DJxSpA1JgM16gs3T4JBVG\nefICjI2rCiAisusb828+CErUpLpdJKvPWcWEJm2O2SDgnVQMDC3KjkiRxw60uTEC\n5JTtWKGq/daY9kiJIhodr2qYsLb5zV5KYWeA/s2lR1jxOArywDGwXBMEQn7tZ+ot\necPX9tCSrwnd66/mRiBFXOXADy2svRMSx+4KWpKqdXNPSLio4AxDkc9f7flPxMt9\n0S35TJnHE1u/tYvHwTt2wFNtR7DDvtpgqdFivZK1BwIDAQABo4ICzTCCAskwDAYD\nVR0TAQH/BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0P\nAQH/BAQDAgWgMDgGA1UdHwQxMC8wLaAroCmGJ2h0dHA6Ly9jcmwuZ29kYWRkeS5j\nb20vZ2RpZzJzMS0yNTEzLmNybDBdBgNVHSAEVjBUMEgGC2CGSAGG/W0BBxcBMDkw\nNwYIKwYBBQUHAgEWK2h0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVw\nb3NpdG9yeS8wCAYGZ4EMAQIBMHYGCCsGAQUFBwEBBGowaDAkBggrBgEFBQcwAYYY\naHR0cDovL29jc3AuZ29kYWRkeS5jb20vMEAGCCsGAQUFBzAChjRodHRwOi8vY2Vy\ndGlmaWNhdGVzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvZ2RpZzIuY3J0MB8GA1Ud\nIwQYMBaAFEDCvSeOzDSDMKIz1/tss/C0LIDOMDEGA1UdEQQqMCiCEHNvaW5nbGVz\ndGVzdC5jb22CFHd3dy5zb2luZ2xlc3Rlc3QuY29tMB0GA1UdDgQWBBQMktRbWCfT\n+54bknq5H7O0xSe06DCCAQQGCisGAQQB1nkCBAIEgfUEgfIA8AB2ACl5vvCeOTkh\n8FZzn2Old+W+V32cYAr4+U1dJlwlXceEAAABdjtYceMAAAQDAEcwRQIgXVxL4rtM\nnUvSS6WnfgdI7VX2HTqxuju2P6jilMQLcFUCIQCt1j1IOmGPKdRX/KMI2qHAXeOB\nAJ0u4RLN1UeH77recgB2ACJFRQdZVSRWlj+hL/H3bYbgIyZjrcBLf13Gg1xu4g8C\nAAABdjtYdDYAAAQDAEcwRQIgfByZMMp3Xwa8Z1Wnv9AMK4wkNCv5knVYtEvBkzM5\nA/ACIQDoO1CLsqhwr62eR/6hwYqwtRoO2QsDPQ98aG30aHK8EDANBgkqhkiG9w0B\nAQsFAAOCAQEApNHhlbFcUakl+lto05CtUVTIARitkGc6EZdb38RLTIVLG764rDeY\nmcmKRgTNAg6VCeb9Hy+LpPpnHMrywrkqmAk0IJaXpsGIqWUy4lFgxZIZxorFY5W8\nS6EUTkvF1awJEdrN7dtJwQWv49JD4xkjI1lOwfP0U58JcAQo4DwM93mwIkkHIW23\nB3yag8aSqSJwvlru7YpZVk1PGICFHs7RGIwe/iiUYidSjkiVwAboChHF5kO5BbCL\nA5EuecMeKa3yZVthAXP/ygSzK/E+rLDCscJUoMyojoBZavTo1oRyMzfMJFLf5USA\n8/fINQbIJrjryU8yfdEekJh2t0UMlOUL7A==\n-----END
+        CERTIFICATE-----\n"},"csr":"-----BEGIN NEW CERTIFICATE REQUEST-----\r\nMIIEQzCCAysCAQAwGzEZMBcGA1UEAwwQc29pbmdsZXNUZXN0LmNvbTCCASIwDQYJ\r\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMz2QAj4VemD++/XHw7jJ+A7jRsBk8T/\r\nDPVhIg702wg08z92BX7MjghbTxdqN2YfewcJEzybQEpGVOhCITlZigwegycUqQNS\r\nYDNeoLN0+CQVRnnyAoyNqwogIrLrG/NvPghK1KS6XSSrz1nFhCZtjtkg4J1UDAwt\r\nyo5IkccOtLkxAuSU7Vihqv3WmPZIiSIaHa9qmLC2+c1eSmFngP7NpUdY8TgK8sAx\r\nsFwTBEJ+7WfqLXnD1/bQkq8J3euv5kYgRVzlwA8trL0TEsfuClqSqnVzT0i4qOAM\r\nQ5HPX+35T8TLfdEt+UyZxxNbv7WLx8E7dsBTbUeww77aYKnRYr2StQcCAwEAAaCC\r\nAeEwGgYKKwYBBAGCNw0CAzEMFgo2LjIuOTIwMC4yME8GCSsGAQQBgjcVFDFCMEAC\r\nAQUMDlJEMDAxNTVEMzFFOTMwDBlXT1JLR1JPVVBcUkQwMDE1NUQzMUU5MzAkDBBX\r\nYVdvcmtlckhvc3QuZXhlMIGCBgorBgEEAYI3DQICMXQwcgIBAR5qAE0AaQBjAHIA\r\nbwBzAG8AZgB0ACAARQBuAGgAYQBuAGMAZQBkACAAUgBTAEEAIABhAG4AZAAgAEEA\r\nRQBTACAAQwByAHkAcAB0AG8AZwByAGEAcABoAGkAYwAgAFAAcgBvAHYAaQBkAGUA\r\ncgMBADCB7AYJKoZIhvcNAQkOMYHeMIHbMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\r\nDDAKBggrBgEFBQcDATCBlAYJKoZIhvcNAQkPBIGGMIGDMA4GCCqGSIb3DQMCAgIA\r\ngDAOBggqhkiG9w0DBAICAIAwBwYFKw4DAgcwCgYIKoZIhvcNAwcwCwYJYIZIAWUD\r\nBAEqMAsGCWCGSAFlAwQBLTALBglghkgBZQMEARYwCwYJYIZIAWUDBAEZMAsGCWCG\r\nSAFlAwQBAjALBglghkgBZQMEAQUwHQYDVR0OBBYEFAyS1FtYJ9P7nhuSerkfs7TF\r\nJ7ToMA0GCSqGSIb3DQEBCwUAA4IBAQBSPtdx7lpGM3uwic6VhcD2ivZ9yE0KG5FX\r\nOv6JoEUX5A1hmAAIDGHfwj0ziUMXZuuHHd4O06d941uzHhQVYnxKVcTJq33UG4XH\r\nOKWmEgBOrc53eEWg7ApgQ0pPxFN3oEIRGCzeflTMqv4Emny44RWveSKPkxM5HPMe\r\nA1Gth2Rb67PD0v2MsWvXkSpzzb9Yy5fo8PhOZy8AnwbO6zAHSItVJB9QZvo7iFG1\r\nHHJPJH3MSkSHV7zNn7RzZNMVhgd6vh14lL6xmtArptBt2C+TrhQ0ma/KsCmWxvrz\r\nw/nZJczu1B+iNHe9r3OBsb9H3XFTbIgPIACzeL7TrLhcEZUDGwk+\r\n-----END
+        NEW CERTIFICATE REQUEST-----\r\n","intermediate":{"version":3,"serialNumber":"07","thumbprint":"27AC9369FAF25207BB2627CEFACCBE4EF9C319B8","subject":"CN=Go
+        Daddy Secure Certificate Authority - G2, OU=http://certs.godaddy.com/repository/,
+        O=\"GoDaddy.com, Inc.\", L=Scottsdale, S=Arizona, C=US","notBefore":"2011-05-03T07:00:00+00:00","notAfter":"2031-05-03T07:00:00+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","rawData":"-----BEGIN CERTIFICATE-----\nMIIE0DCCA7igAwIBAgIBBzANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\nEDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\nEUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\nZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTExMDUwMzA3MDAwMFoXDTMxMDUwMzA3\nMDAwMFowgbQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\nEwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjEtMCsGA1UE\nCxMkaHR0cDovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvMTMwMQYDVQQD\nEypHbyBEYWRkeSBTZWN1cmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIwggEi\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC54MsQ1K92vdSTYuswZLiBCGzD\nBNliF44v/z5lz4/OYuY8UhzaFkVLVat4a2ODYpDOD2lsmcgaFItMzEUz6ojcnqOv\nK/6AYZ15V8TPLvQ/MDxdR/yaFrzDN5ZBUY4RS1T4KL7QjL7wMDge87Am+GZHY23e\ncSZHjzhHU9FGHbTj3ADqRay9vHHZqm8A29vNMDp5T19MR/gd71vCxJ1gO7GyQ5HY\npDNO6rPWJ0+tJYqlxvTV0KaudAVkV4i1RFXULSo6Pvi4vekyCgKUZMQWOlDxSq7n\neTOvDCAHf+jfBDnCaQJsY1L6d8EbyHSHyLmTGFBUNUtpTrw700kuH9zB0lL7AgMB\nAAGjggEaMIIBFjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNV\nHQ4EFgQUQMK9J47MNIMwojPX+2yz8LQsgM4wHwYDVR0jBBgwFoAUOpqFBxBnKLbv\n9r0FQW4gwZTaD94wNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8v\nb2NzcC5nb2RhZGR5LmNvbS8wNQYDVR0fBC4wLDAqoCigJoYkaHR0cDovL2NybC5n\nb2RhZGR5LmNvbS9nZHJvb3QtZzIuY3JsMEYGA1UdIAQ/MD0wOwYEVR0gADAzMDEG\nCCsGAQUFBwIBFiVodHRwczovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkv\nMA0GCSqGSIb3DQEBCwUAA4IBAQAIfmyTEMg4uJapkEv/oV9PBO9sPpyIBslQj6Zz\n91cxG7685C/b+LrTW+C05+Z5Yg4MotdqY3MxtfWoSKQ7CC2iXZDXtHwlTxFWMMS2\nRJ17LJ3lXubvDGGqv+QqG+6EnriDfcFDzkSnE3ANkR/0yBOtg2DZ2HKocyQetawi\nDsoXiWJYRBuriSUBAA/NxBti21G00w9RKpv0vHP8ds42pM3Z2Czqrpv1KrKQ0U11\nGIo/ikGQI31bS/6kA1ibRrLDYGCD+H1QQc7CoZDDu+8CL9IVVO5EFdkKrqeKM+2x\nLXY2JtwE65/3YR8V3Idv7kaWKK2hJn0KCacuBKONvPi8BDAB\n-----END
+        CERTIFICATE-----"},"root":{"version":3,"serialNumber":"00","thumbprint":"47BEABC922EAE80E78783462A79F45C254FDE68B","subject":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","notBefore":"2009-09-01T00:00:00+00:00","notAfter":"2037-12-31T23:59:59+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","rawData":"-----BEGIN CERTIFICATE-----\nMIIDxTCCAq2gAwIBAgIBADANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\nEDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\nEUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\nZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTA5MDkwMTAwMDAwMFoXDTM3MTIzMTIz\nNTk1OVowgYMxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\nEwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjExMC8GA1UE\nAxMoR28gRGFkZHkgUm9vdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgLSBHMjCCASIw\nDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL9xYgjx+lk09xvJGKP3gElY6SKD\nE6bFIEMBO4Tx5oVJnyfq9oQbTqC023CYxzIBsQU+B07u9PpPL1kwIuerGVZr4oAH\n/PMWdYA5UXvl+TW2dE6pjYIT5LY/qQOD+qK+ihVqf94Lw7YZFAXK6sOoBJQ7Rnwy\nDfMAZiLIjWltNowRGLfTshxgtDj6AozO091GB94KPutdfMh8+7ArU6SSYmlRJQVh\nGkSBjCypQ5Yj36w6gZoOKcUcqeldHraenjAKOc7xiID7S13MMuyFYkMlNAJWJwGR\ntDtwKj9useiciAF9n9T521NtYJ2/LOdYq7hfRvzOxBsDPAnrSTFcaUaz4EcCAwEA\nAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYE\nFDqahQcQZyi27/a9BUFuIMGU2g/eMA0GCSqGSIb3DQEBCwUAA4IBAQCZ21151fmX\nWWcDYfF+OwYxdS2hII5PZYe096acvNjpL9DbWu7PdIxztDhC2gV7+AJ1uP2lsdeu\n9tfeE8tTEH6KRtGX+rcuKxGrkLAngPnon1rpN5+r5N9ss4UXnT3ZJE95kTXWXwTr\ngIOrmgIttRD02JDHBHNA7XIloKmf7J6raBKZV8aPEjoJpL1E/QYVN8Gb5DKj7Tjo\n2GTzLH4U/ALqn83/B2gX2yKQOC16jdFU8WnjXzPKej17CuPKf1855eJ1usV2GDPO\nLPAvTK33sefOT6jEm0pUBsV/fdUID+Ic/n4XuKxe9tQWskMJDE32p2u0mYRlynqI\n4uJEvlz36hz1\n-----END
+        CERTIFICATE-----"},"serialNumber":"10333674000992779418","lastCertificateIssuanceTime":"2020-12-07T04:23:02.477829","expirationTime":"2022-01-08T03:56:54","isPrivateKeyExternal":false,"appServiceCertificateNotRenewableReasons":["ExpirationNotInRenewalTimeRange"]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testVerificationCert/providers/Microsoft.CertificateRegistration/certificateOrders/testVerificationCert","name":"testVerificationCert","type":"certificateOrders","location":"global","properties":{"certificates":{"testVerificationCert":{"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg_soingles/providers/microsoft.keyvault/vaults/testcertrotationkv","keyVaultSecretName":"testverificationcertd9e4fa48-86b2-4081-9285-c9c32e23d362","provisioningState":"CertificateOrderFailed"}},"distinguishedName":"CN=a.soingles.com","domainVerificationToken":"gfqk2k6ovq4ufh22jeu9mv4jc5","validityInYears":1,"keySize":2048,"productType":"StandardDomainValidatedSsl","autoRenew":true,"status":"Denied","csr":"-----BEGIN
+        NEW CERTIFICATE REQUEST-----\r\nMIIEQTCCAykCAQAwGTEXMBUGA1UEAwwOYS5zb2luZ2xlcy5jb20wggEiMA0GCSqG\r\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCYrKlS7XZZ9GxSBbzD+f7dsiHxMts2TMPJ\r\nBDWCbgxrNzCB6bJe2ZIoxmN4GaDqLEpC56orByBQktsOPBpAAdQW0zF9adiJCmAn\r\nAZzLSKQtQB/sq1NCitAG1EanvzMWbRt7HdPk4FLc1lk/+BE25UwjMfh1L2EbLjDK\r\ndUteStMe2Hqb8WsvGMYZvm4tsI2nKEYS7eHeLAs3Tw6np+a4ugcfI8WZIL26hPgu\r\n396alD2GbK8nUMUZrciUnUTCqeCW4BroVQzV8GRduaIq7W2R4njQjR88Lbwg2umr\r\nk4QZMNP7N1bJ7yGaDH0ivzcJJ1P/4RQSd1zHeMKSZsnvbLPZsPVvAgMBAAGgggHh\r\nMBwGCisGAQQBgjcNAgMxDhYMMTAuMC4xNDM5My4yME0GCSsGAQQBgjcVFDFAMD4C\r\nAQUMDlJEMDAxNTVENDFFQTM0DB9JSVMgQVBQUE9PTFxHZW9NYXN0ZXJBcHBQb29s\r\nQ3NtDAh3M3dwLmV4ZTCBggYKKwYBBAGCNw0CAjF0MHICAQEeagBNAGkAYwByAG8A\r\ncwBvAGYAdAAgAEUAbgBoAGEAbgBjAGUAZAAgAFIAUwBBACAAYQBuAGQAIABBAEUA\r\nUwAgAEMAcgB5AHAAdABvAGcAcgBhAHAAaABpAGMAIABQAHIAbwB2AGkAZABlAHID\r\nAQAwgewGCSqGSIb3DQEJDjGB3jCB2zAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAww\r\nCgYIKwYBBQUHAwEwgZQGCSqGSIb3DQEJDwSBhjCBgzAOBggqhkiG9w0DAgICAIAw\r\nDgYIKoZIhvcNAwQCAgCAMAcGBSsOAwIHMAoGCCqGSIb3DQMHMAsGCWCGSAFlAwQB\r\nKjALBglghkgBZQMEAS0wCwYJYIZIAWUDBAEWMAsGCWCGSAFlAwQBGTALBglghkgB\r\nZQMEAQIwCwYJYIZIAWUDBAEFMB0GA1UdDgQWBBS9/uG8EGmsAEay2pGu3uVGTABn\r\niTANBgkqhkiG9w0BAQsFAAOCAQEAWdeKScWSosGN/jnoo7HG91b9IroX1vXcCs29\r\n7ihev+mdDZadJHxpHcoz2kZPhRF4YVRVh4DjQxRF7m7FkfDzjkBZBAI82Twbbub6\r\nANSIOx2UcEGRJq21sfdXY6yrr2+syp29grE2CZ3STFu1sJYpiHYVXOrVPzjYMdIL\r\nyMXaMSZUch7j2Fdovh/gTgBuegs0m9mErvA2PzVFHRdHu7FZ/8mPOtGcCeRCB6YG\r\nXiVT/hqsvtoLklFK3crxbc4lgPjo+pfYE3Z4usuG9G+srPiRXMyf926EMo26f5gL\r\n6GVE5AxrjJZojYak/XcJYDDAwFnWTTCSaYlRNk28wCIx5RnX4w==\r\n-----END
+        NEW CERTIFICATE REQUEST-----\r\n","isPrivateKeyExternal":false,"appServiceCertificateNotRenewableReasons":["ExpirationNotInRenewalTimeRange","RegistrationStatusNotSupportedForRenewal"]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testVerificationCertSoingles/providers/Microsoft.CertificateRegistration/certificateOrders/testVerificationCertSoingles","name":"testVerificationCertSoingles","type":"certificateOrders","location":"global","properties":{"certificates":{"testVerificationCertSoingles":{"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/keyvault_sofitest/providers/microsoft.keyvault/vaults/keyvaultsofitest","keyVaultSecretName":"testverificationcertsoingles8d3a3da4-417f-4bff-9f71-3cfa672cc662","provisioningState":"CertificateOrderFailed"}},"distinguishedName":"CN=soinglesTest.com","domainVerificationToken":"e2q54ms8phanfb66soiufpmvlh","validityInYears":1,"keySize":2048,"productType":"StandardDomainValidatedSsl","autoRenew":true,"status":"Denied","csr":"-----BEGIN
+        NEW CERTIFICATE REQUEST-----\r\nMIIEQzCCAysCAQAwGzEZMBcGA1UEAwwQc29pbmdsZXNUZXN0LmNvbTCCASIwDQYJ\r\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOOUm+6UE7xmr1t0futcULLsRKDpvEjA\r\nMf6PEfxYCsGe3T18rVkNqV0373TLOg4z+gMa8HMnkq36B5noTmKwbJZCCwQsyavd\r\ntpugLeLz7rpSXTbh5+AniHtKysU/o62wDpR8wsVYdGTXzCFTYsnSIY+ODYHPYE+h\r\nNRJMiWndLIU6ZVYm4xAAsEwRk7vRuxtI3iKPq+2bl3yCidMxig5KY6xInX8KVDt0\r\n+zHRWGIdCXHse79aA+5Ti4PFbZpL7UPJpxtT6t+A6XZUztLRT5DkNiYWNJZsU7XA\r\nh5oUh4FMA8ngtdPyztvQVX3vUNUYhO/WmYoEV5XipSjeEsqLfsrlBdUCAwEAAaCC\r\nAeEwHAYKKwYBBAGCNw0CAzEOFgwxMC4wLjE0MzkzLjIwTQYJKwYBBAGCNxUUMUAw\r\nPgIBBQwOUkQwMDE1NUQzMUU1NjYMH0lJUyBBUFBQT09MXEdlb01hc3RlckFwcFBv\r\nb2xDc20MCHczd3AuZXhlMIGCBgorBgEEAYI3DQICMXQwcgIBAR5qAE0AaQBjAHIA\r\nbwBzAG8AZgB0ACAARQBuAGgAYQBuAGMAZQBkACAAUgBTAEEAIABhAG4AZAAgAEEA\r\nRQBTACAAQwByAHkAcAB0AG8AZwByAGEAcABoAGkAYwAgAFAAcgBvAHYAaQBkAGUA\r\ncgMBADCB7AYJKoZIhvcNAQkOMYHeMIHbMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\r\nDDAKBggrBgEFBQcDATCBlAYJKoZIhvcNAQkPBIGGMIGDMA4GCCqGSIb3DQMCAgIA\r\ngDAOBggqhkiG9w0DBAICAIAwBwYFKw4DAgcwCgYIKoZIhvcNAwcwCwYJYIZIAWUD\r\nBAEqMAsGCWCGSAFlAwQBLTALBglghkgBZQMEARYwCwYJYIZIAWUDBAEZMAsGCWCG\r\nSAFlAwQBAjALBglghkgBZQMEAQUwHQYDVR0OBBYEFIg9Cx1tLN/9bZLisECAVLtS\r\nHfKiMA0GCSqGSIb3DQEBCwUAA4IBAQB4NFVCc2oP43IETLabGcrOkO76Wp543tqm\r\ni6BvRPB7Q/VJb0UzHQtFQT6ZU/I6bTOrL3oI8vkH0v6Aba0bzANGAIfdbYmWnC1L\r\nOzcoYwGyD6Z4utnXvcoH7IBIU9FZlbbjk3KvUih9Z/1CPha5c+ik1Aok6vaajroB\r\nXfy9ONETUnemDbK3iTEwz6mhgL+78XXlp+kBP94GjVT/Ltrt6bhLbGt6eXHqKBvR\r\numlqsEwXGppl9xmJ9ThvEp93UqFbJ+Vh+6vYRsnPtSgsIFBpnfyRLu5WaMXvejbS\r\nzRbH1Gv3WPKv33aoK9RqygMdBjho45+6kbkFZ8NmMsjjYcmVZ1TF\r\n-----END
+        NEW CERTIFICATE REQUEST-----\r\n","isPrivateKeyExternal":false,"appServiceCertificateNotRenewableReasons":["ExpirationNotInRenewalTimeRange","RegistrationStatusNotSupportedForRenewal"]}}],"nextLink":null,"id":null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1472'
+      - '24180'
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:21 GMT
+      - Mon, 04 Jan 2021 21:54:55 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
+      server:
+      - Microsoft-IIS/10.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
       vary:
       - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
       x-content-type-options:
       - nosniff
-      x-ms-original-request-ids:
-      - 4b33d37d-879a-46de-a8cb-7be4d849a574
-      - 0c43e119-876b-485a-8e88-3d21e403ea3a
-      - 77b738ea-ea6a-4434-820e-d90b1c6dc72f
-      - 4521cacf-f391-4f51-b29c-f42ef3b501ec
-      - e6f63225-dafe-4ea6-9ff4-643079ebe5bd
-      - 9c8a5628-9906-4d14-aa95-1bbc7e7e1f7f
+      x-powered-by:
+      - ASP.NET
     status:
       code: 200
       message: OK
@@ -1313,257 +1359,12 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZRRj6I4AID%2Fy%2BRyT%2BtKGXXjJJOL3gDKbOtaSiu8FcpsoQWroCCb%2Fe9X5zb7cPcLJiEQ0qbAx9fvx0NTDN3XslHtw9OPB28VkTh6eHqQXWfap%2Bm05g3%2FXtRF033m4%2BVcfM6P9bS9ZG1%2BLk1XHpt26mTgbTH7AiYge3MmMyH4hBf54yTPlu4X981ZzpfO1JyP11IU53YKy%2Fx8bI9v3efX4kb5RXfT6%2F3c%2FsVNObnaKXbVZ9cBy4ljD%2FDnH62yjzqqonmOivO1zIs1bwvxidTLSxoNKdushsQFVATwhhtc4UfZEj8HQpsNrQHiKjyRGAfcA11cDyl14p5p3GZUx%2FtKcgySG6tNKIBe7A8ypZ45My3s%2FPmGEsqzmD4%2BfPqFxv1YbGAj%2B9QTrKjxCzpoDnV6tqzaIggXrPF3dMSLRIlZ5usTa3QJ3d4lVfiaec4Y10sV%2BebKGoMKarZxo1FWyzZRsoHB%2FrZ7WaOM3FmKqmD0lG5Cy8rcEkdEPKB2PaMzJp1USc4DfChe1tCyvRCCrtD1T5SgErvSECWvcP%2F8bBlHu5hs%2FvYQwauvH03D%2F6Fu1k5yMAxqk0RVyu2nn1Jf9jDwO1ybqtBpn1CLhtGDRS6xN2%2FTlzDiVkOLTll0Y%2BrJVx74W75ZSzrue6YwLli4iauwxKNyEioi6NpfQajM4qNFLXa56ydW8wqCsE990QsFLrgKq4yGgCmphIu6IlhWMXGWFjnzPt6O%2Fy%2FqQlvrXNALN1zEDVZ2fLCoeE5NBw%2B4hI2Y210QwRh0abCUdhyksUBQzRes8hV0xZxoueP1drRWKq6TgegcWIu3UYN21PduhBmVB%2FiUjEhCZ362Vu8yhi77A07v70N84UA1JPkG77Dn3Hfdqwi2Nx4Mav8v6nD1bYXuvD94Q9S8T8awhS46Rc26pKN%2FSTeGo%2BB%2B9XcZoWdSg6Co0ZYRJKnbW5FFnwfoICydjOHLvbeQ4QOrB27FvzdHQQec7vO5jkdGJbuP82CeQmB6K%2FY7XdKYcj96tjlyB31zyYOlwo5tmiNY%2Fv29Ib%2Fz4cWrbx%2BPNHtBURZAW99UQp2ANAABZOHW3lcYpC5hc5775oA2xiYgdhIH88wNL3xjUBbPF0ThCPn6QBqhs3pvvXWA8GZjZMlRkPbW8zbXxosaqWy9B6LEK6T6FDdCsWDofiWEQLLmzJv99npfD5A%2B4lli10P3pNTz8j0hP3%2F%2BAw%3D%3D
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bim-rg/providers/Microsoft.KeyVault/vaults/bim-kv1","name":"bim-kv1","type":"Microsoft.KeyVault/vaults","location":"eastus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":true,"vaultUri":"https://bim-kv1.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZXbbqM4AED%2fJVrt06QBEjJKpWrVNEBCB2iML7HfDLjDzQ4KEAij%2bfdxOqN92P2CSggJGQE%2bPj78mCkxdt8KVbWzxx8z5zmGKJ49zvKua9rHxUJyxb8LKVT3wKf%2bIh7Ss1y0fdKml6LpirNqF0Zivq9XX825mbwb81WW8TkX6XKeJhvrq%2fVubOyNsWgu52uRiUu7CIr0cm7P793Dq7hh3tfd4no%2ft%2f%2fwpphf9S36qU%2bWYW7mhj7Mv%2f9qK%2f2qcyXUUywu1yIVW96K7AuUm57FI0vIaEA3f00k28dqW%2bDl8QYRuAhkgjdoPM2%2b%2fJmW9bnmFah8YE5GhAS78FTzQOYmNXMvkWDPvCbCVn7W40pId40Uq4F3NKA0y8BtOiRzDlz%2fRjEgqXQmoABP1HYFZfOaGsaEZF3gCdhUNr6oVlO637Kkohat8ihw7B6rvAAua1mVc%2b6Bk9htA%2bKgQY%2bfQ4L7Y%2bky4hg3Cg8jH57ujOMIwf2LE0Lw%2fO2zKfQ%2f1GW%2bhmXoCRJM6FRHseMvKU4NIX3KPbMCVnqjljEEhn2KVZ5r5Uxq5BW3wjVUmb7O1gyDKHTsA5Q2C%2bQ40OkwZm7doxJUom7WjNheSvw9UEyjZEtWZVFquRTJsQzMw8BIA0Rd90fol0GJr2wXvty%2fBypQHKGx0ciJ8%2fl2639RC3kcKGnitLIRknYe1M2FlOGZe86NTn6Op3xNiN2mbuOQ0i80yhVdNlVS2QcE3Yi4fk8tmwd1dSMqLBNEpw%2frCXCQAlGgtgPB6Zjg%2bpQt64K4zNJWR8LzD0h2HBtnk5a%2bkXm4514dJtC9MCd%2fST3%2fBMpt9Ae1%2f%2fz2HN55f%2faGgJG5%2bTWQgMaqLoISmRRnFcdNl%2b5YrmlMtPwQFUHZVcCxTWo1UYjsnnl2Hnu5TarU5par6ZlMr9ZKN6TSG2Of7FgYWMeJOaC6ryaEfiFqv9FiG0E1Uqia4jg5A6l1YzyM2M6NsLOaGDHj5PtHQ%2f7Nh4Oe3z4fabIL48TTyZBMe0xN5pleQO6esRKYdNRbnmfe8cb3YYHNxqA14Clu1vDURAk5jtQyDU2uC4lOjrexaQV0fbETS%2b0lAQ0lJkkI3oenTJM%2fDJpwnHlhjxTWidF%2fi98JgQHccuKsBuj%2bJn%2bUY4ANtqQoWwlNHqlt%2fuH1z5%2b%2fAA%3d%3d"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1959'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 29 Oct 2020 03:19:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-original-request-ids:
-      - 5603d2c4-966d-4be1-92da-7ecca8201aa3
-      - 744a9c05-d002-4c49-a22f-7d8f7ca945cc
-      - e837365b-e265-458f-8d30-53dbc71a2255
-      - 91a56aff-ac43-4994-8f48-67c0f16ce09d
-      - eaf743af-afa6-4982-8291-f466b5cc8f27
-      - 27f43079-4f2b-4344-a174-52d06dd4bdb6
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp config ssl import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --key-vault --key-vault-certificate-name
-      User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZXbbqM4AED%2FJVrt06QBEjJKpWrVNEBCB2iML7HfDLjDzQ4KEAij%2BfdxOqN92P2CSggJGQE%2BPj78mCkxdt8KVbWzxx8z5zmGKJ49zvKua9rHxUJyxb8LKVT3wKf%2BIh7Ss1y0fdKml6LpirNqF0Zivq9XX825mbwb81WW8TkX6XKeJhvrq%2FVubOyNsWgu52uRiUu7CIr0cm7P793Dq7hh3tfd4no%2Ft%2F%2Fwpphf9S36qU%2BWYW7mhj7Mv%2F9qK%2F2qcyXUUywu1yIVW96K7AuUm57FI0vIaEA3f00k28dqW%2BDl8QYRuAhkgjdoPM2%2B%2FJmW9bnmFah8YE5GhAS78FTzQOYmNXMvkWDPvCbCVn7W40pId40Uq4F3NKA0y8BtOiRzDlz%2FRjEgqXQmoABP1HYFZfOaGsaEZF3gCdhUNr6oVlO637Kkohat8ihw7B6rvAAua1mVc%2B6Bk9htA%2BKgQY%2BfQ4L7Y%2Bky4hg3Cg8jH57ujOMIwf2LE0Lw%2FO2zKfQ%2F1GW%2BhmXoCRJM6FRHseMvKU4NIX3KPbMCVnqjljEEhn2KVZ5r5Uxq5BW3wjVUmb7O1gyDKHTsA5Q2C%2BQ40OkwZm7doxJUom7WjNheSvw9UEyjZEtWZVFquRTJsQzMw8BIA0Rd90fol0GJr2wXvty%2FBypQHKGx0ciJ8%2Fl2639RC3kcKGnitLIRknYe1M2FlOGZe86NTn6Op3xNiN2mbuOQ0i80yhVdNlVS2QcE3Yi4fk8tmwd1dSMqLBNEpw%2FrCXCQAlGgtgPB6Zjg%2BpQt64K4zNJWR8LzD0h2HBtnk5a%2BkXm4514dJtC9MCd%2FST3%2FBMpt9Ae1%2F%2Fz2HN55f%2FaGgJG5%2BTWQgMaqLoISmRRnFcdNl%2B5YrmlMtPwQFUHZVcCxTWo1UYjsnnl2Hnu5TarU5par6ZlMr9ZKN6TSG2Of7FgYWMeJOaC6ryaEfiFqv9FiG0E1Uqia4jg5A6l1YzyM2M6NsLOaGDHj5PtHQ%2F7Nh4Oe3z4fabIL48TTyZBMe0xN5pleQO6esRKYdNRbnmfe8cb3YYHNxqA14Clu1vDURAk5jtQyDU2uC4lOjrexaQV0fbETS%2B0lAQ0lJkkI3oenTJM%2FDJpwnHlhjxTWidF%2Fi98JgQHccuKsBuj%2BJn%2BUY4ANtqQoWwlNHqlt%2FuH1z5%2B%2FAA%3D%3D
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bim-rg/providers/Microsoft.KeyVault/vaults/dogfood-env-pwd","name":"dogfood-env-pwd","type":"Microsoft.KeyVault/vaults","location":"eastus","tags":{},"properties":{"sku":{"family":"A","name":"Standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"7d80ae58-a9f9-44ce-b048-636b50d9ad1d","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore"],"secrets":["Get","List","Set","Delete","Recover","Backup","Restore"],"certificates":["Get","List","Update","Create","Import","Delete","Recover","Backup","Restore","ManageContacts","ManageIssuers","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers"]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"d7e17135-d5a7-4b8b-89e5-252aa15b7e01","permissions":{"keys":[],"secrets":["Get"],"certificates":[]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://dogfood-env-pwd.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bim_pl_test_rg/providers/Microsoft.KeyVault/vaults/bimkv-nr-test","name":"bimkv-nr-test","type":"Microsoft.KeyVault/vaults","location":"eastus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","networkAcls":{"bypass":"AzureServices","defaultAction":"Allow","ipRules":[{"value":"1.2.3.4/32"},{"value":"3.4.5.6/32"}],"virtualNetworkRules":[]},"accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://bimkv-nr-test.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bim_pl_test_rg/providers/Microsoft.KeyVault/vaults/bimkv-nr-test2","name":"bimkv-nr-test2","type":"Microsoft.KeyVault/vaults","location":"eastus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","networkAcls":{"bypass":"AzureServices","defaultAction":"Allow","ipRules":[{"value":"1.2.3.4/32"},{"value":"3.4.5.0/24"}],"virtualNetworkRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/bim_pl_test_rg/providers/microsoft.network/virtualnetworks/bimplvnet/subnets/bimsubnet"}]},"accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://bimkv-nr-test2.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZVbj5s4GIb%2fy2i1V01jk0OVkUarScMhTE0aY%2bzYd%2bYwAxgDDZAQqv73OrujvekvGAkhIWNb3%2bPne%2f3zoc7G%2fltRq%2b7h8eeD%2fRySKHx4fMj7vu0e53Mta%2fmW6azuP8tpOGefk0bPuyHuknPR9kVTd3MQw9f18gucwfgVzJZpKmcySxazJN5YX6xXsFltwLw9N5cizc7dHBXJuema1%2f7zS3ajcqj6%2beX%2b7v6RbTG7mF%2fMqk8WgJsZMA%2f8%2b69Oma0aldVPYXa%2bFEm2lV2WfiJ6M4hwFDEbAdsFXxP4NkV6LBH0NbegOjhVH3s4R7ACXK%2f81MUerVuFbbV5%2bPReqvWxakV1fhV2yjKNd8GpkqhUI9PwRcKqj%2brqgK3rZGp3A3t1Ck5tTq1xFHYCkIV7pvuC2WJJVM6CaHmjNRV0gQczf5lofx2WQRm66ZpHqUwt%2boPqTW72WXCYhrGCvZycKtZvV6FyKV18ynZbxOzoRsqAZa5jxv0qruyJVbmS16cnwzg8RMT7agcEP3%2f7aFr9gRruR0GxTDSawtIPEKArwVZN5lSR2OEgVu3ADYpYrfYGiUTWFYooXWQsGKJyK2NFV6T0w4T5nnRhRYG4cJWGgYt7uQuKWOc3dmoP0mlPYSlypNqLUOkhsRz%2brnXDIVaBPt6ku1Fxvb0wBuuM7aejzosjAXetmf3xOvgP1EpdCfEPgcb7xAsq7Ng3TnyZROBmLC6Z3VoGJUi1fYu9tsgqfh%2fvEtjcsN4oushX5iiusQ2HsBYVnpyWaOhk2vfM0UkK7UnsApmaLhCeEAj48G516to3WlIVR3zkKg8RgAMjgUCL7Zqx9uXdav%2f5%2b3Nw5%2fzBs6PGHVf4JY7gEHupkBVdE5XAgLa9cDcSqWbkIL8i157oqTUUaWsEfEnBqjc0Cwz3gFQpMNkwJF6qQtu%2fEQaXsYv3xxrfs%2bbCQQoy7ezDGss4Wo5GaIDUyEndFsfJvpqsOCDXj4TnyNBenTnAEh3%2fzY7%2fY8OOnr9%2fPNLmRgpjF5kbybRyxaFwoYuYvzffJYYc8nurV%2b0PQrY5vUcLgyBldB%2b7o%2fF32%2fLSVzFspog4JQYNZDS%2fZAxzVoqSuXhJyH6J3IALLxeopBY3nmY66NmpOmSVaN%2bjgyCylcxeXonzH%2fmjHhGdnDW3wBXZq4HWuRSTiY5fv34D"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '5488'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 29 Oct 2020 03:19:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-original-request-ids:
-      - f4e421ed-b52b-4a60-bb53-a8ad8dd544da
-      - 8e213d48-af69-4d71-b39d-19c333cdb61c
-      - 6d1f8f9e-62b3-4a78-9141-029a4f078921
-      - 4fd09bbc-b399-4fe7-99bd-0a257e96abd7
-      - 87f8cf6d-f099-48ef-a9d0-876829290199
-      - eccabcf4-e7e4-47ce-af70-a61bdddcfc15
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp config ssl import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --key-vault --key-vault-certificate-name
-      User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZVbj5s4GIb%2Fy2i1V01jk0OVkUarScMhTE0aY%2BzYd%2BYwAxgDDZAQqv73OrujvekvGAkhIWNb3%2BPne%2F3zoc7G%2FltRq%2B7h8eeD%2FRySKHx4fMj7vu0e53Mta%2FmW6azuP8tpOGefk0bPuyHuknPR9kVTd3MQw9f18gucwfgVzJZpKmcySxazJN5YX6xXsFltwLw9N5cizc7dHBXJuema1%2F7zS3ajcqj6%2BeX%2B7v6RbTG7mF%2FMqk8WgJsZMA%2F8%2B69Oma0aldVPYXa%2BFEm2lV2WfiJ6M4hwFDEbAdsFXxP4NkV6LBH0NbegOjhVH3s4R7ACXK%2F81MUerVuFbbV5%2BPReqvWxakV1fhV2yjKNd8GpkqhUI9PwRcKqj%2BrqgK3rZGp3A3t1Ck5tTq1xFHYCkIV7pvuC2WJJVM6CaHmjNRV0gQczf5lofx2WQRm66ZpHqUwt%2BoPqTW72WXCYhrGCvZycKtZvV6FyKV18ynZbxOzoRsqAZa5jxv0qruyJVbmS16cnwzg8RMT7agcEP3%2F7aFr9gRruR0GxTDSawtIPEKArwVZN5lSR2OEgVu3ADYpYrfYGiUTWFYooXWQsGKJyK2NFV6T0w4T5nnRhRYG4cJWGgYt7uQuKWOc3dmoP0mlPYSlypNqLUOkhsRz%2BrnXDIVaBPt6ku1Fxvb0wBuuM7aejzosjAXetmf3xOvgP1EpdCfEPgcb7xAsq7Ng3TnyZROBmLC6Z3VoGJUi1fYu9tsgqfh%2FvEtjcsN4oushX5iiusQ2HsBYVnpyWaOhk2vfM0UkK7UnsApmaLhCeEAj48G516to3WlIVR3zkKg8RgAMjgUCL7Zqx9uXdav%2F5%2B3Nw5%2FzBs6PGHVf4JY7gEHupkBVdE5XAgLa9cDcSqWbkIL8i157oqTUUaWsEfEnBqjc0Cwz3gFQpMNkwJF6qQtu%2FEQaXsYv3xxrfs%2BbCQQoy7ezDGss4Wo5GaIDUyEndFsfJvpqsOCDXj4TnyNBenTnAEh3%2FzY7%2FY8OOnr9%2FPNLmRgpjF5kbybRyxaFwoYuYvzffJYYc8nurV%2B0PQrY5vUcLgyBldB%2B7o%2FF32%2FLSVzFspog4JQYNZDS%2FZAxzVoqSuXhJyH6J3IALLxeopBY3nmY66NmpOmSVaN%2BjgyCylcxeXonzH%2FmjHhGdnDW3wBXZq4HWuRSTiY5fv34D
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bim_pl_test_rg/providers/Microsoft.KeyVault/vaults/bimkv-nr-test3","name":"bimkv-nr-test3","type":"Microsoft.KeyVault/vaults","location":"eastus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","networkAcls":{"bypass":"AzureServices","defaultAction":"Allow","ipRules":[{"value":"1.2.3.4/32"},{"value":"3.4.5.0/24"}],"virtualNetworkRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/bim_pl_test_rg/providers/microsoft.network/virtualnetworks/bimplvnet/subnets/bimsubnet"}]},"accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"enableRbacAuthorization":false,"vaultUri":"https://bimkv-nr-test3.vault.azure.net/","provisioningState":"Succeeded"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bim_pl_test_rg/providers/Microsoft.KeyVault/vaults/bimplkv","name":"bimplkv","type":"Microsoft.KeyVault/vaults","location":"eastus","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","privateEndpointConnections":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bim_pl_test_rg/providers/Microsoft.KeyVault/vaults/bimplkv/privateEndpointConnections/bimconn","etag":"c3232999b52f4d5caaf41599da4f300c","properties":{"provisioningState":"Succeeded","privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/bim_pl_test_rg/providers/Microsoft.Network/privateEndpoints/bimpe"},"privateLinkServiceConnectionState":{"status":"Approved","description":"","actionsRequired":"None"}}}],"accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["Get","Create","Delete","List","Update","Import","Backup","Restore","Recover","Purge"],"secrets":["Get","List","Set","Delete","Backup","Restore","Recover","Purge"],"certificates":["Get","List","Delete","Create","Import","Update","ManageContacts","GetIssuers","ListIssuers","SetIssuers","DeleteIssuers","ManageIssuers","Recover","Purge"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enabledForDiskEncryption":false,"enabledForTemplateDeployment":false,"enableSoftDelete":true,"enableRbacAuthorization":false,"vaultUri":"https://bimplkv.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZXRbqM4FIbfpVrt1XRik5JRKlWrpAECHcPEGBz7zmB3CGCggSTAaN593e5o36ES4gJZIL7%2fP9%2f5ddeocfh%2baqr%2b7vHXnbOJSRLfPd4Vw9D1j4uFFo34qbRqhq9ivpzV17zVi%2f6S9fn51A2ntukXIIOvq4dv8B5mr%2bD%2bQUpxL1S%2bvM%2bztfXNegVrew0W3bm9nqQ69wt0ys9t374OX1%2fUlIpLPSyu7%2ff%2bH9Gd7q%2fmiHnrkwXg%2bh6YC%2f79V1%2bZT7WVap5idb6ecrUVvZJfiF5feDxy1BQ37kiqNN6Fx1qoCq5o08WKhglb1oWqg45UxbOg7l7upUiXm5EBHEkLDzHZcqQLwHchzbU%2fkTLg1OUdp12FKD5myy5C1gGY53GuU0abNEQgXdG6ENJCk5i3JfX6iVdFpLzAT%2fQgUtBCVgYApe2E6FBlZDNyDwpR1xexlyWfwfruyx%2fU1udmjWBw5bsACH2YxL6rsdutuJPbMrHfUuKGSOcjI76dwfqSeV2k6mTkrrwJ2E4h4SV1gjdSYypNVom2Cwz9mRB%2fFDQYkiaMsIVXTNsvEjzMMQl5ZrI1rIXw8FHttih17JY7RZV7wT48BhwBDjkFdrZ5ejKM4ygh%2b2cnJHjz%2fbPXGpnaklrepHZ9XLphVvkWrfIbov4kvcGgKpYsxZVyuyHWwwkDMBISPiuavnGvOGVHNNK0aJF3mFNtc2ThJU9kpBLbJ2RbZsnDRFP5IoDN8LE2Y2CirWSUWy5L9FiaqAFpOhpqPNAyFar2R05hpKhrosDiQD5qTZ3PbxBU2RMxv5a7lWldUIia9%2b8tFRbexwZFusQ3ZtlV5thvbN5GqOId1TaV2p%2fzHTdoD5CRoBewmrnXCbzcTqwu4qyuj2lTmBb7gOouFjpgYs9FvN%2fC91ZLz5nSMq2yhI2sKuIcwMuhdIWoHiADss1uH60ONj824TvnT%2b4OEEz02AVIuw7VY4Rn92a8yZV25g93wG6itRShh%2f1sWYsUcotQm4q0u%2fA5jJC%2bAVqGL8hKj9wbT9j1LbbsYuS5hqqsYzdYMWq3JpXJuIfT%2fcZ4WgJUGSU13ekwOzfj8cic3ydNF6JmA6mGV%2fXzg%2fL%2f2nCSzY%2fPR5ruwjjz0JxoXqCaQbOBPETfNxQv8bKwzahfDbkhOron009Ijp0w1jYWxVHssIlB%2fGLmYK92gcDWYDMSGpIhI3o0G7Q40wqbjYgm2pgN6LorBopbWNdGFUNpkrr8UQdBZCuo83Aj7n%2fkD01YCrK5ETMfqIIDm91Ivm%2fE37%2f%2fBQ%3d%3d"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '4639'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 29 Oct 2020 03:19:22 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-original-request-ids:
-      - c6a4ff8c-329b-4fa7-80d7-8dc4c9c5329c
-      - ccde8801-a2ae-4347-bc25-1d919b24cdee
-      - faacb467-ee5f-4a89-ba89-b449a055439a
-      - 048ec0cc-7efb-4faf-8fe0-ef279a90b698
-      - 360e19a6-cc9a-4343-b952-f61a15d13956
-      - 84ee5db7-d614-4085-8996-249626f7c6ba
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp config ssl import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --key-vault --key-vault-certificate-name
-      User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZXRbqM4FIbfpVrt1XRik5JRKlWrpAECHcPEGBz7zmB3CGCggSTAaN593e5o36ES4gJZIL7%2FP9%2F5ddeocfh%2Baqr%2B7vHXnbOJSRLfPd4Vw9D1j4uFFo34qbRqhq9ivpzV17zVi%2F6S9fn51A2ntukXIIOvq4dv8B5mr%2BD%2BQUpxL1S%2BvM%2BztfXNegVrew0W3bm9nqQ69wt0ys9t374OX1%2FUlIpLPSyu7%2Ff%2BH9Gd7q%2FmiHnrkwXg%2Bh6YC%2F79V1%2BZT7WVap5idb6ecrUVvZJfiF5feDxy1BQ37kiqNN6Fx1qoCq5o08WKhglb1oWqg45UxbOg7l7upUiXm5EBHEkLDzHZcqQLwHchzbU%2FkTLg1OUdp12FKD5myy5C1gGY53GuU0abNEQgXdG6ENJCk5i3JfX6iVdFpLzAT%2FQgUtBCVgYApe2E6FBlZDNyDwpR1xexlyWfwfruyx%2FU1udmjWBw5bsACH2YxL6rsdutuJPbMrHfUuKGSOcjI76dwfqSeV2k6mTkrrwJ2E4h4SV1gjdSYypNVom2Cwz9mRB%2FFDQYkiaMsIVXTNsvEjzMMQl5ZrI1rIXw8FHttih17JY7RZV7wT48BhwBDjkFdrZ5ejKM4ygh%2B2cnJHjz%2FbPXGpnaklrepHZ9XLphVvkWrfIbov4kvcGgKpYsxZVyuyHWwwkDMBISPiuavnGvOGVHNNK0aJF3mFNtc2ThJU9kpBLbJ2RbZsnDRFP5IoDN8LE2Y2CirWSUWy5L9FiaqAFpOhpqPNAyFar2R05hpKhrosDiQD5qTZ3PbxBU2RMxv5a7lWldUIia9%2B8tFRbexwZFusQ3ZtlV5thvbN5GqOId1TaV2p%2FzHTdoD5CRoBewmrnXCbzcTqwu4qyuj2lTmBb7gOouFjpgYs9FvN%2FC91ZLz5nSMq2yhI2sKuIcwMuhdIWoHiADss1uH60ONj824TvnT%2B4OEEz02AVIuw7VY4Rn92a8yZV25g93wG6itRShh%2F1sWYsUcotQm4q0u%2FA5jJC%2BAVqGL8hKj9wbT9j1LbbsYuS5hqqsYzdYMWq3JpXJuIfT%2FcZ4WgJUGSU13ekwOzfj8cic3ydNF6JmA6mGV%2FXzg%2FL%2F2nCSzY%2FPR5ruwjjz0JxoXqCaQbOBPETfNxQv8bKwzahfDbkhOron009Ijp0w1jYWxVHssIlB%2FGLmYK92gcDWYDMSGpIhI3o0G7Q40wqbjYgm2pgN6LorBopbWNdGFUNpkrr8UQdBZCuo83Aj7n%2FkD01YCrK5ETMfqIIDm91Ivm%2FE37%2F%2FBQ%3D%3D
-  response:
-    body:
-      string: '{"value":[],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZXtjps6EIbvZXV0fjUbTMJWWWl1lDRAltSmMcYG%2fzMfW8A2sIFsCFXvvd62OvewkmVppNGM%2fPh9Z37cteU0fq1bOdw9%2frhztxGJo7vHu2oc%2b%2bFxudSiFd9LXbbjvZgv5%2fI%2b7%2fRyuGRDfq77se7aYWll4OVh%2fRksQPZiLdZFIRaizFeLPNvYn%2b0Xa%2bNsrGV%2f7t7qojwPS1jn527oXsb7Y3mj4qLG5dv7Pfwn%2bnrxZlJM1SfbApuFZQ74959BmladLNunqDy%2f1Xm5E0NZfCJ6c%2bHRxGFbXblbsFLjPUqUKFU3pzZA0MYXvqcVbPE5VZUsfexSPaoswVY6B8dcn26sDWohnQtRWGZ%2b8Bw1VEb%2b94lJfIQMJ%2fzAK%2bb1EyOoy3SQRHpSGZuujAG%2fpGrMDkhl0hm4zCfE4IxbpPAcT6Y%2fg8wbiZ4E9p5tvkfHInYemN5IPlubu09%2fUdsfmzW0q9eUFgL5%2bDVuUZjF%2fcgpDpGSN5R4FWy8mRg2wqdx3Hgqi50r04BDaz1T3XMo0yvfBz70T3O2DwQGwZqQIEL%2b6RZpJUvZPxjWIfJUYuo1zPUcLishfJyU%2bx2kXvCaahDmoLtBphpoBTZhTldun54M4yiMyeGLiwjefv3Asj6EhEu6wr2R0Rdo0wMklXkqn43so8xTl8zItNQnO9XWFUonIbpvsMdtoqodvP5GwdyP72yo%2bJlRbJxNX%2fmhr6GurqmsUBmDEZNAZMnJJtpyMoYv2CAwTl2nJDhCjQ%2b47UPqde9OxKX2kmKPKrjazkZ9VmHTJPPHEALlEO2w3AJGzVRSkM5cFmFue2mspwaCYGZNcDaTZqQEhUK5xuk9hhKMcYPq4o%2bzg%2b23LXrn%2fcG9bTlT2qAG0t4lSR8KfZoJA615fSIMrfc5a%2bgJ5Fo3tN8ZQTprHuNj7tPLyeRDK7U5A1dh02dm6kR%2b1TFaDCY%2bZPtdaGLHzF1m8lP83qeJb4a2BeWUkravT7N7ZaoKofF%2b1Hjc%2fP6aySJCp9%2bC%2ft%2fWbrz99vFIsz2KMh%2fOseYVVCngPvAhC55N3OBV5TBVrAz5sfRVmMkOpMyyoI9HRHYhbKTJdyKkejdqqyqT3GLaOUPmzmYrqsgLVoZgYzbQhR8qRUE8Gb8g6DoXPge10fHDX10TSHaCuesr8f6QP7WoEcSbUlD5ZeyMYcJVTMzG%2bvnzFw%3d%3d"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1454'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 29 Oct 2020 03:19:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-original-request-ids:
-      - e5e840d9-c540-47ab-9f29-7cb37fe8fcb7
-      - 18e5369d-e7b9-4ad5-b8dc-1ff8b572d87d
-      - 5955449b-568f-419f-a42a-babab47d8210
-      - 3d8ce8c1-c018-406b-aa1f-543660674567
-      - 14d5c53a-c79e-4e7f-85e5-c5b442b2693b
-      - b46ea981-aa58-4144-8e63-8bacecd4fc0c
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp config ssl import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --key-vault --key-vault-certificate-name
-      User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=1ZXtjps6EIbvZXV0fjUbTMJWWWl1lDRAltSmMcYG%2FzMfW8A2sIFsCFXvvd62OvewkmVppNGM%2FPh9Z37cteU0fq1bOdw9%2FrhztxGJo7vHu2oc%2B%2BFxudSiFd9LXbbjvZgv5%2FI%2B7%2FRyuGRDfq77se7aYWll4OVh%2FRksQPZiLdZFIRaizFeLPNvYn%2B0Xa%2BNsrGV%2F7t7qojwPS1jn527oXsb7Y3mj4qLG5dv7Pfwn%2BnrxZlJM1SfbApuFZQ74959BmladLNunqDy%2F1Xm5E0NZfCJ6c%2BHRxGFbXblbsFLjPUqUKFU3pzZA0MYXvqcVbPE5VZUsfexSPaoswVY6B8dcn26sDWohnQtRWGZ%2B8Bw1VEb%2B94lJfIQMJ%2FzAK%2Bb1EyOoy3SQRHpSGZuujAG%2FpGrMDkhl0hm4zCfE4IxbpPAcT6Y%2Fg8wbiZ4E9p5tvkfHInYemN5IPlubu09%2FUdsfmzW0q9eUFgL5%2BDVuUZjF%2FcgpDpGSN5R4FWy8mRg2wqdx3Hgqi50r04BDaz1T3XMo0yvfBz70T3O2DwQGwZqQIEL%2B6RZpJUvZPxjWIfJUYuo1zPUcLishfJyU%2Bx2kXvCaahDmoLtBphpoBTZhTldun54M4yiMyeGLiwjefv3Asj6EhEu6wr2R0Rdo0wMklXkqn43so8xTl8zItNQnO9XWFUonIbpvsMdtoqodvP5GwdyP72yo%2BJlRbJxNX%2Fmhr6GurqmsUBmDEZNAZMnJJtpyMoYv2CAwTl2nJDhCjQ%2B47UPqde9OxKX2kmKPKrjazkZ9VmHTJPPHEALlEO2w3AJGzVRSkM5cFmFue2mspwaCYGZNcDaTZqQEhUK5xuk9hhKMcYPq4o%2Bzg%2B23LXrn%2FcG9bTlT2qAG0t4lSR8KfZoJA615fSIMrfc5a%2BgJ5Fo3tN8ZQTprHuNj7tPLyeRDK7U5A1dh02dm6kR%2B1TFaDCY%2BZPtdaGLHzF1m8lP83qeJb4a2BeWUkravT7N7ZaoKofF%2B1Hjc%2FP6aySJCp9%2BC%2Ft%2FWbrz99vFIsz2KMh%2FOseYVVCngPvAhC55N3OBV5TBVrAz5sfRVmMkOpMyyoI9HRHYhbKTJdyKkejdqqyqT3GLaOUPmzmYrqsgLVoZgYzbQhR8qRUE8Gb8g6DoXPge10fHDX10TSHaCuesr8f6QP7WoEcSbUlD5ZeyMYcJVTMzG%2BvnzFw%3D%3D
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"559f925e-c126-4b02-a759-f0b2f5d999fe","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.KeyVault/vaults?api-version=2019-09-01&%24skiptoken=3ZVdb6M4FIb%2fS7Taq0mDaehsKlWrtIUk7JhMjPEB35mPFmIMbiAJYTT%2ffZ3OrLR7sXvflRASyBzE8748%2fjZpiqH%2fUjWym9x%2fm7jLkEbh5H5S9r3u7mczJRrxWqii6W%2fEeDwUN1mrZt0x7bJDpfuqbbqZlaKXu%2flnNEXpizWd57mYiiK7nWbpwv5sv1gLZ2HN9KE9VXlx6Ga4yg5t1770N38UFyaOdT87Xc%2fd70JX05NZYqY%2b2BZaTC1zoF9%2f6aR5VSuL5iEsDqcqKx5FV%2bSfqFoceThw3JRn7uZQKPIcxLXAUrccHJFGzh2ohQSXWxDrLVYkjhq2J1aLEoUsgfRarEth7ve0LrcY6btk9GWqyjOwbBBMx8Xak%2bDxE7DcwpaTkEZvU6nHhAby%2bjwzc2G1G7nMt%2fnKczB9FODOz9TLrXTFElClZLevZ6qcp8z247DxeD5ai8mnn6jtj8canoMwXeExUrzEdYL4Cq0w%2bJu%2frikgH9v%2bZtcEkljOhSodZtI5hg2TzN6d%2bfPGEbUcxaoM0uZxnlAfUnDHaE9Kw%2fqS2DpMFVmHqubMNtnsg04ovydNKYXUb1fWme3Rv7PGcojz1VBHo%2feWyBIKYBtGH7c%2fWYP7P6h1rW9BOacCvHW%2bWohUDU4CGgLzqdD4tal7lyACqc2Ou4aJNMaXBJVPeOVesmdfMs%2f%2fEQWqjztTU7N%2boHXeiRWLKPU5rJcXuvfnAfhJtGeSoM2Zy3KbQnDcxeT9N7vW2qBOQhMFs38b%2bHNwwMrbZGvC%2bY9a%2b8uvy%2bDK%2b%2bMV%2bx8SQe3AGZGZ2hgqQQmutgEcCFh7wXFepZGRhUJzDOzI117FxteBmzQw4FGMATfSaUEhZooYwZ5X4PrzhJWBkUh0lRGx0F0SEZl6Otk1%2bZ7Y2VUi73Rpo6vd6J7hKiUX9WGjS2K%2fDlBnFl4%2bPBh5PLkBJcsvUehGy68fj%2fR%2fKGRPbkvHKADyyIlJXAdYtsj00yo8HW%2bpL7Eqx6Q25FwnNgowpI3OJQmNft%2fY3vRe7UzvSWj03BslVCl9dMx2ABnTd1T1UtQ%2b%2bheFmCSCvaDuhXs5ZGZOYbaHd4V8%2f%2f4n"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '2632'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 29 Oct 2020 03:19:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-original-request-ids:
-      - c632ec4c-1477-4626-864b-58ea9e9c136f
-      - b339194c-5253-4eae-8ffe-8b3a1d542d9b
-      - 33a01cd6-912c-4a5d-a676-dec6ab87494b
-      - 32cf9243-1721-48b5-98a7-ec457cabb65e
-      - 62e55b9b-8061-453a-a695-640c448197f3
-      - 5e0138cc-006a-4bf4-b37a-a88641e25b4d
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - webapp config ssl import
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --resource-group --name --key-vault --key-vault-certificate-name
-      User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"559f925e-c126-4b02-a759-f0b2f5d999fe","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000004","name":"kv-ssl-test000004","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000004.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1572,7 +1373,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:19:25 GMT
+      - Mon, 04 Jan 2021 21:54:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1590,7 +1391,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.112.0
+      - 1.1.163.0
       x-powered-by:
       - ASP.NET
     status:
@@ -1610,17 +1411,17 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/99d1d831-0cdf-4a81-8a09-d1d75851b8d3?api-version=1.6
   response:
     body:
       string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
-        ''9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa'' does not exist or one of its queried
-        reference-property objects are not present."},"requestId":"511108c5-b5e3-437a-8122-16423d0be92c","date":"2020-10-29T03:19:26"}}'
+        ''99d1d831-0cdf-4a81-8a09-d1d75851b8d3'' does not exist or one of its queried
+        reference-property objects are not present."},"requestId":"71561d19-9794-4653-881e-46d4b998ef76","date":"2021-01-04T21:54:57"}}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1633,19 +1434,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 29 Oct 2020 03:19:26 GMT
+      - Mon, 04 Jan 2021 21:54:56 GMT
       duration:
-      - '2410389'
+      - '501090'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - OdGMxGQXjcsEi1Ni8TYUlnct7L7Q1SWuomHGX99xfas=
+      - ZteZdd4BYWHqMf8xBUaS03QB6skVcEZNa1oco3ZR9Y8=
       ocp-aad-session-key:
-      - 9NKlD2Q4H6hngGu2oQvu1_irTcwGVXxXs0tLK6uEr57DVSyVIRWBj-Wa3J0MQf67MWvKbOkH2B00_FrRMZdZriFjHPmyG0Ei-XooRz68q5-bzt16I-Hy11MJJJ5gyySs.ag4dsqhozwYh8bh8g6zbfg7qt7Oy9u6gUL4lo5dlPFI
+      - Vgflm-d_Vbra83e9hue6SI3pG-_pQMeA8OfNpuyobWwsD7deyRIIg5LHnfEM0o0QJypqEwSIYOhvI23JyYLy0vLVJEvomUFVKT98vGE0lQED7sKFBcXmQ3lG_-38_ANx.cfre9ko8TCT_SaZH51WXh8OnAIrIVjxbj3nJdHqMzAE
       pragma:
       - no-cache
       request-id:
-      - 511108c5-b5e3-437a-8122-16423d0be92c
+      - 71561d19-9794-4653-881e-46d4b998ef76
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1673,46 +1474,45 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/559f925e-c126-4b02-a759-f0b2f5d999fe?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/f8daea97-62e7-4026-becf-13c2ea98e8b4?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"559f925e-c126-4b02-a759-f0b2f5d999fe","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
-        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":"f8cdef31-a31e-4b4a-93e4-5f571e91255a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft
-        Azure App Service","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
+        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft.Azure.WebSites","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access all the APIs registered with App Service","adminConsentDisplayName":"Access
         APIs registered with App Service","id":"e0ea806b-d128-49dc-ac08-2bf18f7874d8","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access all the APIs registered with App Service","userConsentDisplayName":"Access
-        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":["https://trywebsites.azurewebsites.net/","https://trywebsitesstaging.azurewebsites.net/","https://resources-staging.azure.com","https://resources.azure.com","https://deploy.azure.com","https://deploy-staging.azure.com","https://tryappservice.azure.com","https://tryappservice-staging.azure.com","https://functions.azure.com","https://functions-staging.azure.com","https://functions-next.azure.com","https://scratch.botframework.com/","https://ppe.botframework.com/","https://functions-release.azure.com","https://dev.botframework.com/"],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["abfa0a7c-a6b6-4736-8310-5855508787cd","Microsoft.Azure.WebSites","https://appservice.azure.com"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}'
+        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["Microsoft.Azure.WebSites","abfa0a7c-a6b6-4736-8310-5855508787cd"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2277'
+      - '1674'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 29 Oct 2020 03:19:26 GMT
+      - Mon, 04 Jan 2021 21:54:57 GMT
       duration:
-      - '2247646'
+      - '505703'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - jWy1pWVIgXZ0SZY8XSABL8GowP/FWaDaKWdUnCGB5I0=
+      - YPZ+mmPL+OBXd1POeb7UT5BEZEjGrQEKHfYavB10Rao=
       ocp-aad-session-key:
-      - jbzasMnwh_rCL3TNjiS46PFvd3us31NMpAFRPSVKgR4vGl6q4xHqnln7Maufw_gJ_nx7qmhpiUCnoLyXH2z3pjUPuj_GuU7FV8XzmD4ltqycDI-i_SbIGhEeJvpfQ1YQ.ygZlexZ5szGfSEoOs-HvMWSFhvHc7EEplZrZ77BtvSQ
+      - u9wZmgNCLsSgsrq32UWnG1YK1VhZ9A9RvkwAVUrch6F8M1YKt29zVhIC3PGIaslWG3fHVHwdpF5pNLvOfyFJ9YpwD25J6X-VDm1cppaOjjETFiJWVqohC0sFLuIvNX71.Qkl4Viww8JfayG4kQbOhs9427vdY2mK18D83LjqL2mA
       pragma:
       - no-cache
       request-id:
-      - f43958d1-c297-4083-863a-230f5b056b28
+      - 5c6975c1-a46c-4a33-9f8e-7a2e33a1ff9a
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1746,8 +1546,8 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: PUT
@@ -1764,7 +1564,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:34 GMT
+      - Mon, 04 Jan 2021 21:55:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1785,7 +1585,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -1805,8 +1605,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -1814,18 +1614,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:18:10.3233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T21:53:46.3433333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5638'
+      - '5667'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:35 GMT
+      - Mon, 04 Jan 2021 21:55:06 GMT
       etag:
-      - '"1D6ADA220F4DB35"'
+      - '"1D6E2E4139C3475"'
       expires:
       - '-1'
       pragma:
@@ -1861,8 +1661,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -1870,18 +1670,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:18:10.3233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T21:53:46.3433333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5638'
+      - '5667'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:35 GMT
+      - Mon, 04 Jan 2021 21:55:07 GMT
       etag:
-      - '"1D6ADA220F4DB35"'
+      - '"1D6E2E4139C3475"'
       expires:
       - '-1'
       pragma:
@@ -1917,8 +1717,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -1935,7 +1735,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:36 GMT
+      - Mon, 04 Jan 2021 21:55:07 GMT
       expires:
       - '-1'
       pragma:
@@ -1971,8 +1771,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -1989,9 +1789,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:37 GMT
+      - Mon, 04 Jan 2021 21:55:09 GMT
       etag:
-      - '"1D6ADA220F4DB35"'
+      - '"1D6E2E4139C3475"'
       expires:
       - '-1'
       pragma:
@@ -2034,8 +1834,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: PUT
@@ -2043,20 +1843,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:19:39.9233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
+        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T21:55:12.5133333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
         all","description":"Allow all access"}],"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
-        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5878'
+      - '5907'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:42 GMT
+      - Mon, 04 Jan 2021 21:55:14 GMT
       etag:
-      - '"1D6ADA220F4DB35"'
+      - '"1D6E2E4139C3475"'
       expires:
       - '-1'
       pragma:
@@ -2094,8 +1894,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -2103,18 +1903,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/web-ssl-test000003","name":"web-ssl-test000003","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:19:39.9233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        West","properties":{"name":"web-ssl-test000003","state":"Running","hostNames":["web-ssl-test000003.azurewebsites.net"],"webSpace":"clitest.rg000001-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-JapanWestwebspace/sites/web-ssl-test000003","repositorySiteName":"web-ssl-test000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000003.azurewebsites.net","web-ssl-test000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000003.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/ssl-test-plan000002","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T21:55:12.5133333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000003","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000003\\$web-ssl-test000003","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"web-ssl-test000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5678'
+      - '5707'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:43 GMT
+      - Mon, 04 Jan 2021 21:55:16 GMT
       etag:
-      - '"1D6ADA2565CBB35"'
+      - '"1D6E2E446F8B415"'
       expires:
       - '-1'
       pragma:
@@ -2154,8 +1954,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: POST
@@ -2164,17 +1964,22 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000003 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="pTKyCaj8uvBlXBEuaqvEHEC9SYojBGyN31xh88WkFivu4W5LLoQ9B1tNpX3z"
+        msdeploySite="web-ssl-test000003" userName="$web-ssl-test000003" userPWD="sfHtPZzA0fvlKQ8gkujXFzl4p3dTkZFy6qfJLRAPiAQJq1MscaS0XvMzBzaw"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
         - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="pTKyCaj8uvBlXBEuaqvEHEC9SYojBGyN31xh88WkFivu4W5LLoQ9B1tNpX3z"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="sfHtPZzA0fvlKQ8gkujXFzl4p3dTkZFy6qfJLRAPiAQJq1MscaS0XvMzBzaw"
+        destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
+        - Zip Deploy" publishMethod="ZipDeploy" publishUrl="web-ssl-test000003.scm.azurewebsites.net:443"
+        userName="$web-ssl-test000003" userPWD="sfHtPZzA0fvlKQ8gkujXFzl4p3dTkZFy6qfJLRAPiAQJq1MscaS0XvMzBzaw"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000003
         - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-os1-013dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="pTKyCaj8uvBlXBEuaqvEHEC9SYojBGyN31xh88WkFivu4W5LLoQ9B1tNpX3z"
+        ftpPassiveMode="True" userName="web-ssl-test000003\$web-ssl-test000003" userPWD="sfHtPZzA0fvlKQ8gkujXFzl4p3dTkZFy6qfJLRAPiAQJq1MscaS0XvMzBzaw"
         destinationAppUrl="http://web-ssl-test000003.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -2182,11 +1987,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1678'
+      - '2179'
       content-type:
       - application/xml
       date:
-      - Thu, 29 Oct 2020 03:19:43 GMT
+      - Mon, 04 Jan 2021 21:55:18 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_crossrg.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_ssl_import_crossrg.yaml
@@ -13,24 +13,24 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2020-10-29T03:19:31Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2021-01-04T23:09:24Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '474'
+      - '431'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:19:34 GMT
+      - Mon, 04 Jan 2021 23:09:27 GMT
       expires:
       - '-1'
       pragma:
@@ -63,8 +63,8 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: POST
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:35 GMT
+      - Mon, 04 Jan 2021 23:09:27 GMT
       expires:
       - '-1'
       pragma:
@@ -118,24 +118,24 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2020-10-29T03:19:31Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2021-01-04T23:09:24Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '474'
+      - '431'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:19:35 GMT
+      - Mon, 04 Jan 2021 23:09:27 GMT
       expires:
       - '-1'
       pragma:
@@ -168,8 +168,8 @@ interactions:
       ParameterSetName:
       - -g -n --sku
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: PUT
@@ -177,17 +177,17 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"Japan
-        West","properties":{"serverFarmId":15245,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-JapanWestwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
-        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_15245","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        West","properties":{"serverFarmId":18608,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-JapanWestwebspace","subscription":"cd8e0c02-3a22-4a19-8a6a-46e9e4e5cb86","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
+        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_18608","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"azBalancing":false},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1533'
+      - '1553'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:47 GMT
+      - Mon, 04 Jan 2021 23:09:42 GMT
       expires:
       - '-1'
       pragma:
@@ -205,7 +205,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -225,8 +225,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -234,17 +234,17 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"Japan
-        West","properties":{"serverFarmId":15245,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-JapanWestwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
-        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_15245","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        West","properties":{"serverFarmId":18608,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-JapanWestwebspace","subscription":"cd8e0c02-3a22-4a19-8a6a-46e9e4e5cb86","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
+        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_18608","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"azBalancing":false},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1533'
+      - '1553'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:48 GMT
+      - Mon, 04 Jan 2021 23:09:43 GMT
       expires:
       - '-1'
       pragma:
@@ -285,8 +285,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: POST
@@ -302,7 +302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:49 GMT
+      - Mon, 04 Jan 2021 23:09:44 GMT
       expires:
       - '-1'
       pragma:
@@ -340,8 +340,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -349,17 +349,17 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","name":"ssl-test-plan000003","type":"Microsoft.Web/serverfarms","kind":"app","location":"Japan
-        West","properties":{"serverFarmId":15245,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-JapanWestwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
-        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_15245","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
+        West","properties":{"serverFarmId":18608,"name":"ssl-test-plan000003","workerSize":"Default","workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":"Default","currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":"Ready","webSpace":"clitest.rg000002-JapanWestwebspace","subscription":"cd8e0c02-3a22-4a19-8a6a-46e9e4e5cb86","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":"Dedicated","siteMode":null,"geoRegion":"Japan
+        West","perSiteScaling":false,"maximumElasticWorkerCount":1,"numberOfSites":0,"hostingEnvironmentId":null,"isSpot":false,"spotExpirationTime":null,"freeOfferExpirationTime":null,"tags":null,"kind":"app","resourceGroup":"clitest.rg000002","reserved":false,"isXenon":false,"hyperV":false,"mdmId":"waws-prod-os1-013_18608","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded","webSiteId":null,"existingServerFarmIds":null,"azBalancing":false},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1533'
+      - '1553'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:49 GMT
+      - Mon, 04 Jan 2021 23:09:45 GMT
       expires:
       - '-1'
       pragma:
@@ -399,8 +399,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: POST
@@ -416,7 +416,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:19:50 GMT
+      - Mon, 04 Jan 2021 23:09:45 GMT
       expires:
       - '-1'
       pragma:
@@ -460,8 +460,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: PUT
@@ -469,20 +469,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:19:56.88","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
+        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T23:09:52.8233333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
         all","description":"Allow all access"}],"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
-        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5833'
+      - '5867'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:20:15 GMT
+      - Mon, 04 Jan 2021 23:10:12 GMT
       etag:
-      - '"1D6ADA260F640AB"'
+      - '"1D6E2EEB5F4FB35"'
       expires:
       - '-1'
       pragma:
@@ -524,8 +524,8 @@ interactions:
       ParameterSetName:
       - -g -n --plan
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: POST
@@ -534,17 +534,22 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="c0JYku3WMic2ZApfNaanq8Fyp5u9ldxurtmYzspiH7aQorXw84S8FNYWfE09"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="rdmR4SQl4nKq1CdchTQYywL4bigudSp5W9RjX1jW13Gru9YvSQlnu9vLP5cx"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
         - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="c0JYku3WMic2ZApfNaanq8Fyp5u9ldxurtmYzspiH7aQorXw84S8FNYWfE09"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="rdmR4SQl4nKq1CdchTQYywL4bigudSp5W9RjX1jW13Gru9YvSQlnu9vLP5cx"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
+        - Zip Deploy" publishMethod="ZipDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
+        userName="$web-ssl-test000004" userPWD="rdmR4SQl4nKq1CdchTQYywL4bigudSp5W9RjX1jW13Gru9YvSQlnu9vLP5cx"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
         - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-os1-013dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="c0JYku3WMic2ZApfNaanq8Fyp5u9ldxurtmYzspiH7aQorXw84S8FNYWfE09"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="rdmR4SQl4nKq1CdchTQYywL4bigudSp5W9RjX1jW13Gru9YvSQlnu9vLP5cx"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -552,11 +557,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1678'
+      - '2179'
       content-type:
       - application/xml
       date:
-      - Thu, 29 Oct 2020 03:20:16 GMT
+      - Mon, 04 Jan 2021 23:10:14 GMT
       expires:
       - '-1'
       pragma:
@@ -590,24 +595,24 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-resource/10.2.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-resource/10.3.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2020-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2020-10-29T03:19:30Z","StorageType":"Standard_LRS","type":"test"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"japanwest","tags":{"product":"azurecli","cause":"automation","date":"2021-01-04T23:09:21Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '474'
+      - '431'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:20:17 GMT
+      - Mon, 04 Jan 2021 23:10:14 GMT
       expires:
       - '-1'
       pragma:
@@ -631,7 +636,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-graphrbac/0.60.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -639,33 +644,43 @@ interactions:
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/me?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"consentProvidedForMinor":null,"country":null,"createdDateTime":"2019-10-21T06:37:42Z","creationType":"Invitation","department":null,"dirSyncEnabled":null,"displayName":"Bin
-        Ma","employeeId":null,"facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"legalAgeGroupClassification":null,"mail":"bim@microsoft.com","mailNickname":"bim_microsoft.com#EXT#","mobile":null,"onPremisesDistinguishedName":null,"onPremisesSecurityIdentifier":null,"otherMails":["bim@microsoft.com"],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":["SMTP:bim@microsoft.com"],"refreshTokensValidFromDateTime":"2019-10-21T06:37:41Z","showInAddressList":false,"signInNames":[],"sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"thumbnailPhoto@odata.mediaEditLink":"directoryObjects/9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":null,"userIdentities":[],"userPrincipalName":"bim_microsoft.com#EXT#@AzureSDKTeam.onmicrosoft.com","userState":"Accepted","userStateChangedOn":"2019-10-21T06:39:35Z","userType":"Guest"}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","deletionTimestamp":null,"accountEnabled":true,"ageGroup":null,"assignedLicenses":[{"disabledPlans":["a413a9ff-720c-4822-98ef-2f37c2a21f4c","a6520331-d7d4-4276-95f5-15c0933bc757","ded3d325-1bdc-453e-8432-5bac26d7a014","afa73018-811e-46e9-988f-f75d2b1b8430","b21a6b06-1988-436e-a07b-51ec6d9f52ad","531ee2f8-b1cb-453b-9c21-d2180d014ca5","bf28f719-7844-4079-9c78-c1307898e192","28b0fa46-c39a-4188-89e2-58e979a6b014","199a5c09-e0ca-4e37-8f7c-b05d533e1ea2","65cc641f-cccd-4643-97e0-a17e3045e541","e26c2fcc-ab91-4a61-b35c-03cdc8dddf66","46129a58-a698-46f0-aa5b-17f6586297d9","6db1f1db-2b46-403f-be40-e39395f08dbb","6dc145d6-95dd-4191-b9c3-185575ee6f6b","41fcdd7d-4733-4863-9cf4-c65b83ce2df4","c4801e8a-cb58-4c35-aca6-f2dcc106f287","0898bdbb-73b0-471a-81e5-20f1fe4dd66e","617b097b-4b93-4ede-83de-5f075bb5fb2f","33c4f319-9bdd-48d6-9c4d-410b750a4a5a","8e0c0a52-6a6c-4d40-8370-dd62790dcd70","4828c8ec-dc2e-4779-b502-87ac9ce28ab7","3e26ee1f-8a5f-4d52-aee2-b81ce45c8f40"],"skuId":"c7df2760-2c81-4ef7-b578-5b5392b571df"},{"disabledPlans":[],"skuId":"3d957427-ecdc-4df2-aacd-01cc9d519da8"},{"disabledPlans":[],"skuId":"85aae730-b3d1-4f99-bb28-c9f81b05137c"},{"disabledPlans":[],"skuId":"9f3d9c1d-25a5-4aaa-8e59-23a1e6450a67"},{"disabledPlans":["39b5c996-467e-4e60-bd62-46066f572726"],"skuId":"90d8b3f8-712e-4f7b-aa1e-62e7ae6cbe96"},{"disabledPlans":["e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72"],"skuId":"09015f9f-377f-4538-bbb5-f75ceb09358a"},{"disabledPlans":[],"skuId":"c5928f49-12ba-48f7-ada3-0d743a3601d5"},{"disabledPlans":[],"skuId":"26a18e8f-4d14-46f8-835a-ed3ba424a961"},{"disabledPlans":[],"skuId":"412ce1a7-a499-41b3-8eb6-b38f2bbc5c3f"},{"disabledPlans":[],"skuId":"b05e124f-c7cc-45a0-a6aa-8cf78c946968"},{"disabledPlans":[],"skuId":"488ba24a-39a9-4473-8ee5-19291e71b002"},{"disabledPlans":["0b03f40b-c404-40c3-8651-2aceb74365fa","b650d915-9886-424b-a08d-633cede56f57","e95bec33-7c88-4a70-8e19-b10bd9d0c014","5dbe027f-2339-4123-9542-606e4d348a72","fe71d6c3-a2ea-4499-9778-da042bf08063","fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"],"skuId":"ea126fc5-a19e-42e2-a731-da9d437bffcf"}],"assignedPlans":[{"assignedTimestamp":"2020-12-23T16:01:41Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"fe71d6c3-a2ea-4499-9778-da042bf08063"},{"assignedTimestamp":"2020-12-23T16:01:41Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"199a5c09-e0ca-4e37-8f7c-b05d533e1ea2"},{"assignedTimestamp":"2020-12-23T16:01:41Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"e95bec33-7c88-4a70-8e19-b10bd9d0c014"},{"assignedTimestamp":"2020-12-23T16:01:41Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"5dbe027f-2339-4123-9542-606e4d348a72"},{"assignedTimestamp":"2020-12-23T16:01:41Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"fafd7243-e5c1-4a3a-9e40-495efcb1d3c3"},{"assignedTimestamp":"2020-12-23T10:56:14Z","capabilityStatus":"Enabled","service":"MIPExchangeSolutions","servicePlanId":"cd31b152-6326-4d1b-ae1b-997b625182e6"},{"assignedTimestamp":"2020-12-23T10:56:14Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"2f442157-a11c-46b9-ae5b-6e39ff4e5849"},{"assignedTimestamp":"2020-12-12T03:35:05Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"18fa3aba-b085-4105-87d7-55617b8585e6"},{"assignedTimestamp":"2020-12-12T03:35:05Z","capabilityStatus":"Enabled","service":"ERP","servicePlanId":"69f07c66-bee4-4222-b051-195095efee5b"},{"assignedTimestamp":"2020-12-12T03:35:05Z","capabilityStatus":"Enabled","service":"ProjectProgramsAndPortfolios","servicePlanId":"0a05d977-a21a-45b2-91ce-61c240dbafa2"},{"assignedTimestamp":"2020-11-03T21:28:57Z","capabilityStatus":"Deleted","service":"M365CommunicationCompliance","servicePlanId":"a413a9ff-720c-4822-98ef-2f37c2a21f4c"},{"assignedTimestamp":"2020-10-30T07:25:47Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"7e6d7d78-73de-46ba-83b1-6d25117334ba"},{"assignedTimestamp":"2020-10-17T06:20:29Z","capabilityStatus":"Enabled","service":"WorkplaceAnalytics","servicePlanId":"f477b0f0-3bb1-4890-940c-40fcee6ce05f"},{"assignedTimestamp":"2020-08-14T19:26:04Z","capabilityStatus":"Enabled","service":"YammerEnterprise","servicePlanId":"7547a3fe-08ee-4ccb-b430-5077c5041653"},{"assignedTimestamp":"2020-08-04T05:39:55Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"b622badb-1b45-48d5-920f-4b27a2c0996c"},{"assignedTimestamp":"2020-08-04T05:39:55Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"f3d5636e-ddc2-41bf-bba6-ca6fadece269"},{"assignedTimestamp":"2020-06-18T10:39:50Z","capabilityStatus":"Enabled","service":"MicrosoftPrint","servicePlanId":"795f6fe0-cc4d-4773-b050-5dde4dc704c9"},{"assignedTimestamp":"2019-11-04T22:49:18Z","capabilityStatus":"Enabled","service":"WhiteboardServices","servicePlanId":"4a51bca5-1eff-43f5-878c-177680f191af"},{"assignedTimestamp":"2019-10-14T23:17:04Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"5136a095-5cf0-4aff-bec3-e84448b38ea5"},{"assignedTimestamp":"2019-10-14T23:17:04Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb0351d-3b08-4503-993d-383af8de41e3"},{"assignedTimestamp":"2019-08-09T01:37:07Z","capabilityStatus":"Enabled","service":"MicrosoftFormsProTest","servicePlanId":"97f29a83-1a20-44ff-bf48-5e4ad11f3e51"},{"assignedTimestamp":"2019-05-24T17:22:49Z","capabilityStatus":"Enabled","service":"DYN365AISERVICEINSIGHTS","servicePlanId":"1412cdc1-d593-4ad1-9050-40c30ad0b023"},{"assignedTimestamp":"2019-04-07T07:24:32Z","capabilityStatus":"Enabled","service":"ProjectProgramsAndPortfolios","servicePlanId":"818523f5-016b-4355-9be8-ed6944946ea7"},{"assignedTimestamp":"2019-04-07T07:24:32Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"fa200448-008c-4acb-abd4-ea106ed2199d"},{"assignedTimestamp":"2019-04-07T07:24:32Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"50554c47-71d9-49fd-bc54-42a2765c555c"},{"assignedTimestamp":"2018-12-04T10:31:59Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"b1188c4c-1b36-4018-b48b-ee07604f6feb"},{"assignedTimestamp":"2018-09-06T19:21:02Z","capabilityStatus":"Enabled","service":"OfficeForms","servicePlanId":"e212cbc7-0961-4c40-9825-01117710dcb1"},{"assignedTimestamp":"2018-09-06T19:21:02Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"2bdbaf8f-738f-4ac7-9234-3c3ee2ce7d0f"},{"assignedTimestamp":"2018-09-06T19:21:02Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"663a804f-1c30-4ff0-9915-9db84f0d1cea"},{"assignedTimestamp":"2018-09-06T19:21:02Z","capabilityStatus":"Enabled","service":"SharePoint","servicePlanId":"da792a53-cbc0-4184-a10d-e544dd34b3c1"},{"assignedTimestamp":"2018-08-22T20:29:37Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"018fb91e-cee3-418c-9063-d7562978bdaf"},{"assignedTimestamp":"2018-08-22T20:29:36Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"ca4be917-fbce-4b52-839e-6647467a1668"},{"assignedTimestamp":"2018-08-16T20:56:40Z","capabilityStatus":"Enabled","service":"Deskless","servicePlanId":"8c7d2df8-86f0-4902-b2ed-a0458298f3b3"},{"assignedTimestamp":"2018-08-16T20:56:40Z","capabilityStatus":"Enabled","service":"To-Do","servicePlanId":"3fb82609-8c27-4f7b-bd51-30634711ee67"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"9f431833-0334-42de-a7dc-70aa40db46db"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"MicrosoftCommunicationsOnline","servicePlanId":"0feaeb32-d00e-4d66-bd5a-43b5b83db82c"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"ProcessSimple","servicePlanId":"07699545-9485-468e-95b6-2fca3738be01"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"8c098270-9dd4-4350-9b30-ba4703f3b36b"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"MicrosoftStream","servicePlanId":"6c6042f5-6f01-4d67-b8c1-eb99d36eed3e"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"Sway","servicePlanId":"a23b959c-7ce8-4e57-9140-b90eb88a9e97"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"PowerBI","servicePlanId":"70d33638-9c74-4d01-bfd3-562de28bd4ba"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"ProjectWorkManagement","servicePlanId":"b737dad2-2f6c-4c65-90e3-ca563267e8b9"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"efb87545-963c-4e0d-99df-69c6916d9eb0"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"4de31727-a228-4ec3-a5bf-8e45b5ca48cc"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"TeamspaceAPI","servicePlanId":"57ff2da0-773e-42df-b2af-ffb7a2317929"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"PowerAppsService","servicePlanId":"9c0dab89-a30c-4117-86e7-97bda240acd2"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"exchange","servicePlanId":"34c0d7a0-a70f-4668-9238-47f9fc208882"},{"assignedTimestamp":"2018-08-16T17:18:03Z","capabilityStatus":"Enabled","service":"MicrosoftOffice","servicePlanId":"43de0ff5-c92c-492b-9116-175376d08c38"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"41781fb2-bc02-4b7c-bd55-b576c07bb09d"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"bea4c11e-220a-4e6d-8eb8-8ea15d019f90"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"AADPremiumService","servicePlanId":"eec0eb4f-6444-4f95-aba0-50c24d67f998"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"SCO","servicePlanId":"c1ec4a95-1f05-45b3-a911-aa3fa01094f5"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"AzureAdvancedThreatAnalytics","servicePlanId":"14ab5db5-e6c4-4b20-b4bc-13e36fd2227f"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"6c57d4b6-3b23-47a5-9bc9-69f17b4947b3"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"MultiFactorService","servicePlanId":"8a256a2b-b617-496d-b51b-e76466e88db0"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"RMSOnline","servicePlanId":"5689bec4-755d-4753-8b61-40975025187c"},{"assignedTimestamp":"2018-08-15T07:14:16Z","capabilityStatus":"Enabled","service":"Adallom","servicePlanId":"2e2ddb96-6af9-4b1d-a3f0-d6ecfd22edb2"},{"assignedTimestamp":"2018-08-14T22:39:05Z","capabilityStatus":"Enabled","service":"WindowsDefenderATP","servicePlanId":"871d91ec-ec1a-452b-a83f-bd76c7d770ef"},{"assignedTimestamp":"2018-08-14T22:39:05Z","capabilityStatus":"Enabled","service":"Windows","servicePlanId":"e7c91390-7625-45be-94e0-e16907e03118"},{"assignedTimestamp":"2018-08-14T22:39:03Z","capabilityStatus":"Enabled","service":"Netbreeze","servicePlanId":"03acaee3-9492-4f40-aed4-bcb6b32981b6"},{"assignedTimestamp":"2018-08-14T22:39:03Z","capabilityStatus":"Enabled","service":"CRM","servicePlanId":"d56f3deb-50d8-465a-bedb-f079817ccac1"}],"city":"REDMOND","companyName":"MICROSOFT","consentProvidedForMinor":null,"country":null,"createdDateTime":"2018-08-14T22:20:31Z","creationType":null,"department":"App
+        Svcs_balam_OPEX 1010","dirSyncEnabled":true,"displayName":"Sofi Inglessis","employeeId":null,"facsimileTelephoneNumber":null,"givenName":"Sofi","immutableId":"1308897","isCompromised":null,"jobTitle":"SOFTWARE
+        ENGINEER","lastDirSyncTime":"2020-11-20T14:54:07Z","legalAgeGroupClassification":null,"mail":"Sofi.Inglessis@microsoft.com","mailNickname":"soingles","mobile":null,"onPremisesDistinguishedName":"CN=Sofi
+        Inglessis,OU=MSE,OU=Users,OU=CoreIdentity,DC=redmond,DC=corp,DC=microsoft,DC=com","onPremisesSecurityIdentifier":"S-1-5-21-2127521184-1604012920-1887927527-32814598","otherMails":[],"passwordPolicies":"DisablePasswordExpiration","passwordProfile":null,"physicalDeliveryOfficeName":"41/5A00","postalCode":null,"preferredLanguage":null,"provisionedPlans":[{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"SharePoint"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"MicrosoftCommunicationsOnline"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"exchange"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"Netbreeze"},{"capabilityStatus":"Enabled","provisioningStatus":"Success","service":"CRM"}],"provisioningErrors":[],"proxyAddresses":["x500:/o=ExchangeLabs/ou=Exchange
+        Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=22590aa7de894926877b700eb193308d-Sofi
+        Ingles","X500:/o=microsoft/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=97f7bbfa849144d39b7423844fb56916-Sofi
+        Inglessis","X500:/o=MMS/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=aac473785c84411b85dc865c26812a73-Sofi
+        Inglessiee23cc5","X500:/o=microsoft/ou=Exchange Administrative Group (FYDIBOHF23SPDLT)/cn=Recipients/cn=07e2db4d78de458a852334ad47ef3693-Sofi
+        Inglessis","smtp:soingles@microsoft.onmicrosoft.com","smtp:soingles@service.microsoft.com","smtp:soingles@microsoft.com","SMTP:Sofi.Inglessis@microsoft.com"],"refreshTokensValidFromDateTime":"2020-01-08T01:04:32Z","showInAddressList":null,"signInNames":[],"sipProxyAddress":"soingles@microsoft.com","state":null,"streetAddress":null,"surname":"Inglessis","telephoneNumber":"+1
+        (425) 7041861","thumbnailPhoto@odata.mediaEditLink":"directoryObjects/99d1d831-0cdf-4a81-8a09-d1d75851b8d3/Microsoft.DirectoryServices.User/thumbnailPhoto","usageLocation":"US","userIdentities":[],"userPrincipalName":"soingles@microsoft.com","userState":null,"userStateChangedOn":null,"userType":"Member","extension_18e31482d3fb4a8ea958aa96b662f508_ProfitCenterCode":"P10231243","extension_18e31482d3fb4a8ea958aa96b662f508_CostCenterCode":"10231243","extension_18e31482d3fb4a8ea958aa96b662f508_SupervisorInd":"N","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToPersonnelNbr":"340857","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToFullName":"Panchagnula,
+        Sisira P","extension_18e31482d3fb4a8ea958aa96b662f508_ReportsToEmailName":"SISIRAP","extension_18e31482d3fb4a8ea958aa96b662f508_ZipCode":"98052","extension_18e31482d3fb4a8ea958aa96b662f508_StateProvinceCode":"WA","extension_18e31482d3fb4a8ea958aa96b662f508_PositionNumber":"91419945","extension_18e31482d3fb4a8ea958aa96b662f508_LocationAreaCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_CountryShortCode":"US","extension_18e31482d3fb4a8ea958aa96b662f508_CompanyCode":"1010","extension_18e31482d3fb4a8ea958aa96b662f508_CityName":"REDMOND","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingName":"41","extension_18e31482d3fb4a8ea958aa96b662f508_BuildingID":"309","extension_18e31482d3fb4a8ea958aa96b662f508_AddressLine1":"1
+        Microsoft Way","extension_18e31482d3fb4a8ea958aa96b662f508_PersonnelNumber":"1308897"}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '1668'
+      - '17153'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 29 Oct 2020 03:20:18 GMT
+      - Mon, 04 Jan 2021 23:10:15 GMT
       duration:
-      - '2889664'
+      - '1526350'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - BS93WBAqg2tgnfc21YwW7kpApiYaHzWUo60SWv4lIsw=
+      - DAEEhUUzhQ8pu+4OxvItbpuvqegmLWoSgzWL1kkCnyk=
       ocp-aad-session-key:
-      - IbSsh1YlNNLBSnz0ekO5hf0TOm8U1vodGTflYNISsXQgH136O_7Iy-tIbBq86f7Fu5WSvmRKjTutFYpPqZFcB4dvVyFO5mpb-htCuDg3HTH_hPnpjskJeexAHJTVLI1O.SVwVk1fSD7MJPzHzDtRN7w0YMBaWv6-eDtzEyfTBUFw
+      - k3rFozxG2ULLZ9pTd6LUhh3xHSkrrWdgG8yXXk_MyuE9AmwLJ7MpVZyPg1vCxhbolPZY7GFh7V-tPleHXyh2ruc3tFicYWq9OZcy9jvzOpxp4-23bogtWZfPY0G8ynfo.yUrZCgTdpYIuHuu-qum-d2NxvKno0XXCBYMo_j1wLWM
       pragma:
       - no-cache
       request-id:
-      - 6ce97ea7-2c3a-47a8-8f0c-ac7d9e67ba79
+      - fdbe0c59-c83f-464a-bb27-bd74b939a011
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -680,9 +695,9 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"location": "japanwest", "properties": {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+    body: '{"location": "japanwest", "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
       "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa",
+      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "99d1d831-0cdf-4a81-8a09-d1d75851b8d3",
       "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
       "backup", "restore", "recover"], "secrets": ["get", "list", "set", "delete",
       "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
@@ -707,12 +722,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net","provisioningState":"RegisteringDns"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net","provisioningState":"RegisteringDns"}}'
     headers:
       cache-control:
       - no-cache
@@ -721,7 +736,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:20:24 GMT
+      - Mon, 04 Jan 2021 23:10:25 GMT
       expires:
       - '-1'
       pragma:
@@ -739,9 +754,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.112.0
+      - 1.1.163.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -761,12 +776,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -775,7 +790,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:20:54 GMT
+      - Mon, 04 Jan 2021 23:10:55 GMT
       expires:
       - '-1'
       pragma:
@@ -793,7 +808,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.112.0
+      - 1.1.163.0
       x-powered-by:
       - ASP.NET
     status:
@@ -809,7 +824,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-graphrbac/0.60.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -817,38 +832,37 @@ interactions:
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27Microsoft.Azure.WebSites%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"559f925e-c126-4b02-a759-f0b2f5d999fe","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
-        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":"f8cdef31-a31e-4b4a-93e4-5f571e91255a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft
-        Azure App Service","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
+        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft.Azure.WebSites","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access all the APIs registered with App Service","adminConsentDisplayName":"Access
         APIs registered with App Service","id":"e0ea806b-d128-49dc-ac08-2bf18f7874d8","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access all the APIs registered with App Service","userConsentDisplayName":"Access
-        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":["https://trywebsites.azurewebsites.net/","https://trywebsitesstaging.azurewebsites.net/","https://resources-staging.azure.com","https://resources.azure.com","https://deploy.azure.com","https://deploy-staging.azure.com","https://tryappservice.azure.com","https://tryappservice-staging.azure.com","https://functions.azure.com","https://functions-staging.azure.com","https://functions-next.azure.com","https://scratch.botframework.com/","https://ppe.botframework.com/","https://functions-release.azure.com","https://dev.botframework.com/"],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["abfa0a7c-a6b6-4736-8310-5855508787cd","Microsoft.Azure.WebSites","https://appservice.azure.com"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
+        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["Microsoft.Azure.WebSites","abfa0a7c-a6b6-4736-8310-5855508787cd"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2280'
+      - '1677'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 29 Oct 2020 03:20:54 GMT
+      - Mon, 04 Jan 2021 23:10:55 GMT
       duration:
-      - '2787441'
+      - '559886'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 4pe4P2HysXWVqJ43WA2/sfBmoDTl2Ogd/i0NUIE7FDs=
+      - nzVAAlQLs5CTlSDySYD5R0ZEQHgP45Mt3jtr6wRrsuA=
       ocp-aad-session-key:
-      - OQQa8Iep9fNMjZoPcmBHYVdobs6SxOnrIEpWbka-kc3sJbbbKYY0H_sSIthd_j8iA3EIymt5zRUTevsSJzNtRse2bpOdj7po4oCIhmYmtUkRqc5Ly9_LovAJuCJ69UO-.n0bBBaPq0cY0CyOJ1lKiGF_nunwQOvSPLAl5jBi-Rjg
+      - nk0sM4nNQwXTvfiJS2peVmr9HHRpgE67-dA-GUa_lfD9wCJ95-VcaV6uov9-0pKmYa0MmBJaP8W_G_0eAT68NEPD7ZXaA4GS9lksb09CcUXp1Zkj6xB7775z2n1hqYV-.Pl_IcSR7zf7ZSBVifNZaf2RJUdnCahos0-EQRXR5y4A
       pragma:
       - no-cache
       request-id:
-      - b2c53b33-cb91-4b8c-94d4-4b0b916a54aa
+      - 28510eac-e70d-4df7-9db7-843cc40b6170
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -876,12 +890,12 @@ interactions:
       ParameterSetName:
       - -g --name --spn --secret-permissions
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -890,7 +904,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:20:55 GMT
+      - Mon, 04 Jan 2021 23:10:57 GMT
       expires:
       - '-1'
       pragma:
@@ -908,23 +922,23 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.112.0
+      - 1.1.163.0
       x-powered-by:
       - ASP.NET
     status:
       code: 200
       message: OK
 - request:
-    body: '{"location": "japanwest", "tags": {}, "properties": {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+    body: '{"location": "japanwest", "tags": {}, "properties": {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
       "sku": {"family": "A", "name": "standard"}, "accessPolicies": [{"tenantId":
-      "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa",
+      "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "99d1d831-0cdf-4a81-8a09-d1d75851b8d3",
       "permissions": {"keys": ["get", "create", "delete", "list", "update", "import",
       "backup", "restore", "recover"], "secrets": ["get", "list", "set", "delete",
       "backup", "restore", "recover"], "certificates": ["get", "list", "delete", "create",
       "import", "update", "managecontacts", "getissuers", "listissuers", "setissuers",
       "deleteissuers", "manageissuers", "recover"], "storage": ["get", "list", "delete",
       "set", "update", "regeneratekey", "setsas", "listsas", "getsas", "deletesas"]}},
-      {"tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a", "objectId": "559f925e-c126-4b02-a759-f0b2f5d999fe",
+      {"tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47", "objectId": "f8daea97-62e7-4026-becf-13c2ea98e8b4",
       "permissions": {"secrets": ["get"]}}], "vaultUri": "https://kv-ssl-test000005.vault.azure.net/",
       "enabledForDeployment": false, "enableSoftDelete": true, "softDeleteRetentionInDays":
       90}}'
@@ -944,12 +958,12 @@ interactions:
       ParameterSetName:
       - -g --name --spn --secret-permissions
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"559f925e-c126-4b02-a759-f0b2f5d999fe","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -958,7 +972,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:20:56 GMT
+      - Mon, 04 Jan 2021 23:10:57 GMT
       expires:
       - '-1'
       pragma:
@@ -976,9 +990,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.112.0
+      - 1.1.163.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -998,7 +1012,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-keyvault/7.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -1016,7 +1030,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:20:58 GMT
+      - Mon, 04 Jan 2021 23:10:59 GMT
       expires:
       - '-1'
       pragma:
@@ -1024,16 +1038,16 @@ interactions:
       strict-transport-security:
       - max-age=31536000;includeSubDomains
       www-authenticate:
-      - Bearer authorization="https://login.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
         resource="https://vault.azure.net"
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=167.220.255.120;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.2.58;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - japanwest
       x-ms-keyvault-service-version:
-      - 1.2.58.0
+      - 1.2.99.0
       x-powered-by:
       - ASP.NET
     status:
@@ -1055,7 +1069,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
         azure-keyvault/7.0 Azure-SDK-For-Python
       accept-language:
       - en-US
@@ -1063,7 +1077,7 @@ interactions:
     uri: https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/import?api-version=7.0
   response:
     body:
-      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/d80ead5bcb3b4fcb8db8453aff5f36a1","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/d80ead5bcb3b4fcb8db8453aff5f36a1","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/d80ead5bcb3b4fcb8db8453aff5f36a1","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1603941659,"updated":1603941659,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1603941659,"updated":1603941659}}}'
+      string: '{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/0fc5bf58573448e6a26b4c1f23efc637","kid":"https://kv-ssl-test000005.vault.azure.net/keys/test-cert/0fc5bf58573448e6a26b4c1f23efc637","sid":"https://kv-ssl-test000005.vault.azure.net/secrets/test-cert/0fc5bf58573448e6a26b4c1f23efc637","x5t":"npc1xFx5KwOz_8ymFIUrMu5xrWs","cer":"MIIDYTCCAk2gAwIBAgIQLVKvAHY+rqVB+C7Wbh24QDAJBgUrDgMCHQUAMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0MCAXDTE4MDEwMTA3MDAwMFoYDzIxMTgxMjMxMDcwMDAwWjAxMS8wLQYDVQQDHiYAKgAuAGEAegB1AHIAZQB3AGUAYgBzAGkAdABlAHMALgBuAGUAdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKcqVpT4O7YwltwNd/XSTqITNrpb1lxkLE5r0CpummRxDtjSKbY/vrA7cnHByZS0lRnVPgnZFSyTR0qU0XhGQxedMx+uLGnaDfvDtbCzElsrH4yaMU/dU4959liNYccV//OZOOfr8AB5xnD3k1ix/ssMphIE7sdZx2Icr9TGZzE6Ckm0afEdp7SdwUpXvOjxfB6tFtqyhN5Gtgm1f1rhugCb1QA1UCM1b0Af2XTHbhW057BmUppNI6rzYr3RPed0pXTryeI1/5U3a9ZJ2XFW3VXTXw9Wo+qv8I+9DWIUj0JdoYJ2XkTcZJEeo3woJSBx1yCv2bggR3OUM0wG7/n4HykCAwEAAaN7MHkwEwYDVR0lBAwwCgYIKwYBBQUHAwEwYgYDVR0BBFswWYAQ3sdVft+h9rOb7gSClEWvkaEzMDExLzAtBgNVBAMeJgAqAC4AYQB6AHUAcgBlAHcAZQBiAHMAaQB0AGUAcwAuAG4AZQB0ghAtUq8Adj6upUH4LtZuHbhAMAkGBSsOAwIdBQADggEBAB+08jsd9CeKCX4qeEUNx3i1uklsTAdwoEkK6xQqF4LuHsV9J8NEkQnJow1w2wsg/lULbm+k6LJmM7qCP0NquYOQra3/sdWZvPQflhFM8awpBkIOWO9/wS1oQWhyUHFCwSWUOhJ218bNxBLwIjX6bjCEVNQWNNOFooPz3/dNNVfxqXggqgWXBQ11LuZha+zvU7G82zCttImywZUFcKK3dcvdYPAU9POWQvuuvUqBBdKzPcNCnJAFyXPpJPegW+3ycwphRKxBjYUATe7aP+ulc+/YkyK19dLdUqxBkx2ElJ2HKTcUo6eEXgAuyjQ/jQejZI+fG2FV4NxGEoSned4BKng=","attributes":{"enabled":true,"nbf":1514790000,"exp":4701913200,"created":1609801861,"updated":1609801861,"recoveryLevel":"Recoverable+Purgeable"},"policy":{"id":"https://kv-ssl-test000005.vault.azure.net/certificates/test-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=*.azurewebsites.net","ekus":["1.3.6.1.5.5.7.3.1"],"key_usage":[],"validity_months":1200,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"EmailContacts"}}],"issuer":{"name":"Unknown"},"attributes":{"enabled":true,"created":1609801861,"updated":1609801861}}}'
     headers:
       cache-control:
       - no-cache
@@ -1072,7 +1086,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:21:00 GMT
+      - Mon, 04 Jan 2021 23:11:01 GMT
       expires:
       - '-1'
       pragma:
@@ -1082,11 +1096,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=167.220.255.120;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=167.220.2.58;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - japanwest
       x-ms-keyvault-service-version:
-      - 1.2.58.0
+      - 1.2.99.0
       x-powered-by:
       - ASP.NET
     status:
@@ -1106,8 +1120,8 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -1115,18 +1129,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:19:57.7066667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T23:09:53.6833333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5638'
+      - '5667'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:21:00 GMT
+      - Mon, 04 Jan 2021 23:11:03 GMT
       etag:
-      - '"1D6ADA260F640AB"'
+      - '"1D6E2EEB5F4FB35"'
       expires:
       - '-1'
       pragma:
@@ -1162,12 +1176,101 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - AZURECLI/2.14.0 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.5 (Windows-10-10.0.19041-SP0)
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CertificateRegistration/certificateOrders?api-version=2019-08-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-Storage-EastUS/providers/Microsoft.CertificateRegistration/certificateOrders/testImportCert","name":"testImportCert","type":"certificateOrders","location":"global","properties":{"certificates":{"testImportCert":{"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/keyvault_sofitest/providers/microsoft.keyvault/vaults/keyvaultsofitest","keyVaultSecretName":"testimportcert2c72f30f-62d5-4acc-9a82-e14641877c59","provisioningState":"OperationNotPermittedOnKeyVault"}},"distinguishedName":"CN=soinglesTest.com","domainVerificationToken":"a2ccejppf2f11lgq9kqhs61918","validityInYears":1,"keySize":2048,"productType":"StandardDomainValidatedSsl","autoRenew":true,"status":"Issued","signedCertificate":{"version":3,"serialNumber":"67951DAE3499D4C2","thumbprint":"5DA6DD1F54D401B003292141C5F0B9426A8F9346","subject":"CN=soinglestest.com,
+        OU=Domain Control Validated","notBefore":"2020-09-17T20:13:10+00:00","notAfter":"2021-09-17T20:13:10+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Secure Certificate Authority - G2, OU=http://certs.godaddy.com/repository/,
+        O=\"GoDaddy.com, Inc.\", L=Scottsdale, S=Arizona, C=US","rawData":"-----BEGIN
+        CERTIFICATE-----\nMIIGRDCCBSygAwIBAgIIZ5UdrjSZ1MIwDQYJKoZIhvcNAQELBQAwgbQxCzAJBgNV\nBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQHEwpTY290dHNkYWxlMRow\nGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjEtMCsGA1UECxMkaHR0cDovL2NlcnRz\nLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvMTMwMQYDVQQDEypHbyBEYWRkeSBTZWN1\ncmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIwHhcNMjAwOTE3MjAxMzEwWhcN\nMjEwOTE3MjAxMzEwWjA+MSEwHwYDVQQLExhEb21haW4gQ29udHJvbCBWYWxpZGF0\nZWQxGTAXBgNVBAMTEHNvaW5nbGVzdGVzdC5jb20wggEiMA0GCSqGSIb3DQEBAQUA\nA4IBDwAwggEKAoIBAQDMNCUb+RR6T+e6A4s4ETJLpSbNjG2X8nYTtalHAO2U9HEe\nsW6yRdzuLGEvTcc8rcdSDISImqf6+RfB/GfBEamLj8EYxsMHbEhSWs3M/2N+XJty\ngwgJ/3hL4g2l8fw3XOV4GLz3pKrgki9jRneJ7zyUEajwu5JrybiFmCdidr1gFjtd\nNd5HYWVOurtF+FI6Uc83mbb8pWtZuvaF3t1fAKsSwCnLMYlQaClxOXcGqXcHLmU/\nL4TNx+ePHlDmVbT+jHkpzqgU3eOLz0XpVqAC+zVxr3OVD6PsFwoRyVaQy3CX1qH2\nJORgRC3nTw5r0MqVlGpn+XY5jIpg2hDfcu58t3BLAgMBAAGjggLNMIICyTAMBgNV\nHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAOBgNVHQ8B\nAf8EBAMCBaAwOAYDVR0fBDEwLzAtoCugKYYnaHR0cDovL2NybC5nb2RhZGR5LmNv\nbS9nZGlnMnMxLTIzMDguY3JsMF0GA1UdIARWMFQwSAYLYIZIAYb9bQEHFwEwOTA3\nBggrBgEFBQcCARYraHR0cDovL2NlcnRpZmljYXRlcy5nb2RhZGR5LmNvbS9yZXBv\nc2l0b3J5LzAIBgZngQwBAgEwdgYIKwYBBQUHAQEEajBoMCQGCCsGAQUFBzABhhho\ndHRwOi8vb2NzcC5nb2RhZGR5LmNvbS8wQAYIKwYBBQUHMAKGNGh0dHA6Ly9jZXJ0\naWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVwb3NpdG9yeS9nZGlnMi5jcnQwHwYDVR0j\nBBgwFoAUQMK9J47MNIMwojPX+2yz8LQsgM4wMQYDVR0RBCowKIIQc29pbmdsZXN0\nZXN0LmNvbYIUd3d3LnNvaW5nbGVzdGVzdC5jb20wHQYDVR0OBBYEFHSNO4Rlj7Vi\nOe7Ayy6uUQvWt2e3MIIBBAYKKwYBBAHWeQIEAgSB9QSB8gDwAHYA9lyUL9F3MCIU\nVBgIMJRWjuNNExkzv98MLyALzE7xZOMAAAF0nbMcYAAABAMARzBFAiBMuPqKPhsY\nEJt1j5fChonbEHAz4trqPAnVl/hK+aU0wQIhAOxNTNZl/0Im5wQB9aB+ERzXD6O9\ne0qN4YbGVV5+2+XxAHYAXNxDkv7mq0VEsV6a1FbmEDf71fpH3KFzlLJe5vbHDsoA\nAAF0nbMebQAABAMARzBFAiEAwkz88LrG5u3Rm6HbAC+Sepy+jkBC91ktkDBDGbO+\ntvcCID9ngauuspb1ytYZo5pf1ZOFi9fPUPHCBJt9CmBmcUjnMA0GCSqGSIb3DQEB\nCwUAA4IBAQBuDb8vsiScuSIgCOIhkP0d7s6+A6grmmdrCPmeCRUO52bflPXD+E/L\nKy4rzRIflz09MlB4tqOR+bao/hGxukuIJ3G7wPBX+IDjN0BcBLBIKvQNmbiopUQS\nIiKx/0EvHw8NgG/aDqADU1Qf/nVEuFidD5bYqW4aDp+oJurGigiEu8oQCdGRh16i\nA++YKfJQmgS+gJJ+LKv6DgILdaWAHvmEiYu7ooZiYsgCN16YHTFVhiunqW9BOMgr\nOmchwvfxLVkCVK44TUAc06/bg9LHk3Ra4MA9tfrcApecuBvbV/HSuB0Zms7SGBm5\nl0mm+zIN2s/jOeLDMTEw3aHEKjKvYNxP\n-----END
+        CERTIFICATE-----\n"},"csr":"-----BEGIN NEW CERTIFICATE REQUEST-----\r\nMIIEQzCCAysCAQAwGzEZMBcGA1UEAwwQc29pbmdsZXNUZXN0LmNvbTCCASIwDQYJ\r\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMw0JRv5FHpP57oDizgRMkulJs2MbZfy\r\ndhO1qUcA7ZT0cR6xbrJF3O4sYS9Nxzytx1IMhIiap/r5F8H8Z8ERqYuPwRjGwwds\r\nSFJazcz/Y35cm3KDCAn/eEviDaXx/Ddc5XgYvPekquCSL2NGd4nvPJQRqPC7kmvJ\r\nuIWYJ2J2vWAWO1013kdhZU66u0X4UjpRzzeZtvyla1m69oXe3V8AqxLAKcsxiVBo\r\nKXE5dwapdwcuZT8vhM3H548eUOZVtP6MeSnOqBTd44vPRelWoAL7NXGvc5UPo+wX\r\nChHJVpDLcJfWofYk5GBELedPDmvQypWUamf5djmMimDaEN9y7ny3cEsCAwEAAaCC\r\nAeEwHAYKKwYBBAGCNw0CAzEOFgwxMC4wLjE0MzkzLjIwTQYJKwYBBAGCNxUUMUAw\r\nPgIBBQwOUkQwMDE1NUQ0MUVFM0MMH0lJUyBBUFBQT09MXEdlb01hc3RlckFwcFBv\r\nb2xDc20MCHczd3AuZXhlMIGCBgorBgEEAYI3DQICMXQwcgIBAR5qAE0AaQBjAHIA\r\nbwBzAG8AZgB0ACAARQBuAGgAYQBuAGMAZQBkACAAUgBTAEEAIABhAG4AZAAgAEEA\r\nRQBTACAAQwByAHkAcAB0AG8AZwByAGEAcABoAGkAYwAgAFAAcgBvAHYAaQBkAGUA\r\ncgMBADCB7AYJKoZIhvcNAQkOMYHeMIHbMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\r\nDDAKBggrBgEFBQcDATCBlAYJKoZIhvcNAQkPBIGGMIGDMA4GCCqGSIb3DQMCAgIA\r\ngDAOBggqhkiG9w0DBAICAIAwBwYFKw4DAgcwCgYIKoZIhvcNAwcwCwYJYIZIAWUD\r\nBAEqMAsGCWCGSAFlAwQBLTALBglghkgBZQMEARYwCwYJYIZIAWUDBAEZMAsGCWCG\r\nSAFlAwQBAjALBglghkgBZQMEAQUwHQYDVR0OBBYEFHSNO4Rlj7ViOe7Ayy6uUQvW\r\nt2e3MA0GCSqGSIb3DQEBCwUAA4IBAQCSklCihgAuIslVtbpmglW4sFVDfy3x68i0\r\nJWR4r3/8lvCOYEb1I5r2u++6VUAdyOcryp6MbzTVPvE3hrnKnXQ5gH3TkXA6i1UC\r\ndnJj2yVrC4Bgm9XpQ+lKfMUV9rwz3lE2KdkWcWVPdmM6kZ6sDuwhsl5ho83fmOIo\r\n0CtK7vJ9juhgwoQK4XD9xA1hd6kMkhea9dzuv2fvAW7TkyYOt+Z7UrAslNhwLq/A\r\neAfRieWdcy/NdNuKGnIFtOXPMu0icKJCgSI0CUMxG92ZKKgCxhbTTlJg7bLdK96u\r\nfe94FOKTbVb5uLq7zJyzElsp6nZx4dlT8mCSBDi0TxLgihFYbGbp\r\n-----END
+        NEW CERTIFICATE REQUEST-----\r\n","intermediate":{"version":3,"serialNumber":"07","thumbprint":"27AC9369FAF25207BB2627CEFACCBE4EF9C319B8","subject":"CN=Go
+        Daddy Secure Certificate Authority - G2, OU=http://certs.godaddy.com/repository/,
+        O=\"GoDaddy.com, Inc.\", L=Scottsdale, S=Arizona, C=US","notBefore":"2011-05-03T07:00:00+00:00","notAfter":"2031-05-03T07:00:00+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","rawData":"-----BEGIN CERTIFICATE-----\nMIIE0DCCA7igAwIBAgIBBzANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\nEDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\nEUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\nZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTExMDUwMzA3MDAwMFoXDTMxMDUwMzA3\nMDAwMFowgbQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\nEwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjEtMCsGA1UE\nCxMkaHR0cDovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvMTMwMQYDVQQD\nEypHbyBEYWRkeSBTZWN1cmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIwggEi\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC54MsQ1K92vdSTYuswZLiBCGzD\nBNliF44v/z5lz4/OYuY8UhzaFkVLVat4a2ODYpDOD2lsmcgaFItMzEUz6ojcnqOv\nK/6AYZ15V8TPLvQ/MDxdR/yaFrzDN5ZBUY4RS1T4KL7QjL7wMDge87Am+GZHY23e\ncSZHjzhHU9FGHbTj3ADqRay9vHHZqm8A29vNMDp5T19MR/gd71vCxJ1gO7GyQ5HY\npDNO6rPWJ0+tJYqlxvTV0KaudAVkV4i1RFXULSo6Pvi4vekyCgKUZMQWOlDxSq7n\neTOvDCAHf+jfBDnCaQJsY1L6d8EbyHSHyLmTGFBUNUtpTrw700kuH9zB0lL7AgMB\nAAGjggEaMIIBFjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNV\nHQ4EFgQUQMK9J47MNIMwojPX+2yz8LQsgM4wHwYDVR0jBBgwFoAUOpqFBxBnKLbv\n9r0FQW4gwZTaD94wNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8v\nb2NzcC5nb2RhZGR5LmNvbS8wNQYDVR0fBC4wLDAqoCigJoYkaHR0cDovL2NybC5n\nb2RhZGR5LmNvbS9nZHJvb3QtZzIuY3JsMEYGA1UdIAQ/MD0wOwYEVR0gADAzMDEG\nCCsGAQUFBwIBFiVodHRwczovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkv\nMA0GCSqGSIb3DQEBCwUAA4IBAQAIfmyTEMg4uJapkEv/oV9PBO9sPpyIBslQj6Zz\n91cxG7685C/b+LrTW+C05+Z5Yg4MotdqY3MxtfWoSKQ7CC2iXZDXtHwlTxFWMMS2\nRJ17LJ3lXubvDGGqv+QqG+6EnriDfcFDzkSnE3ANkR/0yBOtg2DZ2HKocyQetawi\nDsoXiWJYRBuriSUBAA/NxBti21G00w9RKpv0vHP8ds42pM3Z2Czqrpv1KrKQ0U11\nGIo/ikGQI31bS/6kA1ibRrLDYGCD+H1QQc7CoZDDu+8CL9IVVO5EFdkKrqeKM+2x\nLXY2JtwE65/3YR8V3Idv7kaWKK2hJn0KCacuBKONvPi8BDAB\n-----END
+        CERTIFICATE-----"},"root":{"version":3,"serialNumber":"00","thumbprint":"47BEABC922EAE80E78783462A79F45C254FDE68B","subject":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","notBefore":"2009-09-01T00:00:00+00:00","notAfter":"2037-12-31T23:59:59+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","rawData":"-----BEGIN CERTIFICATE-----\nMIIDxTCCAq2gAwIBAgIBADANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\nEDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\nEUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\nZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTA5MDkwMTAwMDAwMFoXDTM3MTIzMTIz\nNTk1OVowgYMxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\nEwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjExMC8GA1UE\nAxMoR28gRGFkZHkgUm9vdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgLSBHMjCCASIw\nDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL9xYgjx+lk09xvJGKP3gElY6SKD\nE6bFIEMBO4Tx5oVJnyfq9oQbTqC023CYxzIBsQU+B07u9PpPL1kwIuerGVZr4oAH\n/PMWdYA5UXvl+TW2dE6pjYIT5LY/qQOD+qK+ihVqf94Lw7YZFAXK6sOoBJQ7Rnwy\nDfMAZiLIjWltNowRGLfTshxgtDj6AozO091GB94KPutdfMh8+7ArU6SSYmlRJQVh\nGkSBjCypQ5Yj36w6gZoOKcUcqeldHraenjAKOc7xiID7S13MMuyFYkMlNAJWJwGR\ntDtwKj9useiciAF9n9T521NtYJ2/LOdYq7hfRvzOxBsDPAnrSTFcaUaz4EcCAwEA\nAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYE\nFDqahQcQZyi27/a9BUFuIMGU2g/eMA0GCSqGSIb3DQEBCwUAA4IBAQCZ21151fmX\nWWcDYfF+OwYxdS2hII5PZYe096acvNjpL9DbWu7PdIxztDhC2gV7+AJ1uP2lsdeu\n9tfeE8tTEH6KRtGX+rcuKxGrkLAngPnon1rpN5+r5N9ss4UXnT3ZJE95kTXWXwTr\ngIOrmgIttRD02JDHBHNA7XIloKmf7J6raBKZV8aPEjoJpL1E/QYVN8Gb5DKj7Tjo\n2GTzLH4U/ALqn83/B2gX2yKQOC16jdFU8WnjXzPKej17CuPKf1855eJ1usV2GDPO\nLPAvTK33sefOT6jEm0pUBsV/fdUID+Ic/n4XuKxe9tQWskMJDE32p2u0mYRlynqI\n4uJEvlz36hz1\n-----END
+        CERTIFICATE-----"},"serialNumber":"7463904591480476866","lastCertificateIssuanceTime":"2020-09-17T20:13:41.746614","expirationTime":"2021-09-17T20:13:10","isPrivateKeyExternal":false,"appServiceCertificateNotRenewableReasons":["ExpirationNotInRenewalTimeRange"]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg_soingles/providers/Microsoft.CertificateRegistration/certificateOrders/exampleCert","name":"exampleCert","type":"certificateOrders","location":"global","properties":{"certificates":{"exampleCert":{"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/keyvault_sofitest/providers/microsoft.keyvault/vaults/keyvaultsofitest","keyVaultSecretName":"examplecert1ab3bd4e-25f1-42d9-9c38-d7677a93886b","provisioningState":"OperationNotPermittedOnKeyVault"}},"distinguishedName":"CN=soinglesTest.com","validityInYears":1,"keySize":2048,"productType":"StandardDomainValidatedSsl","autoRenew":true,"status":"Issued","signedCertificate":{"version":3,"serialNumber":"008F6895C0F5DD3C9A","thumbprint":"DDC4C1C4D62C52168CE298CE8DD7D6CC8B3F08D0","subject":"CN=soinglestest.com,
+        OU=Domain Control Validated","notBefore":"2020-12-07T03:56:54+00:00","notAfter":"2022-01-08T03:56:54+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Secure Certificate Authority - G2, OU=http://certs.godaddy.com/repository/,
+        O=\"GoDaddy.com, Inc.\", L=Scottsdale, S=Arizona, C=US","rawData":"-----BEGIN
+        CERTIFICATE-----\nMIIGRTCCBS2gAwIBAgIJAI9olcD13TyaMA0GCSqGSIb3DQEBCwUAMIG0MQswCQYD\nVQQGEwJVUzEQMA4GA1UECBMHQXJpem9uYTETMBEGA1UEBxMKU2NvdHRzZGFsZTEa\nMBgGA1UEChMRR29EYWRkeS5jb20sIEluYy4xLTArBgNVBAsTJGh0dHA6Ly9jZXJ0\ncy5nb2RhZGR5LmNvbS9yZXBvc2l0b3J5LzEzMDEGA1UEAxMqR28gRGFkZHkgU2Vj\ndXJlIENlcnRpZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTIwMTIwNzAzNTY1NFoX\nDTIyMDEwODAzNTY1NFowPjEhMB8GA1UECxMYRG9tYWluIENvbnRyb2wgVmFsaWRh\ndGVkMRkwFwYDVQQDExBzb2luZ2xlc3Rlc3QuY29tMIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAzPZACPhV6YP779cfDuMn4DuNGwGTxP8M9WEiDvTbCDTz\nP3YFfsyOCFtPF2o3Zh97BwkTPJtASkZU6EIhOVmKDB6DJxSpA1JgM16gs3T4JBVG\nefICjI2rCiAisusb828+CErUpLpdJKvPWcWEJm2O2SDgnVQMDC3KjkiRxw60uTEC\n5JTtWKGq/daY9kiJIhodr2qYsLb5zV5KYWeA/s2lR1jxOArywDGwXBMEQn7tZ+ot\necPX9tCSrwnd66/mRiBFXOXADy2svRMSx+4KWpKqdXNPSLio4AxDkc9f7flPxMt9\n0S35TJnHE1u/tYvHwTt2wFNtR7DDvtpgqdFivZK1BwIDAQABo4ICzTCCAskwDAYD\nVR0TAQH/BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0P\nAQH/BAQDAgWgMDgGA1UdHwQxMC8wLaAroCmGJ2h0dHA6Ly9jcmwuZ29kYWRkeS5j\nb20vZ2RpZzJzMS0yNTEzLmNybDBdBgNVHSAEVjBUMEgGC2CGSAGG/W0BBxcBMDkw\nNwYIKwYBBQUHAgEWK2h0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVw\nb3NpdG9yeS8wCAYGZ4EMAQIBMHYGCCsGAQUFBwEBBGowaDAkBggrBgEFBQcwAYYY\naHR0cDovL29jc3AuZ29kYWRkeS5jb20vMEAGCCsGAQUFBzAChjRodHRwOi8vY2Vy\ndGlmaWNhdGVzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvZ2RpZzIuY3J0MB8GA1Ud\nIwQYMBaAFEDCvSeOzDSDMKIz1/tss/C0LIDOMDEGA1UdEQQqMCiCEHNvaW5nbGVz\ndGVzdC5jb22CFHd3dy5zb2luZ2xlc3Rlc3QuY29tMB0GA1UdDgQWBBQMktRbWCfT\n+54bknq5H7O0xSe06DCCAQQGCisGAQQB1nkCBAIEgfUEgfIA8AB2ACl5vvCeOTkh\n8FZzn2Old+W+V32cYAr4+U1dJlwlXceEAAABdjtYceMAAAQDAEcwRQIgXVxL4rtM\nnUvSS6WnfgdI7VX2HTqxuju2P6jilMQLcFUCIQCt1j1IOmGPKdRX/KMI2qHAXeOB\nAJ0u4RLN1UeH77recgB2ACJFRQdZVSRWlj+hL/H3bYbgIyZjrcBLf13Gg1xu4g8C\nAAABdjtYdDYAAAQDAEcwRQIgfByZMMp3Xwa8Z1Wnv9AMK4wkNCv5knVYtEvBkzM5\nA/ACIQDoO1CLsqhwr62eR/6hwYqwtRoO2QsDPQ98aG30aHK8EDANBgkqhkiG9w0B\nAQsFAAOCAQEApNHhlbFcUakl+lto05CtUVTIARitkGc6EZdb38RLTIVLG764rDeY\nmcmKRgTNAg6VCeb9Hy+LpPpnHMrywrkqmAk0IJaXpsGIqWUy4lFgxZIZxorFY5W8\nS6EUTkvF1awJEdrN7dtJwQWv49JD4xkjI1lOwfP0U58JcAQo4DwM93mwIkkHIW23\nB3yag8aSqSJwvlru7YpZVk1PGICFHs7RGIwe/iiUYidSjkiVwAboChHF5kO5BbCL\nA5EuecMeKa3yZVthAXP/ygSzK/E+rLDCscJUoMyojoBZavTo1oRyMzfMJFLf5USA\n8/fINQbIJrjryU8yfdEekJh2t0UMlOUL7A==\n-----END
+        CERTIFICATE-----\n"},"csr":"-----BEGIN NEW CERTIFICATE REQUEST-----\r\nMIIEQzCCAysCAQAwGzEZMBcGA1UEAwwQc29pbmdsZXNUZXN0LmNvbTCCASIwDQYJ\r\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMz2QAj4VemD++/XHw7jJ+A7jRsBk8T/\r\nDPVhIg702wg08z92BX7MjghbTxdqN2YfewcJEzybQEpGVOhCITlZigwegycUqQNS\r\nYDNeoLN0+CQVRnnyAoyNqwogIrLrG/NvPghK1KS6XSSrz1nFhCZtjtkg4J1UDAwt\r\nyo5IkccOtLkxAuSU7Vihqv3WmPZIiSIaHa9qmLC2+c1eSmFngP7NpUdY8TgK8sAx\r\nsFwTBEJ+7WfqLXnD1/bQkq8J3euv5kYgRVzlwA8trL0TEsfuClqSqnVzT0i4qOAM\r\nQ5HPX+35T8TLfdEt+UyZxxNbv7WLx8E7dsBTbUeww77aYKnRYr2StQcCAwEAAaCC\r\nAeEwGgYKKwYBBAGCNw0CAzEMFgo2LjIuOTIwMC4yME8GCSsGAQQBgjcVFDFCMEAC\r\nAQUMDlJEMDAxNTVEMzFFOTMwDBlXT1JLR1JPVVBcUkQwMDE1NUQzMUU5MzAkDBBX\r\nYVdvcmtlckhvc3QuZXhlMIGCBgorBgEEAYI3DQICMXQwcgIBAR5qAE0AaQBjAHIA\r\nbwBzAG8AZgB0ACAARQBuAGgAYQBuAGMAZQBkACAAUgBTAEEAIABhAG4AZAAgAEEA\r\nRQBTACAAQwByAHkAcAB0AG8AZwByAGEAcABoAGkAYwAgAFAAcgBvAHYAaQBkAGUA\r\ncgMBADCB7AYJKoZIhvcNAQkOMYHeMIHbMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\r\nDDAKBggrBgEFBQcDATCBlAYJKoZIhvcNAQkPBIGGMIGDMA4GCCqGSIb3DQMCAgIA\r\ngDAOBggqhkiG9w0DBAICAIAwBwYFKw4DAgcwCgYIKoZIhvcNAwcwCwYJYIZIAWUD\r\nBAEqMAsGCWCGSAFlAwQBLTALBglghkgBZQMEARYwCwYJYIZIAWUDBAEZMAsGCWCG\r\nSAFlAwQBAjALBglghkgBZQMEAQUwHQYDVR0OBBYEFAyS1FtYJ9P7nhuSerkfs7TF\r\nJ7ToMA0GCSqGSIb3DQEBCwUAA4IBAQBSPtdx7lpGM3uwic6VhcD2ivZ9yE0KG5FX\r\nOv6JoEUX5A1hmAAIDGHfwj0ziUMXZuuHHd4O06d941uzHhQVYnxKVcTJq33UG4XH\r\nOKWmEgBOrc53eEWg7ApgQ0pPxFN3oEIRGCzeflTMqv4Emny44RWveSKPkxM5HPMe\r\nA1Gth2Rb67PD0v2MsWvXkSpzzb9Yy5fo8PhOZy8AnwbO6zAHSItVJB9QZvo7iFG1\r\nHHJPJH3MSkSHV7zNn7RzZNMVhgd6vh14lL6xmtArptBt2C+TrhQ0ma/KsCmWxvrz\r\nw/nZJczu1B+iNHe9r3OBsb9H3XFTbIgPIACzeL7TrLhcEZUDGwk+\r\n-----END
+        NEW CERTIFICATE REQUEST-----\r\n","intermediate":{"version":3,"serialNumber":"07","thumbprint":"27AC9369FAF25207BB2627CEFACCBE4EF9C319B8","subject":"CN=Go
+        Daddy Secure Certificate Authority - G2, OU=http://certs.godaddy.com/repository/,
+        O=\"GoDaddy.com, Inc.\", L=Scottsdale, S=Arizona, C=US","notBefore":"2011-05-03T07:00:00+00:00","notAfter":"2031-05-03T07:00:00+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","rawData":"-----BEGIN CERTIFICATE-----\nMIIE0DCCA7igAwIBAgIBBzANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\nEDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\nEUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\nZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTExMDUwMzA3MDAwMFoXDTMxMDUwMzA3\nMDAwMFowgbQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\nEwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjEtMCsGA1UE\nCxMkaHR0cDovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvMTMwMQYDVQQD\nEypHbyBEYWRkeSBTZWN1cmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIwggEi\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC54MsQ1K92vdSTYuswZLiBCGzD\nBNliF44v/z5lz4/OYuY8UhzaFkVLVat4a2ODYpDOD2lsmcgaFItMzEUz6ojcnqOv\nK/6AYZ15V8TPLvQ/MDxdR/yaFrzDN5ZBUY4RS1T4KL7QjL7wMDge87Am+GZHY23e\ncSZHjzhHU9FGHbTj3ADqRay9vHHZqm8A29vNMDp5T19MR/gd71vCxJ1gO7GyQ5HY\npDNO6rPWJ0+tJYqlxvTV0KaudAVkV4i1RFXULSo6Pvi4vekyCgKUZMQWOlDxSq7n\neTOvDCAHf+jfBDnCaQJsY1L6d8EbyHSHyLmTGFBUNUtpTrw700kuH9zB0lL7AgMB\nAAGjggEaMIIBFjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNV\nHQ4EFgQUQMK9J47MNIMwojPX+2yz8LQsgM4wHwYDVR0jBBgwFoAUOpqFBxBnKLbv\n9r0FQW4gwZTaD94wNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8v\nb2NzcC5nb2RhZGR5LmNvbS8wNQYDVR0fBC4wLDAqoCigJoYkaHR0cDovL2NybC5n\nb2RhZGR5LmNvbS9nZHJvb3QtZzIuY3JsMEYGA1UdIAQ/MD0wOwYEVR0gADAzMDEG\nCCsGAQUFBwIBFiVodHRwczovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkv\nMA0GCSqGSIb3DQEBCwUAA4IBAQAIfmyTEMg4uJapkEv/oV9PBO9sPpyIBslQj6Zz\n91cxG7685C/b+LrTW+C05+Z5Yg4MotdqY3MxtfWoSKQ7CC2iXZDXtHwlTxFWMMS2\nRJ17LJ3lXubvDGGqv+QqG+6EnriDfcFDzkSnE3ANkR/0yBOtg2DZ2HKocyQetawi\nDsoXiWJYRBuriSUBAA/NxBti21G00w9RKpv0vHP8ds42pM3Z2Czqrpv1KrKQ0U11\nGIo/ikGQI31bS/6kA1ibRrLDYGCD+H1QQc7CoZDDu+8CL9IVVO5EFdkKrqeKM+2x\nLXY2JtwE65/3YR8V3Idv7kaWKK2hJn0KCacuBKONvPi8BDAB\n-----END
+        CERTIFICATE-----"},"root":{"version":3,"serialNumber":"00","thumbprint":"47BEABC922EAE80E78783462A79F45C254FDE68B","subject":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","notBefore":"2009-09-01T00:00:00+00:00","notAfter":"2037-12-31T23:59:59+00:00","signatureAlgorithm":"sha256RSA","issuer":"CN=Go
+        Daddy Root Certificate Authority - G2, O=\"GoDaddy.com, Inc.\", L=Scottsdale,
+        S=Arizona, C=US","rawData":"-----BEGIN CERTIFICATE-----\nMIIDxTCCAq2gAwIBAgIBADANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\nEDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\nEUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\nZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTA5MDkwMTAwMDAwMFoXDTM3MTIzMTIz\nNTk1OVowgYMxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\nEwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjExMC8GA1UE\nAxMoR28gRGFkZHkgUm9vdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgLSBHMjCCASIw\nDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL9xYgjx+lk09xvJGKP3gElY6SKD\nE6bFIEMBO4Tx5oVJnyfq9oQbTqC023CYxzIBsQU+B07u9PpPL1kwIuerGVZr4oAH\n/PMWdYA5UXvl+TW2dE6pjYIT5LY/qQOD+qK+ihVqf94Lw7YZFAXK6sOoBJQ7Rnwy\nDfMAZiLIjWltNowRGLfTshxgtDj6AozO091GB94KPutdfMh8+7ArU6SSYmlRJQVh\nGkSBjCypQ5Yj36w6gZoOKcUcqeldHraenjAKOc7xiID7S13MMuyFYkMlNAJWJwGR\ntDtwKj9useiciAF9n9T521NtYJ2/LOdYq7hfRvzOxBsDPAnrSTFcaUaz4EcCAwEA\nAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYE\nFDqahQcQZyi27/a9BUFuIMGU2g/eMA0GCSqGSIb3DQEBCwUAA4IBAQCZ21151fmX\nWWcDYfF+OwYxdS2hII5PZYe096acvNjpL9DbWu7PdIxztDhC2gV7+AJ1uP2lsdeu\n9tfeE8tTEH6KRtGX+rcuKxGrkLAngPnon1rpN5+r5N9ss4UXnT3ZJE95kTXWXwTr\ngIOrmgIttRD02JDHBHNA7XIloKmf7J6raBKZV8aPEjoJpL1E/QYVN8Gb5DKj7Tjo\n2GTzLH4U/ALqn83/B2gX2yKQOC16jdFU8WnjXzPKej17CuPKf1855eJ1usV2GDPO\nLPAvTK33sefOT6jEm0pUBsV/fdUID+Ic/n4XuKxe9tQWskMJDE32p2u0mYRlynqI\n4uJEvlz36hz1\n-----END
+        CERTIFICATE-----"},"serialNumber":"10333674000992779418","lastCertificateIssuanceTime":"2020-12-07T04:23:02.477829","expirationTime":"2022-01-08T03:56:54","isPrivateKeyExternal":false,"appServiceCertificateNotRenewableReasons":["ExpirationNotInRenewalTimeRange"]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testVerificationCert/providers/Microsoft.CertificateRegistration/certificateOrders/testVerificationCert","name":"testVerificationCert","type":"certificateOrders","location":"global","properties":{"certificates":{"testVerificationCert":{"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg_soingles/providers/microsoft.keyvault/vaults/testcertrotationkv","keyVaultSecretName":"testverificationcertd9e4fa48-86b2-4081-9285-c9c32e23d362","provisioningState":"CertificateOrderFailed"}},"distinguishedName":"CN=a.soingles.com","domainVerificationToken":"gfqk2k6ovq4ufh22jeu9mv4jc5","validityInYears":1,"keySize":2048,"productType":"StandardDomainValidatedSsl","autoRenew":true,"status":"Denied","csr":"-----BEGIN
+        NEW CERTIFICATE REQUEST-----\r\nMIIEQTCCAykCAQAwGTEXMBUGA1UEAwwOYS5zb2luZ2xlcy5jb20wggEiMA0GCSqG\r\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCYrKlS7XZZ9GxSBbzD+f7dsiHxMts2TMPJ\r\nBDWCbgxrNzCB6bJe2ZIoxmN4GaDqLEpC56orByBQktsOPBpAAdQW0zF9adiJCmAn\r\nAZzLSKQtQB/sq1NCitAG1EanvzMWbRt7HdPk4FLc1lk/+BE25UwjMfh1L2EbLjDK\r\ndUteStMe2Hqb8WsvGMYZvm4tsI2nKEYS7eHeLAs3Tw6np+a4ugcfI8WZIL26hPgu\r\n396alD2GbK8nUMUZrciUnUTCqeCW4BroVQzV8GRduaIq7W2R4njQjR88Lbwg2umr\r\nk4QZMNP7N1bJ7yGaDH0ivzcJJ1P/4RQSd1zHeMKSZsnvbLPZsPVvAgMBAAGgggHh\r\nMBwGCisGAQQBgjcNAgMxDhYMMTAuMC4xNDM5My4yME0GCSsGAQQBgjcVFDFAMD4C\r\nAQUMDlJEMDAxNTVENDFFQTM0DB9JSVMgQVBQUE9PTFxHZW9NYXN0ZXJBcHBQb29s\r\nQ3NtDAh3M3dwLmV4ZTCBggYKKwYBBAGCNw0CAjF0MHICAQEeagBNAGkAYwByAG8A\r\ncwBvAGYAdAAgAEUAbgBoAGEAbgBjAGUAZAAgAFIAUwBBACAAYQBuAGQAIABBAEUA\r\nUwAgAEMAcgB5AHAAdABvAGcAcgBhAHAAaABpAGMAIABQAHIAbwB2AGkAZABlAHID\r\nAQAwgewGCSqGSIb3DQEJDjGB3jCB2zAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAww\r\nCgYIKwYBBQUHAwEwgZQGCSqGSIb3DQEJDwSBhjCBgzAOBggqhkiG9w0DAgICAIAw\r\nDgYIKoZIhvcNAwQCAgCAMAcGBSsOAwIHMAoGCCqGSIb3DQMHMAsGCWCGSAFlAwQB\r\nKjALBglghkgBZQMEAS0wCwYJYIZIAWUDBAEWMAsGCWCGSAFlAwQBGTALBglghkgB\r\nZQMEAQIwCwYJYIZIAWUDBAEFMB0GA1UdDgQWBBS9/uG8EGmsAEay2pGu3uVGTABn\r\niTANBgkqhkiG9w0BAQsFAAOCAQEAWdeKScWSosGN/jnoo7HG91b9IroX1vXcCs29\r\n7ihev+mdDZadJHxpHcoz2kZPhRF4YVRVh4DjQxRF7m7FkfDzjkBZBAI82Twbbub6\r\nANSIOx2UcEGRJq21sfdXY6yrr2+syp29grE2CZ3STFu1sJYpiHYVXOrVPzjYMdIL\r\nyMXaMSZUch7j2Fdovh/gTgBuegs0m9mErvA2PzVFHRdHu7FZ/8mPOtGcCeRCB6YG\r\nXiVT/hqsvtoLklFK3crxbc4lgPjo+pfYE3Z4usuG9G+srPiRXMyf926EMo26f5gL\r\n6GVE5AxrjJZojYak/XcJYDDAwFnWTTCSaYlRNk28wCIx5RnX4w==\r\n-----END
+        NEW CERTIFICATE REQUEST-----\r\n","isPrivateKeyExternal":false,"appServiceCertificateNotRenewableReasons":["ExpirationNotInRenewalTimeRange","RegistrationStatusNotSupportedForRenewal"]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testVerificationCertSoingles/providers/Microsoft.CertificateRegistration/certificateOrders/testVerificationCertSoingles","name":"testVerificationCertSoingles","type":"certificateOrders","location":"global","properties":{"certificates":{"testVerificationCertSoingles":{"keyVaultId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/keyvault_sofitest/providers/microsoft.keyvault/vaults/keyvaultsofitest","keyVaultSecretName":"testverificationcertsoingles8d3a3da4-417f-4bff-9f71-3cfa672cc662","provisioningState":"CertificateOrderFailed"}},"distinguishedName":"CN=soinglesTest.com","domainVerificationToken":"e2q54ms8phanfb66soiufpmvlh","validityInYears":1,"keySize":2048,"productType":"StandardDomainValidatedSsl","autoRenew":true,"status":"Denied","csr":"-----BEGIN
+        NEW CERTIFICATE REQUEST-----\r\nMIIEQzCCAysCAQAwGzEZMBcGA1UEAwwQc29pbmdsZXNUZXN0LmNvbTCCASIwDQYJ\r\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOOUm+6UE7xmr1t0futcULLsRKDpvEjA\r\nMf6PEfxYCsGe3T18rVkNqV0373TLOg4z+gMa8HMnkq36B5noTmKwbJZCCwQsyavd\r\ntpugLeLz7rpSXTbh5+AniHtKysU/o62wDpR8wsVYdGTXzCFTYsnSIY+ODYHPYE+h\r\nNRJMiWndLIU6ZVYm4xAAsEwRk7vRuxtI3iKPq+2bl3yCidMxig5KY6xInX8KVDt0\r\n+zHRWGIdCXHse79aA+5Ti4PFbZpL7UPJpxtT6t+A6XZUztLRT5DkNiYWNJZsU7XA\r\nh5oUh4FMA8ngtdPyztvQVX3vUNUYhO/WmYoEV5XipSjeEsqLfsrlBdUCAwEAAaCC\r\nAeEwHAYKKwYBBAGCNw0CAzEOFgwxMC4wLjE0MzkzLjIwTQYJKwYBBAGCNxUUMUAw\r\nPgIBBQwOUkQwMDE1NUQzMUU1NjYMH0lJUyBBUFBQT09MXEdlb01hc3RlckFwcFBv\r\nb2xDc20MCHczd3AuZXhlMIGCBgorBgEEAYI3DQICMXQwcgIBAR5qAE0AaQBjAHIA\r\nbwBzAG8AZgB0ACAARQBuAGgAYQBuAGMAZQBkACAAUgBTAEEAIABhAG4AZAAgAEEA\r\nRQBTACAAQwByAHkAcAB0AG8AZwByAGEAcABoAGkAYwAgAFAAcgBvAHYAaQBkAGUA\r\ncgMBADCB7AYJKoZIhvcNAQkOMYHeMIHbMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\r\nDDAKBggrBgEFBQcDATCBlAYJKoZIhvcNAQkPBIGGMIGDMA4GCCqGSIb3DQMCAgIA\r\ngDAOBggqhkiG9w0DBAICAIAwBwYFKw4DAgcwCgYIKoZIhvcNAwcwCwYJYIZIAWUD\r\nBAEqMAsGCWCGSAFlAwQBLTALBglghkgBZQMEARYwCwYJYIZIAWUDBAEZMAsGCWCG\r\nSAFlAwQBAjALBglghkgBZQMEAQUwHQYDVR0OBBYEFIg9Cx1tLN/9bZLisECAVLtS\r\nHfKiMA0GCSqGSIb3DQEBCwUAA4IBAQB4NFVCc2oP43IETLabGcrOkO76Wp543tqm\r\ni6BvRPB7Q/VJb0UzHQtFQT6ZU/I6bTOrL3oI8vkH0v6Aba0bzANGAIfdbYmWnC1L\r\nOzcoYwGyD6Z4utnXvcoH7IBIU9FZlbbjk3KvUih9Z/1CPha5c+ik1Aok6vaajroB\r\nXfy9ONETUnemDbK3iTEwz6mhgL+78XXlp+kBP94GjVT/Ltrt6bhLbGt6eXHqKBvR\r\numlqsEwXGppl9xmJ9ThvEp93UqFbJ+Vh+6vYRsnPtSgsIFBpnfyRLu5WaMXvejbS\r\nzRbH1Gv3WPKv33aoK9RqygMdBjho45+6kbkFZ8NmMsjjYcmVZ1TF\r\n-----END
+        NEW CERTIFICATE REQUEST-----\r\n","isPrivateKeyExternal":false,"appServiceCertificateNotRenewableReasons":["ExpirationNotInRenewalTimeRange","RegistrationStatusNotSupportedForRenewal"]}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '24180'
+      content-type:
+      - application/json
+      date:
+      - Mon, 04 Jan 2021 23:11:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp config ssl import
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --name --key-vault --key-vault-certificate-name
+      User-Agent:
+      - AZURECLI/2.17.1 azsdk-python-azure-mgmt-keyvault/8.0.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005?api-version=2019-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"559f925e-c126-4b02-a759-f0b2f5d999fe","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/kv-ssl-test000005","name":"kv-ssl-test000005","type":"Microsoft.KeyVault/vaults","location":"japanwest","tags":{},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"99d1d831-0cdf-4a81-8a09-d1d75851b8d3","permissions":{"keys":["get","create","delete","list","update","import","backup","restore","recover"],"secrets":["get","list","set","delete","backup","restore","recover"],"certificates":["get","list","delete","create","import","update","managecontacts","getissuers","listissuers","setissuers","deleteissuers","manageissuers","recover"],"storage":["get","list","delete","set","update","regeneratekey","setsas","listsas","getsas","deletesas"]}},{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","permissions":{"secrets":["get"]}}],"enabledForDeployment":false,"enableSoftDelete":true,"softDeleteRetentionInDays":90,"vaultUri":"https://kv-ssl-test000005.vault.azure.net/","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1176,7 +1279,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 29 Oct 2020 03:21:01 GMT
+      - Mon, 04 Jan 2021 23:11:05 GMT
       expires:
       - '-1'
       pragma:
@@ -1194,7 +1297,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.1.112.0
+      - 1.1.163.0
       x-powered-by:
       - ASP.NET
     status:
@@ -1214,17 +1317,17 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/99d1d831-0cdf-4a81-8a09-d1d75851b8d3?api-version=1.6
   response:
     body:
       string: '{"odata.error":{"code":"Request_ResourceNotFound","message":{"lang":"en","value":"Resource
-        ''9ac02ab3-5061-4ec6-a3d8-2cdaa5f29efa'' does not exist or one of its queried
-        reference-property objects are not present."},"requestId":"ded9dc6e-bb0f-4fde-9916-c98686213ef4","date":"2020-10-29T03:21:02"}}'
+        ''99d1d831-0cdf-4a81-8a09-d1d75851b8d3'' does not exist or one of its queried
+        reference-property objects are not present."},"requestId":"71cdbdd2-adab-4029-8908-770ad0f09abd","date":"2021-01-04T23:11:06"}}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1237,19 +1340,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 29 Oct 2020 03:21:02 GMT
+      - Mon, 04 Jan 2021 23:11:05 GMT
       duration:
-      - '2520910'
+      - '599471'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - HR3iRY/E6fMbWNiGrWD4HnvRVkbUWeNS+uTue6Qu8uc=
+      - H0ECu2C3fj445zUSyWW2cfK9qFomYi0t8wudfuiYe+I=
       ocp-aad-session-key:
-      - eexVt-o_iCRWqGWCPctAflocLqv-IGA0-KjZ7UCgmh37rVg_P9W3opwnEl3HC86YnPWGH9bUGvwlp3Bs8Zj1akz0J5u8i0zQpzdtzsNkS6aLGIPJtwCV4zGk0Vdjx1Qa.weCiCrTPkODv5UpNtl7eE4lYpN_OSNruSZt7F3GRiZM
+      - I6s2IGXtOXmAF-ehUxnyWhDPY7oAj3_QnT-0LWJ2oLr1RTF4hUXUNB6cu34K4BBUWNQ65pqXKnen3mTqaeYOvEm67Tad9fGzNabwjr3X6XGh9pj0-WBo46VW5fc3Yx2c.liSawmIRi76FjMoMQYYL5IUyl1YFrY-jRxHpW1AR5wo
       pragma:
       - no-cache
       request-id:
-      - ded9dc6e-bb0f-4fde-9916-c98686213ef4
+      - 71cdbdd2-adab-4029-8908-770ad0f09abd
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1277,46 +1380,45 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/559f925e-c126-4b02-a759-f0b2f5d999fe?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals/f8daea97-62e7-4026-becf-13c2ea98e8b4?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"559f925e-c126-4b02-a759-f0b2f5d999fe","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
-        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":"f8cdef31-a31e-4b4a-93e4-5f571e91255a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft
-        Azure App Service","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"f8daea97-62e7-4026-becf-13c2ea98e8b4","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Microsoft
+        Azure App Service","appId":"abfa0a7c-a6b6-4736-8310-5855508787cd","applicationTemplateId":null,"appOwnerTenantId":null,"appRoleAssignmentRequired":false,"appRoles":[],"displayName":"Microsoft.Azure.WebSites","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access all the APIs registered with App Service","adminConsentDisplayName":"Access
         APIs registered with App Service","id":"e0ea806b-d128-49dc-ac08-2bf18f7874d8","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access all the APIs registered with App Service","userConsentDisplayName":"Access
-        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":["https://trywebsites.azurewebsites.net/","https://trywebsitesstaging.azurewebsites.net/","https://resources-staging.azure.com","https://resources.azure.com","https://deploy.azure.com","https://deploy-staging.azure.com","https://tryappservice.azure.com","https://tryappservice-staging.azure.com","https://functions.azure.com","https://functions-staging.azure.com","https://functions-next.azure.com","https://scratch.botframework.com/","https://ppe.botframework.com/","https://functions-release.azure.com","https://dev.botframework.com/"],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["abfa0a7c-a6b6-4736-8310-5855508787cd","Microsoft.Azure.WebSites","https://appservice.azure.com"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}'
+        APIs registered with App Service","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["Microsoft.Azure.WebSites","abfa0a7c-a6b6-4736-8310-5855508787cd"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2277'
+      - '1674'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Thu, 29 Oct 2020 03:21:03 GMT
+      - Mon, 04 Jan 2021 23:11:06 GMT
       duration:
-      - '3135630'
+      - '591579'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 86KurTfxAk/M13kEbCwVuuaB5PoGx7jHOtXdUnHXnic=
+      - 9GQqI6S1ECS4j4T2qnjxLorVEkd1sq21GP7tQfmsPNE=
       ocp-aad-session-key:
-      - 5Im4Ed4w2dfYNwdmZ-S4BKuQNXwXIgP8xyXBYMNx5mWEs3C46jJ5a63E46RbwaamvHqh5AP7Vw8KK-PEEP8_u60Xe2JWZfwk1ES_zvJL3BqPA-NffyEq89KttcPZ-o3h.VhMskz0t1li2LXnPHTdycBfCPntrl4uSI1YiBWCmgYo
+      - cczl4p6D5ouAMbt4P_6D6V4TRj_OjUoevDxp_ivelywiES89f-oYY0jMNiwf6mR-FtisddYb6q__CVWNU78rSaji2GZRJht_Z8x0vWzguMLaQaQPUtkaiEaIY9rOK2hX.ycgfAn3Qe0onbAmL-16-G2a3vS1QwhKoziERkHB13B4
       pragma:
       - no-cache
       request-id:
-      - 7109da29-4859-4f56-b80a-244ad5019068
+      - 458ecb70-78bf-4b01-9dfc-d1e454671ca9
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1350,8 +1452,8 @@ interactions:
       ParameterSetName:
       - --resource-group --name --key-vault --key-vault-certificate-name
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: PUT
@@ -1368,7 +1470,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:21:07 GMT
+      - Mon, 04 Jan 2021 23:11:14 GMT
       expires:
       - '-1'
       pragma:
@@ -1389,7 +1491,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
       x-powered-by:
       - ASP.NET
     status:
@@ -1409,8 +1511,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -1418,18 +1520,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:19:57.7066667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T23:09:53.6833333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5638'
+      - '5667'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:21:08 GMT
+      - Mon, 04 Jan 2021 23:11:16 GMT
       etag:
-      - '"1D6ADA260F640AB"'
+      - '"1D6E2EEB5F4FB35"'
       expires:
       - '-1'
       pragma:
@@ -1465,8 +1567,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -1474,18 +1576,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:19:57.7066667","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T23:09:53.6833333","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5638'
+      - '5667'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:21:09 GMT
+      - Mon, 04 Jan 2021 23:11:17 GMT
       etag:
-      - '"1D6ADA260F640AB"'
+      - '"1D6E2EEB5F4FB35"'
       expires:
       - '-1'
       pragma:
@@ -1521,8 +1623,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -1539,7 +1641,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:21:09 GMT
+      - Mon, 04 Jan 2021 23:11:17 GMT
       expires:
       - '-1'
       pragma:
@@ -1575,8 +1677,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -1593,9 +1695,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:21:11 GMT
+      - Mon, 04 Jan 2021 23:11:19 GMT
       etag:
-      - '"1D6ADA260F640AB"'
+      - '"1D6E2EEB5F4FB35"'
       expires:
       - '-1'
       pragma:
@@ -1638,8 +1740,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: PUT
@@ -1647,20 +1749,20 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:21:14.02","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
+        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T23:11:22.5","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
         all","description":"Allow all access"}],"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":1,"name":"Allow
-        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5873'
+      - '5901'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:21:15 GMT
+      - Mon, 04 Jan 2021 23:11:25 GMT
       etag:
-      - '"1D6ADA260F640AB"'
+      - '"1D6E2EEB5F4FB35"'
       expires:
       - '-1'
       pragma:
@@ -1698,8 +1800,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: GET
@@ -1707,18 +1809,18 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/sites/web-ssl-test000004","name":"web-ssl-test000004","type":"Microsoft.Web/sites","kind":"app","location":"Japan
-        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2020-10-29T03:21:14.02","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"253001F2FCF5A7B1CD759EB861E9BB1596370BE27E47A991F72184277B3D12F2","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
+        West","properties":{"name":"web-ssl-test000004","state":"Running","hostNames":["web-ssl-test000004.azurewebsites.net"],"webSpace":"clitest.rg000002-JapanWestwebspace","selfLink":"https://waws-prod-os1-013.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000002-JapanWestwebspace/sites/web-ssl-test000004","repositorySiteName":"web-ssl-test000004","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["web-ssl-test000004.azurewebsites.net","web-ssl-test000004.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"web-ssl-test000004.azurewebsites.net","sslState":"SniEnabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":"9E9735C45C792B03B3FFCCA614852B32EE71AD6B","toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"web-ssl-test000004.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Web/serverfarms/ssl-test-plan000003","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2021-01-04T23:11:22.5","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","siteConfig":{"numberOfWorkers":null,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":null,"windowsFxVersion":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"azureStorageAccounts":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":null,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"ipSecurityRestrictions":null,"scmIpSecurityRestrictions":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":null,"minTlsVersion":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0},"deploymentId":"web-ssl-test000004","trafficManagerHostNames":null,"sku":"Basic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"CD3ED0E77C1655DB516D33D894E3191E8506647D63389E327890C4FE48D5695C","kind":"app","inboundIpAddress":"40.74.100.129","possibleInboundIpAddresses":"40.74.100.129","ftpUsername":"web-ssl-test000004\\$web-ssl-test000004","ftpsHostName":"ftps://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17","possibleOutboundIpAddresses":"40.74.100.129,40.74.85.64,40.74.126.115,40.74.125.67,40.74.128.17,40.74.127.201,40.74.128.130,23.100.108.106,40.74.128.122,40.74.128.53","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-os1-013","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000002","defaultHostName":"web-ssl-test000004.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":[],"buildVersion":null,"targetBuildVersion":null,"migrationState":null}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '5673'
+      - '5701'
       content-type:
       - application/json
       date:
-      - Thu, 29 Oct 2020 03:21:16 GMT
+      - Mon, 04 Jan 2021 23:11:26 GMT
       etag:
-      - '"1D6ADA28E72BE40"'
+      - '"1D6E2EEEAE55440"'
       expires:
       - '-1'
       pragma:
@@ -1758,8 +1860,8 @@ interactions:
       ParameterSetName:
       - -g -n --certificate-thumbprint --ssl-type
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.14.0
+      - python/3.8.0 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-mgmt-web/0.48.0 Azure-SDK-For-Python AZURECLI/2.17.1
       accept-language:
       - en-US
     method: POST
@@ -1768,17 +1870,22 @@ interactions:
     body:
       string: <publishData><publishProfile profileName="web-ssl-test000004 - Web Deploy"
         publishMethod="MSDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
-        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="c0JYku3WMic2ZApfNaanq8Fyp5u9ldxurtmYzspiH7aQorXw84S8FNYWfE09"
+        msdeploySite="web-ssl-test000004" userName="$web-ssl-test000004" userPWD="rdmR4SQl4nKq1CdchTQYywL4bigudSp5W9RjX1jW13Gru9YvSQlnu9vLP5cx"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
         - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-os1-013.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="c0JYku3WMic2ZApfNaanq8Fyp5u9ldxurtmYzspiH7aQorXw84S8FNYWfE09"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="rdmR4SQl4nKq1CdchTQYywL4bigudSp5W9RjX1jW13Gru9YvSQlnu9vLP5cx"
+        destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
+        mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
+        webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
+        - Zip Deploy" publishMethod="ZipDeploy" publishUrl="web-ssl-test000004.scm.azurewebsites.net:443"
+        userName="$web-ssl-test000004" userPWD="rdmR4SQl4nKq1CdchTQYywL4bigudSp5W9RjX1jW13Gru9YvSQlnu9vLP5cx"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile><publishProfile profileName="web-ssl-test000004
         - ReadOnly - FTP" publishMethod="FTP" publishUrl="ftp://waws-prod-os1-013dr.ftp.azurewebsites.windows.net/site/wwwroot"
-        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="c0JYku3WMic2ZApfNaanq8Fyp5u9ldxurtmYzspiH7aQorXw84S8FNYWfE09"
+        ftpPassiveMode="True" userName="web-ssl-test000004\$web-ssl-test000004" userPWD="rdmR4SQl4nKq1CdchTQYywL4bigudSp5W9RjX1jW13Gru9YvSQlnu9vLP5cx"
         destinationAppUrl="http://web-ssl-test000004.azurewebsites.net" SQLServerDBConnectionString=""
         mySQLDBConnectionString="" hostingProviderForumLink="" controlPanelLink="http://windows.azure.com"
         webSystem="WebSites"><databases /></publishProfile></publishData>
@@ -1786,11 +1893,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1678'
+      - '2179'
       content-type:
       - application/xml
       date:
-      - Thu, 29 Oct 2020 03:21:17 GMT
+      - Mon, 04 Jan 2021 23:11:28 GMT
       expires:
       - '-1'
       pragma:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
I am enabling az webapp config ssl import to also import an app service certificate to a webapp. At the moment, it just allows importing a KeyVault cert. With this change, it can be used for both types of certificate. There will be no breaking change, as we are reusing the paramater names 

**Testing Guide**
<!--Example commands with explanations.-->
Parameters remain the same, as show below: the only difference is that now key-vault-certificate-name can also be an ASC

az webapp config ssl import --name webappName --resource-group rgName --key-vault-certificate-name certName --key-vault keyVaultNameOrId

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
