### PR TITLE
{Role} Remove code for classic events

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -324,7 +324,7 @@ def _get_assignment_events(cli_ctx, start_time=None, end_time=None):
                 start_events[item.operation_id] = item
             else:
                 end_events[item.operation_id] = item
-    return start_events, end_events, client
+    return start_events, end_events
 
 
 # A custom command around 'monitoring' events to produce understandable output for RBAC audit, a common scenario.
@@ -332,7 +332,7 @@ def list_role_assignment_change_logs(cmd, start_time=None, end_time=None):  # py
     # pylint: disable=too-many-nested-blocks, too-many-statements
     result = []
     worker = MultiAPIAdaptor(cmd.cli_ctx)
-    start_events, end_events, client = _get_assignment_events(cmd.cli_ctx, start_time, end_time)
+    start_events, end_events = _get_assignment_events(cmd.cli_ctx, start_time, end_time)
 
     # Use the resource `name` of roleDefinitions as keys, instead of `id`, because `id` can be inherited.
     #   name: b24988ac-6180-42a0-ab88-20f7382dd24c

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -316,17 +316,15 @@ def _get_assignment_events(cli_ctx, start_time=None, end_time=None):
     odata_filters = 'resourceProvider eq Microsoft.Authorization and {}'.format(time_filter)
 
     activity_log = list(client.activity_logs.list(filter=odata_filters))
-    start_events, end_events, offline_events = {}, {}, []
+    start_events, end_events = {}, {}
 
     for item in activity_log:
-        if item.http_request:
+        if item.operation_name.value.startswith('Microsoft.Authorization/roleAssignments'):
             if item.status.value == 'Started':
                 start_events[item.operation_id] = item
             else:
                 end_events[item.operation_id] = item
-        elif item.event_name and item.event_name.value.lower() == 'classicadministrators':
-            offline_events.append(item)
-    return start_events, end_events, offline_events, client
+    return start_events, end_events, client
 
 
 # A custom command around 'monitoring' events to produce understandable output for RBAC audit, a common scenario.
@@ -334,7 +332,7 @@ def list_role_assignment_change_logs(cmd, start_time=None, end_time=None):  # py
     # pylint: disable=too-many-nested-blocks, too-many-statements
     result = []
     worker = MultiAPIAdaptor(cmd.cli_ctx)
-    start_events, end_events, offline_events, client = _get_assignment_events(cmd.cli_ctx, start_time, end_time)
+    start_events, end_events, client = _get_assignment_events(cmd.cli_ctx, start_time, end_time)
 
     # Use the resource `name` of roleDefinitions as keys, instead of `id`, because `id` can be inherited.
     #   name: b24988ac-6180-42a0-ab88-20f7382dd24c
@@ -349,8 +347,7 @@ def list_role_assignment_change_logs(cmd, start_time=None, end_time=None):  # py
                 continue
 
             entry = {}
-            op = e.operation_name and e.operation_name.value
-            if (op.lower().startswith('microsoft.authorization/roleassignments') and e.status.value == 'Succeeded'):
+            if e.status.value == 'Succeeded':
                 s, payload = start_events[op_id], None
                 entry = dict.fromkeys(
                     ['principalId', 'principalName', 'scope', 'scopeName', 'scopeType', 'roleDefinitionId', 'roleName'],
@@ -408,25 +405,6 @@ def list_role_assignment_change_logs(cmd, start_time=None, end_time=None):  # py
             if principal_dics:
                 for e in result:
                     e['principalName'] = principal_dics.get(e['principalId'], None)
-
-    offline_events = [x for x in offline_events if (x.status and x.status.value == 'Succeeded' and x.operation_name and
-                                                    x.operation_name.value.lower().startswith(
-                                                        'microsoft.authorization/classicadministrators'))]
-    for e in offline_events:
-        entry = {
-            'timestamp': e.event_timestamp,
-            'caller': 'Subscription Admin',
-            'roleDefinitionId': None,
-            'principalId': None,
-            'principalType': 'User',
-            'scope': '/subscriptions/' + client.config.subscription_id,
-            'scopeType': 'Subscription',
-            'scopeName': client.config.subscription_id,
-        }
-        if e.properties:
-            entry['principalName'] = e.properties.get('adminEmail')
-            entry['roleName'] = e.properties.get('adminType')
-        result.append(entry)
 
     return result
 


### PR DESCRIPTION
## Context

`az role assignment list-changelogs` (introduced by #5551) calls [Activity Logs - List](https://docs.microsoft.com/en-us/rest/api/monitor/activitylogs/list) to get all activity logs with `$filter=resourceProvider eq Microsoft.Authorization`.

Then it uses

https://github.com/Azure/azure-cli/blob/00c59c2dc52b9b7c71c63fc423e37c16d8186192/src/azure-cli/azure/cli/command_modules/role/custom.py#L422

to retrieve the subscription ID from mgmt client for Classic Administrator events. This operation is not permitted by Track 2 SDKs, as `config` now becomes a protected `_config` attribute.

## Classic Administrator events

Classic Administrator create/delete operation generates 2 types of logs:

### ARM event with `http_request` attribute

CLI currently doesn't show this type, because `operation_name` of the event is `'Microsoft.Authorization/classicadministrators/write'` and the event will be filtered out:

https://github.com/Azure/azure-cli/blob/00c59c2dc52b9b7c71c63fc423e37c16d8186192/src/azure-cli/azure/cli/command_modules/role/custom.py#L353

### "offline" event without `http_request` attribute

CLI currently doesn't show this type either, because `item.event_name.value` should be `'Microsoft.Authorization/classicAdministrators/write'` instead.

https://github.com/Azure/azure-cli/blob/00c59c2dc52b9b7c71c63fc423e37c16d8186192/src/azure-cli/azure/cli/command_modules/role/custom.py#L327

## Conclusion

Therefore, Classic Administrator event will not be shown by the current Azure CLI at all. Adding them back will instead cause a BREAKING CHANGE, as Classic Administrator event has different structure as ARM role assignment event:

Classic Administrator event:
```jsonc
{
    "caller": "Subscription Admin",
    "principalId": null,
    "principalName": "admin07@AzureSDKTeam.onmicrosoft.com",
    "principalType": "User",
    "roleDefinitionId": null,
    "roleName": "CoAdmin",
    "scope": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "scopeName": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "scopeType": "Subscription",
    "timestamp": "2021-01-19T07:10:56.932598+00:00"
}
```

ARM role assignment event:
```jsonc
{
    "action": "Revoked",  // Classic Administrator event doesn't have this field
    "caller": "jiasli@microsoft.com",
    "principalId": "5e914469-5dcf-4f7d-b2b6-ba14e926daba",
    "principalName": "http://azure-cli-2020-12-04-08-00-43",
    "roleDefinitionId": "b24988ac-6180-42a0-ab88-20f7382dd24c",
    "roleName": "Contributor",
    "scope": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "scopeName": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "scopeType": "Subscription",
    "timestamp": "2021-01-19T05:38:43.228672+00:00"
}
```

Also `Microsoft.Authorization/classicAdministrators/delete` event doesn't have `adminEmail` field. `principalName` will be left as `null`.

```jsonc
{
    "caller": "Subscription Admin",
    "principalId": null,
    "principalName": null,
    "principalType": "User",
    "roleDefinitionId": null,
    "roleName": null,
    "scope": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "scopeName": "0b1f6471-1bf0-4dda-aec3-cb9272f09590",
    "scopeType": "Subscription",
    "timestamp": "2021-01-19T07:13:15.805340+00:00"
}
```

To query it, we have to call [Classic Administrators - List](https://docs.microsoft.com/en-us/rest/api/authorization/classicadministrators/list) which will of course add more complexity.

## Changes

Since Azure CLI doesn't support creating Classic Administrator assignment or showing Classic Administrator events, this PR removes the logic for Classic Administrator event.

## Testing guide

Run this command from both current CLI and changed CLI, the result number should be the same (849 in `/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590`).

```
az role assignment list-changelogs --start-time 2020-12-19T00:00:00Z --end-time 2021-01-19T09:00:00Z --query '"length(@)"'
```

## Additional information

The only public API for `classicAdministrators` is [Classic Administrators - List](https://docs.microsoft.com/en-us/rest/api/authorization/classicadministrators/list).

The `Classic Administrators - PUT` API which Azure Portal calls is not publicly documented.

```http
PUT https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/
    Microsoft.Authorization/classicadministrators/<netId>?api-version=2015-06-01
```

`netId` (e.g. `1003200042CF7CB1`) is an internal property of a user which is not exposed by AD Graph API v1.6 [Operations on users](https://docs.microsoft.com/en-us/previous-versions/azure/ad/graph/api/users-operations). 

Azure Portal queries it with an internal API:

```http
POST https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$batch

--batch_521e3e95-7c5f-404f-b5fa-4b97bb020737
Content-Type: application/http
Content-Transfer-Encoding: binary

GET /54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/users?$top=101 HTTP/1.1
Host: graph.windows.net
Accept: application/json

--batch_521e3e95-7c5f-404f-b5fa-4b97bb020737--
```

