### PR TITLE
[BACKUP] az backup protection backup-now: Set default retention period to 30 days

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from datetime import datetime, timezone, timedelta
 import azure.cli.command_modules.backup.custom as custom
 import azure.cli.command_modules.backup.custom_afs as custom_afs
 import azure.cli.command_modules.backup.custom_help as custom_help
@@ -99,6 +100,9 @@ def backup_now(cmd, client, resource_group_name, vault_name, item_name, retain_u
 
     if isinstance(item, list):
         raise ValidationError("Multiple items found. Please give native names instead.")
+
+    if retain_until is None:
+        retain_until = datetime.now(timezone.utc) + timedelta(days=30)
 
     if item.properties.backup_management_type.lower() == "azureiaasvm":
         return custom.backup_now(cmd, client, resource_group_name, vault_name, item, retain_until)


### PR DESCRIPTION
**Description**<!--Mandatory-->
When --retain-until parameter value is not provided by the user in backup-now command default retention period is set to 30 days. Till now it was giving 0 days default retention.

**Testing Guide**
az backup protection backup-now -g {rg} -v {vault} -c {container} -i {item}
az backup protection backup-now -g {rg} -v {vault} -c {container} -i {item} --retain-until {dd-mm-yyyy}

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
