### PR TITLE
{Core} Config knack only once

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -38,6 +38,25 @@ ALWAYS_LOADED_MODULES = []
 ALWAYS_LOADED_EXTENSIONS = ['azext_ai_examples']
 
 
+def _configure_knack():
+    """Override consts defined in knack to make them Azure CLI-specific."""
+
+    # Customize status tag messages.
+    from knack.util import status_tag_messages
+    ref_message = "Reference and support levels: https://aka.ms/CLI_refstatus"
+    # Override the preview message.
+    status_tag_messages['preview'] = "{} is in preview and under development. " + ref_message
+    # Override the experimental message.
+    status_tag_messages['experimental'] = "{} is experimental and under development. " + ref_message
+
+    # Allow logs from 'azure' logger to be displayed.
+    from knack.log import cli_logger_names
+    cli_logger_names.append('azure')
+
+
+_configure_knack()
+
+
 class AzCli(CLI):
 
     def __init__(self, **kwargs):
@@ -83,8 +102,6 @@ class AzCli(CLI):
 
         if not self.enable_color:
             format_styled_text.theme = 'none'
-
-        _configure_knack()
 
     def refresh_request_id(self):
         """Assign a new random GUID as x-ms-client-request-id
@@ -858,19 +875,3 @@ def get_default_cli():
                  logging_cls=AzCliLogging,
                  output_cls=AzOutputProducer,
                  help_cls=AzCliHelp)
-
-
-def _configure_knack():
-    """Override consts defined in knack to make them Azure CLI-specific."""
-
-    # Customize status tag messages.
-    from knack.util import status_tag_messages
-    ref_message = "Reference and support levels: https://aka.ms/CLI_refstatus"
-    # Override the preview message.
-    status_tag_messages['preview'] = "{} is in preview and under development. " + ref_message
-    # Override the experimental message.
-    status_tag_messages['experimental'] = "{} is experimental and under development. " + ref_message
-
-    # Allow logs from 'azure' logger to be displayed.
-    from knack.log import cli_logger_names
-    cli_logger_names.append("azure")


### PR DESCRIPTION
## Description

#16301 introduced function `_configure_knack`.

During tests, `AzCli` can be created multiple times in the same process, causing `_configure_knack` to be executed multiple times, resulting in duplicated `'azure'` entries in `cli_logger_names`:

```
['cli', 'azure', 'azure', 'azure', 'azure', ...]
```

This causes huge delay on **CLI Automation Full Test / Automation Test Python38**.

https://dev.azure.com/azure-sdk/public/_pipeline/analytics/duration?definitionId=1623&contextType=build

![image](https://user-images.githubusercontent.com/4003950/105500403-d5e57c80-5cfd-11eb-96c8-40bbcd1f0961.png)

https://dev.azure.com/azure-sdk/public/_build/results?buildId=697879&view=results

- **Automation Test Python36**: 25m 30s
- **Automation Test Python38**: 56m 1s

Tested with Python 3.7 and it also suffers from the slowness.

## Changes

This PR utilizes Python's [module cache](https://docs.python.org/3/reference/import.html#the-module-cache) to make sure `cli_logger_names` is only changed once to

```
['cli', 'azure']
```