### PR TITLE
[AppService] Fixes #16125: az webapp ssh if using a windows client, open browser to scm link

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -4035,7 +4035,8 @@ def ssh_webapp(cmd, resource_group_name, name, port=None, slot=None, timeout=Non
         config = get_site_configs(cmd, resource_group_name, name, slot)
         if config.remote_debugging_enabled:
             raise ValidationError('Remote debugging is enabled, please disable')
-        create_tunnel_and_session(cmd, resource_group_name, name, port=port, slot=slot, timeout=timeout, instance=instance)
+        create_tunnel_and_session(
+            cmd, resource_group_name, name, port=port, slot=slot, timeout=timeout, instance=instance)
 
 
 def create_devops_pipeline(

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -779,9 +779,6 @@ class LinuxWebappSSHScenarioTest(ScenarioTest):
         # On Windows, test 'webapp ssh' throws error
         import platform
         if platform.system() == "Windows":
-            from azure.cli.core.util import CLIError
-            with self.assertRaises(CLIError):
-                self.cmd('webapp ssh -g {} -n {} --timeout 5'.format("foo", "bar"))
             return
 
         runtime = 'node|12-lts'


### PR DESCRIPTION
**Description**<!--Mandatory-->
We currently don't support SSH from a windows client. 
![image](https://user-images.githubusercontent.com/14339314/103721845-8d029980-4f83-11eb-954f-fea2c2a1c8e4.png)


Instead of showing error msg, as a mitigation we should open browser to web-ssh console that is part of every Linux app

![image](https://user-images.githubusercontent.com/14339314/103721838-88d67c00-4f83-11eb-902e-0ba78c5f32f8.png)


**Testing Guide**
Run `az webapp ssh -n {} -g {}` on a windows client

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
