### PR TITLE
{Packaging} Bump ADAL to 1.2.6

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -43,7 +43,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'adal~=1.2.3',
+    'adal~=1.2.6',
     'argcomplete~=1.8',
     'azure-cli-telemetry==1.0.6.*',
     'colorama~=0.4.1',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -1,4 +1,4 @@
-adal==1.2.3
+adal==1.2.6
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.9
 argcomplete==1.11.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -1,4 +1,4 @@
-adal==1.2.3
+adal==1.2.6
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.9
 argcomplete==1.11.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -1,4 +1,4 @@
-adal==1.2.3
+adal==1.2.6
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.7
 argcomplete==1.11.1


### PR DESCRIPTION
**Description**

Bump ADAL to 1.2.6 to incorporate 

https://github.com/AzureAD/azure-activedirectory-library-for-python/pull/246: Make ADAL compatible with PyJWT 1 & 2
