### PR TITLE
{Network} Migrate network SDK that is used by some other modules to track2

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_validators.py
@@ -14,7 +14,6 @@ from azure.cli.core.profiles import ResourceType
 from azure.cli.core.azclierror import CLIInternalError, InvalidArgumentValueError, \
     RequiredArgumentMissingError
 from knack.log import get_logger
-from msrestazure.azure_exceptions import CloudError
 from msrestazure.tools import is_valid_resource_id
 from msrestazure.tools import parse_resource_id
 from msrestazure.tools import resource_id
@@ -91,6 +90,7 @@ def validate_pull_secret(namespace):
 
 def validate_subnet(key):
     def _validate_subnet(cmd, namespace):
+        from azure.core.exceptions import HttpResponseError
         subnet = getattr(namespace, key)
 
         if not is_valid_resource_id(subnet):
@@ -134,7 +134,7 @@ def validate_subnet(key):
         try:
             client.subnets.get(parts['resource_group'],
                                parts['name'], parts['child_name_1'])
-        except CloudError as err:
+        except HttpResponseError as err:
             raise CLIInternalError(err.message)
 
     return _validate_subnet

--- a/src/azure-cli/azure/cli/command_modules/container/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/container/custom.py
@@ -246,12 +246,12 @@ def _build_identities_info(identities):
 
 
 def _get_resource(client, resource_group_name, *subresources):
-    from msrestazure.azure_exceptions import CloudError
+    from azure.core.exceptions import HttpResponseError
     try:
         resource = client.get(resource_group_name, *subresources)
         return resource
-    except CloudError as ex:
-        if ex.error.error == "NotFound" or ex.error.error == "ResourceNotFound":
+    except HttpResponseError as ex:
+        if ex.error.code == "NotFound" or ex.error.code == "ResourceNotFound":
             return None
         raise
 

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -6667,7 +6667,7 @@ def create_virtual_router_peering(cmd, resource_group_name, virtual_router_name,
     try:
         vhub_client = network_client_factory(cmd.cli_ctx).virtual_hubs
         vhub_client.get(resource_group_name, virtual_hub_name)
-    except CloudError:
+    except HttpResponseError:
         msg = 'The VirtualRouter "{}" under resource group "{}" was not found'.format(virtual_hub_name,
                                                                                       resource_group_name)
         raise CLIError(msg)
@@ -6728,7 +6728,7 @@ def list_virtual_router_peering(cmd, resource_group_name, virtual_router_name):
         try:
             vhub_client = network_client_factory(cmd.cli_ctx).virtual_hubs
             vhub_client.get(resource_group_name, virtual_hub_name)
-        except CloudError:
+        except HttpResponseError:
             msg = 'The VirtualRouter "{}" under resource group "{}" was not found'.format(virtual_hub_name,
                                                                                           resource_group_name)
             raise CLIError(msg)
@@ -6743,7 +6743,7 @@ def list_virtual_router_peering(cmd, resource_group_name, virtual_router_name):
     try:
         vhub_bgp_conn_client = network_client_factory(cmd.cli_ctx).virtual_hub_bgp_connections
         vhub_bgp_connections = list(vhub_bgp_conn_client.list(resource_group_name, virtual_hub_name))
-    except CloudError:
+    except HttpResponseError:
         vhub_bgp_connections = []
 
     return list(vrouter_peerings) + list(vhub_bgp_connections)
@@ -6767,7 +6767,7 @@ def show_virtual_router_peering(cmd, resource_group_name, virtual_router_name, p
     try:
         vhub_client = network_client_factory(cmd.cli_ctx).virtual_hubs
         vhub_client.get(resource_group_name, virtual_hub_name)
-    except CloudError:
+    except HttpResponseError:
         msg = 'The VirtualRouter "{}" under resource group "{}" was not found'.format(virtual_hub_name,
                                                                                       resource_group_name)
         raise CLIError(msg)
@@ -6777,6 +6777,7 @@ def show_virtual_router_peering(cmd, resource_group_name, virtual_router_name, p
 
 
 def delete_virtual_router_peering(cmd, resource_group_name, virtual_router_name, peering_name):
+    from azure.core.exceptions import HttpResponseError
     try:
         vrouter_client = network_client_factory(cmd.cli_ctx).virtual_routers
         vrouter_client.get(resource_group_name, virtual_router_name)
@@ -6793,7 +6794,7 @@ def delete_virtual_router_peering(cmd, resource_group_name, virtual_router_name,
     try:
         vhub_client = network_client_factory(cmd.cli_ctx).virtual_hubs
         vhub_client.get(resource_group_name, virtual_hub_name)
-    except CloudError:
+    except HttpResponseError:
         msg = 'The VirtualRouter "{}" under resource group "{}" was not found'.format(virtual_hub_name,
                                                                                       resource_group_name)
         raise CLIError(msg)

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -6,7 +6,6 @@
 # pylint: disable=unused-argument, line-too-long
 
 from msrestazure.tools import is_valid_resource_id, parse_resource_id  # pylint: disable=import-error
-from msrestazure.azure_exceptions import CloudError
 from knack.log import get_logger
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.commands.client_factory import get_subscription_id
@@ -46,8 +45,8 @@ def prepare_vnet(cmd, server_name, vnet, subnet, resource_group_name, loc, deleg
                 if not subnet_result.delegations:
                     logger.info('Adding "%s" delegation to the existing subnet.', )
                     subnet_result.delegations = [delegation]
-                    subnet_result = nw_client.subnets.create_or_update(resource_group, vnet_name, subnet_name,
-                                                                       subnet_result).result()
+                    subnet_result = nw_client.subnets.begin_create_or_update(resource_group, vnet_name, subnet_name,
+                                                                             subnet_result).result()
                 else:
                     for delgtn in subnet_result.delegations:
                         if delgtn.service_name != delegation_service_name:
@@ -129,8 +128,8 @@ def _create_with_resource_names(cmd, vnet, subnet, resource_group_name, delegati
             if not subnet_result.delegations:
                 logger.info('Adding "%s" delegation to the existing subnet.', )
                 subnet_result.delegations = [delegation]
-                subnet_result = nw_client.subnets.create_or_update(resource_group_name, vnet, subnet,
-                                                                   subnet_result).result()
+                subnet_result = nw_client.subnets.begin_create_or_update(resource_group_name, vnet, subnet,
+                                                                         subnet_result).result()
             else:
                 for delgtn in subnet_result.delegations:
                     if delgtn.service_name != delegation_service_name:
@@ -162,18 +161,19 @@ def check_resource_existence(cmd, subnet_name, vnet_name, resource_group_name, )
 
 def _create_vnet_subnet_delegation(nw_client, resource_group, vnet_name, subnet_name, location, server_name, delegation,
                                    VirtualNetwork, Subnet, AddressSpace, vnet_address_pref, subnet_address_pref):
+    from azure.core.exceptions import HttpResponseError
     try:
         vnet_exist = _get_resource(nw_client.virtual_networks, resource_group, vnet_name)
         if not vnet_exist:
             logger.info('The Vnet does not exist. Creating new vnet "%s" in resource group "%s"',
                         vnet_name, resource_group)
-            nw_client.virtual_networks.create_or_update(resource_group,
-                                                        vnet_name,
-                                                        VirtualNetwork(name=vnet_name,
-                                                                       location=location,
-                                                                       address_space=AddressSpace(
-                                                                           address_prefixes=[
-                                                                               vnet_address_pref])))
+            nw_client.virtual_networks.begin_create_or_update(resource_group,
+                                                              vnet_name,
+                                                              VirtualNetwork(name=vnet_name,
+                                                                             location=location,
+                                                                             address_space=AddressSpace(
+                                                                                 address_prefixes=[
+                                                                                     vnet_address_pref])))
         subnet_result = Subnet(
             name=subnet_name,
             location=location,
@@ -181,21 +181,22 @@ def _create_vnet_subnet_delegation(nw_client, resource_group, vnet_name, subnet_
             delegations=[delegation])
 
         logger.info('Creating new subnet "%s" in resource group "%s"', subnet_name, resource_group)
-        return nw_client.subnets.create_or_update(resource_group, vnet_name, subnet_name,
-                                                  subnet_result).result()
-    except CloudError as err:
-        if err.error.error == 'NetcfgInvalidSubnet':
+        return nw_client.subnets.begin_create_or_update(resource_group, vnet_name, subnet_name,
+                                                        subnet_result).result()
+    except HttpResponseError as err:
+        if err.error.code == 'NetcfgInvalidSubnet':
             raise CLIError('Cannot add the subnet {} to the vnet {}.The subnet address space exceeds'
                            ' the available vnet address space.'.format(subnet_name, vnet_name))
         raise
 
 
 def _get_resource(client, resource_group_name, *subresources):
+    from azure.core.exceptions import HttpResponseError
     try:
         resource = client.get(resource_group_name, *subresources)
         return resource
-    except CloudError as ex:
-        if ex.error.error == "NotFound" or ex.error.error == "ResourceNotFound":
+    except HttpResponseError as ex:
+        if ex.error.code == "NotFound" or ex.error.code == "ResourceNotFound":
             return None
         raise
 
@@ -208,16 +209,16 @@ def create_vnet(cmd, servername, location, resource_group_name, delegation_servi
     vnet_name, subnet_name, vnet_address_prefix, subnet_prefix = _create_vnet_metadata(servername[6:])
 
     logger.warning('Creating new vnet "%s" in resource group "%s"...', vnet_name, resource_group_name)
-    client.virtual_networks.create_or_update(resource_group_name, vnet_name,
-                                             VirtualNetwork(name=vnet_name, location=location,
-                                                            address_space=AddressSpace(
-                                                                address_prefixes=[vnet_address_prefix])))
-    delegation = Delegation(name=delegation_service_name, service_name=delegation_service_name)
+    client.virtual_networks.begin_create_or_update(resource_group_name, vnet_name,
+                                                   VirtualNetwork(name=vnet_name, location=location,
+                                                                  address_space=AddressSpace(
+                                                                      address_prefixes=[vnet_address_prefix])))
+    delegation = Delegation(name=delegation_service_name, serv_name=delegation_service_name)
     subnet = Subnet(name=subnet_name, location=location, address_prefix=subnet_prefix, delegations=[delegation])
 
     logger.warning('Creating new subnet "%s" in resource group "%s" and delegating it to "%s"...', subnet_name,
                    resource_group_name, delegation_service_name)
-    subnet = client.subnets.create_or_update(resource_group_name, vnet_name, subnet_name, subnet).result()
+    subnet = client.subnets.begin_create_or_update(resource_group_name, vnet_name, subnet_name, subnet).result()
     return subnet.id
 
 

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
@@ -810,10 +810,10 @@ def _create_vmss(cmd, resource_group_name, cluster_name, cluster, node_type_name
 
     if address_prefix is None:
         raise CLIError("Failed to generate the address prefix")
-    poller = network_client.subnets.create_or_update(resource_group_name,
-                                                     virtual_network.name,
-                                                     subnet_name,
-                                                     Subnet(address_prefix=address_prefix))
+    poller = network_client.subnets.begin_create_or_update(resource_group_name,
+                                                           virtual_network.name,
+                                                           subnet_name,
+                                                           Subnet(address_prefix=address_prefix))
 
     subnet = LongRunningOperation(cli_ctx)(poller)
 
@@ -825,11 +825,11 @@ def _create_vmss(cmd, resource_group_name, cluster_name, cluster, node_type_name
                                   node_type_name.lower(), index)
     if len(lb_name) >= 24:
         lb_name = '{}{}'.format(lb_name[0:21], index)
-    poller = network_client.public_ip_addresses.create_or_update(resource_group_name,
-                                                                 public_address_name,
-                                                                 PublicIPAddress(public_ip_allocation_method='Dynamic',
-                                                                                 location=location,
-                                                                                 dns_settings=PublicIPAddressDnsSettings(domain_name_label=dns_label)))
+    poller = network_client.public_ip_addresses.begin_create_or_update(resource_group_name,
+                                                                       public_address_name,
+                                                                       PublicIPAddress(public_ip_allocation_method='Dynamic',
+                                                                                       location=location,
+                                                                                       dns_settings=PublicIPAddressDnsSettings(domain_name_label=dns_label)))
 
     publicIp = LongRunningOperation(cli_ctx)(poller)
     from azure.cli.core.commands.client_factory import get_subscription_id
@@ -906,7 +906,7 @@ def _create_vmss(cmd, resource_group_name, cluster_name, cluster, node_type_name
                                                                        frontend_port_range_start=DEFAULT_FRONTEND_PORT_RANGE_START,
                                                                        frontend_port_range_end=DEFAULT_FRONTEND_PORT_RANGE_END)])
 
-    poller = network_client.load_balancers.create_or_update(
+    poller = network_client.load_balancers.begin_create_or_update(
         resource_group_name, lb_name, new_load_balancer)
     LongRunningOperation(cli_ctx)(poller)
 


### PR DESCRIPTION
Here are main changes for Network migration to track2:
- LRO operations are renamed to `begin_xxx_xxx`, for example in track1, the name is `create_or_update`; while in track2, the name is `begin_create_or_update`.
- In track2, use `HttpResponseError` instead of `CloudError`.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
