### PR TITLE
{Core} Add polling start time and end time in telemetry 

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -988,7 +988,7 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
             handle_long_running_operation_exception(client_exception)
 
         self.cli_ctx.get_progress_controller().end()
-        if poll_flag is True:
+        if poll_flag:
             telemetry.poll_end()
         return result
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -953,7 +953,9 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
         cli_logger = get_logger()  # get CLI logger which has the level set through command lines
         is_verbose = any(handler.level <= logs.INFO for handler in cli_logger.handlers)
         telemetry.poll_start()
+        poll_flag = False
         while not poller.done():
+            poll_flag = True
             self.cli_ctx.get_progress_controller().add(message='Running')
             try:
                 # pylint: disable=protected-access
@@ -986,7 +988,8 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
             handle_long_running_operation_exception(client_exception)
 
         self.cli_ctx.get_progress_controller().end()
-        telemetry.poll_end()
+        if poll_flag is True:
+            telemetry.poll_end()
         return result
 
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -952,7 +952,7 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
 
         cli_logger = get_logger()  # get CLI logger which has the level set through command lines
         is_verbose = any(handler.level <= logs.INFO for handler in cli_logger.handlers)
-
+        telemetry.poll_start()
         while not poller.done():
             self.cli_ctx.get_progress_controller().add(message='Running')
             try:
@@ -986,7 +986,7 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
             handle_long_running_operation_exception(client_exception)
 
         self.cli_ctx.get_progress_controller().end()
-
+        telemetry.poll_end()
         return result
 
 

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -62,6 +62,8 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         # stops generate_payload() from adding new azurecli/command event
         # used for interactive to send new custom event upon exit
         self.suppress_new_event = False
+        self.poll_start_time = None
+        self.poll_end_time = None
 
     def add_exception(self, exception, fault_type, description=None, message=''):
         # Move the exception info into userTask record, in order to make one Telemetry record for one command
@@ -196,6 +198,8 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         set_custom_properties(result, 'error_type', self.error_type)
         set_custom_properties(result, 'exception_name', self.exception_name)
         set_custom_properties(result, 'debug_info', ','.join(self.debug_info))
+        set_custom_properties(result, 'PollStartTime', str(self.poll_start_time))
+        set_custom_properties(result, 'PollEndTime', str(self.poll_end_time))
 
         return result
 
@@ -256,6 +260,16 @@ def set_init_time_elapsed(init_time_elapsed):
 @decorators.suppress_all_exceptions()
 def set_invoke_time_elapsed(invoke_time_elapsed):
     _session.invoke_time_elapsed = invoke_time_elapsed
+
+
+@decorators.suppress_all_exceptions()
+def poll_start():
+    _session.poll_start_time = datetime.datetime.utcnow()
+
+
+@decorators.suppress_all_exceptions()
+def poll_end():
+    _session.poll_end_time = datetime.datetime.utcnow()
 
 
 @_user_agrees_to_telemetry


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
After the change we could see the following two items in telemetry as shown below in my test env.
![image](https://user-images.githubusercontent.com/49508232/103972631-4e99f400-51a8-11eb-9aca-1d7f5d3ebf88.png)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
