### PR TITLE
{Extension} Add retry when getting extension index

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/_index.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_index.py
@@ -33,8 +33,12 @@ def get_index(index_url=None):
             msg = ERR_TMPL_NON_200.format(response.status_code, index_url)
             raise CLIError(msg)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError) as err:
-            msg = ERR_TMPL_NO_NETWORK.format(str(err))
-            raise CLIError(msg)
+            if try_number == TRIES - 1:
+                msg = ERR_TMPL_NO_NETWORK.format(str(err))
+                raise CLIError(msg)
+            import time
+            time.sleep(0.5)
+            continue
         except ValueError as err:
             # Indicates that url is not redirecting properly to intended index url, we stop retrying after TRIES calls
             if try_number == TRIES - 1:

--- a/src/azure-cli-core/azure/cli/core/extension/_index.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_index.py
@@ -34,12 +34,7 @@ def get_index(index_url=None):
             raise CLIError(msg)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError, ValueError) as err:
             if try_number == TRIES - 1:
-                if isinstance(err, ValueError):
-                    # Indicates that url is not redirecting properly to intended index url, we stop retrying after
-                    # TRIES calls
-                    msg = ERR_TMPL_BAD_JSON.format(str(err))
-                else:
-                    msg = ERR_TMPL_NO_NETWORK.format(str(err))
+                msg = ERR_TMPL_BAD_JSON.format(str(err)) if isinstance(err, ValueError) else ERR_TMPL_NO_NETWORK.format(str(err))
                 raise CLIError(msg)
             import time
             time.sleep(0.5)

--- a/src/azure-cli-core/azure/cli/core/extension/_index.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_index.py
@@ -34,7 +34,9 @@ def get_index(index_url=None):
             raise CLIError(msg)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError, ValueError) as err:
             if try_number == TRIES - 1:
-                msg = ERR_TMPL_BAD_JSON.format(str(err)) if isinstance(err, ValueError) else ERR_TMPL_NO_NETWORK.format(str(err))
+                # ValueError indicates that shortlink url is not redirecting properly to intended index url
+                msg = ERR_TMPL_BAD_JSON.format(str(err)) if isinstance(err, ValueError) else \
+                    ERR_TMPL_NO_NETWORK.format(str(err))
                 raise CLIError(msg)
             import time
             time.sleep(0.5)

--- a/src/azure-cli-core/azure/cli/core/extension/_index.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_index.py
@@ -32,17 +32,14 @@ def get_index(index_url=None):
                 return response.json()
             msg = ERR_TMPL_NON_200.format(response.status_code, index_url)
             raise CLIError(msg)
-        except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError) as err:
+        except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError, ValueError) as err:
             if try_number == TRIES - 1:
-                msg = ERR_TMPL_NO_NETWORK.format(str(err))
-                raise CLIError(msg)
-            import time
-            time.sleep(0.5)
-            continue
-        except ValueError as err:
-            # Indicates that url is not redirecting properly to intended index url, we stop retrying after TRIES calls
-            if try_number == TRIES - 1:
-                msg = ERR_TMPL_BAD_JSON.format(str(err))
+                if isinstance(err, ValueError):
+                    # Indicates that url is not redirecting properly to intended index url, we stop retrying after
+                    # TRIES calls
+                    msg = ERR_TMPL_BAD_JSON.format(str(err))
+                else:
+                    msg = ERR_TMPL_NO_NETWORK.format(str(err))
                 raise CLIError(msg)
             import time
             time.sleep(0.5)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
We're seeing increasing failures of `Test Extensions Loading Python36` task in CI when downloading the extension index file. Add retry to mitigate the issue while we trying to figure out the root cause.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
