### PR TITLE
[BACKUP] az backup protection check-vm: Add vm and resource-group as optional params

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -210,7 +210,7 @@ def load_arguments(self, _):
         c.argument('workload_type', workload_type)
 
     with self.argument_context('backup protection check-vm') as c:
-        c.argument('vm_id', help='ID of the virtual machine to be checked for protection.')
+        c.argument('vm_id', help='ID of the virtual machine to be checked for protection.', deprecate_info=c.deprecate(redirect='--vm', hide=True))
 
     with self.argument_context('backup protection enable-for-vm') as c:
         c.argument('diskslist', diskslist_type)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -262,7 +262,11 @@ def check_protection_enabled_for_vm(cmd, vm_id=None, vm=None, resource_group_nam
             vm_id = vm
         else:
             vm_id = virtual_machines_cf(cmd.cli_ctx).get(resource_group_name, vm).id
-
+    else:
+        logger.warning(
+            """
+            Please use --vm argument instead of --vm-id. --vm-id may get deprecated in future releases.
+            """)
     vaults = list_vaults(vaults_cf(cmd.cli_ctx))
     for vault in vaults:
         vault_rg = _get_resource_group_from_id(vault.id)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -262,7 +262,10 @@ def check_protection_enabled_for_vm(cmd, vm_id=None, vm=None, resource_group_nam
             vm_id = vm
         else:
             if vm is None or resource_group_name is None:
-                raise RequiredArgumentMissingError("--vm or --resource-group missing. Please provide the required arguments.")
+                raise RequiredArgumentMissingError(
+                    """
+                    --vm or --resource-group missing. Please provide the required arguments.
+                    """)
             vm_id = virtual_machines_cf(cmd.cli_ctx).get(resource_group_name, vm).id
     vaults = list_vaults(vaults_cf(cmd.cli_ctx))
     for vault in vaults:

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -261,12 +261,9 @@ def check_protection_enabled_for_vm(cmd, vm_id=None, vm=None, resource_group_nam
         if is_valid_resource_id(vm):
             vm_id = vm
         else:
+            if vm is None or resource_group_name is None:
+                raise RequiredArgumentMissingError("--vm or --resource-group missing. Please provide the required arguments.")
             vm_id = virtual_machines_cf(cmd.cli_ctx).get(resource_group_name, vm).id
-    else:
-        logger.warning(
-            """
-            Please use --vm argument instead of --vm-id. --vm-id may get deprecated in future releases.
-            """)
     vaults = list_vaults(vaults_cf(cmd.cli_ctx))
     for vault in vaults:
         vault_rg = _get_resource_group_from_id(vault.id)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -256,7 +256,13 @@ def list_containers(client, resource_group_name, vault_name, container_type="Azu
     return _get_containers(client, container_type, status, resource_group_name, vault_name)
 
 
-def check_protection_enabled_for_vm(cmd, vm_id):
+def check_protection_enabled_for_vm(cmd, vm_id=None, vm=None, resource_group_name=None):
+    if vm_id is None:
+        if is_valid_resource_id(vm):
+            vm_id = vm
+        else:
+            vm_id = virtual_machines_cf(cmd.cli_ctx).get(resource_group_name, vm).id
+
     vaults = list_vaults(vaults_cf(cmd.cli_ctx))
     for vault in vaults:
         vault_rg = _get_resource_group_from_id(vault.id)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -262,10 +262,8 @@ def check_protection_enabled_for_vm(cmd, vm_id=None, vm=None, resource_group_nam
             vm_id = vm
         else:
             if vm is None or resource_group_name is None:
-                raise RequiredArgumentMissingError(
-                    """
-                    --vm or --resource-group missing. Please provide the required arguments.
-                    """)
+                raise RequiredArgumentMissingError("--vm or --resource-group missing. Please provide the required "
+                                                   "arguments.")
             vm_id = virtual_machines_cf(cmd.cli_ctx).get(resource_group_name, vm).id
     vaults = list_vaults(vaults_cf(cmd.cli_ctx))
     for vault in vaults:

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
@@ -261,8 +261,8 @@ def re_register_wl_container(cmd, client, vault_name, resource_group_name, workl
                                               container_name, backup_management_type)
 
 
-def check_protection_enabled_for_vm(cmd, vm_id):
-    return custom.check_protection_enabled_for_vm(cmd, vm_id)
+def check_protection_enabled_for_vm(cmd, vm_id=None, vm=None, resource_group_name=None):
+    return custom.check_protection_enabled_for_vm(cmd, vm_id, vm, resource_group_name)
 
 
 def enable_protection_for_vm(cmd, client, resource_group_name, vault_name, vm, policy_name, diskslist=None,


### PR DESCRIPTION
**Description**<!--Mandatory-->
az backup protection check-vm command had only --vm-id as input parameter. To make it consistent with other commands added --vm and --resource-group as optional parameters.

**Testing Guide**
az backup protection check-vm --resource-group {rg_name} --vm {vm_name/vm_id}

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
