### PR TITLE
[AppService] az webapp up: Save defaults for "runtime" and "os_type" parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -610,9 +610,15 @@ def load_arguments(self, _):
                    help="name of the appserviceplan associated with the webapp",
                    local_context_attribute=LocalContextAttribute(name='plan_name', actions=[LocalContextAction.GET]))
         c.argument('sku', arg_type=sku_arg_type)
-        c.argument('os_type', options_list=['--os-type'], arg_type=get_enum_type(OS_TYPES), help="Set the OS type for the app to be created.")
+        c.argument('os_type', options_list=['--os-type'], arg_type=get_enum_type(OS_TYPES), help="Set the OS type for the app to be created.",
+                                                                                            configured_default='os',
+                                                                                            local_context_attribute=LocalContextAttribute(name='os',
+                                                                                                              actions=[LocalContextAction.GET, LocalContextAction.SET]))
         c.argument('runtime', options_list=['--runtime', '-r'], help="canonicalized web runtime in the format of Framework|Version, e.g. \"PHP|7.2\". Allowed delimiters: \"|\" or \":\". "
-                                                                     "Use `az webapp list-runtimes` for available list.")
+                                                                     "Use `az webapp list-runtimes` for available list.",
+                                                                configured_default='runtime',
+                                                                local_context_attribute=LocalContextAttribute(name='runtime',
+                                                                                                              actions=[LocalContextAction.GET, LocalContextAction.SET]))
         c.argument('dryrun', help="show summary of the create and deploy operation instead of executing it",
                    default=False, action='store_true')
         c.argument('location', arg_type=get_location_type(self.cli_ctx))

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3851,6 +3851,8 @@ def webapp_up(cmd, name=None, resource_group_name=None, plan=None, location=None
         cmd.cli_ctx.config.set_value('defaults', 'appserviceplan', plan)
         cmd.cli_ctx.config.set_value('defaults', 'location', loc)
         cmd.cli_ctx.config.set_value('defaults', 'web', name)
+        cmd.cli_ctx.config.set_value('defaults', 'runtime', runtime_version)
+        cmd.cli_ctx.config.set_value('defaults', 'os', os_name.lower())
     return create_json
 
 

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -187,7 +187,8 @@ setup(
         'azure.cli.command_modules.appservice': [
             'resources/WindowsFunctionsStacks.json',
             'resources/LinuxFunctionsStacks.json',
-            'resources/WebappRuntimeStacks.json'
+            'resources/WebappRuntimeStacks.json',
+            'resources/GenerateRandomAppNames.json'
         ],
         'azure.cli.command_modules.rdbms': [
             'randomname/adjectives.txt',


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

For `az webapp up` command, defaults are saved for "group", "sku", "appserviceplan", "location", "web" parameters.
Recently added parameters "runtime" and "os_type", however defaults weren't being saved for these parameters

**Testing Guide**
- Run `az webapp up` with --runtime or --os-type parameter
- On later runs of `az webapp up`, the overrided runtime/os_type parameters aren't being used since they weren't saved in defaults.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
