### PR TITLE
[ACR] az acr connected-registry install: deprecate ACR_SYNC_TOKEN_USERNAME from the output

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -1224,7 +1224,7 @@ examples:
   - name: Create a connected registry in registry mode with access to repos app/hello-world and service/mycomponent. It'll create a sync token and scope-map with the right repo permissions.
     text: |
         az acr connected-registry create --registry mycloudregistry --name myconnectedregistry \\
-            --repository "app/hello-world service/mycomponent"
+            --repository "app/hello-world" "service/mycomponent"
   - name: Create a mirror connected registry with only read permissions and pass the sync token
     text: |
         az acr connected-registry create --registry mycloudregistry  --name mymirroracr \\
@@ -1232,7 +1232,7 @@ examples:
   - name: Create a mirror connected registry with client tokens, that syncs every day at midninght and sync window of 4 hours.
     text: |
         az acr connected-registry create -r mycloudregistry -n mymirroracr -p myconnectedregistry \\
-            --repository app/mycomponent -m mirror -s "0 12 * * *" -w PT4H \\
+            --repository "app/mycomponent" -m mirror -s "0 12 * * *" -w PT4H \\
             --client-tokens myTokenName1 myTokenName2
 """
 

--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -430,9 +430,12 @@ def _get_install_info(cmd,
         sync_username = sync_token_name
         sync_password = "<sync token password>"
 
+    logger.warning("Value 'ACR_SYNC_TOKEN_USERNAME' has been deprecated and will be removed in a future release."
+                   " Use 'ACR_SYNC_TOKEN_NAME' instead.")
     return {
         "ACR_REGISTRY_NAME": connected_registry_name,
         "ACR_REGISTRY_LOGIN_SERVER": connected_registry_login_server,
+        "ACR_SYNC_TOKEN_NAME": sync_username,
         "ACR_SYNC_TOKEN_USERNAME": sync_username,
         "ACR_SYNC_TOKEN_PASSWORD": sync_password,
         "ACR_PARENT_GATEWAY_ENDPOINT": parent_gateway_endpoint,


### PR DESCRIPTION
**Description**<!--Mandatory-->
ACR_SYNC_TOKEN_USERNAME is being deprecated from the install command group. The new value will be ACR_SYNC_TOKEN_NAME

**Testing Guide**
az acr connected-registry install info -n <connected-registry-name> -r <acr-name>
az acr connected-registry install renew-credentials -n <connected-registry-name> -r <acr-name>

**History Notes**
[ACR connected-registry] az acr connected-registry install info: Add new key ACR_SYNC_TOKEN_NAME with the same value as ACR_SYNC_TOKEN_USERNAME. A warning that the latter will be deprecated is displayed.
[ACR connected-registry] az acr connected-registry install renew-credentials: Add new key ACR_SYNC_TOKEN_NAME with the same value as ACR_SYNC_TOKEN_USERNAME. A warning that the latter will be deprecated is displayed.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
