### PR TITLE
{Misc.} Update CODEOWNERS - add backup owner for help

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,38 +15,38 @@
 /src/azure-cli/azure/cli/command_modules/acr/ @djyou @fengzhou-msft @yungezz
 /src/azure-cli/azure/cli/command_modules/acs/ @rjtsdl @fengzhou-msft
 /src/azure-cli/azure/cli/command_modules/advisor/ @Prasanna-Padmanabhan
+/src/azure-cli/azure/cli/command_modules/apim/ @kevinhillinger @jonlester
 /src/azure-cli/azure/cli/command_modules/appconfig/ @shenmuxiaosen @avanigupta @qwordy
 /src/azure-cli/azure/cli/command_modules/appservice/ @qwordy @Juliehzl
+/src/azure-cli/azure/cli/command_modules/aro/ @mjudeikis @jim-minter
 /src/azure-cli/azure/cli/command_modules/backup/ @dragonfly91 @fengzhou-msft
 /src/azure-cli/azure/cli/command_modules/batch/ @bgklein @gingi @dpwatrous @paterasMSFT @qwordy
 /src/azure-cli/azure/cli/command_modules/batchai/ @AlexanderYukhanov
-/src/azure-cli/azure/cli/command_modules/cosmosdb/ @dmakwana
 /src/azure-cli/azure/cli/command_modules/cloud/ @jiasli @fengzhou-msft @Juliehzl
-/src/azure-cli/azure/cli/command_modules/container/ @zhoxing-ms @fengzhou-msft
 /src/azure-cli/azure/cli/command_modules/consumption/ @sandeepnl
+/src/azure-cli/azure/cli/command_modules/container/ @zhoxing-ms @fengzhou-msft
+/src/azure-cli/azure/cli/command_modules/cosmosdb/ @dmakwana
+/src/azure-cli/azure/cli/command_modules/databoxedge/ @evelyn-ys @Juliehzl
 /src/azure-cli/azure/cli/command_modules/dls/ @akharit @rahuldutta90 @Juliehzl @jsntcy
 /src/azure-cli/azure/cli/command_modules/dms/ @temandr @binuj
+/src/azure-cli/azure/cli/command_modules/eventhubs/ @v-ajnava
 /src/azure-cli/azure/cli/command_modules/extension/ @fengzhou-msft @msyyc
+/src/azure-cli/azure/cli/command_modules/hdinsight/ @aim-for-better @Juliehzl @kairu-ms
+/src/azure-cli/azure/cli/command_modules/iot/ @digimaun
 /src/azure-cli/azure/cli/command_modules/keyvault/ @fengzhou-msft @yungezz @houk-ms
 /src/azure-cli/azure/cli/command_modules/monitor/ @msyyc @jsntcy @kairu-ms
 /src/azure-cli/azure/cli/command_modules/natgateway/ @khannarheams @jsntcy @kairu-ms @msyyc
 /src/azure-cli/azure/cli/command_modules/network/ @jsntcy @kairu-ms @msyyc
-/src/azure-cli/azure/cli/command_modules/privatedns/ @jsntcy @kairu-ms @msyyc
 /src/azure-cli/azure/cli/command_modules/policyinsights/ @cheggert
+/src/azure-cli/azure/cli/command_modules/privatedns/ @jsntcy @kairu-ms @msyyc
 /src/azure-cli/azure/cli/command_modules/profile/ @jiasli @evelyn-ys @fengzhou-msft
 /src/azure-cli/azure/cli/command_modules/rdbms/ @arde0708 @Juliehzl @evelyn-ys
 /src/azure-cli/azure/cli/command_modules/resource/ @Juliehzl @zhoxing-ms
 /src/azure-cli/azure/cli/command_modules/role/ @jiasli @evelyn-ys @jsntcy @fengzhou-msft
-/src/azure-cli/azure/cli/command_modules/storage/ @Juliehzl @jsntcy @zhoxing-ms @evelyn-ys
+/src/azure-cli/azure/cli/command_modules/servicebus/ @v-ajnava @fengzhou-msft
 /src/azure-cli/azure/cli/command_modules/servicefabric/ @QingChenmsft @qwordy
 /src/azure-cli/azure/cli/command_modules/sql/ @jaredmoo @Juliehzl @evelyn-ys
-/src/azure-cli/azure/cli/command_modules/vm/ @qwordy @houk-ms @yungezz
-/src/azure-cli/azure/cli/command_modules/eventhubs/ @v-ajnava
-/src/azure-cli/azure/cli/command_modules/servicebus/ @v-ajnava @fengzhou-msft
-/src/azure-cli/azure/cli/command_modules/apim/ @kevinhillinger @jonlester
-/src/azure-cli/azure/cli/command_modules/iot/ @digimaun
-/src/azure-cli/azure/cli/command_modules/aro/ @mjudeikis @jim-minter
-/src/azure-cli/azure/cli/command_modules/util/ @jiasli @Juliehzl @zhoxing-ms
+/src/azure-cli/azure/cli/command_modules/storage/ @Juliehzl @jsntcy @zhoxing-ms @evelyn-ys
 /src/azure-cli/azure/cli/command_modules/synapse/ @idear1203 @sunsw1994 @aim-for-better
-/src/azure-cli/azure/cli/command_modules/hdinsight/ @aim-for-better @Juliehzl @kairu-ms
-/src/azure-cli/azure/cli/command_modules/databoxedge/ @evelyn-ys @Juliehzl
+/src/azure-cli/azure/cli/command_modules/util/ @jiasli @Juliehzl @zhoxing-ms
+/src/azure-cli/azure/cli/command_modules/vm/ @qwordy @houk-ms @yungezz

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # See for instructions on this file https://help.github.com/articles/about-codeowners/
 
-*help.py @msyyc
-*help.yaml @msyyc
-*help.yml @msyyc
+*help.py @msyyc @jiasli
+*help.yaml @msyyc @jiasli
+*help.yml @msyyc @jiasli
 
 /linter_exclusions.yml @jsntcy @kairu-ms
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # See for instructions on this file https://help.github.com/articles/about-codeowners/
 
-*help.py @msyyc @jiasli
-*help.yaml @msyyc @jiasli
-*help.yml @msyyc @jiasli
+*help.py @msyyc @jiasli @jsntcy
+*help.yaml @msyyc @jiasli @jsntcy
+*help.yml @msyyc @jiasli @jsntcy
 
 /linter_exclusions.yml @jsntcy @kairu-ms
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,6 +43,7 @@
 /src/azure-cli/azure/cli/command_modules/rdbms/ @arde0708 @Juliehzl @evelyn-ys
 /src/azure-cli/azure/cli/command_modules/resource/ @Juliehzl @zhoxing-ms
 /src/azure-cli/azure/cli/command_modules/role/ @jiasli @evelyn-ys @jsntcy @fengzhou-msft
+/src/azure-cli/azure/cli/command_modules/search/ @huangbolun @kairu-ms
 /src/azure-cli/azure/cli/command_modules/servicebus/ @v-ajnava @fengzhou-msft
 /src/azure-cli/azure/cli/command_modules/servicefabric/ @QingChenmsft @qwordy
 /src/azure-cli/azure/cli/command_modules/sql/ @jaredmoo @Juliehzl @evelyn-ys


### PR DESCRIPTION
The current `CODEOWNERS` only has @msyyc for help-related files. In case of out-of-office, PRs requiring approval for help-related files (e.g. https://github.com/Azure/azure-cli/pull/16707) cannot be merged.

Note that 

```
src/azure-cli/azure/cli/command_modules/search/
```

doesn't have an owner, so 

```
src/azure-cli/azure/cli/command_modules/search/_help.py
```

will need approval from @msyyc.