### PR TITLE
[KeyVault] `az keyvault key import`: Support `--curve` parameter for importing BYOK keys

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -20,7 +20,7 @@ from azure.cli.command_modules.keyvault._completers import (
     get_keyvault_name_completion_list, get_keyvault_version_completion_list)
 from azure.cli.command_modules.keyvault._validators import (
     datetime_type, certificate_type,
-    get_vault_base_url_type, get_hsm_base_url_type,
+    get_vault_base_url_type, get_hsm_base_url_type, validate_key_import_type,
     validate_key_import_source, validate_key_type, validate_policy_permissions, validate_principal,
     validate_resource_group_name, validate_x509_certificate_chain,
     secret_text_encoding_values, secret_binary_encoding_values, validate_subnet,
@@ -70,6 +70,12 @@ def load_arguments(self, _):
     class CLIKeyTypeForBYOKImport(str, Enum):
         ec = "EC"  #: Elliptic Curve.
         rsa = "RSA"  #: RSA (https://tools.ietf.org/html/rfc3447)
+
+    class CLIJsonWebKeyCurveName(str, Enum):
+        p_256 = "P-256"  #: The NIST P-256 elliptic curve, AKA SECG curve SECP256R1.
+        p_256k = "P-256K"  #: The SECG SECP256K1 elliptic curve.
+        p_384 = "P-384"  #: The NIST P-384 elliptic curve, AKA SECG curve SECP384R1.
+        p_521 = "P-521"  #: The NIST P-521 elliptic curve, AKA SECG curve SECP521R1.
 
     (KeyPermissions, SecretPermissions, CertificatePermissions, StoragePermissions,
      NetworkRuleBypassOptions, NetworkRuleAction) = self.get_models(
@@ -347,8 +353,10 @@ def load_arguments(self, _):
                    help='Elliptic curve name. For valid values, see: https://docs.microsoft.com/en-us/rest/api/keyvault/createkey/createkey#jsonwebkeycurvename')
 
     with self.argument_context('keyvault key import') as c:
-        c.argument('kty', arg_type=get_enum_type(CLIKeyTypeForBYOKImport),
+        c.argument('kty', arg_type=get_enum_type(CLIKeyTypeForBYOKImport), validator=validate_key_import_type,
                    help='The type of key to import (only for BYOK).')
+        c.argument('curve', arg_type=get_enum_type(CLIJsonWebKeyCurveName), validator=validate_key_import_type,
+                   help='The curve name of the key to import (only for BYOK).')
 
     with self.argument_context('keyvault key import', arg_group='Key Source') as c:
         c.argument('pem_file', type=file_type, help='PEM file containing the key to be imported.', completer=FilesCompleter(), validator=validate_key_import_source)

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -191,7 +191,7 @@ def validate_key_import_type(ns):
 
     if (kty == 'EC' and crv is None) or (kty != 'EC' and crv):
         from azure.cli.core.azclierror import ValidationError
-        raise ValidationError('parameter --curve should be specified when key type is EC.')
+        raise ValidationError('parameter --curve should be specified when key type --kty is EC.')
 
 
 def validate_key_type(ns):

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -184,6 +184,16 @@ def validate_key_import_source(ns):
         raise ValueError('--pem-password must be used with --pem-file or --pem-string')
 
 
+def validate_key_import_type(ns):
+    # Default value of kty is: RSA
+    kty = getattr(ns, 'kty', None)
+    crv = getattr(ns, 'curve', None)
+
+    if (kty == 'EC' and crv is None) or (kty != 'EC' and crv):
+        from azure.cli.core.azclierror import ValidationError
+        raise ValidationError('parameter --curve should be specified when key type is EC.')
+
+
 def validate_key_type(ns):
     crv = getattr(ns, 'curve', None)
     kty = getattr(ns, 'kty', None) or ('EC' if crv else 'RSA')

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -1189,7 +1189,7 @@ def import_key(cmd, client, key_name=None, vault_base_url=None,  # pylint: disab
                hsm_name=None, identifier=None,  # pylint: disable=unused-argument
                protection=None, key_ops=None, disabled=False, expires=None,
                not_before=None, tags=None, pem_file=None, pem_string=None, pem_password=None, byok_file=None,
-               byok_string=None, kty='RSA'):
+               byok_string=None, kty='RSA', curve=None):
     """ Import a private key. Supports importing base64 encoded private keys from PEM files or strings.
         Supports importing BYOK keys into HSM for premium key vaults. """
     KeyAttributes = cmd.get_models('KeyAttributes', resource_type=ResourceType.DATA_KEYVAULT)
@@ -1234,7 +1234,9 @@ def import_key(cmd, client, key_name=None, vault_base_url=None,  # pylint: disab
 
         key_obj.kty = kty + '-HSM'
         key_obj.t = byok_data
+        key_obj.crv = curve
 
+        print(key_obj)
     return client.import_key(vault_base_url, key_name, key_obj, protection == 'hsm', key_attrs, tags)
 
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -1236,7 +1236,6 @@ def import_key(cmd, client, key_name=None, vault_base_url=None,  # pylint: disab
         key_obj.t = byok_data
         key_obj.crv = curve
 
-        print(key_obj)
     return client.import_key(vault_base_url, key_name, key_obj, protection == 'hsm', key_attrs, tags)
 
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->
This PR fixes https://github.com/Azure/azure-cli-pr/issues/121

It provides the `--curve` paramter in `az keyvault key import` command.
```
--curve          : The curve name of the key to import (only for BYOK).  Allowed values:
                   P-256, P-256K, P-384, P-521.
```

The command below could be used for key importing after the fix.
```
az keyvault key import --vault-name MyVault --name KeyName --byok-file BYOKFilePath --kty EC --curve P-256
```
The behavior of `--kty` and `--curve` paramters.
- `--kty` has the default value `RSA`
- `--curve` should be specified together with `--kty EC`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
