### PR TITLE
[AppService] functionapp: Take Node.js 14 out of preview

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/resources/LinuxFunctionsStacks.json
+++ b/src/azure-cli/azure/cli/command_modules/appservice/resources/LinuxFunctionsStacks.json
@@ -113,7 +113,7 @@
                             "use32BitWorkerProcess": false,
                             "linuxFxVersion": "Node|14"
                         },
-                        "isPreview": true,
+                        "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
                     },

--- a/src/azure-cli/azure/cli/command_modules/appservice/resources/LinuxFunctionsStacks.json
+++ b/src/azure-cli/azure/cli/command_modules/appservice/resources/LinuxFunctionsStacks.json
@@ -103,7 +103,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": false,
+                        "isDefault": true,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
@@ -123,7 +123,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": true,
+                        "isDefault": false,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {

--- a/src/azure-cli/azure/cli/command_modules/appservice/resources/WindowsFunctionsStacks.json
+++ b/src/azure-cli/azure/cli/command_modules/appservice/resources/WindowsFunctionsStacks.json
@@ -101,7 +101,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": false,
+                        "isDefault": true,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {
@@ -121,7 +121,7 @@
                         "supportedFunctionsExtensionVersions": [
                             "~3"
                         ],
-                        "isDefault": true,
+                        "isDefault": false,
                         "minorVersions": [],
                         "applicationInsights": true,
                         "appSettingsDictionary": {

--- a/src/azure-cli/azure/cli/command_modules/appservice/resources/WindowsFunctionsStacks.json
+++ b/src/azure-cli/azure/cli/command_modules/appservice/resources/WindowsFunctionsStacks.json
@@ -111,7 +111,7 @@
                         "siteConfigPropertiesDictionary": {
                             "use32BitWorkerProcess": true
                         },
-                        "isPreview": true,
+                        "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
                     },


### PR DESCRIPTION
**Description**<!--Mandatory-->
This is a stacks update. We're adding taking Node 14 apps out of preview.

Resolves https://github.com/Azure/Azure-Functions/issues/1745
Resolves https://github.com/Azure/azure-cli/issues/15407

**Testing Guide**
These don't change any functionality, just the json the create function uses to know the available options.

**History Notes**
[AppService] az functionapp create: Removed preview flag from Node.js 14.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
