### PR TITLE
[ARM] Az Deployments : Add support for --query-string

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -51,6 +51,7 @@ def load_arguments(self, _):
                                                     help="a template file path in the file system")
     deployment_template_uri_type = CLIArgumentType(options_list=['--template-uri', '-u'], help='a uri to a remote template file')
     deployment_template_spec_type = CLIArgumentType(options_list=['--template-spec', '-s'], is_preview=True, min_api='2019-06-01', help="The template spec resource id.")
+    deployment_query_string_type = CLIArgumentType(options_list=['--query-string', '-q'], is_preview=True, help="The query string (a SAS token) to be used with the template-uri in the case of linked templates.")
     deployment_parameters_type = CLIArgumentType(options_list=['--parameters', '-p'], action='append', nargs='+', completer=FilesCompleter(), help='the deployment parameters')
     filter_type = CLIArgumentType(options_list=['--filter'], is_preview=True,
                                   help='Filter expression using OData notation. You can use --filter "provisioningState eq \'{state}\'" to filter provisioningState. '
@@ -262,6 +263,7 @@ def load_arguments(self, _):
         c.argument('template_file', arg_type=deployment_template_file_type)
         c.argument('template_uri', arg_type=deployment_template_uri_type)
         c.argument('template_spec', arg_type=deployment_template_spec_type)
+        c.argument('query_string', arg_type=deployment_query_string_type)
         c.argument('parameters', arg_type=deployment_parameters_type)
 
     with self.argument_context('deployment create') as c:

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -428,7 +428,7 @@ def deploy_arm_template_at_subscription_scope(cmd,
                                               deployment_name=None, deployment_location=None,
                                               no_wait=False, handle_extended_json_format=None, no_prompt=False,
                                               confirm_with_what_if=None, what_if_result_format=None,
-                                              what_if_exclude_change_types=None, template_spec=None):
+                                              what_if_exclude_change_types=None, template_spec=None, query_string=None):
     if confirm_with_what_if:
         what_if_deploy_arm_template_at_subscription_scope(cmd,
                                                           template_file=template_file, template_uri=template_uri,
@@ -436,7 +436,7 @@ def deploy_arm_template_at_subscription_scope(cmd,
                                                           deployment_location=deployment_location,
                                                           result_format=what_if_result_format,
                                                           exclude_change_types=what_if_exclude_change_types,
-                                                          no_prompt=no_prompt, template_spec=template_spec)
+                                                          no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
         from knack.prompting import prompt_y_n
 
         if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
@@ -446,7 +446,7 @@ def deploy_arm_template_at_subscription_scope(cmd,
                                                       template_file=template_file, template_uri=template_uri, parameters=parameters,
                                                       deployment_name=deployment_name, deployment_location=deployment_location,
                                                       validate_only=False, no_wait=no_wait,
-                                                      no_prompt=no_prompt, template_spec=template_spec)
+                                                      no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
 
 
 # pylint: disable=unused-argument
@@ -454,23 +454,23 @@ def validate_arm_template_at_subscription_scope(cmd,
                                                 template_file=None, template_uri=None, parameters=None,
                                                 deployment_name=None, deployment_location=None,
                                                 no_wait=False, handle_extended_json_format=None,
-                                                no_prompt=False, template_spec=None):
+                                                no_prompt=False, template_spec=None, query_string=None):
     return _deploy_arm_template_at_subscription_scope(cmd=cmd,
                                                       template_file=template_file, template_uri=template_uri, parameters=parameters,
                                                       deployment_name=deployment_name, deployment_location=deployment_location,
                                                       validate_only=True, no_wait=no_wait,
-                                                      no_prompt=no_prompt, template_spec=template_spec,)
+                                                      no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,)
 
 
 def _deploy_arm_template_at_subscription_scope(cmd,
                                                template_file=None, template_uri=None, parameters=None,
                                                deployment_name=None, deployment_location=None, validate_only=False,
-                                               no_wait=False, no_prompt=False, template_spec=None):
+                                               no_wait=False, no_prompt=False, template_spec=None, query_string=None):
     deployment_properties = _prepare_deployment_properties_unmodified(cmd, template_file=template_file,
                                                                       template_uri=template_uri, parameters=parameters,
                                                                       mode='Incremental',
                                                                       no_prompt=no_prompt,
-                                                                      template_spec=template_spec)
+                                                                      template_spec=template_spec, query_string=query_string)
 
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
 
@@ -506,7 +506,7 @@ def deploy_arm_template_at_resource_group(cmd,
                                           no_wait=False, handle_extended_json_format=None,
                                           aux_subscriptions=None, aux_tenants=None, no_prompt=False,
                                           confirm_with_what_if=None, what_if_result_format=None,
-                                          what_if_exclude_change_types=None, template_spec=None):
+                                          what_if_exclude_change_types=None, template_spec=None, query_string=None):
     if confirm_with_what_if:
         what_if_deploy_arm_template_at_resource_group(cmd,
                                                       resource_group_name=resource_group_name,
@@ -514,7 +514,7 @@ def deploy_arm_template_at_resource_group(cmd,
                                                       parameters=parameters, deployment_name=deployment_name, mode=mode,
                                                       aux_tenants=aux_tenants, result_format=what_if_result_format,
                                                       exclude_change_types=what_if_exclude_change_types,
-                                                      no_prompt=no_prompt, template_spec=template_spec)
+                                                      no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
         from knack.prompting import prompt_y_n
 
         if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
@@ -526,7 +526,7 @@ def deploy_arm_template_at_resource_group(cmd,
                                                   deployment_name=deployment_name, mode=mode, rollback_on_error=rollback_on_error,
                                                   validate_only=False, no_wait=no_wait,
                                                   aux_subscriptions=aux_subscriptions, aux_tenants=aux_tenants,
-                                                  no_prompt=no_prompt, template_spec=template_spec)
+                                                  no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
 
 
 # pylint: disable=unused-argument
@@ -534,13 +534,13 @@ def validate_arm_template_at_resource_group(cmd,
                                             resource_group_name=None,
                                             template_file=None, template_uri=None, parameters=None,
                                             deployment_name=None, mode=None, rollback_on_error=None,
-                                            no_wait=False, handle_extended_json_format=None, no_prompt=False, template_spec=None):
+                                            no_wait=False, handle_extended_json_format=None, no_prompt=False, template_spec=None, query_string=None):
     return _deploy_arm_template_at_resource_group(cmd,
                                                   resource_group_name=resource_group_name,
                                                   template_file=template_file, template_uri=template_uri, parameters=parameters,
                                                   deployment_name=deployment_name, mode=mode, rollback_on_error=rollback_on_error,
                                                   validate_only=True, no_wait=no_wait,
-                                                  no_prompt=no_prompt, template_spec=template_spec)
+                                                  no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
 
 
 def _deploy_arm_template_at_resource_group(cmd,
@@ -548,12 +548,12 @@ def _deploy_arm_template_at_resource_group(cmd,
                                            template_file=None, template_uri=None, parameters=None,
                                            deployment_name=None, mode=None, rollback_on_error=None,
                                            validate_only=False, no_wait=False,
-                                           aux_subscriptions=None, aux_tenants=None, no_prompt=False, template_spec=None):
+                                           aux_subscriptions=None, aux_tenants=None, no_prompt=False, template_spec=None, query_string=None):
     deployment_properties = _prepare_deployment_properties_unmodified(cmd, template_file=template_file,
                                                                       template_uri=template_uri,
                                                                       parameters=parameters, mode=mode,
                                                                       rollback_on_error=rollback_on_error,
-                                                                      no_prompt=no_prompt, template_spec=template_spec)
+                                                                      no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
 
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, aux_subscriptions=aux_subscriptions,
                                                     aux_tenants=aux_tenants, plug_pipeline=(template_uri is None and template_spec is None))
@@ -588,7 +588,7 @@ def deploy_arm_template_at_management_group(cmd,
                                             deployment_name=None, deployment_location=None,
                                             no_wait=False, handle_extended_json_format=None, no_prompt=False,
                                             confirm_with_what_if=None, what_if_result_format=None,
-                                            what_if_exclude_change_types=None, template_spec=None):
+                                            what_if_exclude_change_types=None, template_spec=None, query_string=None):
     if confirm_with_what_if:
         what_if_deploy_arm_template_at_management_group(cmd,
                                                         management_group_id=management_group_id,
@@ -597,7 +597,7 @@ def deploy_arm_template_at_management_group(cmd,
                                                         deployment_location=deployment_location,
                                                         result_format=what_if_result_format,
                                                         exclude_change_types=what_if_exclude_change_types,
-                                                        no_prompt=no_prompt, template_spec=template_spec)
+                                                        no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
         from knack.prompting import prompt_y_n
 
         if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
@@ -608,7 +608,7 @@ def deploy_arm_template_at_management_group(cmd,
                                                     template_file=template_file, template_uri=template_uri, parameters=parameters,
                                                     deployment_name=deployment_name, deployment_location=deployment_location,
                                                     validate_only=False, no_wait=no_wait,
-                                                    no_prompt=no_prompt, template_spec=template_spec)
+                                                    no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
 
 
 # pylint: disable=unused-argument
@@ -617,24 +617,24 @@ def validate_arm_template_at_management_group(cmd,
                                               template_file=None, template_uri=None, parameters=None,
                                               deployment_name=None, deployment_location=None,
                                               no_wait=False, handle_extended_json_format=None,
-                                              no_prompt=False, template_spec=None):
+                                              no_prompt=False, template_spec=None, query_string=None):
     return _deploy_arm_template_at_management_group(cmd=cmd,
                                                     management_group_id=management_group_id,
                                                     template_file=template_file, template_uri=template_uri, parameters=parameters,
                                                     deployment_name=deployment_name, deployment_location=deployment_location,
                                                     validate_only=True, no_wait=no_wait,
-                                                    no_prompt=no_prompt, template_spec=template_spec)
+                                                    no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
 
 
 def _deploy_arm_template_at_management_group(cmd,
                                              management_group_id=None,
                                              template_file=None, template_uri=None, parameters=None,
                                              deployment_name=None, deployment_location=None, validate_only=False,
-                                             no_wait=False, no_prompt=False, template_spec=None):
+                                             no_wait=False, no_prompt=False, template_spec=None, query_string=None):
     deployment_properties = _prepare_deployment_properties_unmodified(cmd, template_file=template_file,
                                                                       template_uri=template_uri,
                                                                       parameters=parameters, mode='Incremental',
-                                                                      no_prompt=no_prompt, template_spec=template_spec)
+                                                                      no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
 
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
 
@@ -670,7 +670,7 @@ def deploy_arm_template_at_tenant_scope(cmd,
                                         deployment_name=None, deployment_location=None,
                                         no_wait=False, handle_extended_json_format=None, no_prompt=False,
                                         confirm_with_what_if=None, what_if_result_format=None,
-                                        what_if_exclude_change_types=None, template_spec=None):
+                                        what_if_exclude_change_types=None, template_spec=None, query_string=None):
     if confirm_with_what_if:
         what_if_deploy_arm_template_at_tenant_scope(cmd,
                                                     template_file=template_file, template_uri=template_uri,
@@ -678,7 +678,7 @@ def deploy_arm_template_at_tenant_scope(cmd,
                                                     deployment_location=deployment_location,
                                                     result_format=what_if_result_format,
                                                     exclude_change_types=what_if_exclude_change_types,
-                                                    no_prompt=no_prompt, template_spec=template_spec)
+                                                    no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
         from knack.prompting import prompt_y_n
 
         if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
@@ -688,29 +688,29 @@ def deploy_arm_template_at_tenant_scope(cmd,
                                                 template_file=template_file, template_uri=template_uri, parameters=parameters,
                                                 deployment_name=deployment_name, deployment_location=deployment_location,
                                                 validate_only=False, no_wait=no_wait,
-                                                no_prompt=no_prompt, template_spec=template_spec)
+                                                no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
 
 
 # pylint: disable=unused-argument
 def validate_arm_template_at_tenant_scope(cmd,
                                           template_file=None, template_uri=None, parameters=None,
                                           deployment_name=None, deployment_location=None,
-                                          no_wait=False, handle_extended_json_format=None, no_prompt=False, template_spec=None):
+                                          no_wait=False, handle_extended_json_format=None, no_prompt=False, template_spec=None, query_string=None):
     return _deploy_arm_template_at_tenant_scope(cmd=cmd,
                                                 template_file=template_file, template_uri=template_uri, parameters=parameters,
                                                 deployment_name=deployment_name, deployment_location=deployment_location,
                                                 validate_only=True, no_wait=no_wait,
-                                                no_prompt=no_prompt, template_spec=template_spec)
+                                                no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
 
 
 def _deploy_arm_template_at_tenant_scope(cmd,
                                          template_file=None, template_uri=None, parameters=None,
                                          deployment_name=None, deployment_location=None, validate_only=False,
-                                         no_wait=False, no_prompt=False, template_spec=None):
+                                         no_wait=False, no_prompt=False, template_spec=None, query_string=None):
     deployment_properties = _prepare_deployment_properties_unmodified(cmd, template_file=template_file,
                                                                       template_uri=template_uri,
                                                                       parameters=parameters, mode='Incremental',
-                                                                      no_prompt=no_prompt, template_spec=template_spec,)
+                                                                      no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,)
 
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
 
@@ -745,9 +745,9 @@ def what_if_deploy_arm_template_at_resource_group(cmd, resource_group_name,
                                                   deployment_name=None, mode=DeploymentMode.incremental,
                                                   aux_tenants=None, result_format=None,
                                                   no_pretty_print=None, no_prompt=False,
-                                                  exclude_change_types=None, template_spec=None):
+                                                  exclude_change_types=None, template_spec=None, query_string=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, template_file, template_uri,
-                                                                parameters, mode, result_format, no_prompt, template_spec)
+                                                                parameters, mode, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, aux_tenants=aux_tenants,
                                                     plug_pipeline=(template_uri is None and template_spec is None))
     what_if_poller = mgmt_client.what_if(resource_group_name, deployment_name, what_if_properties)
@@ -759,9 +759,9 @@ def what_if_deploy_arm_template_at_subscription_scope(cmd,
                                                       template_file=None, template_uri=None, parameters=None,
                                                       deployment_name=None, deployment_location=None,
                                                       result_format=None, no_pretty_print=None, no_prompt=False,
-                                                      exclude_change_types=None, template_spec=None):
+                                                      exclude_change_types=None, template_spec=None, query_string=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, template_file, template_uri, parameters,
-                                                                DeploymentMode.incremental, result_format, no_prompt, template_spec)
+                                                                DeploymentMode.incremental, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
     what_if_poller = mgmt_client.what_if_at_subscription_scope(deployment_name, what_if_properties, deployment_location)
 
@@ -772,9 +772,9 @@ def what_if_deploy_arm_template_at_management_group(cmd, management_group_id=Non
                                                     template_file=None, template_uri=None, parameters=None,
                                                     deployment_name=None, deployment_location=None,
                                                     result_format=None, no_pretty_print=None, no_prompt=False,
-                                                    exclude_change_types=None, template_spec=None):
+                                                    exclude_change_types=None, template_spec=None, query_string=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, template_file, template_uri, parameters,
-                                                                DeploymentMode.incremental, result_format, no_prompt, template_spec=template_spec)
+                                                                DeploymentMode.incremental, result_format, no_prompt, template_spec=template_spec, query_string=query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
     what_if_poller = mgmt_client.what_if_at_management_group_scope(management_group_id, deployment_name,
                                                                    deployment_location, what_if_properties)
@@ -786,9 +786,9 @@ def what_if_deploy_arm_template_at_tenant_scope(cmd,
                                                 template_file=None, template_uri=None, parameters=None,
                                                 deployment_name=None, deployment_location=None,
                                                 result_format=None, no_pretty_print=None, no_prompt=False,
-                                                exclude_change_types=None, template_spec=None):
+                                                exclude_change_types=None, template_spec=None, query_string=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, template_file, template_uri, parameters,
-                                                                DeploymentMode.incremental, result_format, no_prompt, template_spec)
+                                                                DeploymentMode.incremental, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
     what_if_poller = mgmt_client.what_if_at_tenant_scope(deployment_name, deployment_location, what_if_properties)
 
@@ -842,8 +842,18 @@ def _build_preflight_error_message(preflight_error):
     return '\n'.join(err_messages)
 
 
+def _prepare_template_uri_with_query_string(template_uri, input_query_string):
+    from six.moves.urllib.parse import urlencode, parse_qs, urlsplit, urlunsplit  # pylint: disable=import-error
+
+    scheme, netloc, path, query_string, fragment = urlsplit(template_uri)  # pylint: disable=unused-variable
+    query_params = parse_qs(input_query_string)
+    new_query_string = urlencode(query_params, doseq=True)
+
+    return urlunsplit((scheme, netloc, path, new_query_string, fragment))
+
+
 def _prepare_deployment_properties_unmodified(cmd, template_file=None, template_uri=None, parameters=None,
-                                              mode=None, rollback_on_error=None, no_prompt=False, template_spec=None):
+                                              mode=None, rollback_on_error=None, no_prompt=False, template_spec=None, query_string=None):
     cli_ctx = cmd.cli_ctx
     DeploymentProperties, TemplateLink, OnErrorDeployment = get_sdk(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES,
                                                                     'DeploymentProperties', 'TemplateLink',
@@ -852,8 +862,16 @@ def _prepare_deployment_properties_unmodified(cmd, template_file=None, template_
     template_obj = None
     on_error_deployment = None
     template_content = None
+
+    if query_string and not template_uri:
+        raise IncorrectUsageError('please provide --template-uri if --query-string is specified')
+
     if template_uri:
-        template_link = TemplateLink(uri=template_uri)
+        if query_string:
+            template_link = TemplateLink(uri=template_uri, query_string=query_string)
+            template_uri = _prepare_template_uri_with_query_string(template_uri=template_uri, input_query_string=query_string)
+        else:
+            template_link = TemplateLink(uri=template_uri)
         template_obj = _remove_comments_from_json(_urlretrieve(template_uri).decode('utf-8'), file_path=template_uri)
     elif template_spec:
         template_link = TemplateLink(id=template_spec, mode="Incremental")
@@ -879,13 +897,13 @@ def _prepare_deployment_properties_unmodified(cmd, template_file=None, template_
 
 
 def _prepare_deployment_what_if_properties(cmd, template_file, template_uri, parameters,
-                                           mode, result_format, no_prompt, template_spec):
+                                           mode, result_format, no_prompt, template_spec, query_string):
     DeploymentWhatIfProperties, DeploymentWhatIfSettings = get_sdk(cmd.cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES,
                                                                    'DeploymentWhatIfProperties', 'DeploymentWhatIfSettings',
                                                                    mod='models')
 
     deployment_properties = _prepare_deployment_properties_unmodified(cmd=cmd, template_file=template_file, template_uri=template_uri,
-                                                                      parameters=parameters, mode=mode, no_prompt=no_prompt, template_spec=template_spec)
+                                                                      parameters=parameters, mode=mode, no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
     deployment_what_if_properties = DeploymentWhatIfProperties(template=deployment_properties.template, template_link=deployment_properties.template_link,
                                                                parameters=deployment_properties.parameters, mode=deployment_properties.mode,
                                                                what_if_settings=DeploymentWhatIfSettings(result_format=result_format))

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -266,8 +266,11 @@ def _ssl_context():
 
 
 def _urlretrieve(url):
-    req = urlopen(url, context=_ssl_context())
-    return req.read()
+    try:
+        req = urlopen(url, context=_ssl_context())
+        return req.read()
+    except Exception:  # pylint: disable=broad-except
+        raise CLIError('Unable to retrieve url {}'.format(url))
 
 
 # pylint: disable=redefined-outer-name
@@ -852,7 +855,8 @@ def _prepare_template_uri_with_query_string(template_uri, input_query_string):
 
         return urlunsplit((scheme, netloc, path, new_query_string, fragment))
     except Exception:  # pylint: disable=broad-except
-        raise CLIError('Unable to parse parameter: {} .Make sure the value is formed correctly.'.format(input_query_string))
+        from azure.cli.core.azclierror import InvalidArgumentValueError
+        raise InvalidArgumentValueError('Unable to parse parameter: {} .Make sure the value is formed correctly.'.format(input_query_string))
 
 
 def _prepare_deployment_properties_unmodified(cmd, template_file=None, template_uri=None, parameters=None,

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -845,11 +845,14 @@ def _build_preflight_error_message(preflight_error):
 def _prepare_template_uri_with_query_string(template_uri, input_query_string):
     from six.moves.urllib.parse import urlencode, parse_qs, urlsplit, urlunsplit  # pylint: disable=import-error
 
-    scheme, netloc, path, query_string, fragment = urlsplit(template_uri)  # pylint: disable=unused-variable
-    query_params = parse_qs(input_query_string)
-    new_query_string = urlencode(query_params, doseq=True)
+    try:
+        scheme, netloc, path, query_string, fragment = urlsplit(template_uri)  # pylint: disable=unused-variable
+        query_params = parse_qs(input_query_string)
+        new_query_string = urlencode(query_params, doseq=True)
 
-    return urlunsplit((scheme, netloc, path, new_query_string, fragment))
+        return urlunsplit((scheme, netloc, path, new_query_string, fragment))
+    except Exception:  # pylint: disable=broad-except
+        raise CLIError('Unable to parse parameter: {} .Make sure the value is formed correctly.'.format(input_query_string))
 
 
 def _prepare_deployment_properties_unmodified(cmd, template_file=None, template_uri=None, parameters=None,

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/createKeyVaultWithSecret.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/createKeyVaultWithSecret.json
@@ -26,7 +26,7 @@
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2019-10-01",
+      "apiVersion": "2020-10-01",
       "name": "keyVault",
       "properties": {
         "mode": "Incremental",

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/resource_group_level_linked_template.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/resource_group_level_linked_template.json
@@ -1,0 +1,98 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "projectName": {
+        "type": "string",
+        "minLength": 3,
+        "maxLength": 11,
+        "metadata": {
+          "description": "Specify a project name that is used to generate resource names."
+        }
+      },
+      "location": {
+        "type": "string",
+        "defaultValue": "[resourceGroup().location]",
+        "metadata": {
+          "description": "Specify a location for the resources."
+        }
+      },
+      "linuxFxVersion": {
+        "type": "string",
+        "defaultValue": "php|7.0",
+        "metadata": {
+          "description": "The Runtime stack of current web app"
+        }
+      }
+    },
+    "variables": {
+      "storageAccountName": "[concat(parameters('projectName'), 'store')]",
+      "webAppName": "[concat(parameters('projectName'), 'WebApp')]",
+      "appServicePlanName": "[concat(parameters('projectName'), 'Plan')]"
+    },
+    "resources": [
+      {
+        "name": "storage_account_linked_template",
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2020-10-01",
+        "properties": {
+          "mode": "Incremental",
+          "templateLink": {
+            "relativePath":"storage_account_linked_template.json",
+            "contentVersion":"1.0.0.0"
+          },
+          "parameters": {
+            "storageAccountName": {
+              "value": "[variables('storageAccountName')]"
+            },
+            "location": {
+              "value": "[parameters('location')]"
+            }
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Web/serverfarms",
+        "apiVersion": "2016-09-01",
+        "name": "[variables('appServicePlanName')]",
+        "location": "[parameters('location')]",
+        "sku": {
+          "name": "B1",
+          "tier": "Basic",
+          "size": "B1",
+          "family": "B",
+          "capacity": 1
+        },
+        "kind": "linux",
+        "properties": {
+          "perSiteScaling": false,
+          "reserved": true,
+          "targetWorkerCount": 0,
+          "targetWorkerSizeId": 0
+        }
+      },
+      {
+        "type": "Microsoft.Web/sites",
+        "apiVersion": "2018-11-01",
+        "name": "[variables('webAppName')]",
+        "location": "[parameters('location')]",
+        "dependsOn": [
+          "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
+        ],
+        "kind": "app",
+        "properties": {
+          "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
+          "siteConfig": {
+            "linuxFxVersion": "[parameters('linuxFxVersion')]"
+          }
+        }
+      }
+    ],
+    "outputs": {
+      "storageEndpoint": {
+        "type": "object",
+        "value": "[reference('storage_account_linked_template').outputs.storageEndpoint.value]"
+      }
+    }
+  }
+  

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/storage_account_linked_template.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/storage_account_linked_template.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "storageAccountName": {
+        "type": "string",
+        "metadata": {
+          "description": "Specify the storage account name."
+        }
+      },
+      "location": {
+        "type": "string",
+        "metadata": {
+          "description": "Specify a location for the resources."
+        }
+      },
+      "storageSKU": {
+        "type": "string",
+        "defaultValue": "Standard_LRS",
+        "allowedValues": [
+          "Standard_LRS",
+          "Standard_GRS",
+          "Standard_RAGRS",
+          "Standard_ZRS",
+          "Premium_LRS",
+          "Premium_ZRS",
+          "Standard_GZRS",
+          "Standard_RAGZRS"
+        ],
+        "metadata": {
+          "description": "Specify the storage account type."
+        }
+      }
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Storage/storageAccounts",
+        "apiVersion": "2019-04-01",
+        "name": "[parameters('storageAccountName')]",
+        "location": "[parameters('location')]",
+        "sku": {
+          "name": "[parameters('storageSKU')]"
+        },
+        "kind": "StorageV2",
+        "properties": {
+          "supportsHttpsTrafficOnly": true
+        }
+      }
+    ],
+    "outputs": {
+      "storageEndpoint": {
+        "type": "object",
+        "value": "[reference(parameters('storageAccountName')).primaryEndpoints]"
+      }
+    }
+  }
+  

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/subscription_level_linked_template.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/subscription_level_linked_template.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    /*
+    comment
+    */
+    "parameters": {
+      "rgName": {
+        "type": "string"
+      },
+      "rgLocation": {
+        "type": "string"
+      },
+      "keyVaultName": {
+        "type": "string"
+      }
+    },
+    "variables": {},
+    "resources": [
+      {
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2020-10-01",
+        "name": "deploymentRg",
+        "location": "[parameters('rgLocation')]",
+        "properties": {
+          "mode": "Incremental",
+          "templateLink": {
+            "relativePath":"createResourceGroup.json",
+            "contentVersion":"1.0.0.0"
+          },
+          "parameters": {
+              "rgName":{"value": "[parameters('rgName')]"},
+              "rgLocation":{"value": "[parameters('rgLocation')]"}
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2020-10-01",
+        "name": "keyVaultAndSecret",
+        "resourceGroup": "[parameters('rgName')]",
+        "dependsOn": [
+          "deploymentRg"
+        ],
+        "properties": {
+          "mode": "Incremental",
+          "templateLink": {
+            "relativePath":"createKeyVaultWithSecret.json",
+            "contentVersion":"1.0.0.0"
+          },
+          "parameters": {
+              "keyVaultName":{"value": "[parameters('keyVaultName')]"}
+          }
+        }
+      }
+    ],
+    "outputs": {}
+  }
+  

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -13,7 +13,7 @@ import unittest
 from azure.cli.core.parser import IncorrectUsageError
 from azure_devtools.scenario_tests.const import MOCKED_SUBSCRIPTION_ID
 from azure_devtools.scenario_tests import AllowLargeResponse
-from azure.cli.testsdk import (ScenarioTest, LocalContextScenarioTest, LiveScenarioTest, ResourceGroupPreparer,
+from azure.cli.testsdk import (ScenarioTest, LocalContextScenarioTest, LiveScenarioTest, ResourceGroupPreparer, StorageAccountPreparer,
                                create_random_name, live_only, record_only)
 from azure.cli.core.util import get_file_json
 from knack.util import CLIError
@@ -1010,6 +1010,99 @@ class TemplateSpecsExportTest(LiveScenarioTest):
         self.assertTrue(os.path.isfile(_artifactFile1))
         self.assertTrue(os.path.isfile(_artifactFile2))\
 
+
+
+class DeploymentTestsWithQueryString(LiveScenarioTest):
+    @ResourceGroupPreparer(name_prefix='cli_test_query_str_rg', location='eastus')
+    @StorageAccountPreparer(name_prefix='testquerystrrg', location='eastus', kind='StorageV2')
+    def test_resource_group_level_deployment_with_query_string(self, resource_group, resource_group_location, storage_account):
+
+        container_name = self.create_random_name('querystr', 20)
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        tf = os.path.join(curr_dir, 'resource_group_level_linked_template.json')
+        linked_template = os.path.join(curr_dir, 'storage_account_linked_template.json')
+
+        self.kwargs.update({
+            'resource_group': resource_group,
+            'storage_account': storage_account,
+            'container_name': container_name,
+            'tf': tf,
+            'linked_tf': linked_template
+        })
+
+        self.kwargs['storage_key'] = str(self.cmd('az storage account keys list -n {storage_account} -g {resource_group} --query "[0].value"').output)
+
+        self.cmd('storage container create -n {container_name} --account-name {storage_account} --account-key {storage_key}')
+
+        self.cmd('storage blob upload -c {container_name} -f "{tf}" -n mainTemplate --account-name {storage_account} --account-key {storage_key}')
+        self.cmd('storage blob upload -c {container_name} -f "{linked_tf}" -n storage_account_linked_template.json --account-name {storage_account} --account-key {storage_key}')
+
+        from datetime import datetime, timedelta
+        self.kwargs['expiry'] = (datetime.utcnow() + timedelta(hours=12)).strftime('%Y-%m-%dT%H:%MZ')
+
+        self.kwargs['sas_token'] = self.cmd(
+            'storage container generate-sas --account-name {storage_account} --account-key {storage_key} --name {container_name} --permissions rw --expiry {expiry}  -otsv').output.strip()
+
+        self.kwargs['blob_url'] = self.cmd(
+            'storage blob url -c {container_name} -n mainTemplate --account-name {storage_account} --account-key {storage_key}').output.strip()
+
+        self.cmd('deployment group validate -g {resource_group} --template-uri {blob_url} --query-string "{sas_token}" --parameters projectName=qsproject', checks=[
+            self.check('properties.provisioningState', 'Succeeded')
+        ])
+
+        self.cmd('deployment group create -g {resource_group} --template-uri {blob_url} --query-string "{sas_token}" --parameters projectName=qsproject', checks=[
+            self.check('properties.provisioningState', 'Succeeded')
+        ])
+
+    @ResourceGroupPreparer(name_prefix='cli_test_query_str_sub', location='eastus')
+    @StorageAccountPreparer(name_prefix='testquerystrsub', location='eastus', kind='StorageV2')
+    def test_subscription_level_deployment_with_query_string(self, resource_group, resource_group_location, storage_account):
+
+        container_name = self.create_random_name('querystr', 20)
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        tf = os.path.join(curr_dir, 'subscription_level_linked_template.json')
+        linked_tf = os.path.join(curr_dir, 'createResourceGroup.json')
+        linked_tf1 = os.path.join(curr_dir, 'createKeyVault.json')
+        linked_tf2 = os.path.join(curr_dir, 'createKeyVaultWithSecret.json')
+
+        self.kwargs.update({
+            'resource_group': resource_group,
+            'resource_group_location': resource_group_location,
+            'storage_account': storage_account,
+            'container_name': container_name,
+            'tf': tf,
+            'linked_tf': linked_tf,
+            'linked_tf1': linked_tf1,
+            'linked_tf2': linked_tf2
+        })
+
+        self.kwargs['storage_key'] = str(self.cmd('az storage account keys list -n {storage_account} -g {resource_group} --query "[0].value"').output)
+
+        self.cmd('storage container create -n {container_name} --account-name {storage_account} --account-key {storage_key}')
+
+        self.cmd('storage blob upload -c {container_name} -f "{tf}" -n mainTemplate --account-name {storage_account} --account-key {storage_key}')
+        self.cmd('storage blob upload -c {container_name} -f "{linked_tf}" -n createResourceGroup.json --account-name {storage_account} --account-key {storage_key}')
+        self.cmd('storage blob upload -c {container_name} -f "{linked_tf1}" -n createKeyVault.json --account-name {storage_account} --account-key {storage_key}')
+        self.cmd('storage blob upload -c {container_name} -f "{linked_tf2}" -n createKeyVaultWithSecret.json --account-name {storage_account} --account-key {storage_key}')
+
+        from datetime import datetime, timedelta
+        self.kwargs['expiry'] = (datetime.utcnow() + timedelta(hours=12)).strftime('%Y-%m-%dT%H:%MZ')
+
+        self.kwargs['sas_token'] = self.cmd(
+            'storage container generate-sas --account-name {storage_account} --name {container_name} --permissions dlrw --expiry {expiry} --https-only -otsv').output.strip()
+
+        self.kwargs['blob_url'] = self.cmd(
+            'storage blob url -c {container_name} -n mainTemplate --account-name {storage_account}').output.strip()
+
+        self.kwargs['key_vault'] = self.create_random_name('querystrKV', 20)
+
+        self.cmd('deployment sub validate -l {resource_group_location} --template-uri {blob_url} --query-string "{sas_token}" --parameters keyVaultName="{key_vault}" rgName="{resource_group}" rgLocation="{resource_group_location}"', checks=[
+            self.check('properties.provisioningState', 'Succeeded')
+        ])
+
+        self.cmd('deployment sub create -l {resource_group_location} --template-uri {blob_url} --query-string "{sas_token}" --parameters keyVaultName="{key_vault}" rgName="{resource_group}" rgLocation="{resource_group_location}"', checks=[
+            self.check('properties.provisioningState', 'Succeeded')
+        ])
 
 
 class DeploymentTestAtSubscriptionScope(ScenarioTest):


### PR DESCRIPTION
Closed : https://github.com/Azure/azure-cli/pull/16400 

**Description**<!--Mandatory-->

Az deployments now supports  --query-string to be used with --template-uri for linked template deployments; --query-string is a SAS token for a storage container that contains the main template and linked template(s).  Support for the --query-string parameter will facilitate the transition to template specs. Like with template specs linked templates are referenced through the relative path field in template link as illustrated below:
      
        "templateLink":  {
                  "relativePath":"linked_template.json",
                   "contentVersion":"1.0.0.0"
         }

**Testing Guide**
<!--Example commands with explanations.-->

1. Create storage account container and upload files for deployment. 

     az storage account create -n {} -g {} -l {} --sku {} --kind {} 
     az storage container create -n {} --account-name {}
     az storage blob upload -c {} -f "{}" -n {} --account-name {}

2. Generate an SAS token for the entire container (query-string parameter) 

     az storage container generate-sas --account-name {} --account-key {} --name {} --permissions dlrw --expiry {}

3. Generate the url for the main template (template-uri parameter) 

     az storage blob url -c {} -n {} --account-name {}

4. Deploy with --template-uri and --query-string parameter. 

     az deployment group create -g {} --template-uri {blob_url} --query-string "{sas_token}"
     az deployment sub create -g {} --template-uri {blob_url} --query-string "{sas_token}"
     az deployment mg validate  -g {} --template-uri {blob_url} --query-string "{sas_token}"
     az deployment tenant validate  -g {} --template-uri {blob_url} --query-string "{sas_token}"


