### PR TITLE
{Misc.} Bump humanfriendly to 9.1

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -47,7 +47,7 @@ DEPENDENCIES = [
     'argcomplete~=1.8',
     'azure-cli-telemetry==1.0.6.*',
     'colorama~=0.4.1',
-    'humanfriendly>=4.7,<9.0',
+    'humanfriendly>=4.7,<10.0',
     'jmespath',
     'knack==0.7.2',
     'msal~=1.0.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -96,7 +96,7 @@ colorama==0.4.1
 ConfigArgParse==0.14.0
 cryptography==2.8
 fabric==2.4.0
-humanfriendly==8.0
+humanfriendly==9.1
 idna==2.8
 invoke==1.2.0
 isodate==0.6.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -96,7 +96,7 @@ colorama==0.4.1
 ConfigArgParse==0.14.0
 cryptography==2.8
 fabric==2.4.0
-humanfriendly==8.0
+humanfriendly==9.1
 idna==2.8
 invoke==1.2.0
 isodate==0.6.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -95,7 +95,7 @@ chardet==3.0.4
 colorama==0.4.1
 cryptography==2.8
 fabric==2.4.0
-humanfriendly==8.0
+humanfriendly==9.1
 idna==2.8
 invoke==1.2.0
 isodate==0.6.0


### PR DESCRIPTION
## Description
Requested by https://github.com/Azure/azure-cli/pull/12477#issuecomment-748666626.

**FreeBSD 13** only ships with [py37-humanfriendly-9.1.txz](https://freebsd.pkgs.org/13/freebsd-i386/py37-humanfriendly-9.1.txz.html).

https://pkgs.org/search/?q=humanfriendly

![image](https://user-images.githubusercontent.com/4003950/103116256-c8a68500-46a0-11eb-9eab-6bddbe1955d1.png)

Bump humanfriendly to `9.1` and limit to `10.0` so that Azure CLI can be installed on **FreeBSD 13** with their own packaging system.

**Testing Guide**

```
> az group delete -n xxx
 - Running ..  
```
