### PR TITLE
{Identity} Beta 2.18.0.1

### DIFF
--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ===============
 
-2.17.11
+2.18.10
 +++++++
 
 * Migrate the authentication library from ADAL to MSAL.

--- a/src/azure-cli-core/HISTORY.rst
+++ b/src/azure-cli-core/HISTORY.rst
@@ -3,8 +3,8 @@
 Release History
 ===============
 
-2.18.10
-+++++++
+2.18.0.1
+++++++++
 
 * Migrate the authentication library from ADAL to MSAL.
 

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -6,7 +6,7 @@
 
 from __future__ import print_function
 
-__version__ = "2.18.10"
+__version__ = "2.18.0.1"
 
 import os
 import sys

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -661,7 +661,7 @@ class Profile:
             if in_cloud_console() and account[_USER_ENTITY].get(_CLOUD_SHELL_ID):
                 if aux_tenant_id:
                     raise CLIError("Tenant shouldn't be specified for Cloud Shell account")
-                return Identity.get_managed_identity_credential()
+                return identity.get_managed_identity_credential()
 
             # EnvironmentCredential. Ignore user_type
             if is_environment:
@@ -680,7 +680,7 @@ class Profile:
         # MSI
         if aux_tenant_id:
             raise CLIError("Tenant shouldn't be specified for MSI account")
-        return Identity.get_managed_identity_credential(identity_id)
+        return identity.get_managed_identity_credential(identity_id)
 
     def get_login_credentials(self, resource=None, client_id=None, subscription_id=None, aux_subscriptions=None,
                               aux_tenants=None):

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "2.18.10"
+VERSION = "2.18.0.1"
 
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -3,8 +3,8 @@
 Release History
 ===============
 
-2.18.10
-+++++++
+2.18.0.1
+++++++++
 
 * Migrate the authentication library from ADAL to MSAL.
 

--- a/src/azure-cli/azure/cli/__main__.py
+++ b/src/azure-cli/azure/cli/__main__.py
@@ -17,7 +17,7 @@ from knack.completion import ARGCOMPLETE_ENV_NAME
 from knack.log import get_logger
 
 __author__ = "Microsoft Corporation <python@microsoft.com>"
-__version__ = "2.18.10"
+__version__ = "2.18.0.1"
 
 
 # A workaround for https://bugs.python.org/issue32502 (https://github.com/Azure/azure-cli/issues/5184)

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -60,10 +60,11 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('username', options_list=['--username', '-u'], help='user name, service principal, or managed service identity ID')
             c.argument('tenant', options_list=['--tenant', '-t'], help='The AAD tenant, must provide when using service principals.', validator=validate_tenant)
             c.argument('tenant_access', action='store_true',
+                       deprecate_info=c.deprecate(target='--tenant-access', hide=True),
                        help='Only log in to the home tenant or the tenant specified by --tenant. CLI will not perform '
                             'ARM operations to list tenants and subscriptions. Then you may run tenant-level commands, '
                             'such as `az ad`, `az account get-access-token`.')
-            c.argument('allow_no_subscriptions', action='store_true', deprecate_info=c.deprecate(target='--allow-no-subscriptions', expiration='3.0.0', redirect="--tenant-access", hide=False),
+            c.argument('allow_no_subscriptions', action='store_true',
                        help="Support access tenants without subscriptions. It's uncommon but useful to run tenant level commands, such as `az ad`")
             c.ignore('_subscription')  # hide the global subscription parameter
             c.argument('identity', options_list=('-i', '--identity'), action='store_true', help="Log in using the Virtual Machine's managed identity", arg_group='Managed Identity')
@@ -72,6 +73,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
                        help="Use CLI's old authentication flow based on device code. CLI will also use this if it can't launch a browser in your behalf, e.g. in remote SSH or Cloud Shell")
             c.argument('use_cert_sn_issuer', action='store_true', help='used with a service principal configured with Subject Name and Issuer Authentication in order to support automatic certificate rolls')
             c.argument('environment', options_list=['--environment', '-e'], action='store_true',
+                       deprecate_info=c.deprecate(target='--environment', hide=True),
                        help='Use EnvironmentCredential. Both user and service principal accounts are supported. '
                             'For required environment variables, see https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#environment-variables')
 

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -34,24 +34,6 @@ examples:
       text: az login --identity
     - name: Log in using a VM's user-assigned managed identity. Client or object ids of the service identity also work.
       text: az login --identity -u /subscriptions/<subscriptionId>/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
-    - name: Log in with a service principal using EnvironmentCredential.
-      text: |-
-        # Bash script
-        export AZURE_TENANT_ID='<tenant ID>'
-        export AZURE_CLIENT_ID='<service principal appId>'
-        # With secret
-        export AZURE_CLIENT_SECRET='<secret>'
-        # Or with certificate
-        # export AZURE_CLIENT_CERTIFICATE_PATH='<path to a PEM-encoded certificate file>'
-        az login --environment
-    - name: Log in with a user account using EnvironmentCredential.
-      text: |-
-        # Bash script
-        # AZURE_CLIENT_ID defaults to Azure CLI's client ID
-        # export AZURE_CLIENT_ID='04b07795-8ddb-461a-bbee-02f9e1bf7b46'
-        export AZURE_USERNAME='<username>'
-        export AZURE_PASSWORD='<password>'
-        az login --environment
 """
 
 helps['account'] = """

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -11,16 +11,10 @@ helps['login'] = """
 type: command
 short-summary: Log in to Azure.
 long-summary: >-
-    By default, this command logs in with a user account. To login with a service principal, specify --service-principal.
+    By default, this command logs in with a user account. CLI will try to launch a web browser to log in interactively.
+    If a web browser is not available, CLI will fallback to device code login.
 
-
-    For user login, CLI will try to launch a web browser to log in interactively. If a web browser is not available,
-    CLI will fallback to device code login.
-
-
-    To retrieve the login credential from environment variables (EnvironmentCredential), specify --environment.
-    For details on using EnvironmentCredential, see
-    https://docs.microsoft.com/python/api/overview/azure/identity-readme#environment-variables
+    To login with a service principal, specify --service-principal.
 examples:
     - name: Log in interactively.
       text: az login

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -12,7 +12,7 @@ type: command
 short-summary: Log in to Azure.
 long-summary: >-
     By default, this command logs in with a user account. CLI will try to launch a web browser to log in interactively.
-    If a web browser is not available, CLI will fallback to device code login.
+    If a web browser is not available, CLI will fall back to device code login.
 
     To login with a service principal, specify --service-principal.
 examples:

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -5,8 +5,8 @@ argcomplete==1.11.1
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==10.0.0
-azure-cli==2.18.10
-azure-cli-core==2.18.10
+azure-cli==2.18.0.1
+azure-cli-core==2.18.0.1
 azure-cli-telemetry==1.0.6
 azure-common==1.1.22
 azure-cosmos==3.2.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -5,8 +5,8 @@ argcomplete==1.11.1
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==10.0.0
-azure-cli==2.18.10
-azure-cli-core==2.18.10
+azure-cli==2.18.0.1
+azure-cli-core==2.18.0.1
 azure-cli-telemetry==1.0.6
 azure-common==1.1.22
 azure-cosmos==3.2.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -5,8 +5,8 @@ argcomplete==1.11.1
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==10.0.0
-azure-cli==2.18.10
-azure-cli-core==2.18.10
+azure-cli==2.18.0.1
+azure-cli-core==2.18.0.1
 azure-cli-telemetry==1.0.6
 azure-common==1.1.22
 azure-cosmos==3.2.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -53,7 +53,7 @@ DEPENDENCIES = [
     'antlr4-python3-runtime~=4.7.2',
     'azure-appconfiguration~=1.1.1',
     'azure-batch~=10.0.0',
-    'azure-cli-core=={}.*'.format(".".join(VERSION.split(".")[:3])),
+    'azure-cli-core=={}'.format(VERSION),
     'azure-cosmos~=3.0,>=3.0.2',
     'azure-datalake-store~=0.0.49',
     'azure-functions-devops-build~=0.0.22',

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -18,7 +18,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "2.18.10"
+VERSION = "2.18.0.1"
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:


### PR DESCRIPTION
**Description**<!--Mandatory-->

- Pass `kwargs` to credentials so that `logging_enable=True` can be passed to credentials to enable unredacted HTTP logging. 
- Hide `--environment` and `--tenant-access` temporarily. 
