### PR TITLE
{Core} Add check for empty command_str in _search_in_extension_commands

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -359,7 +359,8 @@ class AzCliCommandParser(CLICommandParser):
             ...
         }
         """
-
+        if not command_str:
+            return None
         cmd_chain = self._get_extension_command_tree()
         if not cmd_chain:
             return None


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In the case of running `az --debug a`, the `command_str` got with `command_str = roughly_parse_command(args[1:])` is empty so the `_search_in_extension_commands` function will return all extensions with a prefix match.  Users are then prompted to choose an extension to install from all extensions.

To fix the issue, this PR adds empty check for `command_str` to return None for empty value.

**Testing Guide**
<!--Example commands with explanations.-->
Run `az --debug a`.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
