### PR TITLE
[Compute] az vm (extension) image list: Make it more robust

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_actions.py
@@ -47,10 +47,10 @@ def load_images_thru_services(cli_ctx, publisher, offer, sku, location):
         location = get_one_of_subscription_locations(cli_ctx)
 
     def _load_images_from_publisher(publisher):
-        from msrestazure.azure_exceptions import CloudError
+        from azure.core.exceptions import ResourceNotFoundError
         try:
             offers = client.virtual_machine_images.list_offers(location, publisher)
-        except CloudError as e:
+        except ResourceNotFoundError as e:
             logger.warning(str(e))
             return
         if offer:
@@ -58,7 +58,7 @@ def load_images_thru_services(cli_ctx, publisher, offer, sku, location):
         for o in offers:
             try:
                 skus = client.virtual_machine_images.list_skus(location, publisher, o.name)
-            except CloudError as e:
+            except ResourceNotFoundError as e:
                 logger.warning(str(e))
                 continue
             if sku:
@@ -66,7 +66,7 @@ def load_images_thru_services(cli_ctx, publisher, offer, sku, location):
             for s in skus:
                 try:
                     images = client.virtual_machine_images.list(location, publisher, o.name, s.name)
-                except CloudError as e:
+                except ResourceNotFoundError as e:
                     logger.warning(str(e))
                     continue
                 for i in images:
@@ -148,17 +148,22 @@ def load_extension_images_thru_services(cli_ctx, publisher, name, version, locat
         location = get_one_of_subscription_locations(cli_ctx)
 
     def _load_extension_images_from_publisher(publisher):
-        from msrestazure.azure_exceptions import CloudError
+        from azure.core.exceptions import ResourceNotFoundError
         try:
             types = client.virtual_machine_extension_images.list_types(location, publisher)
-        except CloudError:  # PIR image publishers might not have any extension images, exception could raise
+        except ResourceNotFoundError as e:
+            # PIR image publishers might not have any extension images, exception could raise
+            logger.warning(str(e))
             types = []
         if name:
             types = [t for t in types if _matched(name, t.name, partial_match)]
         for t in types:
-            versions = client.virtual_machine_extension_images.list_versions(location,
-                                                                             publisher,
-                                                                             t.name)
+            try:
+                versions = client.virtual_machine_extension_images.list_versions(
+                    location, publisher, t.name)
+            except ResourceNotFoundError as e:
+                logger.warning(str(e))
+                continue
             if version:
                 versions = [v for v in versions if _matched(version, v.name, partial_match)]
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Resolve https://github.com/Azure/azure-cli/issues/11767
A recent update of Azure Python SDK throws `azure.core.exceptions.ResourceNotFoundError` instead of `msrestazure.azure_exceptions.CloudError`


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
