### PR TITLE
{Misc.} Use MSIFASTINSTALL

### DIFF
--- a/build_scripts/windows/Product.wxs
+++ b/build_scripts/windows/Product.wxs
@@ -29,6 +29,7 @@
     <Property Id="ARPHELPLINK" Value="https://docs.microsoft.com/cli/azure" />
     <Property Id="ARPURLINFOABOUT" Value="https://docs.microsoft.com/cli/azure/overview" />
     <Property Id="ARPURLUPDATEINFO" Value="https://docs.microsoft.com/cli/azure/overview" />
+    <Property Id="MSIFASTINSTALL" Value="7" />
     <Property Id="ApplicationFolderName" Value="Microsoft SDKs\Azure" />
     <Property Id="WixAppFolder" Value="WixPerMachineFolder" />
 


### PR DESCRIPTION
**Description**
This setting will make the installer on Windows go faster. Its used by many other products with lots of files like Visual Studio. I tested it and saw it take 13 seconds off the clean install time on my machine.