### PR TITLE
{Packaging} Bump setuptools to 52.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # basic
-setuptools==40.0.0
+setuptools==52.0.0
 pip>=9.0.1


### PR DESCRIPTION
**Description**<!--Mandatory-->
Bump [setuptools](https://pypi.org/project/setuptools/) to 52.0.0 for Python 3.9 support.

On Python 3.9, `pip install -e D:\cli\azure-cli/src/azure-cli-telemetry --no-deps` fails with setuptools 40.0.0:

```
Obtaining file:///D:/cli/azure-cli/src/azure-cli-telemetry
    ERROR: Command errored out with exit status 1:
     command: 'D:\cli\env39\Scripts\python.exe' -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'D:\\cli\\azure-cli\\src\\azure-cli-telemetry\\setup.py'"'"'; __file__='"'"'D:\\cli\\azure-cli\\src\\azure-cli-telemetry\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base 'C:\Users\jiasli\AppData\Local\Temp\pip-pip-egg-info-s2_jb1ye'
         cwd: D:\cli\azure-cli\src\azure-cli-telemetry\
    Complete output (11 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "D:\cli\env39\lib\site-packages\setuptools\__init__.py", line 14, in <module>
        from setuptools.dist import Distribution, Feature
      File "D:\cli\env39\lib\site-packages\setuptools\dist.py", line 24, in <module>
        from setuptools.depends import Require
      File "D:\cli\env39\lib\site-packages\setuptools\depends.py", line 7, in <module>
        from .py33compat import Bytecode
      File "D:\cli\env39\lib\site-packages\setuptools\py33compat.py", line 55, in <module>
        unescape = getattr(html, 'unescape', html_parser.HTMLParser().unescape)
    AttributeError: 'HTMLParser' object has no attribute 'unescape'
    ----------------------------------------
WARNING: Discarding file:///D:/cli/azure-cli/src/azure-cli-telemetry. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

This was fixed by https://github.com/pypa/setuptools/pull/1788.
