### PR TITLE
{Misc.} Change deprecation expiration to 4.0.0

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -187,14 +187,14 @@ def load_arguments(self, _):
         c.argument('https_only', help="Redirect all traffic made to an app using HTTP to HTTPS.",
                    arg_type=get_three_state_flag(return_label=True))
         c.argument('force_dns_registration', help="If true, web app hostname is force registered with DNS",
-                   arg_type=get_three_state_flag(return_label=True), deprecate_info=c.deprecate(expiration='3.0.0'))
+                   arg_type=get_three_state_flag(return_label=True), deprecate_info=c.deprecate(expiration='4.0.0'))
         c.argument('skip_custom_domain_verification',
                    help="If true, custom (non *.azurewebsites.net) domains associated with web app are not verified",
-                   arg_type=get_three_state_flag(return_label=True), deprecate_info=c.deprecate(expiration='3.0.0'))
+                   arg_type=get_three_state_flag(return_label=True), deprecate_info=c.deprecate(expiration='4.0.0'))
         c.argument('ttl_in_seconds', help="Time to live in seconds for web app's default domain name",
-                   arg_type=get_three_state_flag(return_label=True), deprecate_info=c.deprecate(expiration='3.0.0'))
+                   arg_type=get_three_state_flag(return_label=True), deprecate_info=c.deprecate(expiration='4.0.0'))
         c.argument('skip_dns_registration', help="If true web app hostname is not registered with DNS on creation",
-                   arg_type=get_three_state_flag(return_label=True), deprecate_info=c.deprecate(expiration='3.0.0'))
+                   arg_type=get_three_state_flag(return_label=True), deprecate_info=c.deprecate(expiration='4.0.0'))
 
     with self.argument_context('webapp browse') as c:
         c.argument('logs', options_list=['--logs', '-l'], action='store_true',
@@ -204,7 +204,7 @@ def load_arguments(self, _):
         c.argument('keep_empty_plan', action='store_true', help='keep empty app service plan')
         c.argument('keep_metrics', action='store_true', help='keep app metrics')
         c.argument('keep_dns_registration', action='store_true', help='keep DNS registration',
-                   deprecate_info=c.deprecate(expiration='3.0.0'))
+                   deprecate_info=c.deprecate(expiration='4.0.0'))
 
     with self.argument_context('webapp webjob') as c:
         c.argument('webjob_name', help='The name of the webjob', options_list=['--webjob-name', '-w'])

--- a/src/azure-cli/azure/cli/command_modules/botservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/_params.py
@@ -70,7 +70,7 @@ def load_arguments(self, _):
         c.argument('code_dir', options_list=['--code-dir'], help='The directory to upload bot code from.')
         c.argument('proj_file_path', options_list=['--proj-file-path', c.deprecate(target='--proj-name',
                                                                                    redirect='--proj-file-path',
-                                                                                   hide=True, expiration='3.0.0')],
+                                                                                   hide=True, expiration='4.0.0')],
                    help='Path to the start up project file name. (E.g. "./EchoBotWithCounter.csproj")')
         c.argument('version', options_list=['-v', '--version'],
                    help='The Microsoft Bot Builder SDK version of the bot.')
@@ -113,7 +113,7 @@ def load_arguments(self, _):
     with self.argument_context('bot prepare-publish') as c:
         c.argument('proj_file_path', options_list=['--proj-file-path', c.deprecate(target='--proj-name',
                                                                                    redirect='--proj-file-path',
-                                                                                   hide=True, expiration='3.0.0')],
+                                                                                   hide=True, expiration='4.0.0')],
                    help='Path to the start up project file name. (E.g. "./EchoBotWithCounter.csproj") '
                         'Required only for C#.')
         c.argument('sln_name', help='Name of the start up solution file name. Required only for C#.')

--- a/src/azure-cli/azure/cli/command_modules/monitor/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_params.py
@@ -330,11 +330,11 @@ def load_arguments(self, _):
         c.argument('offset', type=get_period_type(as_timedelta=True))
 
     with self.argument_context('monitor activity-log list', arg_group='Filter') as c:
-        c.argument('filters', deprecate_info=c.deprecate(target='--filters', hide=True, expiration='3.0.0'), help='OData filters. Will ignore other filter arguments.')
+        c.argument('filters', deprecate_info=c.deprecate(target='--filters', hide=True, expiration='4.0.0'), help='OData filters. Will ignore other filter arguments.')
         c.argument('correlation_id')
         c.argument('resource_group', resource_group_name_type)
         c.argument('resource_id')
-        c.argument('resource_provider', options_list=['--namespace', c.deprecate(target='--resource-provider', redirect='--namespace', hide=True, expiration='3.0.0')])
+        c.argument('resource_provider', options_list=['--namespace', c.deprecate(target='--resource-provider', redirect='--namespace', hide=True, expiration='4.0.0')])
         c.argument('caller')
         c.argument('status')
     # endregion

--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -1911,7 +1911,7 @@ def load_arguments(self, _):
     with self.argument_context('network vnet peering') as c:
         c.argument('virtual_network_name', virtual_network_name_type)
         c.argument('virtual_network_peering_name', options_list=['--name', '-n'], help='The name of the VNet peering.', id_part='child_name_1')
-        c.argument('remote_virtual_network', options_list=['--remote-vnet', c.deprecate(target='--remote-vnet-id', hide=True, expiration='3.0.0')], help='Resource ID or name of the remote VNet.')
+        c.argument('remote_virtual_network', options_list=['--remote-vnet', c.deprecate(target='--remote-vnet-id', hide=True, expiration='4.0.0')], help='Resource ID or name of the remote VNet.')
 
     with self.argument_context('network vnet peering create') as c:
         c.argument('allow_virtual_network_access', options_list='--allow-vnet-access', action='store_true', help='Allows access from the local VNet to the remote VNet.')
@@ -1943,7 +1943,7 @@ def load_arguments(self, _):
 
     for scope in ['network vnet subnet list', 'network vnet peering list']:
         with self.argument_context(scope) as c:
-            c.argument('ids', deprecate_info=c.deprecate(hide=True, expiration='3.0.0'))
+            c.argument('ids', deprecate_info=c.deprecate(hide=True, expiration='4.0.0'))
             c.argument('virtual_network_name', id_part=None)
 
     with self.argument_context('network vnet subnet delete') as c:

--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -453,7 +453,7 @@ def load_arguments(self, _):
     with self.argument_context('vm extension') as c:
         c.argument('vm_extension_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachines/extensions'), help='Name of the extension.', id_part='child_name_1')
         c.argument('vm_name', arg_type=existing_vm_name, options_list=['--vm-name'], id_part='name')
-        c.argument('expand', deprecate_info=c.deprecate(expiration='3.0.0', hide=True))
+        c.argument('expand', deprecate_info=c.deprecate(expiration='4.0.0', hide=True))
 
     with self.argument_context('vm extension list') as c:
         c.argument('vm_name', arg_type=existing_vm_name, options_list=['--vm-name'], id_part=None)
@@ -1037,7 +1037,7 @@ def load_arguments(self, _):
         c.ignore('gallery_image')
 
     with self.argument_context('sig image-version') as c:
-        deprecated_option = c.deprecate(target='--gallery-image-version-name', redirect='--gallery-image-version', hide=True, expiration="3.0.0")
+        deprecated_option = c.deprecate(target='--gallery-image-version-name', redirect='--gallery-image-version', hide=True, expiration="4.0.0")
         c.argument('gallery_image_version_name', options_list=['--gallery-image-version', '-e', deprecated_option],
                    help='Gallery image version in semantic version pattern. The allowed characters are digit and period. Digits must be within the range of a 32-bit integer, e.g. `<MajorVersion>.<MinorVersion>.<Patch>`')
 

--- a/src/azure-cli/azure/cli/command_modules/vm/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/commands.py
@@ -357,7 +357,7 @@ def load_command_table(self, _):
         g.custom_command('list-skus', 'list_sku')
         g.custom_command('list', 'list_vm_images')
         g.custom_command('accept-terms', 'accept_market_ordering_terms',
-                         deprecate_info=g.deprecate(redirect='az vm image terms accept', expiration='3.0.0'))
+                         deprecate_info=g.deprecate(redirect='az vm image terms accept', expiration='4.0.0'))
         g.custom_show_command('show', 'show_vm_image')
 
     with self.command_group('vm image terms', compute_vm_image_term_sdk, validator=None) as g:


### PR DESCRIPTION
**Description**<!--Mandatory-->
As we are bumping to 3.0.0 for [Azure Identity Integration](https://github.com/Azure/azure-cli/labels/Azure%20Identity%20Integration), several arguments will stop working since 3.0.0 and cause many CI failures.

```
_____ BotTests.test_prepare_publish_with_unregistered_bot_name_should_fail _____
...
----------------------------- Captured stderr call -----------------------------
RequiredArgumentMissingError: the following arguments are required: --proj-file-path
------------------------------ Captured log call -------------------------------
ERROR    cli.azure.cli.core.azclierror:azclierror.py:55 RequiredArgumentMissingError: the following arguments are required: --proj-file-path
```

This draft PR aims to assist command module owners to resolve these expirations by

1. Removing `expiration` if no explicit deprecation plan is provided.
2. Setting `expiration` to higher versions like `4.0.0`, but the release plan of `4.0.0` is undetermined and this issue will occur again when bumping to `4.0.0`.

ℹ The regex used to search for the occurrence of `expiration` is 

```regex
expiration=['"]3.0.0['"]
```
