### PR TITLE
[AppService] az webapp up/az webapp create: Fix nonetype errors

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -154,7 +154,8 @@ def create_webapp(cmd, resource_group_name, name, plan, runtime=None, startup_fi
             site_config.linux_fx_version = _format_fx_version(encoded_config_file, multicontainer_config_type)
 
     elif plan_info.is_xenon:  # windows container webapp
-        site_config.windows_fx_version = _format_fx_version(deployment_container_image_name)
+        if deployment_container_image_name:
+            site_config.windows_fx_version = _format_fx_version(deployment_container_image_name)
         # set the needed app settings for container image validation
         if name_validation.name_available:
             site_config.app_settings.append(NameValuePair(name="DOCKER_REGISTRY_SERVER_USERNAME",
@@ -3718,7 +3719,7 @@ def webapp_up(cmd, name=None, resource_group_name=None, plan=None, location=None
                            "Please check if you have configured defaults for plan name and re-run command."
                            .format(plan, current_plan))
         plan = plan or plan_details['name']
-        plan_info = client.app_service_plans.get(rg_name, plan)
+        plan_info = client.app_service_plans.get(plan_details['resource_group'], plan)
         sku = plan_info.sku.name if isinstance(plan_info, AppServicePlan) else 'Free'
         current_os = 'Linux' if plan_info.reserved else 'Windows'
         # Raise error if current OS of the app is different from the current one


### PR DESCRIPTION
**Description**<!--Mandatory-->
Fix null reference errors in `az webapp up` and `az webapp create`
Closes #15752, #16565, #16061, #16475

- If appservice and appservice plan are in different resource groups, `az webapp up` will try and find appservice plan in the wrong resource group
- Nonetype error when creating windows container app using `az webapp create` if deployment_container_image_name is not supplied

**Testing Guide**
- Create a webapp, then mov ewebapp to another resource group, then run `az webapp up`
- Create a windows container appservice plan, then create a webapp with this appservice plan using `az webapp create`

These two scenarios shouldn't give nonetype error

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
