### PR TITLE
[rdbms] Hotfix: `az mysql flexible-server create -l eastus2euap` : Fix for bad input parameters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -213,7 +213,7 @@ def create_vnet(cmd, servername, location, resource_group_name, delegation_servi
                                                    VirtualNetwork(name=vnet_name, location=location,
                                                                   address_space=AddressSpace(
                                                                       address_prefixes=[vnet_address_prefix])))
-    delegation = Delegation(name=delegation_service_name, serv_name=delegation_service_name)
+    delegation = Delegation(name=delegation_service_name, service_name=delegation_service_name)
     subnet = Subnet(name=subnet_name, location=location, address_prefix=subnet_prefix, delegations=[delegation])
 
     logger.warning('Creating new subnet "%s" in resource group "%s" and delegating it to "%s"...', subnet_name,


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix the bad name of https://github.com/Azure/azure-cli/pull/15992
![image](https://user-images.githubusercontent.com/70930885/103256984-4a145500-49ca-11eb-9b7d-8e39cc253dbc.png)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
