### PR TITLE
[KeyVault] BREAKING CHANGE: `az keyvault role assignment/definition list`: `roleDefinitionName` should be `roleName` in command output

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
@@ -22,12 +22,12 @@ from azure.cli.command_modules.keyvault._validators import (
 
 def transform_assignment_list(result):
     return [OrderedDict([('Principal', r['principalName']),
-                         ('Role', r['roleDefinitionName']),
+                         ('RoleName', r['roleName']),
                          ('Scope', r['scope'])]) for r in result]
 
 
 def transform_definition_list(result):
-    return [OrderedDict([('Name', r['roleName']), ('Type', r['type']),
+    return [OrderedDict([('Name', r['name']), ('RoleName', r['roleName']), ('Type', r['type']),
                          ('Description', r['description'])]) for r in result]
 
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -1857,9 +1857,9 @@ def _reconstruct_role_assignment(role_dics, principal_dics, role_assignment):
     role_definition_id = getattr(role_assignment, 'role_definition_id', None)
     ret['roleDefinitionId'] = role_definition_id
     if role_definition_id:
-        ret['roleDefinitionName'] = role_dics.get(role_definition_id)
+        ret['roleName'] = role_dics.get(role_definition_id)
     else:
-        ret['roleDefinitionName'] = None  # the role definition might have been deleted
+        ret['roleName'] = None  # the role definition might have been deleted
 
     # fill in principal names
     principal_id = getattr(role_assignment, 'principal_id', None)

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_commands.py
@@ -547,7 +547,7 @@ class KeyVaultHSMRoleScenarioTest(ScenarioTest):
                                     checks=[
                                         self.check('name', '{role_assignment_name1}'),
                                         self.check('roleDefinitionId', '{role_def_id1}'),
-                                        self.check('roleDefinitionName', '{role_name1}'),
+                                        self.check('roleName', '{role_name1}'),
                                         self.check('principalName', '{user1}'),
                                         self.check('scope', '/keys')
                                     ]).get_output_in_json()
@@ -558,7 +558,7 @@ class KeyVaultHSMRoleScenarioTest(ScenarioTest):
                                     checks=[
                                         self.check('name', '{role_assignment_name2}'),
                                         self.check('roleDefinitionId', '{role_def_id2}'),
-                                        self.check('roleDefinitionName', '{role_name2}'),
+                                        self.check('roleName', '{role_name2}'),
                                         self.check('principalName', '{user1}'),
                                         self.check('scope', '/')
                                     ]).get_output_in_json()
@@ -570,7 +570,7 @@ class KeyVaultHSMRoleScenarioTest(ScenarioTest):
                  checks=[
                      self.check('name', '{role_assignment_name3}'),
                      self.check('roleDefinitionId', '{role_def_id1}'),
-                     self.check('roleDefinitionName', '{role_name1}'),
+                     self.check('roleName', '{role_name1}'),
                      self.check('principalName', '{user2}'),
                      self.check('scope', '/keys')
                  ]).get_output_in_json()
@@ -580,7 +580,7 @@ class KeyVaultHSMRoleScenarioTest(ScenarioTest):
                  checks=[
                      self.check('name', '{role_assignment_name4}'),
                      self.check('roleDefinitionId', '{role_def_id2}'),
-                     self.check('roleDefinitionName', '{role_name2}'),
+                     self.check('roleName', '{role_name2}'),
                      self.check('principalName', '{user2}'),
                      self.check('scope', '/')
                  ]).get_output_in_json()
@@ -592,7 +592,7 @@ class KeyVaultHSMRoleScenarioTest(ScenarioTest):
                      self.check('name', '{role_assignment_name5}'),
                      self.check('principalId', '{user3_principal_id}'),
                      self.check('roleDefinitionId', '{role_def_id1}'),
-                     self.check('roleDefinitionName', '{role_name1}'),
+                     self.check('roleName', '{role_name1}'),
                      self.check('principalName', '{user3}'),
                      self.check('scope', '/keys')
                  ]).get_output_in_json()
@@ -603,7 +603,7 @@ class KeyVaultHSMRoleScenarioTest(ScenarioTest):
                      self.check('name', '{role_assignment_name6}'),
                      self.check('principalId', '{user3_principal_id}'),
                      self.check('roleDefinitionId', '{role_def_id2}'),
-                     self.check('roleDefinitionName', '{role_name2}'),
+                     self.check('roleName', '{role_name2}'),
                      self.check('principalName', '{user3}'),
                      self.check('scope', '/')
                  ]).get_output_in_json()


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

- `roleName` is the name of a role, which is provided by user as the display name.
- `roleDefinitionName` is the name of a role definition, which is a GUID. It's called `roleDefinitionName` in the request body while is called `name` in response.

**This pr provides two improvements**

1. In the current command output of `az keyvault role assignment list`, the `roleDefinitionName` actually is `roleName`, this pr fixes the problem.

previously

![image](https://user-images.githubusercontent.com/62928370/106709841-0a2b3800-6630-11eb-9969-2a69aa61b363.png)

now

![image](https://user-images.githubusercontent.com/62928370/106709768-f2ec4a80-662f-11eb-896a-ab29766413b3.png)

2. Besides, the pr provides another column for the table view of command `az keyvault role definition list`, so that users won't be confused by the two names.

previously

![image](https://user-images.githubusercontent.com/62928370/106709936-2fb84180-6630-11eb-933e-2aabe47db7ef.png)

now

![image](https://user-images.githubusercontent.com/62928370/106709615-c5070600-662f-11eb-9298-6cd7ed4befee.png)


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
