### PR TITLE
{Core} Don't leak socket on connectivity check

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -781,10 +781,10 @@ def check_connectivity(url='https://example.org', max_retries=5, timeout=1):
     start = timeit.default_timer()
     success = None
     try:
-        s = requests.Session()
-        s.mount(url, requests.adapters.HTTPAdapter(max_retries=max_retries))
-        s.head(url, timeout=timeout)
-        success = True
+        with requests.Session() as s:
+            s.mount(url, requests.adapters.HTTPAdapter(max_retries=max_retries))
+            s.head(url, timeout=timeout)
+            success = True
     except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as ex:
         logger.info('Connectivity problem detected.')
         logger.debug(ex)


### PR DESCRIPTION
Fix #16307

**Description**
Python 3.8+ and [pytest 6.2+](https://docs.pytest.org/en/stable/usage.html#warning-about-unraisable-exceptions-and-unhandled-thread-exceptions) reveal a leaked socket at:

```
if not check_connectivity(max_retries=0):
E    ResourceWarning: unclosed <ssl.SSLSocket fd=1444, family=AddressFamily.AF_INET6, type=SocketKind.SOCK_STREAM, proto=0, ...
```
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
