### PR TITLE
[Profile] az login: Launch browser in WSL 2

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -672,7 +672,11 @@ def _get_platform_info():
 
 def is_wsl():
     platform_name, release = _get_platform_info()
-    return platform_name == 'linux' and release.split('-')[-1] == 'microsoft'
+    # "Official" way of detecting WSL: https://github.com/Microsoft/WSL/issues/423#issuecomment-221627364
+    # Run `uname -a` to get 'release' without python
+    #   - WSL 1: '4.4.0-19041-Microsoft'
+    #   - WSL 2: '4.19.128-microsoft-standard'
+    return platform_name == 'linux' and 'microsoft' in release
 
 
 def is_windows():


### PR DESCRIPTION
**Description**<!--Mandatory-->

Resolve #14656: `az login` WSL 2 Ubuntu 18.04 does not open browser 

This PR makes Azure CLI launch browser in WSL 2.

Following the "official" way of detecting WSL https://github.com/Microsoft/WSL/issues/423#issuecomment-221627364, run `uname -a` to get `release`: 

- WSL 1: `4.4.0-19041-Microsoft`
- WSL 2: `4.19.128-microsoft-standard`

So instead of checking if the `release` string ends with `microsoft`, we should check if it contains `microsoft`.

**Testing Guide**

In WSL 1 and WSL 2:

```
az login
```

ℹ For installing WSL 2 and switching between WSL 1 and WSL 2, see https://docs.microsoft.com/en-us/windows/wsl/install-win10

