### PR TITLE
[Botservice] az bot update: Renaming Encryption-OFF arg to CMK-OFF and updating api version

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/botservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/_params.py
@@ -108,7 +108,7 @@ def load_arguments(self, _):
                         'you want to view analytics about your bot in the Analytics blade.')
         c.argument('icon_url', help='Icon URL for bot avatar. Accepts PNG files with file size limit of 30KB.')
         c.argument('cmek_key_vault_url', options_list=['--cmk-key-vault-key-url', '--cmk'], help='The key vault key url to enable Customer Managed Keys encryption')
-        c.argument('encryption_off', options_list=['--encryption-off'], help='Set encryption to Microsoft-Managed Keys', action='store_true')
+        c.argument('encryption_off', options_list=['--cmk-off'], help='Set encryption to Microsoft-Managed Keys', action='store_true')
 
     with self.argument_context('bot prepare-publish') as c:
         c.argument('proj_file_path', options_list=['--proj-file-path', c.deprecate(target='--proj-name',

--- a/src/azure-cli/azure/cli/command_modules/botservice/tests/latest/recordings/test_update_bot_should_raise_mutuallyexclusiveargumenterror.yaml
+++ b/src/azure-cli/azure/cli/command_modules/botservice/tests/latest/recordings/test_update_bot_should_raise_mutuallyexclusiveargumenterror.yaml
@@ -109,7 +109,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 02 Feb 2021 03:31:06 GMT
+      - Thu, 04 Feb 2021 04:13:43 GMT
       expires:
       - '-1'
       pragma:
@@ -158,7 +158,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 02 Feb 2021 03:31:07 GMT
+      - Thu, 04 Feb 2021 04:13:44 GMT
       expires:
       - '-1'
       pragma:
@@ -178,7 +178,7 @@ interactions:
       message: OK
 - request:
     body: '{"location": "global", "sku": {"name": "F0"}, "kind": "bot", "properties":
-      {"displayName": "cli000002", "endpoint": "", "msaAppId": "86f0407d-7c59-4501-bcc8-5a7b6eb7dccc",
+      {"displayName": "cli000002", "endpoint": "", "msaAppId": "010d724c-dc51-4efa-b09d-c8de3e8d8b29",
       "isCmekEnabled": false}}'
     headers:
       Accept:
@@ -204,7 +204,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.BotService/botServices/cli000002?api-version=2020-06-02
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.BotService/botServices/cli000002","name":"cli000002","type":"Microsoft.BotService/botServices","etag":"\"8f00e05f-0000-0200-0000-6018c77e0000\"","location":"global","sku":{"name":"F0"},"kind":"bot","tags":{},"properties":{"displayName":"cli000002","description":null,"iconUrl":"https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png","endpoint":"","msaAppId":"86f0407d-7c59-4501-bcc8-5a7b6eb7dccc","developerAppInsightKey":null,"developerAppInsightsApplicationId":null,"luisAppIds":[],"endpointVersion":"3.0","configuredChannels":["webchat"],"enabledChannels":["webchat","directline"],"isDeveloperAppInsightsApiKeySet":false,"isStreamingSupported":false,"publishingCredentials":null,"parameters":null,"allSettings":null,"manifestUrl":null,"storageResourceId":null,"migrationToken":null,"isCmekEnabled":false,"cmekKeyVaultUrl":null,"openWithHint":null,"appPasswordHint":null,"cmekEncryptionStatus":"Off","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.BotService/botServices/cli000002","name":"cli000002","type":"Microsoft.BotService/botServices","etag":"\"9a00917a-0000-0200-0000-601b747a0000\"","location":"global","sku":{"name":"F0"},"kind":"bot","tags":{},"properties":{"displayName":"cli000002","description":null,"iconUrl":"https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png","endpoint":"","msaAppId":"010d724c-dc51-4efa-b09d-c8de3e8d8b29","developerAppInsightKey":null,"developerAppInsightsApplicationId":null,"luisAppIds":[],"endpointVersion":"3.0","configuredChannels":["webchat"],"enabledChannels":["webchat","directline"],"isDeveloperAppInsightsApiKeySet":false,"isStreamingSupported":false,"publishingCredentials":null,"parameters":null,"allSettings":null,"manifestUrl":null,"storageResourceId":null,"migrationToken":null,"isCmekEnabled":false,"cmekKeyVaultUrl":null,"openWithHint":null,"appPasswordHint":null,"cmekEncryptionStatus":"Off","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -213,9 +213,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 02 Feb 2021 03:31:10 GMT
+      - Thu, 04 Feb 2021 04:13:47 GMT
       etag:
-      - '"8f00e05f-0000-0200-0000-6018c77e0000"'
+      - '"9a00917a-0000-0200-0000-601b747a0000"'
       expires:
       - '-1'
       pragma:
@@ -225,7 +225,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -241,7 +241,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n --encryption-off --cmk-key-vault-key-url
+      - -g -n --cmk-off --cmk-key-vault-key-url
       User-Agent:
       - python/3.8.2 (macOS-10.14.3-x86_64-i386-64bit) msrest/0.6.18 msrest_azure/0.6.3
         azure-mgmt-botservice/0.3.0 Azure-SDK-For-Python AZURECLI/2.18.0
@@ -251,7 +251,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.BotService/botServices/cli000002?api-version=2020-06-02
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.BotService/botServices/cli000002","name":"cli000002","type":"Microsoft.BotService/botServices","etag":"\"8f00e05f-0000-0200-0000-6018c77e0000\"","location":"global","sku":{"name":"F0"},"kind":"bot","tags":{},"properties":{"displayName":"cli000002","description":null,"iconUrl":"https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png","endpoint":"","msaAppId":"86f0407d-7c59-4501-bcc8-5a7b6eb7dccc","developerAppInsightKey":null,"developerAppInsightsApplicationId":null,"luisAppIds":[],"endpointVersion":"3.0","configuredChannels":["webchat"],"enabledChannels":["webchat","directline"],"isDeveloperAppInsightsApiKeySet":false,"isStreamingSupported":false,"publishingCredentials":null,"parameters":null,"allSettings":null,"manifestUrl":null,"storageResourceId":null,"migrationToken":null,"isCmekEnabled":false,"cmekKeyVaultUrl":null,"openWithHint":null,"appPasswordHint":null,"cmekEncryptionStatus":"Off","provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.BotService/botServices/cli000002","name":"cli000002","type":"Microsoft.BotService/botServices","etag":"\"9a00917a-0000-0200-0000-601b747a0000\"","location":"global","sku":{"name":"F0"},"kind":"bot","tags":{},"properties":{"displayName":"cli000002","description":null,"iconUrl":"https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png","endpoint":"","msaAppId":"010d724c-dc51-4efa-b09d-c8de3e8d8b29","developerAppInsightKey":null,"developerAppInsightsApplicationId":null,"luisAppIds":[],"endpointVersion":"3.0","configuredChannels":["webchat"],"enabledChannels":["webchat","directline"],"isDeveloperAppInsightsApiKeySet":false,"isStreamingSupported":false,"publishingCredentials":null,"parameters":null,"allSettings":null,"manifestUrl":null,"storageResourceId":null,"migrationToken":null,"isCmekEnabled":false,"cmekKeyVaultUrl":null,"openWithHint":null,"appPasswordHint":null,"cmekEncryptionStatus":"Off","provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -260,9 +260,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 02 Feb 2021 03:31:11 GMT
+      - Thu, 04 Feb 2021 04:13:48 GMT
       etag:
-      - '"8f00e05f-0000-0200-0000-6018c77e0000"'
+      - '"9a00917a-0000-0200-0000-601b747a0000"'
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/botservice/tests/latest/test_bot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/tests/latest/test_bot_commands.py
@@ -791,7 +791,7 @@ class BotTests(ScenarioTest):
             ])
 
         try:
-            self.cmd('az bot update -g {rg} -n {botname} --encryption-off --cmk-key-vault-key-url test.url')
+            self.cmd('az bot update -g {rg} -n {botname} --cmk-off --cmk-key-vault-key-url test.url')
             raise AssertionError('should have thrown an error.')
         except MutuallyExclusiveArgumentError:
             pass
@@ -872,7 +872,7 @@ class BotLiveOnlyTests(LiveScenarioTest):
         assert resultsCreate['properties']['isCmekEnabled'] is True
 
         results = self.cmd('az bot update -g {rg} -n {botname} '
-                           '--encryption-off',
+                           '--cmk-off',
                            checks=[
                                self.check('name', '{botname}'),
                                self.check('resourceGroup', '{rg}')])
@@ -971,7 +971,7 @@ class BotLiveOnlyTests(LiveScenarioTest):
         assert resultsShow['properties']['isCmekEnabled'] is True
 
         results = self.cmd('az bot update -g {rg} -n {botname} '
-                           '--encryption-off',
+                           '--cmk-off',
                            checks=[
                                self.check('name', '{botname}'),
                                self.check('resourceGroup', '{rg}')])

--- a/src/azure-cli/azure/cli/command_modules/botservice/webappv4.template.json
+++ b/src/azure-cli/azure/cli/command_modules/botservice/webappv4.template.json
@@ -156,7 +156,7 @@
             ]
         },
         {
-            "apiVersion": "2018-07-12",
+            "apiVersion": "2020-06-02",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
There is a request from BotFramework PM team to rename the argument --encryption-off to --cmk-off which maps to the azure portal experience.
The ARM template for Bot Service is also update to reflect the latest generated schema changes.

**Testing Guide**
<!--Example commands with explanations.-->
```
// Disables CMK encryption.
az bot update --name <BotResourceName> --resource-group <ResourceGroupName> --cmk-off
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
