### PR TITLE
[BACKUP] az backup protectable-item list: Add protectable-item-type as an optional argument

### DIFF
--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -695,6 +695,11 @@ backup protectable-item show:
     protectable_item_type:
       rule_exclusions:
       - option_length_too_long
+backup protectable-item list:
+  parameters:
+    protectable_item_type:
+      rule_exclusions:
+      - option_length_too_long
 backup protection auto-enable-for-azurewl:
   parameters:
     protectable_item_name:

--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -244,6 +244,9 @@ def load_arguments(self, _):
         c.argument('server_name', options_list=['--server-name'], help='Parent Server name of the item.')
         c.argument('protectable_item_type', protectable_item_type)
 
+    with self.argument_context('backup protectable-item list') as c:
+        c.argument('protectable_item_type', protectable_item_type)
+
     # Restore
     # TODO: Need to use recovery_point.id once https://github.com/Azure/msrestazure-for-python/issues/80 is fixed.
     with self.argument_context('backup restore') as c:

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
@@ -212,7 +212,8 @@ def list_protectable_items(cmd, client, resource_group_name, vault_name, workloa
                 Multiple containers with same Friendly Name found. Please give native names instead.
                 """)
             container_uri = container.name
-    return custom_wl.list_protectable_items(client, resource_group_name, vault_name, workload_type, container_uri, protectable_item_type)
+    return custom_wl.list_protectable_items(client, resource_group_name, vault_name, workload_type, container_uri,
+                                            protectable_item_type)
 
 
 def show_protectable_item(cmd, client, resource_group_name, vault_name, name, server_name, protectable_item_type,

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
@@ -196,7 +196,8 @@ def list_associated_items_for_policy(client, resource_group_name, vault_name, na
                                                    backup_management_type)
 
 
-def list_protectable_items(cmd, client, resource_group_name, vault_name, workload_type, container_name=None):
+def list_protectable_items(cmd, client, resource_group_name, vault_name, workload_type, container_name=None,
+                           protectable_item_type=None):
     container_uri = None
     if container_name:
         if custom_help.is_native_name(container_name):
@@ -211,7 +212,7 @@ def list_protectable_items(cmd, client, resource_group_name, vault_name, workloa
                 Multiple containers with same Friendly Name found. Please give native names instead.
                 """)
             container_uri = container.name
-    return custom_wl.list_protectable_items(client, resource_group_name, vault_name, workload_type, container_uri)
+    return custom_wl.list_protectable_items(client, resource_group_name, vault_name, workload_type, container_uri, protectable_item_type)
 
 
 def show_protectable_item(cmd, client, resource_group_name, vault_name, name, server_name, protectable_item_type,

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
@@ -300,11 +300,11 @@ def list_protectable_items(client, resource_group_name, vault_name, workload_typ
     if protectable_item_type is not None:
         # Protectable Item Type filter
         paged_items = [item for item in paged_items if
-                          item.properties.protectable_item_type.lower() == protectable_item_type.lower()]
+                       item.properties.protectable_item_type.lower() == protectable_item_type.lower()]
     if container_uri:
         return [item for item in paged_items if
                 cust_help.get_protection_container_uri_from_id(item.id).lower() == container_uri.lower()]
-    
+
     return paged_items
 
 

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
@@ -283,8 +283,11 @@ def show_protectable_instance(items, server_name, protectable_item_type):
     return cust_help.get_none_one_or_many(filtered_items)
 
 
-def list_protectable_items(client, resource_group_name, vault_name, workload_type, container_uri=None):
+def list_protectable_items(client, resource_group_name, vault_name, workload_type, container_uri=None,
+                           protectable_item_type=None):
     workload_type = _check_map(workload_type, workload_type_map)
+    if protectable_item_type is not None:
+        protectable_item_type = _check_map(protectable_item_type, protectable_item_type_map)
 
     filter_string = cust_help.get_filter_string({
         'backupManagementType': "AzureWorkload",
@@ -293,9 +296,15 @@ def list_protectable_items(client, resource_group_name, vault_name, workload_typ
     # Items list
     items = client.list(vault_name, resource_group_name, filter_string)
     paged_items = cust_help.get_list_from_paged_response(items)
+
+    if protectable_item_type is not None:
+        # Protectable Item Type filter
+        paged_items = [item for item in paged_items if
+                          item.properties.protectable_item_type.lower() == protectable_item_type.lower()]
     if container_uri:
         return [item for item in paged_items if
                 cust_help.get_protection_container_uri_from_id(item.id).lower() == container_uri.lower()]
+    
     return paged_items
 
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
Added protectable-item-type as an optional argument to az backup protectable-item list command. Now the users will be able to filter the list using a specific protectable-item-type.

**Testing Guide**
az backup protectable-item list -g {rg} -v {vault} --workload-type {MSSQL/SAPHANA} --protectable-item-type {HANAInstance/SAPHanaDatabase/SAPHanaSystem/SQLAG/SQLDatabase/SQLInstance}

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
