### PR TITLE
{Packaging} Pin PyJWT to 1.7.1

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -54,7 +54,7 @@ DEPENDENCIES = [
     'msal-extensions~=0.1.3',
     'msrestazure>=0.6.3',
     'paramiko>=2.0.8,<3.0.0',
-    'PyJWT',
+    'PyJWT==1.7.1',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
     'requests~=2.22',
     'six~=1.12',


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix #16416: `az login --identity` fails: load_pem_private_key() missing 1 required positional argument: 'backend'

The error is caused by a conflicting dependency on `cryptography` from [PyJWT 2.0.1](https://pypi.org/project/PyJWT/2.0.1/)

https://github.com/jpadilla/pyjwt/blob/3993ce1d3503b58cf74699a89ba9e5c18ef9b556/setup.cfg#L55

```py
cryptography>=3.3.1,<4.0.0
```
and Azure CLI

https://github.com/Azure/azure-cli/blob/6f255051203445da73c99687e64f15d58c4006a7/src/azure-cli/setup.py#L134

There is an ongoing PR https://github.com/Azure/azure-cli/pull/15687 to bump `cryptography` to the latest version. 

Also the current [MSAL 1.8.0](https://pypi.org/project/msal/) requires 

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/1.8.0/setup.py#L76

```
'PyJWT[crypto]>=1.0.0,<2'
```

Using the old version of `pip` may cause failure.

MSAL starts to be compatible with PyJWT 2 since https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/296. Waiting for the next release.
