### PR TITLE
[Role] az ad app permission list/grant: Refine error message when no associated Service Principal exists for the App

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -853,13 +853,17 @@ def create_application(cmd, display_name, homepage=None, identifier_uris=None,  
 
 def _get_grant_permissions(graph_client, client_sp_object_id=None, query_filter=None):
     query_filter = query_filter or ("clientId eq '{}'".format(client_sp_object_id) if client_sp_object_id else None)
+    grant_info = graph_client.oauth2_permission_grant.list(filter=query_filter)
     try:
-        grant_info = graph_client.oauth2_permission_grant.list(filter=query_filter)
-    except CloudError as ex:  # Graph doesn't follow the ARM error; otherwise would be caught by msrest-azure
+        # Make the REST request immediately so that errors can be raised and handled.
+        return list(grant_info)
+    except CloudError as ex:
         if ex.status_code == 404:
-            return []
+            raise CLIError("Service principal with appId or objectId '{id}' doesn't exist. "
+                           "If '{id}' is an appId, make sure an associated service principal is created "
+                           "for the app. To create one, run `az ad sp create --id {id}`."
+                           .format(id=client_sp_object_id))
         raise
-    return grant_info
 
 
 def list_permissions(cmd, identifier):
@@ -870,13 +874,14 @@ def list_permissions(cmd, identifier):
 
     # first get the permission grant history
     client_sp_object_id = _resolve_service_principal(graph_client.service_principals, identifier)
-    grant_permissions = _get_grant_permissions(graph_client, client_sp_object_id=client_sp_object_id)
 
     # get original permissions required by the application, we will cross check the history
     # and mark out granted ones
     graph_client = _graph_client_factory(cmd.cli_ctx)
     application = show_application(graph_client.applications, identifier)
     permissions = application.required_resource_access
+    if permissions:
+        grant_permissions = _get_grant_permissions(graph_client, client_sp_object_id=client_sp_object_id)
     for p in permissions:
         result = list(graph_client.service_principals.list(
             filter="servicePrincipalNames/any(c:c eq '{}')".format(p.resource_app_id)))

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_graph_required_access_e2e.yaml
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_graph_required_access_e2e.yaml
@@ -13,8 +13,8 @@ interactions:
       ParameterSetName:
       - --name --skip-assignment
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
@@ -34,19 +34,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:27:56 GMT
+      - Tue, 23 Feb 2021 08:45:18 GMT
       duration:
-      - '2202000'
+      - '2456415'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - trS+TTjT2L5qy1n32RHzYO5RlOXnIrE6h+m2AhirV2E=
+      - TdLvWkdujJqYENkUdgrFC/nrTmofgUFMp99cJ0tui9M=
       ocp-aad-session-key:
-      - maoN389-_Zpu3rzbaiSHzLmL6zbdixzvP8HxhUsZqA2LsLK3EUpaa8BYVa6ooXvpzCLdKVCb_a1Ag8FYGar6_OzQ56yxCF0knpLBQgbZrkZ4SRhOWQJu4kNOum4_ZEmmWe2ekEK4KeaC7PlEm4zoyX32zoG1CHzBdTYc8zXHrJI.s8Jfidty7_ympuhnfW5ajryoXX3Vqj9ttz1Yu-UFias
+      - EqDn_GW_5xF9Hz-Vt8UMB90a9Ysfuk7W7r8bLeyf5DgpFU1IY0bjnTvrzRotGpcLjKa9BTlAj3jS9QlpHVMbzr5tJHrXL3b5Z5HTMpOJTHYHhe8IZWXnSHM3v2UEs80zV_2hc3P5G8xEB6o3vuGN7jdnzEevm3BOfF_BAngg0q4.Rc0sy4OS-8nmtUCG6oUng5SGQMToKIYxBy7LAy2JXjg
       pragma:
       - no-cache
       request-id:
-      - c506d02a-35e7-4e0d-a949-50baabfcdfa2
+      - a56c3952-488e-4907-a9e7-c772910ef906
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -74,8 +74,8 @@ interactions:
       ParameterSetName:
       - --name --skip-assignment
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
@@ -95,19 +95,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:27:57 GMT
+      - Tue, 23 Feb 2021 08:45:19 GMT
       duration:
-      - '2185536'
+      - '2338711'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - EVLtQcrJ9JxBZUfYXhNr3D4P5qtOPgIk7JssC1AjEQ8=
+      - MdYKab+f1k/jT4+SBMVYVpCE+tJ6P2f3U1bu2p02V6s=
       ocp-aad-session-key:
-      - S2l9BUmdR6hs-9NgaYbbtEmZZ4vXHKsF_kUPFQSZW7aIexvxFtjRpTGRzXj-5ysOrfRf_ZL7Hm-iWp0WocJXZcamN3XtrZW9g6cSMlH1y8Svy6NcmfKnZ8PkGVXY8R7wRM0Y-0WzoSOCmnLQs8fo7zs-BQLbGxWjTSWw2_zF790.g_9RGEaZyi4OGWdjsP5N9_vVd64VGIxGFCvPAogUE-s
+      - R_gxgwcNCJimqbvWI9e_8izNXf-vQO1tUKzyT2ko34c87lNdAwcWrA3lTaEfvL_Gvf1iayC5LZfIBHCQMrrI068ilxRgpJr8qMpE7__ziKbcRG5414Lvx2D2bDUhhXATaYel4e8wWOkXYVkSpAp_XbvTiDkIC3M3EY7BEIR6Kvc.dCyQOWfURguW8TiweG637lVOxZhi6aO-9y5tHaZofgw
       pragma:
       - no-cache
       request-id:
-      - ee37d415-7c1a-4e76-b560-0c34af527e7f
+      - 226fdb20-b547-437d-bc68-f9c2dd434778
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -123,8 +123,8 @@ interactions:
       message: OK
 - request:
     body: '{"availableToOtherTenants": false, "homepage": "https://cli-app-000001",
-      "passwordCredentials": [{"startDate": "2020-08-21T06:27:56.96504Z", "endDate":
-      "2021-08-21T06:27:56.96504Z", "keyId": "2197cada-aa78-47b4-a229-20f138077dcc",
+      "passwordCredentials": [{"startDate": "2021-02-23T08:45:19.356502Z", "endDate":
+      "2022-02-23T08:45:19.356502Z", "keyId": "51069578-2878-4b11-8c54-efd3bc482403",
       "value": "ReplacedSPPassword123*", "customKeyIdentifier": "//5yAGIAYQBjAA=="}],
       "displayName": "cli-app-000001", "identifierUris": ["http://cli-app-000001"]}'
     headers:
@@ -137,14 +137,14 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '403'
+      - '405'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - --name --skip-assignment
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: POST
@@ -153,28 +153,28 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "a30a4689-338b-4f07-9b4f-d7af2ded5a12", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "a929150b-3dde-4fd6-a64c-f9cf898c4150",
+        "objectId": "b5e22543-b770-45de-bffb-9246b51b25fe", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "5b91ffae-ddfc-4f85-94e2-78cbb12c92f2",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
         false, "displayName": "cli-app-000001", "errorUrl": null, "groupMembershipClaims":
         null, "homepage": "https://cli-app-000001", "identifierUris": ["http://cli-app-000001"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
         "Allow the application to access cli-app-000001 on behalf of the signed-in
-        user.", "adminConsentDisplayName": "Access cli-app-000001", "id": "5a70fe9f-831e-488b-a70a-8615c45b78b2",
+        user.", "adminConsentDisplayName": "Access cli-app-000001", "id": "61dde3fa-d94f-42c0-9230-7d297ce42185",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
         to access cli-app-000001 on your behalf.", "userConsentDisplayName": "Access
         cli-app-000001", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
-        [{"customKeyIdentifier": "//5yAGIAYQBjAA==", "endDate": "2021-08-21T06:27:56.96504Z",
-        "keyId": "2197cada-aa78-47b4-a229-20f138077dcc", "startDate": "2020-08-21T06:27:56.96504Z",
+        [{"customKeyIdentifier": "//5yAGIAYQBjAA==", "endDate": "2022-02-23T08:45:19.356502Z",
+        "keyId": "51069578-2878-4b11-8c54-efd3bc482403", "startDate": "2021-02-23T08:45:19.356502Z",
         "value": "ReplacedSPPassword123*"}], "publicClient": null, "publisherDomain":
         "AzureSDKTeam.onmicrosoft.com", "recordConsentConditions": null, "replyUrls":
         [], "requiredResourceAccess": [], "samlMetadataUrl": null, "signInAudience":
@@ -185,27 +185,27 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2280'
+      - '2282'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:27:58 GMT
+      - Tue, 23 Feb 2021 08:45:19 GMT
       duration:
-      - '4635394'
+      - '6320220'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - Ohqk6OQf/jwJtTJy4Zm4joGjpo0dqkwF43bWgh9upC4=
+      - mkOxQgt1GztTCi6cw3QS4uQo+BlJr8pBiXvrVMpsxE0=
       ocp-aad-session-key:
-      - eyPFLtu_lgRs9BLOpT-SscHmBpmMbtj4RNeSihlUulG-d5QPf9OXFfAnzWls2Nr1r2KHJhJRfJPJqDIhzwT6v9wPygBi-TJU-WRFjgMpFlHxWWg_ur-NTWYsEU55RxIORIhSvWAPuQNDISGCDsZWGSePD8CnraoolZfi_YPBMmY.LvN6pt_nt2OObvyMoM_zC5rLTqKzb9zW6XtvLQl9arc
+      - X6agkNyLBTUJfhiZf4e27HGS3if9yfIdlI6FczV61awvXnjDCbwiCQxuag6FA1RrOaOclQOrY7QI3m9EmMyuohruZmG09OFCHRWBsEHQsQrpAs8OjN3sN5DoQw6PpCAn0PHyNtU91LIDu0D8Rs5zNvMhdBpoGgd0e8TlGVkRPvM.pZqP3X0YRORjg-xsr5YljfbB7VjOGunB78Zwjh8KCtc
       pragma:
       - no-cache
       request-id:
-      - 20cb3e81-7d51-4ccf-9f3f-924d0e46d70e
+      - b18c13e7-941e-40d1-a6f9-170116f8c3d7
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -220,7 +220,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"accountEnabled": "True", "appId": "a929150b-3dde-4fd6-a64c-f9cf898c4150"}'
+    body: '{"accountEnabled": "True", "appId": "5b91ffae-ddfc-4f85-94e2-78cbb12c92f2"}'
     headers:
       Accept:
       - application/json
@@ -237,19 +237,19 @@ interactions:
       ParameterSetName:
       - --name --skip-assignment
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"64c73637-ae71-44f6-9170-da2c257cbbe6","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"32a71f9a-621a-424b-841c-6637352eee4a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["a929150b-3dde-4fd6-a64c-f9cf898c4150","http://cli-app-000001"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","http://cli-app-000001"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -262,21 +262,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:27:58 GMT
+      - Tue, 23 Feb 2021 08:45:20 GMT
       duration:
-      - '3211774'
+      - '3579548'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/64c73637-ae71-44f6-9170-da2c257cbbe6/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/32a71f9a-621a-424b-841c-6637352eee4a/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - QAuHhTm9RVpaK7Xjr9yexfLWEjSix2PbQozeTqB2czc=
+      - 4eXT1YDgU7Uxk8Cw2vd1WlZ2CS7p5+x13l4Wj+OfRac=
       ocp-aad-session-key:
-      - M_gSTSzPI3FEz34zCbqwEbhsFvBYdzK23bQB8rhgDAVLWa5xKvvy-XEg4jMLLPqOcMfyQsov2YLdqQ63WJNvubuKxrM838FQeaommGX0m_51EsesVXbVuw2HGsRUD_JyVHORc64ZxWufqZ9TwDofhzwGzZRXx6Xe8fdzaBtl66c.WbYoNi_iHjoq-t7R_bX-ZHp9IVlLJIqLr1dLVByPkdo
+      - eR3i85k0rsRalG9v036QAR_SRt_QJJObtN5jb0yi7Z4BDecAfEA7fELthEo1c_JYZ85PYYQcdE58-d_ptfr537S1Zp1IZ2j2Gnlbzoyb94bAmWuHmbblx_SLTvY0LObspjL6NPn556-0-k0jwfXowbmlAhf8LyzSHoXRhm-SxEo.ApOGOiZL7ZxlVwcNrpd9zfy_naaGq59YU77vNX_WcFU
       pragma:
       - no-cache
       request-id:
-      - 094e6937-925d-4371-94c4-ee046e58b7d4
+      - 2d460f24-348a-45ba-83aa-bee9c08ce5cd
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -304,12 +304,12 @@ interactions:
       ParameterSetName:
       - --id --api --api-permissions
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -325,19 +325,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:27:58 GMT
+      - Tue, 23 Feb 2021 08:45:21 GMT
       duration:
-      - '2135062'
+      - '2338050'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - eM4RAlrWvAKWWS0VxGJgfo3pEtBBb5fXNwiVR1R3sps=
+      - FoZ1NBiTyxGdTpKCvUu33a5LTTVlJ384nOGAfeQM8m4=
       ocp-aad-session-key:
-      - Gih30cTHJwpkHlEweIo64uDmvJVZigBmsquR0edfVX0dEXtCTwjo9PH_XfxbJm7iaDnHD_6EvIpr2fsUW1yx-efyje19KMXhzca8DoWweKIpkOfvBe3852io-aAqTfhc9bl2iIbwTTZY1_C8QA00qXgfluyS5Kql9D3j8u_GwUM.hLpLvC7Ev7nnD1fe2EMWpoNFlkm71-Eu49VXR3OGvEg
+      - cSYaUO8AGn1mOWCKbPaoMMSdfNuBPRxKR_EpTIl_e8wcxVSodEpPsQi-EG6wULbsTV8tN4Gj3th-ZLK72UD35OoDtQt22ZqoEyDBWdiJDUdPQ0FpueOjgdJfnBauN7GbRIgG45EGk5JdKA6nwWTprAZMBZ1IPnrqKiemvA48g68.vWRPlXtYKgF363Biw-2yEAqQWKNZcfKVy8vw_D_4I9M
       pragma:
       - no-cache
       request-id:
-      - c8026269-bd78-4340-b2ac-04d3f4768313
+      - bcb131a0-b432-49c5-8904-44a939f72661
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -365,44 +365,44 @@ interactions:
       ParameterSetName:
       - --id --api --api-permissions
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a30a4689-338b-4f07-9b4f-d7af2ded5a12","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"b5e22543-b770-45de-bffb-9246b51b25fe","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2021-08-21T06:27:56.96504Z","keyId":"2197cada-aa78-47b4-a229-20f138077dcc","startDate":"2020-08-21T06:27:56.96504Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2022-02-23T08:45:19.356502Z","keyId":"51069578-2878-4b11-8c54-efd3bc482403","startDate":"2021-02-23T08:45:19.356502Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2197'
+      - '2199'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:27:59 GMT
+      - Tue, 23 Feb 2021 08:45:21 GMT
       duration:
-      - '3070211'
+      - '2617905'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 7aPIIBM9F67f67B178yBUSx82WhjIC+frQ+bJ4Jdp/A=
+      - 325c1weenAEwhRUiNCQcR/pLOE+cRMl9RKDvdgYoO5E=
       ocp-aad-session-key:
-      - wd-HEqaMMlJtSxVU-Ib6jy_xfTCZ1J8MeV_6fb8dlvX-gp0yhYPD--Y2owqFUbi3hJcL-Vyy3YMJmtutuhwEYFU1CbioxpXkwB4IVCtzTS0ClKkCp_6blJuxlsFhYneKmCCwdQAc90ViPPJ5JTdNhFKtrMoltsBoSF7QtS40sVg.u0AAAOaJnXCvDIYWTvwfT07Ruh_Ma9cGTvs1A1HJ-uE
+      - WwXuQH5q_OL_ApnFWF9X42d1eg-3gfGTAu7LYoevEUaQpQ9QSWErvDsGkoZFTHj09rjpftdFgiqARRRLlBrofz6LpP5lgA-O4F7XwLFr0zY9rrTlX8wEYx6pbfqFkE_xuTN7hkPKtP1_Bu7Li1YAyzLgJuJt37Z3MZW-vurpEog.Hg8vDjvSIkD_9cVJI_1alSYQyQK62eoXzp0L8ABRkak
       pragma:
       - no-cache
       request-id:
-      - 337e1269-fee5-42b1-afde-67354ba9716f
+      - 65f86d0e-480f-4707-863a-d4924955a23d
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -430,44 +430,44 @@ interactions:
       ParameterSetName:
       - --id --api --api-permissions
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/a30a4689-338b-4f07-9b4f-d7af2ded5a12?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/b5e22543-b770-45de-bffb-9246b51b25fe?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a30a4689-338b-4f07-9b4f-d7af2ded5a12","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"b5e22543-b770-45de-bffb-9246b51b25fe","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2021-08-21T06:27:56.96504Z","keyId":"2197cada-aa78-47b4-a229-20f138077dcc","startDate":"2020-08-21T06:27:56.96504Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2022-02-23T08:45:19.356502Z","keyId":"51069578-2878-4b11-8c54-efd3bc482403","startDate":"2021-02-23T08:45:19.356502Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2194'
+      - '2196'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:00 GMT
+      - Tue, 23 Feb 2021 08:45:22 GMT
       duration:
-      - '2289333'
+      - '2486974'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - OLyruse+78JH08I5RN/wxIatmflBNwSlEb2bxx4qGLA=
+      - xwdS7DpTBA/e0+ZzbZoO7wP6bS7GUsuTlQFVjYI5NrM=
       ocp-aad-session-key:
-      - QFk3aEy-ECxwyBlBK8IffZpiV5XSXZsmvdCQrvRQOSzpZOrVeyp0WmWZPnP9dRWgF0T9Mzapp9HFQvpvZEBhHY3rh2hQMJ-vh56mvC7afgtkj5Ck0iWFdtpNiefhvlxlryhlZZCoylwyKeiCWRWw7QEU7BOHH6bshQwX4Iw3Sos.fiD3MhoDDnqBwJ4OcsUtFpgoclGm9LIoy9iYed5vkek
+      - DcVk93hZcDKAH4lzFGFJMDRdyTe8XPDKXLdIS5AKmwkNTwXyemMhAOlWpdBYVvK-YYR4W_Jud08bAYLiJywF5ZIQTkrX3_4Y_mCbPtEk3vGjQOkEj-Ouwts_9Z8Owj8sYWpo25jLyYnHVsxvtsEax4GNPLKMH29kMQA8uWEw7y0.OtM6Z3cqntHdfT96FMv6mh8rAK60o9s4lSSwbZS_JQM
       pragma:
       - no-cache
       request-id:
-      - 8915e829-bcee-448e-bd53-e6d252cdbadd
+      - 54f292ac-836b-4d88-b93b-c3de21128044
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -500,12 +500,12 @@ interactions:
       ParameterSetName:
       - --id --api --api-permissions
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/a30a4689-338b-4f07-9b4f-d7af2ded5a12?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/b5e22543-b770-45de-bffb-9246b51b25fe?api-version=1.6
   response:
     body:
       string: ''
@@ -515,19 +515,19 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Fri, 21 Aug 2020 06:28:01 GMT
+      - Tue, 23 Feb 2021 08:45:22 GMT
       duration:
-      - '3884020'
+      - '4810691'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - T0KBN8JJNjzrTXfSE4A3/1+Mtrd7U9HmkOr+9K4PXjs=
+      - pIMS29bumLUaSZ04mX1rCh7FHHupIdNPgTHPqT8e/ho=
       ocp-aad-session-key:
-      - YHFH23p_nhTMvC0it5dhRMfcnLwZSUpvHgdI3et1ATRJTAajFs-d_u3JRQhch9XNaok8WTFCXeDqcBHOYmijcpnMMQYdQ0SS9rUArnxBlZ_FfC8lWk-Gl2CuKuSKsHRw57r-1L2U9nzd1Jxkk1-30tbCGaWrteadMP6EHWYqb-g.F-d-vlenicfL_mkUiB2Bu7V4LqixQ9IhSetRZSi9s0I
+      - osIJJy2uG0_Nbq4zuYUk3MZC5FwgBOurk25JVTp2-OPCMXX5MHsT96hqC3EAy2cEESUUFlVfeeQobYOSftHUML0Lw9IvjB89re5nQj8VUG_orPdZpcy9S6PuFEru-tn3Al5BsZH5uR0ysVdRxRDXXUPUbKCU0I3Nm9Z2L1QVeKI.8y35vHlfFIPseny790IEwYIoK8dw7iFd4pkAH6RYZdI
       pragma:
       - no-cache
       request-id:
-      - bae9f69e-c5e9-482f-b165-e871cff830cb
+      - c8a84e40-32d6-4d27-be31-5524d5a452b3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -555,19 +555,19 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"64c73637-ae71-44f6-9170-da2c257cbbe6","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"32a71f9a-621a-424b-841c-6637352eee4a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","a929150b-3dde-4fd6-a64c-f9cf898c4150"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
+        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","5b91ffae-ddfc-4f85-94e2-78cbb12c92f2"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -580,19 +580,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:01 GMT
+      - Tue, 23 Feb 2021 08:45:23 GMT
       duration:
-      - '2294021'
+      - '3487160'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - Pic1F65Epb09dO+KPYO5B5p6FEUjmCGfdDxaTmD237o=
+      - NNF6SU7oblm2gmtiFVxJ4lF5Yr+vPdeEUYWyFEInbKo=
       ocp-aad-session-key:
-      - DzerHVIkSAyFJUd8Js199Snpj6B1IOHQLUZtkPjPGNZCH0WKIe7q0HWPxOK8h39ulBXOh7unSNCZ08sNJc8MYZTGCEB2Xj_tyKyd-tJcQYM2qRb0rQK6jg35upQMR_Mcz5O5OHGNowln8E8eZeGj0ogzSXmo84ab_g7f2xlXvUE.fhpmHTAg5psPb4nB1CcfOQ5PnrHIeKp-L37scIEvx3o
+      - PTe7NfvAsc6Wt7e1DhkwOpEDa43HT9Zh6zoWkU3Hj9_aT9m50qBo73XlAsPy0UzDaR9qh8nXwiwDO4TC8DbIfC1-tBH0d6OJWp_NuFiuizT2LpFTdMD8JxDaPPIjJ1CIN3J_uxB2O8NTLHvy41uOVWWON_4N92oSooRhVDNKilY.tsh5QiUzp2RSNZbPcfkB8k4OhbUCi_G6Sg4H0F2E1GU
       pragma:
       - no-cache
       request-id:
-      - 63a0cd26-8269-4f8f-ad56-22aea9606e65
+      - 69b1e234-1911-43fe-91f4-240cef01a026
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -620,8 +620,8 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
@@ -630,70 +630,49 @@ interactions:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"fba255ef-08f7-4f9b-b673-318fcb87f042","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Windows
         Azure Active Directory","appId":"00000002-0000-0000-c000-000000000000","applicationTemplateId":null,"appOwnerTenantId":"f8cdef31-a31e-4b4a-93e4-5f571e91255a","appRoleAssignmentRequired":false,"appRoles":[{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read all your organization''s policies without a signed-in user.
-        ","displayName":"Read your organization''s policies","id":"6c2d1b1d-a490-4178-ba6b-7efceda9129b","isEnabled":true,"value":"Policy.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read data in your company or school directory, such as users, groups,
-        and apps.","displayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"value":"Directory.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write all domain properties without a signed in user.  Also
-        allows the app to add,  verify and remove domains.","displayName":"Read and
-        write domains","id":"abefe9df-d5a9-41c6-a60b-27b38eac3efb","isEnabled":true,"value":"Domain.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write data in your company or school directory, such as
-        users, and groups.  Does not allow user or group deletion.","displayName":"Read
-        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"value":"Directory.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write all device properties without a signed in user.  Does
-        not allow device creation, device deletion or update of device alternative
-        security identifiers.","displayName":"Read and write devices","id":"1138cb37-bd11-4084-a2b7-9f71582aeddb","isEnabled":true,"value":"Device.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read the memberships of hidden groups and administrative units
-        without a signed-in user.","displayName":"Read all hidden memberships","id":"9728c0c4-a06b-4e0e-8d1b-3d694e8ec207","isEnabled":true,"value":"Member.Read.Hidden"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read applications and service principals without a signed-in user","displayName":"Read
+        all applications","id":"3afa6a7d-9b1a-42eb-948e-1650a849e176","isEnabled":true,"value":"Application.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to create, read, update and delete applications and service principals
+        without a signed-in user.  Does not allow management of consent grants.","displayName":"Read
+        and write all applications","id":"1cda74f2-2616-4834-b122-5cb1b07f8a59","isEnabled":true,"value":"Application.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to create other applications, and fully manage those applications
         (read, update, update application secrets and delete), without a signed-in
         user.  It cannot update any apps that it is not an owner of.","displayName":"Manage
         apps that this app creates or owns","id":"824c81eb-e3f8-4ee6-8f6d-de7f50d565b7","isEnabled":true,"value":"Application.ReadWrite.OwnedBy"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to create, read, update and delete applications and service principals
-        without a signed-in user.  Does not allow management of consent grants.","displayName":"Read
-        and write all applications","id":"1cda74f2-2616-4834-b122-5cb1b07f8a59","isEnabled":true,"value":"Application.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read the memberships of hidden groups and administrative units
+        without a signed-in user.","displayName":"Read all hidden memberships","id":"9728c0c4-a06b-4e0e-8d1b-3d694e8ec207","isEnabled":true,"value":"Member.Read.Hidden"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read and write all device properties without a signed in user.  Does
+        not allow device creation, device deletion or update of device alternative
+        security identifiers.","displayName":"Read and write devices","id":"1138cb37-bd11-4084-a2b7-9f71582aeddb","isEnabled":true,"value":"Device.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read and write data in your company or school directory, such as
+        users, and groups.  Does not allow user or group deletion.","displayName":"Read
+        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"value":"Directory.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to read and write all domain properties without a signed in user.  Also
         allows the app to add,  verify and remove domains.","displayName":"Read and
-        write domains","id":"aaff0dfd-0295-48b6-a5cc-9f465bc87928","isEnabled":true,"value":"Domain.ReadWrite.All"}],"displayName":"Windows
-        Azure Active Directory","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allows
-        the app to read your organization''s policies on behalf of the signed-in user.","adminConsentDisplayName":"Read
-        your organization''s policies","id":"80e5b1bf-3ad0-4365-943a-0ec983009b67","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read your organization''s policies on your behalf.","userConsentDisplayName":"Read
-        your organization''s policies","value":"Policy.Read.All"},{"adminConsentDescription":"Allows
-        the app to have the same access to information in the directory as the signed-in
-        user.","adminConsentDisplayName":"Access the directory as the signed-in user","id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","isEnabled":true,"type":"User","userConsentDescription":"Allows
-        the app to have the same access to information in your work or school directory
-        as you do.","userConsentDisplayName":"Access the directory as you","value":"Directory.AccessAsUser.All"},{"adminConsentDescription":"Allows
+        write domains","id":"abefe9df-d5a9-41c6-a60b-27b38eac3efb","isEnabled":true,"value":"Domain.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to read data in your company or school directory, such as users, groups,
-        and apps.","adminConsentDisplayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read data in your company or school directory, such as other users,
-        groups and apps.","userConsentDisplayName":"Read directory data","value":"Directory.Read.All"},{"adminConsentDescription":"Allows
-        the app to read and write data in your company or school directory, such as
-        users, and groups.  Does not allow user or group deletion.","adminConsentDisplayName":"Read
-        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read and write data in your company or school directory, such as
-        other users, groups.  Does not allow user or group deletion on your behalf.","userConsentDisplayName":"Read
-        and write directory data","value":"Directory.ReadWrite.All"},{"adminConsentDescription":"Allows
-        the app to create groups on behalf of the signed-in user and read all group
-        properties and memberships. Additionally, this allows the app to update group
-        properties and memberships for the groups the signed-in user owns.","adminConsentDisplayName":"Read
-        and write all groups","id":"970d6fa6-214a-4a9b-8513-08fad511e2fd","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to create groups on your behalf and read all group properties and
-        memberships. Additionally, this allows the app to update group properties
-        and memberships for groups you own.","userConsentDisplayName":"Read and write
-        all groups","value":"Group.ReadWrite.All"},{"adminConsentDescription":"Allows
-        the app to read basic group properties and memberships on behalf of the signed-in
-        user.","adminConsentDisplayName":"Read all groups","id":"6234d376-f627-4f0f-90e0-dff25c5211a3","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read all group properties and memberships on your behalf.","userConsentDisplayName":"Read
-        all groups","value":"Group.Read.All"},{"adminConsentDescription":"Allows the
-        app to read the full set of profile properties of all users in your company
-        or school, on behalf of the signed-in user. Additionally, this allows the
-        app to read the profiles of the signed-in user''s reports and manager.","adminConsentDisplayName":"Read
-        all users'' full profiles","id":"c582532d-9d9e-43bd-a97c-2667a28ce295","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read the full set of profile properties of all users in your company
-        or school, on your behalf.  Additionally, this allows the app to read the
-        profiles of your reports and manager.","userConsentDisplayName":"Read all
-        user''s full profiles","value":"User.Read.All"},{"adminConsentDescription":"Allows
+        and apps.","displayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"value":"Directory.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read all your organization''s policies without a signed-in user.
+        ","displayName":"Read your organization''s policies","id":"6c2d1b1d-a490-4178-ba6b-7efceda9129b","isEnabled":true,"value":"Policy.Read.All"},{"allowedMemberTypes":["Application"],"description":"(Deprecated)
+        Allows the app to read and write all domain properties, without a signed-in
+        user. Also allows the app to add, verify, and remove domains. This permission
+        will be disabled in the future. Developers should request the Domain.ReadWrite.All
+        permission with id abefe9df-d5a9-41c6-a60b-27b38eac3efb instead.","displayName":"Read
+        and write domains (deprecated)","id":"aaff0dfd-0295-48b6-a5cc-9f465bc87928","isEnabled":true,"value":"Domain.ReadWrite.All"}],"displayName":"Windows
+        Azure Active Directory","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allows
+        the app to read the memberships of hidden groups and administrative units
+        on behalf of the signed-in user, for those hidden groups and administrative
+        units that the signed-in user has access to.","adminConsentDisplayName":"Read
+        hidden memberships","id":"2d05a661-f651-4d57-a595-489c91eda336","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read the memberships of hidden groups or administrative units on
+        your behalf, for those hidden groups or administrative units that you have
+        access to.","userConsentDisplayName":"Read your hidden memberships","value":"Member.Read.Hidden"},{"adminConsentDescription":"Allows
+        users to sign in to the app, and allows the app to read the profile of signed-in
+        users. It also allow the app to read basic company information of signed-in
+        users.","adminConsentDisplayName":"Sign in and read user profile","id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","isEnabled":true,"type":"User","userConsentDescription":"Allows
+        you to sign in to the app with your work account and let the app read your
+        profile. It also allows the app to read basic company information.","userConsentDisplayName":"Sign
+        you in and read your profile","value":"User.Read"},{"adminConsentDescription":"Allows
         the app to read a basic set of profile properties of all users in your company
         or school on behalf of the signed-in user. Includes display name, first and
         last name, photo, and email address. Additionally, this allows the app to
@@ -704,44 +683,69 @@ interactions:
         and email address. Additionally, this allows the app to read basic info about
         your reports and manager.","userConsentDisplayName":"Read all user''s basic
         profiles","value":"User.ReadBasic.All"},{"adminConsentDescription":"Allows
-        users to sign in to the app, and allows the app to read the profile of signed-in
-        users. It also allow the app to read basic company information of signed-in
-        users.","adminConsentDisplayName":"Sign in and read user profile","id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","isEnabled":true,"type":"User","userConsentDescription":"Allows
-        you to sign in to the app with your work account and let the app read your
-        profile. It also allows the app to read basic company information.","userConsentDisplayName":"Sign
-        you in and read your profile","value":"User.Read"},{"adminConsentDescription":"Allows
-        the app to read the memberships of hidden groups and administrative units
-        on behalf of the signed-in user, for those hidden groups and administrative
-        units that the signed-in user has access to.","adminConsentDisplayName":"Read
-        hidden memberships","id":"2d05a661-f651-4d57-a595-489c91eda336","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read the memberships of hidden groups or administrative units on
-        your behalf, for those hidden groups or administrative units that you have
-        access to.","userConsentDisplayName":"Read your hidden memberships","value":"Member.Read.Hidden"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["00000002-0000-0000-c000-000000000000/graph.microsoftazure.us","https://graph.microsoftazure.us","Microsoft.Azure.ActiveDirectory","00000002-0000-0000-c000-000000000000","00000002-0000-0000-c000-000000000000/directory.windows.net","00000002-0000-0000-c000-000000000000/graph.windows.net","https://graph.windows.net","https://graph.windows.net/"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
+        the app to read the full set of profile properties of all users in your company
+        or school, on behalf of the signed-in user. Additionally, this allows the
+        app to read the profiles of the signed-in user''s reports and manager.","adminConsentDisplayName":"Read
+        all users'' full profiles","id":"c582532d-9d9e-43bd-a97c-2667a28ce295","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read the full set of profile properties of all users in your company
+        or school, on your behalf.  Additionally, this allows the app to read the
+        profiles of your reports and manager.","userConsentDisplayName":"Read all
+        user''s full profiles","value":"User.Read.All"},{"adminConsentDescription":"Allows
+        the app to read basic group properties and memberships on behalf of the signed-in
+        user.","adminConsentDisplayName":"Read all groups","id":"6234d376-f627-4f0f-90e0-dff25c5211a3","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read all group properties and memberships on your behalf.","userConsentDisplayName":"Read
+        all groups","value":"Group.Read.All"},{"adminConsentDescription":"Allows the
+        app to create groups on behalf of the signed-in user and read all group properties
+        and memberships. Additionally, this allows the app to update group properties
+        and memberships for the groups the signed-in user owns.","adminConsentDisplayName":"Read
+        and write all groups","id":"970d6fa6-214a-4a9b-8513-08fad511e2fd","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to create groups on your behalf and read all group properties and
+        memberships. Additionally, this allows the app to update group properties
+        and memberships for groups you own.","userConsentDisplayName":"Read and write
+        all groups","value":"Group.ReadWrite.All"},{"adminConsentDescription":"Allows
+        the app to read and write data in your company or school directory, such as
+        users, and groups.  Does not allow user or group deletion.","adminConsentDisplayName":"Read
+        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read and write data in your company or school directory, such as
+        other users, groups.  Does not allow user or group deletion on your behalf.","userConsentDisplayName":"Read
+        and write directory data","value":"Directory.ReadWrite.All"},{"adminConsentDescription":"Allows
+        the app to read data in your company or school directory, such as users, groups,
+        and apps.","adminConsentDisplayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read data in your company or school directory, such as other users,
+        groups and apps.","userConsentDisplayName":"Read directory data","value":"Directory.Read.All"},{"adminConsentDescription":"Allows
+        the app to have the same access to information in the directory as the signed-in
+        user.","adminConsentDisplayName":"Access the directory as the signed-in user","id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","isEnabled":true,"type":"User","userConsentDescription":"Allows
+        the app to have the same access to information in your work or school directory
+        as you do.","userConsentDisplayName":"Access the directory as you","value":"Directory.AccessAsUser.All"},{"adminConsentDescription":"Allows
+        the app to read your organization''s policies on behalf of the signed-in user.","adminConsentDisplayName":"Read
+        your organization''s policies","id":"80e5b1bf-3ad0-4365-943a-0ec983009b67","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read your organization''s policies on your behalf.","userConsentDisplayName":"Read
+        your organization''s policies","value":"Policy.Read.All"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["https://graph.windows.net/","https://graph.windows.net","00000002-0000-0000-c000-000000000000/graph.windows.net","00000002-0000-0000-c000-000000000000/directory.windows.net","00000002-0000-0000-c000-000000000000","Microsoft.Azure.ActiveDirectory","https://graph.microsoftazure.us","00000002-0000-0000-c000-000000000000/graph.microsoftazure.us"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '10401'
+      - '10860'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:02 GMT
+      - Tue, 23 Feb 2021 08:45:24 GMT
       duration:
-      - '2238082'
+      - '2490502'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - eazGIPeVlW4JWHa8sKZ9JGmiK0APCMuK94ElGRk0dmU=
+      - yYf00uvbu/b4xRkRr3A8ayRUREJ7XKpNjx+yrR+t9vo=
       ocp-aad-session-key:
-      - 89pKum9tt3B1cS4CujALUoo84hq9NR3tj_9oT8rB8lefuc2uiS3xHCd51Khkie3Hj2V33bqIsCShlY4W09B8DUFTOi00xVVsesPLt8v2GNTJQ9e3lI3xAOiarcqlCmF3cFD8NtvEke-HyGm08kKaYopj3w7i6FF26w3h4NbkWrA.W0MiTNv_Oreg9ks9EgwAkdKiCWT2NqF5RX2JKLalWR8
+      - 0-oESojF8KUtaElA-mrxIfsWvyFLEZkiMt70tlhHHr7EckaImnS75Jo4QH0V5xN_IuBT9RWQOzi10p-s1M9IauwhsaMalftET3Fcxwom2ovsLzHGOo9kGynl0yD1ZBhOdZmpIqAoRfvjqYr0xTqhwHoESV1m1BWgD9oKou8x8DQ.7_Sx7hWGQSUqjPeIIU6apGA9BQDgjO1lHZj9dvvRJ04
       pragma:
       - no-cache
       request-id:
-      - 0a022a4a-50e2-4e7b-aa17-b7b052783b08
+      - 16f56100-9b71-4a1f-93d4-dc98a257982a
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -769,12 +773,12 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?$filter=clientId%20eq%20%2764c73637-ae71-44f6-9170-da2c257cbbe6%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?$filter=clientId%20eq%20%2732a71f9a-621a-424b-841c-6637352eee4a%27&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants","value":[]}'
@@ -790,19 +794,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:02 GMT
+      - Tue, 23 Feb 2021 08:45:24 GMT
       duration:
-      - '2234401'
+      - '2138867'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - CY7xnABdb5AX/ElOxd/b3seyzI09IWY1JnGZf6862jg=
+      - XdO2K3gnwACPHgxFtyUlUw2zZl4sb176ov6CnnirAnw=
       ocp-aad-session-key:
-      - y82aQW7mxf6LU9MvkmEIFCUhJxB9pWy1GhvYGE2cdrlVZezIamT4OoUGWpJ3tmJwP0eWjFN2Qiga9iNc5NRL7G1ioxTT5bPPY3oTgktHq1Y3sUVArwSEcqKLrnKB6PrL_cqPeFQT5eNTWwsElhTftcdq9ZIw72SJTvzcChMZyX8.Jy6FiJw9XnsraEuOR16WnZrrxU0O8fWXzWfWePynFwc
+      - w6QoXH4wvT6ufB4u2dTWhoAw1MPFzwNOlsSkEmfC0eiTz2JaPT3-Fz0cUVTAfNXoYSDABbZoNu3NGWK-lDJQlD3Gl-npMaE-jpb6KGBmf5YmWYYY2Oh-kaHmqJm9LcBejqIywGi-9nwLDWEk_A3YtsNg90P5yBTNpxGg7oPL3-M.UaytaITkarPC3aLTFeBIUdEHo3kGn9hDrfBvnXmCvc0
       pragma:
       - no-cache
       request-id:
-      - 2725dc5d-9435-4286-afcc-daeb228e8076
+      - aeb818e3-f08c-46a4-93b4-1996ba7d6432
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -818,9 +822,9 @@ interactions:
       message: OK
 - request:
     body: '{"odata.type": "Microsoft.DirectoryServices.OAuth2PermissionGrant", "clientId":
-      "64c73637-ae71-44f6-9170-da2c257cbbe6", "consentType": "AllPrincipals", "resourceId":
+      "32a71f9a-621a-424b-841c-6637352eee4a", "consentType": "AllPrincipals", "resourceId":
       "fba255ef-08f7-4f9b-b673-318fcb87f042", "scope": "user_impersonation", "startTime":
-      "2020-08-21T06:28:02.837234", "expiryTime": "2021-08-21T06:28:02.837234"}'
+      "2021-02-23T08:45:25.417176", "expiryTime": "2022-02-23T08:45:25.417176"}'
     headers:
       Accept:
       - application/json
@@ -837,15 +841,15 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants/@Element","clientId":"64c73637-ae71-44f6-9170-da2c257cbbe6","consentType":"AllPrincipals","expiryTime":"2021-08-21T06:28:02.837234","objectId":"NzbHZHGu9kSRcNosJXy75u9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2020-08-21T06:28:02.837234"}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants/@Element","clientId":"32a71f9a-621a-424b-841c-6637352eee4a","consentType":"AllPrincipals","expiryTime":"2022-02-23T08:45:25.417176","objectId":"mh-nMhpiS0KEHGY3NS7uSu9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2021-02-23T08:45:25.417176"}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -858,21 +862,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:03 GMT
+      - Tue, 23 Feb 2021 08:45:25 GMT
       duration:
-      - '3431333'
+      - '3720873'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants/NzbHZHGu9kSRcNosJXy75u9Vovv3CJtPtnMxj8uH8EI
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants/mh-nMhpiS0KEHGY3NS7uSu9Vovv3CJtPtnMxj8uH8EI
       ocp-aad-diagnostics-server-name:
-      - 7aPIIBM9F67f67B178yBUSx82WhjIC+frQ+bJ4Jdp/A=
+      - fUwdOlBxj0W43cnnXFV7+S+AOuEgmYeWaq8fw8xGlYQ=
       ocp-aad-session-key:
-      - dEoYN7MM-Sy3nAAuqBVZecHsv_PlobsIH4JYmmqhblWAsvVxzCORTTY-hmdomgEyDRaqe9nqSXHJq4Bl93R_3TkKGUvt6yMjqPyuYf0w04jK7LJizHXMoQ7zARA_RLPrCZZEPU0jYcP_LtpkSF37BvAjScr64VWGgY81-5Tarfw.pnNhQwrdClcIniGh1giv01BtBXr1KNjSgukwy4ZtDFs
+      - ZTdYMsA6q-T8Yf--xeTp1PGP8GJU8eVlV1n-mJ97l7o1kdrmqEmHrCkaLLY_Wfj3zkvSXknSBPKAg4PEXuYgaLISTUuEm8vU1aWduNYShOxnGiu0HxuOEbtEzZfZq_bP4NIz1ikTrve-mnAW5OCP6wnDQeFwQvpIkxnQEESNTxc.sfRagbL6GCTODjdDhsgrKADYt3qbx85RJW4zJNE_LGI
       pragma:
       - no-cache
       request-id:
-      - ca2acb32-cdbb-4868-bd24-7d157a9ff94e
+      - fef3d39f-015b-41a6-8bc5-c04cb0fddc42
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -900,19 +904,19 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"64c73637-ae71-44f6-9170-da2c257cbbe6","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"32a71f9a-621a-424b-841c-6637352eee4a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","a929150b-3dde-4fd6-a64c-f9cf898c4150"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
+        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","5b91ffae-ddfc-4f85-94e2-78cbb12c92f2"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -925,19 +929,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:02 GMT
+      - Tue, 23 Feb 2021 08:45:26 GMT
       duration:
-      - '2241691'
+      - '2387588'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 6nTxeccwHlqMkcfQH4EpKBUB0g7BKgCGffdUym5sXt8=
+      - 0ARWRPt7zeq0r1MrOGcLMtYcnKdTWOxkG4NDjKbCN0o=
       ocp-aad-session-key:
-      - 2vlaE4eHI4DyIbyfC_fpzfv_MUifnFMq2F5AiPRxIeX34bezi9A87Tb0YkxcaA3kK0XB91Tc5Mo6wvoFZLQG5APB1SExCmr83hN5HGMe4zOOlLRBEl9KBvOBeC0l-uxAt82YAGNiEXE9luBZFynVXLVHdOrRHM93UqZYuv7btlQ.biOvnqWBxjcL0XTUY0gySh5U1pmdiZNklhSasGKnOUg
+      - D8f8-b6OkrM5cSl0dUEfgfNLeaWudUGe_H2lqkk8x7AFEAWg5EC9riW-mgO_j8QUbWyZ9sKvNhp27XYN3WV6rB8iWk73FeqhJ9nRltmqCQpzPXOvTOhnQ3-Gw5wXV2R4G1DNbZ4DOVubeHT8BIu6EtH8UI6Njte8oGkpl_qLIhM.KKwo4buxqwFYVw2mwlO8qvDfg9VVUINjvuPsPHxK1o0
       pragma:
       - no-cache
       request-id:
-      - 9cfd189c-dec1-41b4-8f6e-99db5f5e1572
+      - a7b15b67-8150-41eb-bf0d-4bc9f7de7bb8
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -965,12 +969,73 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?$filter=clientId%20eq%20%2732a71f9a-621a-424b-841c-6637352eee4a%27&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants","value":[{"clientId":"32a71f9a-621a-424b-841c-6637352eee4a","consentType":"AllPrincipals","expiryTime":"2022-02-23T08:45:25.417176","objectId":"mh-nMhpiS0KEHGY3NS7uSu9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2021-02-23T08:45:25.417176"}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '448'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Tue, 23 Feb 2021 08:45:26 GMT
+      duration:
+      - '2360615'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - o2W+bEsb3lTocpGslc4ho2LcCIx+P6+WVk/BynigNgk=
+      ocp-aad-session-key:
+      - YEHh7libXn_Ax23URGXMvGzl2ciW0lR76J0KXey6Qj9nBFdUlmdAaL8wtUQZwnwt4kfXz5ig8rOFCU5dWYRgW12iE71AGFsS5_FsMXn9YXjTTfeejO90ONdetPWWv32kwhAbOcKcC1F3xIhMazfdPy0e8keYLr1bCOBmTvIxgFk.BeL3gegAIizL4UidbwECKE5B-JVhD8c6OkwyvTeCWx0
+      pragma:
+      - no-cache
+      request-id:
+      - 04a1faf2-48cf-47f9-937a-d386f5770380
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-ms-resource-unit:
+      - '2'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app permission list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -986,19 +1051,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:04 GMT
+      - Tue, 23 Feb 2021 08:45:26 GMT
       duration:
-      - '2150666'
+      - '2301378'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - ujUSmj8FiX4t/EX+dTu/7F8x7hmXB38pLUyIq9mZgws=
+      - hGomVvsPji/BAtd9+ASice+iAk5pRs9k5kZgBhvfpK0=
       ocp-aad-session-key:
-      - I-5kqwmWUbo7Ng7cuNr8AfMv7kRi2TY31SflIh6yS_C6PSlWkGOOMrvIvpIDT_V_48etLnkvfOmS_yFyLvRF9oQ9KRckGkaAjgnhjW_cjVePoTVYgw_ZUNRg4AjdPxD7t-IbP0SEmbRfqr6i3aY8XOl2H9p31fXUvzpcC6SOVZk.Dwz0RgsQ-YrqM4l7nJThribl8g8vKJr01j4Mhr1S3TM
+      - MKFVXYLqL-mJ2kGAqqVycq36ih8XtdBXwX-bfwVgs9zpuEW466apJ3bdKk7JXR5CNL4P7zlPaWWNV84iNqdpe9a8AULBAJ36UGsWcJ92tkrTZhusOH-EmX2I2tMlp9HTKALbR_o8FAM0von9YFnVgAmGV_WO256IJzhx42DMbUg.RqOv7sCALAwZkWpfaPvHg16Xh11FvmNGexmj9cI-75I
       pragma:
       - no-cache
       request-id:
-      - f671e2c6-163d-4e72-8a12-458c3ac9af05
+      - 500b5587-da5d-46f7-bc2c-c900cdd8f578
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1026,44 +1091,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a30a4689-338b-4f07-9b4f-d7af2ded5a12","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"b5e22543-b770-45de-bffb-9246b51b25fe","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2021-08-21T06:27:56.96504Z","keyId":"2197cada-aa78-47b4-a229-20f138077dcc","startDate":"2020-08-21T06:27:56.96504Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2022-02-23T08:45:19.356502Z","keyId":"51069578-2878-4b11-8c54-efd3bc482403","startDate":"2021-02-23T08:45:19.356502Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2333'
+      - '2335'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:04 GMT
+      - Tue, 23 Feb 2021 08:45:27 GMT
       duration:
-      - '2217215'
+      - '2254958'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - N74c8ldu8hl9jU3L0P00lqK53hRnYh0rKSMTbFc2+Rs=
+      - DVIlhXLci/vtXO9sslcoJbjb4PLMqmqKPLIAkofesrU=
       ocp-aad-session-key:
-      - DM842toJEDZWs3XO00fQKoi8CcLr7YPr_ocwMSRiDX4F_-FsGA3HGLLXQzjc8AtLbWW6ri1ciA-VqYIaMxNr3XpNaoW7rgFIYYx9piOpbYWXd9Yc-pNqlmVqtWEa5oJAz_TFQegKThXgZXTXx9NZ0mpyF1dEgkifwpqbHXgYD_g.YHs5dJb2-vQLxu_hXR6-wOfWiIyscU1YskwJPf7ADe8
+      - uqykJ_2ypd_GiIRqJu3JMBEvPhdjZp24876H5ALVqMLwQGMmvPxikogD5IjmA7AEaR2WAtHQOWSY6seWj3GAWQ5BCiF8giaRGBQ5jzwRB_JgVLtwK3X77u3JyF2vXKr843189NTsfkUTJqTwym7eaCERQTF6tpcTPAQug4w5c8c.IWeFtnB8oEUyhpet8GOYGGW5FenUJ5s0K1zIaXKYIPo
       pragma:
       - no-cache
       request-id:
-      - a81d2355-6d87-4f5f-9f6e-4b7567bebb68
+      - 3a67e89b-7dbd-42bf-a519-606f8e0e4778
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1091,44 +1156,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/a30a4689-338b-4f07-9b4f-d7af2ded5a12?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/b5e22543-b770-45de-bffb-9246b51b25fe?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a30a4689-338b-4f07-9b4f-d7af2ded5a12","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"b5e22543-b770-45de-bffb-9246b51b25fe","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2021-08-21T06:27:56.96504Z","keyId":"2197cada-aa78-47b4-a229-20f138077dcc","startDate":"2020-08-21T06:27:56.96504Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2022-02-23T08:45:19.356502Z","keyId":"51069578-2878-4b11-8c54-efd3bc482403","startDate":"2021-02-23T08:45:19.356502Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2330'
+      - '2332'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:05 GMT
+      - Tue, 23 Feb 2021 08:45:28 GMT
       duration:
-      - '2238876'
+      - '3206867'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - om0QIa8Bj4//k+kQSxhRarsBgG9G181jsSBY9te4TGM=
+      - qf85fXXWIq0T1cSRRnmQGBj9jTwTJKRzkgA5gpt0m6I=
       ocp-aad-session-key:
-      - 7KnSTJ_kjkSa8KqUkrwbaPvfbcYpm9CglDpH39w35qQqLIlWYhE7-JPXhW0jUTsT6-nB40dGh_bZ7UwwjC_iYHw-fg3AH8o1D4BT5eEdbnZd0a3suN4scrf_VrdCTV582tbC9See_T4NT1YWHnRl8vGvPxRwCPBbuAe23RUI6iM.t1CPVcOtBx5bSthbo6hF__Gvs5xSPUggj6Ubsl3eEKY
+      - yGNzVu4fTia7k8Il7iaLGdJs0HbS-qG5G4uaj4LD1WpFSsjDdI9puArhbVJFL7Cn9_affUW2SQTreCD4986Q4SlOIv613o1Tg7mmLCGEuSzKp0fRjLSI5kb1wZqt-J1G3miXw8jTnjWtoYRCL_OUim14exy_HsEDmK8r2wvMDPI.-VfB3CP1Wx2GqtwYvi21-6XL7acsEjaAltKvG8VvD9c
       pragma:
       - no-cache
       request-id:
-      - d1861de7-44f6-4ce2-a9b2-8d7e496c417d
+      - d4526758-062e-401c-aa5d-0658c4f72ada
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1156,8 +1221,8 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
@@ -1166,70 +1231,49 @@ interactions:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"fba255ef-08f7-4f9b-b673-318fcb87f042","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Windows
         Azure Active Directory","appId":"00000002-0000-0000-c000-000000000000","applicationTemplateId":null,"appOwnerTenantId":"f8cdef31-a31e-4b4a-93e4-5f571e91255a","appRoleAssignmentRequired":false,"appRoles":[{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read all your organization''s policies without a signed-in user.
-        ","displayName":"Read your organization''s policies","id":"6c2d1b1d-a490-4178-ba6b-7efceda9129b","isEnabled":true,"value":"Policy.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read data in your company or school directory, such as users, groups,
-        and apps.","displayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"value":"Directory.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write all domain properties without a signed in user.  Also
-        allows the app to add,  verify and remove domains.","displayName":"Read and
-        write domains","id":"abefe9df-d5a9-41c6-a60b-27b38eac3efb","isEnabled":true,"value":"Domain.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write data in your company or school directory, such as
-        users, and groups.  Does not allow user or group deletion.","displayName":"Read
-        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"value":"Directory.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write all device properties without a signed in user.  Does
-        not allow device creation, device deletion or update of device alternative
-        security identifiers.","displayName":"Read and write devices","id":"1138cb37-bd11-4084-a2b7-9f71582aeddb","isEnabled":true,"value":"Device.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read the memberships of hidden groups and administrative units
-        without a signed-in user.","displayName":"Read all hidden memberships","id":"9728c0c4-a06b-4e0e-8d1b-3d694e8ec207","isEnabled":true,"value":"Member.Read.Hidden"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read applications and service principals without a signed-in user","displayName":"Read
+        all applications","id":"3afa6a7d-9b1a-42eb-948e-1650a849e176","isEnabled":true,"value":"Application.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to create, read, update and delete applications and service principals
+        without a signed-in user.  Does not allow management of consent grants.","displayName":"Read
+        and write all applications","id":"1cda74f2-2616-4834-b122-5cb1b07f8a59","isEnabled":true,"value":"Application.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to create other applications, and fully manage those applications
         (read, update, update application secrets and delete), without a signed-in
         user.  It cannot update any apps that it is not an owner of.","displayName":"Manage
         apps that this app creates or owns","id":"824c81eb-e3f8-4ee6-8f6d-de7f50d565b7","isEnabled":true,"value":"Application.ReadWrite.OwnedBy"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to create, read, update and delete applications and service principals
-        without a signed-in user.  Does not allow management of consent grants.","displayName":"Read
-        and write all applications","id":"1cda74f2-2616-4834-b122-5cb1b07f8a59","isEnabled":true,"value":"Application.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read the memberships of hidden groups and administrative units
+        without a signed-in user.","displayName":"Read all hidden memberships","id":"9728c0c4-a06b-4e0e-8d1b-3d694e8ec207","isEnabled":true,"value":"Member.Read.Hidden"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read and write all device properties without a signed in user.  Does
+        not allow device creation, device deletion or update of device alternative
+        security identifiers.","displayName":"Read and write devices","id":"1138cb37-bd11-4084-a2b7-9f71582aeddb","isEnabled":true,"value":"Device.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read and write data in your company or school directory, such as
+        users, and groups.  Does not allow user or group deletion.","displayName":"Read
+        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"value":"Directory.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to read and write all domain properties without a signed in user.  Also
         allows the app to add,  verify and remove domains.","displayName":"Read and
-        write domains","id":"aaff0dfd-0295-48b6-a5cc-9f465bc87928","isEnabled":true,"value":"Domain.ReadWrite.All"}],"displayName":"Windows
-        Azure Active Directory","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allows
-        the app to read your organization''s policies on behalf of the signed-in user.","adminConsentDisplayName":"Read
-        your organization''s policies","id":"80e5b1bf-3ad0-4365-943a-0ec983009b67","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read your organization''s policies on your behalf.","userConsentDisplayName":"Read
-        your organization''s policies","value":"Policy.Read.All"},{"adminConsentDescription":"Allows
-        the app to have the same access to information in the directory as the signed-in
-        user.","adminConsentDisplayName":"Access the directory as the signed-in user","id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","isEnabled":true,"type":"User","userConsentDescription":"Allows
-        the app to have the same access to information in your work or school directory
-        as you do.","userConsentDisplayName":"Access the directory as you","value":"Directory.AccessAsUser.All"},{"adminConsentDescription":"Allows
+        write domains","id":"abefe9df-d5a9-41c6-a60b-27b38eac3efb","isEnabled":true,"value":"Domain.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to read data in your company or school directory, such as users, groups,
-        and apps.","adminConsentDisplayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read data in your company or school directory, such as other users,
-        groups and apps.","userConsentDisplayName":"Read directory data","value":"Directory.Read.All"},{"adminConsentDescription":"Allows
-        the app to read and write data in your company or school directory, such as
-        users, and groups.  Does not allow user or group deletion.","adminConsentDisplayName":"Read
-        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read and write data in your company or school directory, such as
-        other users, groups.  Does not allow user or group deletion on your behalf.","userConsentDisplayName":"Read
-        and write directory data","value":"Directory.ReadWrite.All"},{"adminConsentDescription":"Allows
-        the app to create groups on behalf of the signed-in user and read all group
-        properties and memberships. Additionally, this allows the app to update group
-        properties and memberships for the groups the signed-in user owns.","adminConsentDisplayName":"Read
-        and write all groups","id":"970d6fa6-214a-4a9b-8513-08fad511e2fd","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to create groups on your behalf and read all group properties and
-        memberships. Additionally, this allows the app to update group properties
-        and memberships for groups you own.","userConsentDisplayName":"Read and write
-        all groups","value":"Group.ReadWrite.All"},{"adminConsentDescription":"Allows
-        the app to read basic group properties and memberships on behalf of the signed-in
-        user.","adminConsentDisplayName":"Read all groups","id":"6234d376-f627-4f0f-90e0-dff25c5211a3","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read all group properties and memberships on your behalf.","userConsentDisplayName":"Read
-        all groups","value":"Group.Read.All"},{"adminConsentDescription":"Allows the
-        app to read the full set of profile properties of all users in your company
-        or school, on behalf of the signed-in user. Additionally, this allows the
-        app to read the profiles of the signed-in user''s reports and manager.","adminConsentDisplayName":"Read
-        all users'' full profiles","id":"c582532d-9d9e-43bd-a97c-2667a28ce295","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read the full set of profile properties of all users in your company
-        or school, on your behalf.  Additionally, this allows the app to read the
-        profiles of your reports and manager.","userConsentDisplayName":"Read all
-        user''s full profiles","value":"User.Read.All"},{"adminConsentDescription":"Allows
+        and apps.","displayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"value":"Directory.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read all your organization''s policies without a signed-in user.
+        ","displayName":"Read your organization''s policies","id":"6c2d1b1d-a490-4178-ba6b-7efceda9129b","isEnabled":true,"value":"Policy.Read.All"},{"allowedMemberTypes":["Application"],"description":"(Deprecated)
+        Allows the app to read and write all domain properties, without a signed-in
+        user. Also allows the app to add, verify, and remove domains. This permission
+        will be disabled in the future. Developers should request the Domain.ReadWrite.All
+        permission with id abefe9df-d5a9-41c6-a60b-27b38eac3efb instead.","displayName":"Read
+        and write domains (deprecated)","id":"aaff0dfd-0295-48b6-a5cc-9f465bc87928","isEnabled":true,"value":"Domain.ReadWrite.All"}],"displayName":"Windows
+        Azure Active Directory","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allows
+        the app to read the memberships of hidden groups and administrative units
+        on behalf of the signed-in user, for those hidden groups and administrative
+        units that the signed-in user has access to.","adminConsentDisplayName":"Read
+        hidden memberships","id":"2d05a661-f651-4d57-a595-489c91eda336","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read the memberships of hidden groups or administrative units on
+        your behalf, for those hidden groups or administrative units that you have
+        access to.","userConsentDisplayName":"Read your hidden memberships","value":"Member.Read.Hidden"},{"adminConsentDescription":"Allows
+        users to sign in to the app, and allows the app to read the profile of signed-in
+        users. It also allow the app to read basic company information of signed-in
+        users.","adminConsentDisplayName":"Sign in and read user profile","id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","isEnabled":true,"type":"User","userConsentDescription":"Allows
+        you to sign in to the app with your work account and let the app read your
+        profile. It also allows the app to read basic company information.","userConsentDisplayName":"Sign
+        you in and read your profile","value":"User.Read"},{"adminConsentDescription":"Allows
         the app to read a basic set of profile properties of all users in your company
         or school on behalf of the signed-in user. Includes display name, first and
         last name, photo, and email address. Additionally, this allows the app to
@@ -1240,44 +1284,69 @@ interactions:
         and email address. Additionally, this allows the app to read basic info about
         your reports and manager.","userConsentDisplayName":"Read all user''s basic
         profiles","value":"User.ReadBasic.All"},{"adminConsentDescription":"Allows
-        users to sign in to the app, and allows the app to read the profile of signed-in
-        users. It also allow the app to read basic company information of signed-in
-        users.","adminConsentDisplayName":"Sign in and read user profile","id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","isEnabled":true,"type":"User","userConsentDescription":"Allows
-        you to sign in to the app with your work account and let the app read your
-        profile. It also allows the app to read basic company information.","userConsentDisplayName":"Sign
-        you in and read your profile","value":"User.Read"},{"adminConsentDescription":"Allows
-        the app to read the memberships of hidden groups and administrative units
-        on behalf of the signed-in user, for those hidden groups and administrative
-        units that the signed-in user has access to.","adminConsentDisplayName":"Read
-        hidden memberships","id":"2d05a661-f651-4d57-a595-489c91eda336","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read the memberships of hidden groups or administrative units on
-        your behalf, for those hidden groups or administrative units that you have
-        access to.","userConsentDisplayName":"Read your hidden memberships","value":"Member.Read.Hidden"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["00000002-0000-0000-c000-000000000000/graph.microsoftazure.us","https://graph.microsoftazure.us","Microsoft.Azure.ActiveDirectory","00000002-0000-0000-c000-000000000000","00000002-0000-0000-c000-000000000000/directory.windows.net","00000002-0000-0000-c000-000000000000/graph.windows.net","https://graph.windows.net","https://graph.windows.net/"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
+        the app to read the full set of profile properties of all users in your company
+        or school, on behalf of the signed-in user. Additionally, this allows the
+        app to read the profiles of the signed-in user''s reports and manager.","adminConsentDisplayName":"Read
+        all users'' full profiles","id":"c582532d-9d9e-43bd-a97c-2667a28ce295","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read the full set of profile properties of all users in your company
+        or school, on your behalf.  Additionally, this allows the app to read the
+        profiles of your reports and manager.","userConsentDisplayName":"Read all
+        user''s full profiles","value":"User.Read.All"},{"adminConsentDescription":"Allows
+        the app to read basic group properties and memberships on behalf of the signed-in
+        user.","adminConsentDisplayName":"Read all groups","id":"6234d376-f627-4f0f-90e0-dff25c5211a3","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read all group properties and memberships on your behalf.","userConsentDisplayName":"Read
+        all groups","value":"Group.Read.All"},{"adminConsentDescription":"Allows the
+        app to create groups on behalf of the signed-in user and read all group properties
+        and memberships. Additionally, this allows the app to update group properties
+        and memberships for the groups the signed-in user owns.","adminConsentDisplayName":"Read
+        and write all groups","id":"970d6fa6-214a-4a9b-8513-08fad511e2fd","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to create groups on your behalf and read all group properties and
+        memberships. Additionally, this allows the app to update group properties
+        and memberships for groups you own.","userConsentDisplayName":"Read and write
+        all groups","value":"Group.ReadWrite.All"},{"adminConsentDescription":"Allows
+        the app to read and write data in your company or school directory, such as
+        users, and groups.  Does not allow user or group deletion.","adminConsentDisplayName":"Read
+        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read and write data in your company or school directory, such as
+        other users, groups.  Does not allow user or group deletion on your behalf.","userConsentDisplayName":"Read
+        and write directory data","value":"Directory.ReadWrite.All"},{"adminConsentDescription":"Allows
+        the app to read data in your company or school directory, such as users, groups,
+        and apps.","adminConsentDisplayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read data in your company or school directory, such as other users,
+        groups and apps.","userConsentDisplayName":"Read directory data","value":"Directory.Read.All"},{"adminConsentDescription":"Allows
+        the app to have the same access to information in the directory as the signed-in
+        user.","adminConsentDisplayName":"Access the directory as the signed-in user","id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","isEnabled":true,"type":"User","userConsentDescription":"Allows
+        the app to have the same access to information in your work or school directory
+        as you do.","userConsentDisplayName":"Access the directory as you","value":"Directory.AccessAsUser.All"},{"adminConsentDescription":"Allows
+        the app to read your organization''s policies on behalf of the signed-in user.","adminConsentDisplayName":"Read
+        your organization''s policies","id":"80e5b1bf-3ad0-4365-943a-0ec983009b67","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read your organization''s policies on your behalf.","userConsentDisplayName":"Read
+        your organization''s policies","value":"Policy.Read.All"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["https://graph.windows.net/","https://graph.windows.net","00000002-0000-0000-c000-000000000000/graph.windows.net","00000002-0000-0000-c000-000000000000/directory.windows.net","00000002-0000-0000-c000-000000000000","Microsoft.Azure.ActiveDirectory","https://graph.microsoftazure.us","00000002-0000-0000-c000-000000000000/graph.microsoftazure.us"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '10401'
+      - '10860'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:05 GMT
+      - Tue, 23 Feb 2021 08:45:28 GMT
       duration:
-      - '2434445'
+      - '2376680'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - OLyruse+78JH08I5RN/wxIatmflBNwSlEb2bxx4qGLA=
+      - fUwdOlBxj0W43cnnXFV7+S+AOuEgmYeWaq8fw8xGlYQ=
       ocp-aad-session-key:
-      - xlFCcUklJe1HECT9WKT_Fz_kSqyQy_Op7504IWSH35iGfx-NtRtFs8CyCQWpdMW50ivFyd1uVUMqVs2JtZK8AE67baoAV-_7ZkXEkRp0Sv8hloFWJLD-G8FvPQOTU6zin48ekkUtS2T3vzgKRBqplZPzJ296FB9DcmsGDPEWjGw.VR03TijqN0Qz0LrAExR5J5Yjz61yqSuLntHyq1O_hHI
+      - U0bW6bWKUpOTTWL0fEncjhhDzMjIsigzk_DZI3nleUm9bLRu9vjhamuaMbHWLGz2fs_L6_jdPo49i_8k5rVbBtgWYGotbDrPQ_kyBhyATfjXr2SSYIHtbALV_HUK7ltaAtBSgT_bTOyH4uY16pJrmcBnZrwFS76QeeomESQ_Q3g.DsuA5KZNXAvMwYCPSLfoPqsTfqEhyR2_E6JRajHbIcA
       pragma:
       - no-cache
       request-id:
-      - cf1a673f-aedb-481f-9112-85e7712cd98b
+      - a4b4758a-0bcc-44fc-9c8f-0aadcc80220a
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1299,86 +1368,25 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - ad app permission list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --id
-      User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
-      accept-language:
-      - en-US
-    method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?$filter=clientId%20eq%20%2764c73637-ae71-44f6-9170-da2c257cbbe6%27&api-version=1.6
-  response:
-    body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants","value":[{"clientId":"64c73637-ae71-44f6-9170-da2c257cbbe6","consentType":"AllPrincipals","expiryTime":"2021-08-21T06:28:02.837234","objectId":"NzbHZHGu9kSRcNosJXy75u9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2020-08-21T06:28:02.837234"}]}'
-    headers:
-      access-control-allow-origin:
-      - '*'
-      cache-control:
-      - no-cache
-      content-length:
-      - '448'
-      content-type:
-      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
-      dataserviceversion:
-      - 3.0;
-      date:
-      - Fri, 21 Aug 2020 06:28:06 GMT
-      duration:
-      - '2218340'
-      expires:
-      - '-1'
-      ocp-aad-diagnostics-server-name:
-      - hhJdfLW66JLi2nEcbTnUgI+AxnSecUxb4zj7RAMm+V0=
-      ocp-aad-session-key:
-      - MsbooRTaAdgTZzKkSP9PAwLxVBCoIl-evseb0BqJcBMUsGygVcnmuoyTImSaOK5Z2_KuW6zoEGjk1tAOk9tCqjW9t6cr8_VucWxGirs6KQSkG24WRhiLgTNvBpaIrROubVtW5b0laLR8BhWkNi2P63MFO-2Zlzl6VYh7guun3yE.TK2800p-pbM0T4GhaePWJEtkjBfeXAomGQnR8_cvxkc
-      pragma:
-      - no-cache
-      request-id:
-      - e09f6fa9-3c1d-4c32-84af-da1df693c9e4
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-aspnet-version:
-      - 4.0.30319
-      x-ms-dirapi-data-contract-version:
-      - '1.6'
-      x-ms-resource-unit:
-      - '2'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
       - ad app permission list-grants
       Connection:
       - keep-alive
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"64c73637-ae71-44f6-9170-da2c257cbbe6","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"32a71f9a-621a-424b-841c-6637352eee4a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","a929150b-3dde-4fd6-a64c-f9cf898c4150"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
+        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","5b91ffae-ddfc-4f85-94e2-78cbb12c92f2"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1391,19 +1399,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:06 GMT
+      - Tue, 23 Feb 2021 08:45:29 GMT
       duration:
-      - '2348555'
+      - '2346211'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - F+0yP1/iovhvk5VOGuzH+4JSs/ok0ZbZeIgR5yYgVQ4=
+      - vhrB7Ly6aO9kiBJkxy7erZpi8qLwLccvj46KGXjDAwI=
       ocp-aad-session-key:
-      - 0bTPp7i9PPVQLK0OWRq5pJtc-1DXpUaJkCmYzhoG-QsppT2y9iR1yoIYIlra0kj4KfXF1lJf7m6kInZAXkdf5HpHtXh1Lau8qqU5JraW3lADSVD6FYJ2HlXtioHmwGR-S4XDY_kB8YdlzZoJdIqyRA17BRDNLSw5cpVO3B0dTE4.dif_xszjXiyRhIs3AD_5fikyyokxsDFQ3tiBgtRiWxU
+      - aDfyU35xYl8p4oXhOtcC4-o6fpGrFbBMa5mNEHyqOYEfX7aXGFPPIJcewH4EktENYLD8rSpAAEaveamILDPGAe0mu_PXq_6dXplc_Y5sshA6Z1osQyqVqR7WtPP6B2eaIY_7A8JPlEVhARGiOUcmq1dEPOvZMhxhZmLeqoOj_y4.e_81qmnysxxSz13Pe0I9MHPRqpaf4VZNVHT5cl2PJQA
       pragma:
       - no-cache
       request-id:
-      - 852e1386-f5f2-4d13-83ad-c4e5ed8a0a77
+      - dbaae122-3a92-429b-ba5a-430013195fa9
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1431,15 +1439,15 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?$filter=clientId%20eq%20%2764c73637-ae71-44f6-9170-da2c257cbbe6%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?$filter=clientId%20eq%20%2732a71f9a-621a-424b-841c-6637352eee4a%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants","value":[{"clientId":"64c73637-ae71-44f6-9170-da2c257cbbe6","consentType":"AllPrincipals","expiryTime":"2021-08-21T06:28:02.837234","objectId":"NzbHZHGu9kSRcNosJXy75u9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2020-08-21T06:28:02.837234"}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants","value":[{"clientId":"32a71f9a-621a-424b-841c-6637352eee4a","consentType":"AllPrincipals","expiryTime":"2022-02-23T08:45:25.417176","objectId":"mh-nMhpiS0KEHGY3NS7uSu9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2021-02-23T08:45:25.417176"}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1452,19 +1460,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:07 GMT
+      - Tue, 23 Feb 2021 08:45:29 GMT
       duration:
-      - '2199791'
+      - '2304410'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - om0QIa8Bj4//k+kQSxhRarsBgG9G181jsSBY9te4TGM=
+      - TUnGpeLvLxEtKV4aQ+Wc/rHh0cCKeEx3SiuusE59UvA=
       ocp-aad-session-key:
-      - YVsY0VArfDrbBbCjwfS6U98EPY_0Bqicf7nIzLPjHRJtzYmSRKsMWZ-Xb2L8NPoxZyuaU9IRLOS4P90neuQxUzTokRfQC1pCFDSxtf0lPtk2hgLIstyIDFuJO2UM6yzARNZZ-3-kV0NJ2i4bSPRxa2saGgZMoTgwPkdZ0MGCTEs.JoVCfhuJex5qBI_miNcabrja5Zihf8yOZYG_7dy81tA
+      - yV61QIfm-rKck5OnRL1QjQ822oGTV3PtwFukzrhlsInH4zSAr3PQZYWihbDWU8PAni2kfezJa-QsMqQJUhyBVeog0YPFUbyPWE7RrwMC9pBZgbB28YDcItlMLOMwZ8JSLp5OkNdYpKkDXb0uPVze2y9EnMICLB8WGqKlntK9dp0.ThgeucaNR1HOe3Om41xJB77Kq4mdAPtX-CigKYSV_-c
       pragma:
       - no-cache
       request-id:
-      - 737916bb-8d97-49cc-8505-6a93f1bf4a89
+      - 451bbd03-eac6-4ec0-b54b-0e50fac65a27
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1492,19 +1500,19 @@ interactions:
       ParameterSetName:
       - --id --show-resource-name
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"64c73637-ae71-44f6-9170-da2c257cbbe6","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"32a71f9a-621a-424b-841c-6637352eee4a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","a929150b-3dde-4fd6-a64c-f9cf898c4150"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
+        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","5b91ffae-ddfc-4f85-94e2-78cbb12c92f2"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1517,19 +1525,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:08 GMT
+      - Tue, 23 Feb 2021 08:45:30 GMT
       duration:
-      - '2290941'
+      - '2550243'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - ltdErb/EUtDqqofgNqOFJZSK42vqehyhW+MdcYj4hS4=
+      - 1ZC4RfTkKKTCec81HM4ZssvzbSWTeMBWN/Vh8nxjyAY=
       ocp-aad-session-key:
-      - O5aXDNfxgHrMKiITPh2fEm4V8p56XLYffP6acISLXwtRcb46Xjgzx50XEF2UFdnw-In1Pj7v9R4u5zNgo4aPf3B8WXQeq7I545qzjc7btWY-qLsAmJUxauIHlQbRcVeTf57_vO5CfsunX66CN43LWItnsnQbVMRMbw2LhUBaxHM.k9T11d0HPgLTYYg-Gx56_w3cOSem929q1qhDFvcXfHA
+      - Q00Vz4VMhAMMWJZ9qlgfVqJ3PQvE29n7jtcTpkVeQOf-RhlJkGF06dfZfm5zy2LW9XUrpJuHk8rd2ynt2AJO-5PXQDKotjhU60yuh3X_404wCAsT2oxv_mFAFiinXTxUeURTAE7c0tzfLEl5SzB4dlMaF6StdMM8-q_Iob1sQ5g.j9rCUeSpzx_FFBsRvTdlNQk0FtLPz2FoF7HlHkuzISk
       pragma:
       - no-cache
       request-id:
-      - 74636e6b-6f79-4222-ba38-58e05ce81e23
+      - 93f274ac-0eb9-4085-9f62-de92dc31416e
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1557,15 +1565,15 @@ interactions:
       ParameterSetName:
       - --id --show-resource-name
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?$filter=clientId%20eq%20%2764c73637-ae71-44f6-9170-da2c257cbbe6%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?$filter=clientId%20eq%20%2732a71f9a-621a-424b-841c-6637352eee4a%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants","value":[{"clientId":"64c73637-ae71-44f6-9170-da2c257cbbe6","consentType":"AllPrincipals","expiryTime":"2021-08-21T06:28:02.837234","objectId":"NzbHZHGu9kSRcNosJXy75u9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2020-08-21T06:28:02.837234"}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants","value":[{"clientId":"32a71f9a-621a-424b-841c-6637352eee4a","consentType":"AllPrincipals","expiryTime":"2022-02-23T08:45:25.417176","objectId":"mh-nMhpiS0KEHGY3NS7uSu9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2021-02-23T08:45:25.417176"}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1578,19 +1586,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:08 GMT
+      - Tue, 23 Feb 2021 08:45:30 GMT
       duration:
-      - '2242111'
+      - '2252059'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 7/al7S0Qh57bz+89nP+mnwDwdim1hKdV5Sukqtc2xmA=
+      - 1tRm08/+cz4W18hEoDlDTUteGfEPt3isiGVqvBWKqyw=
       ocp-aad-session-key:
-      - Hf45DKK0_kC9g5wVPxXoesG23elYQ4ioXvly7r31WmcgP_Z7uy9yO9AepoDRu49hN_5BmXWPmTSOHzTPZ0JudBTzR0tVBGaM45Gp8N258XaD1ExL6TxroyfKkN8huHCIpM-CxcFu21QDe8oN_a4-g0w4dHRm2Q_1v5X1Te9q0ZA.rzIhvGJzRRisZOXm7C81TxjJ_HGyKz-pemQijsJ5XMg
+      - LQLJgNjH_GhGvj1zSj7VfjZdlSyR8VkWYn41lpgOYG6QJ0AIIOjLZMwcyJGaTo0WPde8UwaratvAscHXopQzjmFvX9eXFxYw3OwImaa_lX3tKr9AjAG5iUJo0MxOoJ8shGjC0PD703DRMxTlAjCfBUzjEgCJsPRy4l2R1cFHYXs.SbVIPvydD8t4xgwbI5NF0witghA8MRWIt6mmnATZ9uk
       pragma:
       - no-cache
       request-id:
-      - fa07fe01-79e4-44bc-a6da-aa076c8dce5f
+      - fd665227-08a0-4612-ba4a-ae227c925a40
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1618,8 +1626,8 @@ interactions:
       ParameterSetName:
       - --id --show-resource-name
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
@@ -1628,70 +1636,49 @@ interactions:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"fba255ef-08f7-4f9b-b673-318fcb87f042","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Windows
         Azure Active Directory","appId":"00000002-0000-0000-c000-000000000000","applicationTemplateId":null,"appOwnerTenantId":"f8cdef31-a31e-4b4a-93e4-5f571e91255a","appRoleAssignmentRequired":false,"appRoles":[{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read all your organization''s policies without a signed-in user.
-        ","displayName":"Read your organization''s policies","id":"6c2d1b1d-a490-4178-ba6b-7efceda9129b","isEnabled":true,"value":"Policy.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read data in your company or school directory, such as users, groups,
-        and apps.","displayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"value":"Directory.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write all domain properties without a signed in user.  Also
-        allows the app to add,  verify and remove domains.","displayName":"Read and
-        write domains","id":"abefe9df-d5a9-41c6-a60b-27b38eac3efb","isEnabled":true,"value":"Domain.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write data in your company or school directory, such as
-        users, and groups.  Does not allow user or group deletion.","displayName":"Read
-        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"value":"Directory.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write all device properties without a signed in user.  Does
-        not allow device creation, device deletion or update of device alternative
-        security identifiers.","displayName":"Read and write devices","id":"1138cb37-bd11-4084-a2b7-9f71582aeddb","isEnabled":true,"value":"Device.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read the memberships of hidden groups and administrative units
-        without a signed-in user.","displayName":"Read all hidden memberships","id":"9728c0c4-a06b-4e0e-8d1b-3d694e8ec207","isEnabled":true,"value":"Member.Read.Hidden"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read applications and service principals without a signed-in user","displayName":"Read
+        all applications","id":"3afa6a7d-9b1a-42eb-948e-1650a849e176","isEnabled":true,"value":"Application.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to create, read, update and delete applications and service principals
+        without a signed-in user.  Does not allow management of consent grants.","displayName":"Read
+        and write all applications","id":"1cda74f2-2616-4834-b122-5cb1b07f8a59","isEnabled":true,"value":"Application.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to create other applications, and fully manage those applications
         (read, update, update application secrets and delete), without a signed-in
         user.  It cannot update any apps that it is not an owner of.","displayName":"Manage
         apps that this app creates or owns","id":"824c81eb-e3f8-4ee6-8f6d-de7f50d565b7","isEnabled":true,"value":"Application.ReadWrite.OwnedBy"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to create, read, update and delete applications and service principals
-        without a signed-in user.  Does not allow management of consent grants.","displayName":"Read
-        and write all applications","id":"1cda74f2-2616-4834-b122-5cb1b07f8a59","isEnabled":true,"value":"Application.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read the memberships of hidden groups and administrative units
+        without a signed-in user.","displayName":"Read all hidden memberships","id":"9728c0c4-a06b-4e0e-8d1b-3d694e8ec207","isEnabled":true,"value":"Member.Read.Hidden"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read and write all device properties without a signed in user.  Does
+        not allow device creation, device deletion or update of device alternative
+        security identifiers.","displayName":"Read and write devices","id":"1138cb37-bd11-4084-a2b7-9f71582aeddb","isEnabled":true,"value":"Device.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read and write data in your company or school directory, such as
+        users, and groups.  Does not allow user or group deletion.","displayName":"Read
+        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"value":"Directory.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to read and write all domain properties without a signed in user.  Also
         allows the app to add,  verify and remove domains.","displayName":"Read and
-        write domains","id":"aaff0dfd-0295-48b6-a5cc-9f465bc87928","isEnabled":true,"value":"Domain.ReadWrite.All"}],"displayName":"Windows
-        Azure Active Directory","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allows
-        the app to read your organization''s policies on behalf of the signed-in user.","adminConsentDisplayName":"Read
-        your organization''s policies","id":"80e5b1bf-3ad0-4365-943a-0ec983009b67","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read your organization''s policies on your behalf.","userConsentDisplayName":"Read
-        your organization''s policies","value":"Policy.Read.All"},{"adminConsentDescription":"Allows
-        the app to have the same access to information in the directory as the signed-in
-        user.","adminConsentDisplayName":"Access the directory as the signed-in user","id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","isEnabled":true,"type":"User","userConsentDescription":"Allows
-        the app to have the same access to information in your work or school directory
-        as you do.","userConsentDisplayName":"Access the directory as you","value":"Directory.AccessAsUser.All"},{"adminConsentDescription":"Allows
+        write domains","id":"abefe9df-d5a9-41c6-a60b-27b38eac3efb","isEnabled":true,"value":"Domain.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to read data in your company or school directory, such as users, groups,
-        and apps.","adminConsentDisplayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read data in your company or school directory, such as other users,
-        groups and apps.","userConsentDisplayName":"Read directory data","value":"Directory.Read.All"},{"adminConsentDescription":"Allows
-        the app to read and write data in your company or school directory, such as
-        users, and groups.  Does not allow user or group deletion.","adminConsentDisplayName":"Read
-        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read and write data in your company or school directory, such as
-        other users, groups.  Does not allow user or group deletion on your behalf.","userConsentDisplayName":"Read
-        and write directory data","value":"Directory.ReadWrite.All"},{"adminConsentDescription":"Allows
-        the app to create groups on behalf of the signed-in user and read all group
-        properties and memberships. Additionally, this allows the app to update group
-        properties and memberships for the groups the signed-in user owns.","adminConsentDisplayName":"Read
-        and write all groups","id":"970d6fa6-214a-4a9b-8513-08fad511e2fd","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to create groups on your behalf and read all group properties and
-        memberships. Additionally, this allows the app to update group properties
-        and memberships for groups you own.","userConsentDisplayName":"Read and write
-        all groups","value":"Group.ReadWrite.All"},{"adminConsentDescription":"Allows
-        the app to read basic group properties and memberships on behalf of the signed-in
-        user.","adminConsentDisplayName":"Read all groups","id":"6234d376-f627-4f0f-90e0-dff25c5211a3","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read all group properties and memberships on your behalf.","userConsentDisplayName":"Read
-        all groups","value":"Group.Read.All"},{"adminConsentDescription":"Allows the
-        app to read the full set of profile properties of all users in your company
-        or school, on behalf of the signed-in user. Additionally, this allows the
-        app to read the profiles of the signed-in user''s reports and manager.","adminConsentDisplayName":"Read
-        all users'' full profiles","id":"c582532d-9d9e-43bd-a97c-2667a28ce295","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read the full set of profile properties of all users in your company
-        or school, on your behalf.  Additionally, this allows the app to read the
-        profiles of your reports and manager.","userConsentDisplayName":"Read all
-        user''s full profiles","value":"User.Read.All"},{"adminConsentDescription":"Allows
+        and apps.","displayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"value":"Directory.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read all your organization''s policies without a signed-in user.
+        ","displayName":"Read your organization''s policies","id":"6c2d1b1d-a490-4178-ba6b-7efceda9129b","isEnabled":true,"value":"Policy.Read.All"},{"allowedMemberTypes":["Application"],"description":"(Deprecated)
+        Allows the app to read and write all domain properties, without a signed-in
+        user. Also allows the app to add, verify, and remove domains. This permission
+        will be disabled in the future. Developers should request the Domain.ReadWrite.All
+        permission with id abefe9df-d5a9-41c6-a60b-27b38eac3efb instead.","displayName":"Read
+        and write domains (deprecated)","id":"aaff0dfd-0295-48b6-a5cc-9f465bc87928","isEnabled":true,"value":"Domain.ReadWrite.All"}],"displayName":"Windows
+        Azure Active Directory","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allows
+        the app to read the memberships of hidden groups and administrative units
+        on behalf of the signed-in user, for those hidden groups and administrative
+        units that the signed-in user has access to.","adminConsentDisplayName":"Read
+        hidden memberships","id":"2d05a661-f651-4d57-a595-489c91eda336","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read the memberships of hidden groups or administrative units on
+        your behalf, for those hidden groups or administrative units that you have
+        access to.","userConsentDisplayName":"Read your hidden memberships","value":"Member.Read.Hidden"},{"adminConsentDescription":"Allows
+        users to sign in to the app, and allows the app to read the profile of signed-in
+        users. It also allow the app to read basic company information of signed-in
+        users.","adminConsentDisplayName":"Sign in and read user profile","id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","isEnabled":true,"type":"User","userConsentDescription":"Allows
+        you to sign in to the app with your work account and let the app read your
+        profile. It also allows the app to read basic company information.","userConsentDisplayName":"Sign
+        you in and read your profile","value":"User.Read"},{"adminConsentDescription":"Allows
         the app to read a basic set of profile properties of all users in your company
         or school on behalf of the signed-in user. Includes display name, first and
         last name, photo, and email address. Additionally, this allows the app to
@@ -1702,44 +1689,69 @@ interactions:
         and email address. Additionally, this allows the app to read basic info about
         your reports and manager.","userConsentDisplayName":"Read all user''s basic
         profiles","value":"User.ReadBasic.All"},{"adminConsentDescription":"Allows
-        users to sign in to the app, and allows the app to read the profile of signed-in
-        users. It also allow the app to read basic company information of signed-in
-        users.","adminConsentDisplayName":"Sign in and read user profile","id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","isEnabled":true,"type":"User","userConsentDescription":"Allows
-        you to sign in to the app with your work account and let the app read your
-        profile. It also allows the app to read basic company information.","userConsentDisplayName":"Sign
-        you in and read your profile","value":"User.Read"},{"adminConsentDescription":"Allows
-        the app to read the memberships of hidden groups and administrative units
-        on behalf of the signed-in user, for those hidden groups and administrative
-        units that the signed-in user has access to.","adminConsentDisplayName":"Read
-        hidden memberships","id":"2d05a661-f651-4d57-a595-489c91eda336","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read the memberships of hidden groups or administrative units on
-        your behalf, for those hidden groups or administrative units that you have
-        access to.","userConsentDisplayName":"Read your hidden memberships","value":"Member.Read.Hidden"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["00000002-0000-0000-c000-000000000000/graph.microsoftazure.us","https://graph.microsoftazure.us","Microsoft.Azure.ActiveDirectory","00000002-0000-0000-c000-000000000000","00000002-0000-0000-c000-000000000000/directory.windows.net","00000002-0000-0000-c000-000000000000/graph.windows.net","https://graph.windows.net","https://graph.windows.net/"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}'
+        the app to read the full set of profile properties of all users in your company
+        or school, on behalf of the signed-in user. Additionally, this allows the
+        app to read the profiles of the signed-in user''s reports and manager.","adminConsentDisplayName":"Read
+        all users'' full profiles","id":"c582532d-9d9e-43bd-a97c-2667a28ce295","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read the full set of profile properties of all users in your company
+        or school, on your behalf.  Additionally, this allows the app to read the
+        profiles of your reports and manager.","userConsentDisplayName":"Read all
+        user''s full profiles","value":"User.Read.All"},{"adminConsentDescription":"Allows
+        the app to read basic group properties and memberships on behalf of the signed-in
+        user.","adminConsentDisplayName":"Read all groups","id":"6234d376-f627-4f0f-90e0-dff25c5211a3","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read all group properties and memberships on your behalf.","userConsentDisplayName":"Read
+        all groups","value":"Group.Read.All"},{"adminConsentDescription":"Allows the
+        app to create groups on behalf of the signed-in user and read all group properties
+        and memberships. Additionally, this allows the app to update group properties
+        and memberships for the groups the signed-in user owns.","adminConsentDisplayName":"Read
+        and write all groups","id":"970d6fa6-214a-4a9b-8513-08fad511e2fd","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to create groups on your behalf and read all group properties and
+        memberships. Additionally, this allows the app to update group properties
+        and memberships for groups you own.","userConsentDisplayName":"Read and write
+        all groups","value":"Group.ReadWrite.All"},{"adminConsentDescription":"Allows
+        the app to read and write data in your company or school directory, such as
+        users, and groups.  Does not allow user or group deletion.","adminConsentDisplayName":"Read
+        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read and write data in your company or school directory, such as
+        other users, groups.  Does not allow user or group deletion on your behalf.","userConsentDisplayName":"Read
+        and write directory data","value":"Directory.ReadWrite.All"},{"adminConsentDescription":"Allows
+        the app to read data in your company or school directory, such as users, groups,
+        and apps.","adminConsentDisplayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read data in your company or school directory, such as other users,
+        groups and apps.","userConsentDisplayName":"Read directory data","value":"Directory.Read.All"},{"adminConsentDescription":"Allows
+        the app to have the same access to information in the directory as the signed-in
+        user.","adminConsentDisplayName":"Access the directory as the signed-in user","id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","isEnabled":true,"type":"User","userConsentDescription":"Allows
+        the app to have the same access to information in your work or school directory
+        as you do.","userConsentDisplayName":"Access the directory as you","value":"Directory.AccessAsUser.All"},{"adminConsentDescription":"Allows
+        the app to read your organization''s policies on behalf of the signed-in user.","adminConsentDisplayName":"Read
+        your organization''s policies","id":"80e5b1bf-3ad0-4365-943a-0ec983009b67","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read your organization''s policies on your behalf.","userConsentDisplayName":"Read
+        your organization''s policies","value":"Policy.Read.All"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["https://graph.windows.net/","https://graph.windows.net","00000002-0000-0000-c000-000000000000/graph.windows.net","00000002-0000-0000-c000-000000000000/directory.windows.net","00000002-0000-0000-c000-000000000000","Microsoft.Azure.ActiveDirectory","https://graph.microsoftazure.us","00000002-0000-0000-c000-000000000000/graph.microsoftazure.us"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '10398'
+      - '10857'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:08 GMT
+      - Tue, 23 Feb 2021 08:45:31 GMT
       duration:
-      - '2274769'
+      - '2358616'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - QAuHhTm9RVpaK7Xjr9yexfLWEjSix2PbQozeTqB2czc=
+      - NzCWzqZGrkFblNn1tcLgH3TINaD+z/ZrvJjJAF/TqNQ=
       ocp-aad-session-key:
-      - -Ips7L7UayxYnbnL78Itoa78_YhbRnoF5rBQ98DTzeRDjZ56HxOjMP81_BSyqu_t1Ac6LfOgrizta2jPU39ho3A69J5BotrGWic0AQMSHONmEwGM_UOMF8BFESQXbW65u7nZhDGRkKQJZvzJ38OmEoHwz6hiHuxi003fXgJz-ec.F8PBGFNYFYMmj-bmez-OABWfAaTdHPO0GQpmo5kdhKo
+      - zs0HNVXqKLRERNepFNHMW14JTKVcTehcl6_a60kjGUrbwO3mtaSzFwOG8Sb7UttFMMzRjEPgpvgY4xhsSHgv5F6eQL5n6ghEcAcxP3DeNCPe6QAqQBk9GIniaRw26dHnO5FCkRigUxzp5f3_w3KH2aHoF2hd_d1ZJyBE2m_5KiY.Lfr_UGy47YiErVAEfDQs2VSHeS7Yohf6S6eF-gbykPI
       pragma:
       - no-cache
       request-id:
-      - 8119ee88-36ce-476f-97bf-31b9713f0ca8
+      - f29ddf4f-26cf-434b-9f8f-2803f25f1354
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1767,12 +1779,12 @@ interactions:
       ParameterSetName:
       - --id --api --api-permissions
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -1788,19 +1800,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:08 GMT
+      - Tue, 23 Feb 2021 08:45:31 GMT
       duration:
-      - '2896109'
+      - '2167548'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - Xggm2lV7GH3yEUVfEvzm26S1umz7EprHWD9kDtATl70=
+      - hK1N7/8MDvnZtJ41DCjHIOdzJ4PKytJZkw0+mTgMCbE=
       ocp-aad-session-key:
-      - Psi5ErPIHwYrTPrZnnHiotFjvOxPvBoTWQjylvaC2WhAIzTH5xdHTNDEg3TYUyrSXYMQpZZif2B7GXtM3vr48S09a0E8RsPSj8GeOiaNEPJGTO4MB5sTr8Z4zJl8Ews2MVtUhV_FuZ-8iEzkIAgJI2TrqOQN2jlX6HPPZWtbwdw.MGKRUW-xGMbh2tel-acyi9XGtjtKcSRMeUkLd3yqzPI
+      - 5B3MUmRxximLhmzpFOt8kekBpnAUTTDQJDY40CUDhYQjYowU9jbOinyZ8VwL7iQyu6bqAzpQzTEW0tV6y0vmZ1Gd3iiuqPfEhg6n0xqs0WunYnb4nrLGSuUwK9PFmCA_Jyh6oPoMCSFSiMQe89FA9y6JGSbGzbXBivnh5ZH6c6A.A-Pjgw6S59l_5MDzDWmboog79emjnu-U7ytVAkNcO5g
       pragma:
       - no-cache
       request-id:
-      - 184089e8-4367-4219-b45e-9eb389f2d7b7
+      - 54537c66-7fd6-4ee1-9fd5-e076c535039d
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1828,44 +1840,44 @@ interactions:
       ParameterSetName:
       - --id --api --api-permissions
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a30a4689-338b-4f07-9b4f-d7af2ded5a12","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"b5e22543-b770-45de-bffb-9246b51b25fe","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2021-08-21T06:27:56.96504Z","keyId":"2197cada-aa78-47b4-a229-20f138077dcc","startDate":"2020-08-21T06:27:56.96504Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2022-02-23T08:45:19.356502Z","keyId":"51069578-2878-4b11-8c54-efd3bc482403","startDate":"2021-02-23T08:45:19.356502Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2333'
+      - '2335'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:09 GMT
+      - Tue, 23 Feb 2021 08:45:32 GMT
       duration:
-      - '2211740'
+      - '2341076'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - uw2DI55YPxO27iCQ9gmp7jkFjvTBnlg/TMjn48ai3jY=
+      - CZPc4K4tyMWVBPSgScqW0fLKaGto2QkdunrFbC489g8=
       ocp-aad-session-key:
-      - IBqwEhnsdK3jVWHs-jKm_deXwKzZJ3WGxriOdDmopN4gQVNEM1a-xZZN_EW_CFlap_ZDKmfGIufXaeqwFtLAJ8as0Uaa9q7kjOJnjVjh4bmgtX_WRKNpCzbb7_qqRKlbV6HfiLJvE-3fO95BXpt65Dj8gJfai4kzZAso8r68QKc.U2NdLhh7ZUtD1pg-EiwGRfz1hwRUUwH4SRq7Dcxdr7I
+      - xX4FDSi3x9M7dtN8_VjxkSzCZ4-LQENs4svGlInsiEn0xCD9BDJ-1BgiIED5aDXyEzyROn0kONEAujM0W2tZB5kfkAcEtYe8stiRQtVUOZuRH9EM5Jml68K0LwCoepSIHhUbTrKuM2pjNI95n8oD4gyGo1R0ju5-UPXqiK4U_qI.HAh69Ky55z-kgpVB6yDk3wITXgVkEattv7LdKheqAzw
       pragma:
       - no-cache
       request-id:
-      - 1445442c-3162-48b2-87eb-bcb87aa80125
+      - 668cae8f-80c3-470e-8627-7807cb6e1d98
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1893,44 +1905,44 @@ interactions:
       ParameterSetName:
       - --id --api --api-permissions
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/a30a4689-338b-4f07-9b4f-d7af2ded5a12?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/b5e22543-b770-45de-bffb-9246b51b25fe?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a30a4689-338b-4f07-9b4f-d7af2ded5a12","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"b5e22543-b770-45de-bffb-9246b51b25fe","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2021-08-21T06:27:56.96504Z","keyId":"2197cada-aa78-47b4-a229-20f138077dcc","startDate":"2020-08-21T06:27:56.96504Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2022-02-23T08:45:19.356502Z","keyId":"51069578-2878-4b11-8c54-efd3bc482403","startDate":"2021-02-23T08:45:19.356502Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2330'
+      - '2332'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:10 GMT
+      - Tue, 23 Feb 2021 08:45:32 GMT
       duration:
-      - '2188193'
+      - '3281792'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - eazGIPeVlW4JWHa8sKZ9JGmiK0APCMuK94ElGRk0dmU=
+      - s27maLuCh4SSz6qTCwOOsuIpRUEkmURTX7mTnvuwaM4=
       ocp-aad-session-key:
-      - MKFW8grmBPRySXUI6UFnrvw4On-LWCrd_ZFQjoneea06GHK9O7xEUk5pUuGlyLX6lSRulJLzfRGuVJPDAp-WTe_8KLFcgpfAK7j8znEOg90cf3oRA3kn2nKjxOW1RMv8k_XwscvW9gwZ1zvCRQ7qchpQTtZ--83rwBuVI-MUytA.8FYcc1n_n6wn_e9QUyXHp_r0tkrYDsqKwD7-fyb_2Cc
+      - IgfOPepRfwSXE0OTeA_lglpG3LP-3bfRC4v-i80Y6-aj8QDrlvb3Jb1V98__D3t69QxUtmwAg7rUVlnXuRSicXh_O9iju4ecuBTbZSjqBevGQMoJENBi_vG93yxgngFZOfGux2oxVRT9opl9TLYhrg-XNS7q2IZ2Xs4HJjk1LkM.vsCKQEqZgEt57iwnsfRWZODtARkYIN35yhay0ajtmv4
       pragma:
       - no-cache
       request-id:
-      - 66d75687-8b02-436a-ad4a-404c72fcbd6e
+      - 0d41f7cc-01e2-4f77-9cba-a5cd8ecbfa6d
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1964,12 +1976,12 @@ interactions:
       ParameterSetName:
       - --id --api --api-permissions
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/a30a4689-338b-4f07-9b4f-d7af2ded5a12?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/b5e22543-b770-45de-bffb-9246b51b25fe?api-version=1.6
   response:
     body:
       string: ''
@@ -1979,19 +1991,19 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Fri, 21 Aug 2020 06:28:11 GMT
+      - Tue, 23 Feb 2021 08:45:33 GMT
       duration:
-      - '3879170'
+      - '7072222'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 6nTxeccwHlqMkcfQH4EpKBUB0g7BKgCGffdUym5sXt8=
+      - Di/JcYzC6RA0nEYUk94b7MkejxeEu1vMBxkIifstNlg=
       ocp-aad-session-key:
-      - -4l2ac0MSS9HW7l9ba2PNy_ndDlwI3TSqTfWlbRi-NtJF0bg6btyQ4R-3q-zjHi5loZIZf67im9yYSJWuMkd71SCMZ_LP3g4By7c2cIvmzqOQ1wI5JLuyRSFJYUDzl-kEtl6HNGGrkYoK_z06ooRSeSMNEVFCKQwzparD3Eh6sc.If9ylttf3PVfFJiZTnPt6q8Xt_37KgrwaCse996TWJc
+      - 5wu8O4qT5Jh7VbfzYveHGOOZLBsgX9kdoQyco2J2pbFMxDP8t6RRbz28E-XRCu9zFuTJSKUvT1gElPP4cFmwHjMmLi_hQq880LN8b59bTGyLSkyRAyVA2Un2hqBjyEM-GabZCsQCRejh4umPwfkYuNclBQSJAh4suHgygsPnDmU.CFN2cjjXBmwO5o26oQsmF409Tw4WWH0yrR15GneYErs
       pragma:
       - no-cache
       request-id:
-      - efed3a78-25bf-466b-9b23-bd099db48f95
+      - b9455d70-0477-4890-a0be-64e09ef2a94f
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2019,19 +2031,19 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"64c73637-ae71-44f6-9170-da2c257cbbe6","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"32a71f9a-621a-424b-841c-6637352eee4a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","a929150b-3dde-4fd6-a64c-f9cf898c4150"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
+        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","5b91ffae-ddfc-4f85-94e2-78cbb12c92f2"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -2044,19 +2056,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:11 GMT
+      - Tue, 23 Feb 2021 08:45:33 GMT
       duration:
-      - '2259311'
+      - '2405654'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - ebU53QxJfpCdJXPiVbGF1wEyIq0LiZq4xFmMAgxOTy8=
+      - +tQU6bkptA6UkxTQOtXdS6NvW1vsWTKwyBitItXzfmI=
       ocp-aad-session-key:
-      - n5nhnquH6pjpyj-JyL2jCTsyZcA2-M31xTI8Uq5G3EnG5QNYpESefUKxNUz2tICn4Fm4FiTMjqhnONPfrkB6qKQ9eQHFXaBObFGvtkaddTI4v0b8owSJ4zYb5CW2C906-fO8uAtiiurMVov4h4WP9rmo3RzgK2kWt34DSZaENFI.EfQwgV9pmQP3cs4eOG1AuyZ_IWwa0l2TVGxU0AeJIC4
+      - bDbM68dwlPV-7FWxj9FgwmM7ITKTf8w_QMKRJbNztNahVB6y8uLs_yf8T-c8sYg6ZmKyMkHOeWqUCDmC9LTUkWruV1KfKo6KJq8OVzyTzOpJiME4NcOI_fQ7kvSKjdA_1fuAB07l2CMOlo2eKTZ02bcsbfH_N5DMp4dq8YsZxE0.MVoTzZvB6S2wkxmPIleRLdw6Wd0seWS8zy8jk0iJDFw
       pragma:
       - no-cache
       request-id:
-      - e37c73a1-e4ae-4eed-a4e1-9f29828ef17a
+      - f02356f9-31a9-42d6-8d5f-d385b206f4b0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2084,8 +2096,8 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
@@ -2094,70 +2106,49 @@ interactions:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"fba255ef-08f7-4f9b-b673-318fcb87f042","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"Windows
         Azure Active Directory","appId":"00000002-0000-0000-c000-000000000000","applicationTemplateId":null,"appOwnerTenantId":"f8cdef31-a31e-4b4a-93e4-5f571e91255a","appRoleAssignmentRequired":false,"appRoles":[{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read all your organization''s policies without a signed-in user.
-        ","displayName":"Read your organization''s policies","id":"6c2d1b1d-a490-4178-ba6b-7efceda9129b","isEnabled":true,"value":"Policy.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read data in your company or school directory, such as users, groups,
-        and apps.","displayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"value":"Directory.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write all domain properties without a signed in user.  Also
-        allows the app to add,  verify and remove domains.","displayName":"Read and
-        write domains","id":"abefe9df-d5a9-41c6-a60b-27b38eac3efb","isEnabled":true,"value":"Domain.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write data in your company or school directory, such as
-        users, and groups.  Does not allow user or group deletion.","displayName":"Read
-        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"value":"Directory.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read and write all device properties without a signed in user.  Does
-        not allow device creation, device deletion or update of device alternative
-        security identifiers.","displayName":"Read and write devices","id":"1138cb37-bd11-4084-a2b7-9f71582aeddb","isEnabled":true,"value":"Device.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to read the memberships of hidden groups and administrative units
-        without a signed-in user.","displayName":"Read all hidden memberships","id":"9728c0c4-a06b-4e0e-8d1b-3d694e8ec207","isEnabled":true,"value":"Member.Read.Hidden"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read applications and service principals without a signed-in user","displayName":"Read
+        all applications","id":"3afa6a7d-9b1a-42eb-948e-1650a849e176","isEnabled":true,"value":"Application.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to create, read, update and delete applications and service principals
+        without a signed-in user.  Does not allow management of consent grants.","displayName":"Read
+        and write all applications","id":"1cda74f2-2616-4834-b122-5cb1b07f8a59","isEnabled":true,"value":"Application.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to create other applications, and fully manage those applications
         (read, update, update application secrets and delete), without a signed-in
         user.  It cannot update any apps that it is not an owner of.","displayName":"Manage
         apps that this app creates or owns","id":"824c81eb-e3f8-4ee6-8f6d-de7f50d565b7","isEnabled":true,"value":"Application.ReadWrite.OwnedBy"},{"allowedMemberTypes":["Application"],"description":"Allows
-        the app to create, read, update and delete applications and service principals
-        without a signed-in user.  Does not allow management of consent grants.","displayName":"Read
-        and write all applications","id":"1cda74f2-2616-4834-b122-5cb1b07f8a59","isEnabled":true,"value":"Application.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read the memberships of hidden groups and administrative units
+        without a signed-in user.","displayName":"Read all hidden memberships","id":"9728c0c4-a06b-4e0e-8d1b-3d694e8ec207","isEnabled":true,"value":"Member.Read.Hidden"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read and write all device properties without a signed in user.  Does
+        not allow device creation, device deletion or update of device alternative
+        security identifiers.","displayName":"Read and write devices","id":"1138cb37-bd11-4084-a2b7-9f71582aeddb","isEnabled":true,"value":"Device.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read and write data in your company or school directory, such as
+        users, and groups.  Does not allow user or group deletion.","displayName":"Read
+        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"value":"Directory.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to read and write all domain properties without a signed in user.  Also
         allows the app to add,  verify and remove domains.","displayName":"Read and
-        write domains","id":"aaff0dfd-0295-48b6-a5cc-9f465bc87928","isEnabled":true,"value":"Domain.ReadWrite.All"}],"displayName":"Windows
-        Azure Active Directory","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allows
-        the app to read your organization''s policies on behalf of the signed-in user.","adminConsentDisplayName":"Read
-        your organization''s policies","id":"80e5b1bf-3ad0-4365-943a-0ec983009b67","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read your organization''s policies on your behalf.","userConsentDisplayName":"Read
-        your organization''s policies","value":"Policy.Read.All"},{"adminConsentDescription":"Allows
-        the app to have the same access to information in the directory as the signed-in
-        user.","adminConsentDisplayName":"Access the directory as the signed-in user","id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","isEnabled":true,"type":"User","userConsentDescription":"Allows
-        the app to have the same access to information in your work or school directory
-        as you do.","userConsentDisplayName":"Access the directory as you","value":"Directory.AccessAsUser.All"},{"adminConsentDescription":"Allows
+        write domains","id":"abefe9df-d5a9-41c6-a60b-27b38eac3efb","isEnabled":true,"value":"Domain.ReadWrite.All"},{"allowedMemberTypes":["Application"],"description":"Allows
         the app to read data in your company or school directory, such as users, groups,
-        and apps.","adminConsentDisplayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read data in your company or school directory, such as other users,
-        groups and apps.","userConsentDisplayName":"Read directory data","value":"Directory.Read.All"},{"adminConsentDescription":"Allows
-        the app to read and write data in your company or school directory, such as
-        users, and groups.  Does not allow user or group deletion.","adminConsentDisplayName":"Read
-        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read and write data in your company or school directory, such as
-        other users, groups.  Does not allow user or group deletion on your behalf.","userConsentDisplayName":"Read
-        and write directory data","value":"Directory.ReadWrite.All"},{"adminConsentDescription":"Allows
-        the app to create groups on behalf of the signed-in user and read all group
-        properties and memberships. Additionally, this allows the app to update group
-        properties and memberships for the groups the signed-in user owns.","adminConsentDisplayName":"Read
-        and write all groups","id":"970d6fa6-214a-4a9b-8513-08fad511e2fd","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to create groups on your behalf and read all group properties and
-        memberships. Additionally, this allows the app to update group properties
-        and memberships for groups you own.","userConsentDisplayName":"Read and write
-        all groups","value":"Group.ReadWrite.All"},{"adminConsentDescription":"Allows
-        the app to read basic group properties and memberships on behalf of the signed-in
-        user.","adminConsentDisplayName":"Read all groups","id":"6234d376-f627-4f0f-90e0-dff25c5211a3","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read all group properties and memberships on your behalf.","userConsentDisplayName":"Read
-        all groups","value":"Group.Read.All"},{"adminConsentDescription":"Allows the
-        app to read the full set of profile properties of all users in your company
-        or school, on behalf of the signed-in user. Additionally, this allows the
-        app to read the profiles of the signed-in user''s reports and manager.","adminConsentDisplayName":"Read
-        all users'' full profiles","id":"c582532d-9d9e-43bd-a97c-2667a28ce295","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read the full set of profile properties of all users in your company
-        or school, on your behalf.  Additionally, this allows the app to read the
-        profiles of your reports and manager.","userConsentDisplayName":"Read all
-        user''s full profiles","value":"User.Read.All"},{"adminConsentDescription":"Allows
+        and apps.","displayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"value":"Directory.Read.All"},{"allowedMemberTypes":["Application"],"description":"Allows
+        the app to read all your organization''s policies without a signed-in user.
+        ","displayName":"Read your organization''s policies","id":"6c2d1b1d-a490-4178-ba6b-7efceda9129b","isEnabled":true,"value":"Policy.Read.All"},{"allowedMemberTypes":["Application"],"description":"(Deprecated)
+        Allows the app to read and write all domain properties, without a signed-in
+        user. Also allows the app to add, verify, and remove domains. This permission
+        will be disabled in the future. Developers should request the Domain.ReadWrite.All
+        permission with id abefe9df-d5a9-41c6-a60b-27b38eac3efb instead.","displayName":"Read
+        and write domains (deprecated)","id":"aaff0dfd-0295-48b6-a5cc-9f465bc87928","isEnabled":true,"value":"Domain.ReadWrite.All"}],"displayName":"Windows
+        Azure Active Directory","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allows
+        the app to read the memberships of hidden groups and administrative units
+        on behalf of the signed-in user, for those hidden groups and administrative
+        units that the signed-in user has access to.","adminConsentDisplayName":"Read
+        hidden memberships","id":"2d05a661-f651-4d57-a595-489c91eda336","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read the memberships of hidden groups or administrative units on
+        your behalf, for those hidden groups or administrative units that you have
+        access to.","userConsentDisplayName":"Read your hidden memberships","value":"Member.Read.Hidden"},{"adminConsentDescription":"Allows
+        users to sign in to the app, and allows the app to read the profile of signed-in
+        users. It also allow the app to read basic company information of signed-in
+        users.","adminConsentDisplayName":"Sign in and read user profile","id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","isEnabled":true,"type":"User","userConsentDescription":"Allows
+        you to sign in to the app with your work account and let the app read your
+        profile. It also allows the app to read basic company information.","userConsentDisplayName":"Sign
+        you in and read your profile","value":"User.Read"},{"adminConsentDescription":"Allows
         the app to read a basic set of profile properties of all users in your company
         or school on behalf of the signed-in user. Includes display name, first and
         last name, photo, and email address. Additionally, this allows the app to
@@ -2168,44 +2159,69 @@ interactions:
         and email address. Additionally, this allows the app to read basic info about
         your reports and manager.","userConsentDisplayName":"Read all user''s basic
         profiles","value":"User.ReadBasic.All"},{"adminConsentDescription":"Allows
-        users to sign in to the app, and allows the app to read the profile of signed-in
-        users. It also allow the app to read basic company information of signed-in
-        users.","adminConsentDisplayName":"Sign in and read user profile","id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","isEnabled":true,"type":"User","userConsentDescription":"Allows
-        you to sign in to the app with your work account and let the app read your
-        profile. It also allows the app to read basic company information.","userConsentDisplayName":"Sign
-        you in and read your profile","value":"User.Read"},{"adminConsentDescription":"Allows
-        the app to read the memberships of hidden groups and administrative units
-        on behalf of the signed-in user, for those hidden groups and administrative
-        units that the signed-in user has access to.","adminConsentDisplayName":"Read
-        hidden memberships","id":"2d05a661-f651-4d57-a595-489c91eda336","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
-        the app to read the memberships of hidden groups or administrative units on
-        your behalf, for those hidden groups or administrative units that you have
-        access to.","userConsentDisplayName":"Read your hidden memberships","value":"Member.Read.Hidden"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["00000002-0000-0000-c000-000000000000/graph.microsoftazure.us","https://graph.microsoftazure.us","Microsoft.Azure.ActiveDirectory","00000002-0000-0000-c000-000000000000","00000002-0000-0000-c000-000000000000/directory.windows.net","00000002-0000-0000-c000-000000000000/graph.windows.net","https://graph.windows.net","https://graph.windows.net/"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
+        the app to read the full set of profile properties of all users in your company
+        or school, on behalf of the signed-in user. Additionally, this allows the
+        app to read the profiles of the signed-in user''s reports and manager.","adminConsentDisplayName":"Read
+        all users'' full profiles","id":"c582532d-9d9e-43bd-a97c-2667a28ce295","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read the full set of profile properties of all users in your company
+        or school, on your behalf.  Additionally, this allows the app to read the
+        profiles of your reports and manager.","userConsentDisplayName":"Read all
+        user''s full profiles","value":"User.Read.All"},{"adminConsentDescription":"Allows
+        the app to read basic group properties and memberships on behalf of the signed-in
+        user.","adminConsentDisplayName":"Read all groups","id":"6234d376-f627-4f0f-90e0-dff25c5211a3","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read all group properties and memberships on your behalf.","userConsentDisplayName":"Read
+        all groups","value":"Group.Read.All"},{"adminConsentDescription":"Allows the
+        app to create groups on behalf of the signed-in user and read all group properties
+        and memberships. Additionally, this allows the app to update group properties
+        and memberships for the groups the signed-in user owns.","adminConsentDisplayName":"Read
+        and write all groups","id":"970d6fa6-214a-4a9b-8513-08fad511e2fd","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to create groups on your behalf and read all group properties and
+        memberships. Additionally, this allows the app to update group properties
+        and memberships for groups you own.","userConsentDisplayName":"Read and write
+        all groups","value":"Group.ReadWrite.All"},{"adminConsentDescription":"Allows
+        the app to read and write data in your company or school directory, such as
+        users, and groups.  Does not allow user or group deletion.","adminConsentDisplayName":"Read
+        and write directory data","id":"78c8a3c8-a07e-4b9e-af1b-b5ccab50a175","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read and write data in your company or school directory, such as
+        other users, groups.  Does not allow user or group deletion on your behalf.","userConsentDisplayName":"Read
+        and write directory data","value":"Directory.ReadWrite.All"},{"adminConsentDescription":"Allows
+        the app to read data in your company or school directory, such as users, groups,
+        and apps.","adminConsentDisplayName":"Read directory data","id":"5778995a-e1bf-45b8-affa-663a9f3f4d04","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read data in your company or school directory, such as other users,
+        groups and apps.","userConsentDisplayName":"Read directory data","value":"Directory.Read.All"},{"adminConsentDescription":"Allows
+        the app to have the same access to information in the directory as the signed-in
+        user.","adminConsentDisplayName":"Access the directory as the signed-in user","id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","isEnabled":true,"type":"User","userConsentDescription":"Allows
+        the app to have the same access to information in your work or school directory
+        as you do.","userConsentDisplayName":"Access the directory as you","value":"Directory.AccessAsUser.All"},{"adminConsentDescription":"Allows
+        the app to read your organization''s policies on behalf of the signed-in user.","adminConsentDisplayName":"Read
+        your organization''s policies","id":"80e5b1bf-3ad0-4365-943a-0ec983009b67","isEnabled":true,"type":"Admin","userConsentDescription":"Allows
+        the app to read your organization''s policies on your behalf.","userConsentDisplayName":"Read
+        your organization''s policies","value":"Policy.Read.All"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":null,"replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["https://graph.windows.net/","https://graph.windows.net","00000002-0000-0000-c000-000000000000/graph.windows.net","00000002-0000-0000-c000-000000000000/directory.windows.net","00000002-0000-0000-c000-000000000000","Microsoft.Azure.ActiveDirectory","https://graph.microsoftazure.us","00000002-0000-0000-c000-000000000000/graph.microsoftazure.us"],"servicePrincipalType":"Application","signInAudience":"AzureADMultipleOrgs","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '10401'
+      - '10860'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:12 GMT
+      - Tue, 23 Feb 2021 08:45:35 GMT
       duration:
-      - '2296575'
+      - '2349606'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - r4tEev3be7u87PpO7+VPxPcExk2Mrz1MtcoSUZnMit4=
+      - p01X/F7l60M7JMeTd4lTtRWsh5t5VsJ4VJF4DT8uGA4=
       ocp-aad-session-key:
-      - 2KB5-6tna2odVBnyqOXj_1vVNX8f9dJy7jBpcJOlxRhLZtL2sSlQ_oC6hvxT92McW2EjK6kRwhVIbJmOJ6ub_41WQVM--KMTaSB4eNDbkkT7XNmRfsYGTCkBWr7C0A5dv_TLO5nSRrokVA62cF4I0NTaKiP5I5fexLor2KDvUAQ.AOI4hSljLqutlFRdlJ3ZHyYZm9pxEfmkL82TPQyUMM8
+      - ZQIhdC6R6xR6-ux_b6siVNBfmgpP5If8LeX8FmyriLcsXgck6ZDDVlTIjstqy5b6YuSb6JRSuS-C_6kGDbnu6SaQACGV2fkP4Z3I67VKLk9agZejlRnpjkDI5kDemVQB-hXnEF7-VJLbgjmJYwXTSjZPwb6FgvmFTioI4Y9LYAo.A3jWYifonH2aOAuZePugN--UsXXvkH60cW9xiwVntYM
       pragma:
       - no-cache
       request-id:
-      - 2d703f2c-d9fb-478d-9c6c-8dc372f2496b
+      - f68d84e2-ac19-4112-88b1-d3a1d92cd78c
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2233,15 +2249,15 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?$filter=clientId%20eq%20%2764c73637-ae71-44f6-9170-da2c257cbbe6%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?$filter=clientId%20eq%20%2732a71f9a-621a-424b-841c-6637352eee4a%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants","value":[{"clientId":"64c73637-ae71-44f6-9170-da2c257cbbe6","consentType":"AllPrincipals","expiryTime":"2021-08-21T06:28:02.837234","objectId":"NzbHZHGu9kSRcNosJXy75u9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2020-08-21T06:28:02.837234"}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants","value":[{"clientId":"32a71f9a-621a-424b-841c-6637352eee4a","consentType":"AllPrincipals","expiryTime":"2022-02-23T08:45:25.417176","objectId":"mh-nMhpiS0KEHGY3NS7uSu9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2021-02-23T08:45:25.417176"}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -2254,19 +2270,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:12 GMT
+      - Tue, 23 Feb 2021 08:45:35 GMT
       duration:
-      - '2478410'
+      - '2162697'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - N74c8ldu8hl9jU3L0P00lqK53hRnYh0rKSMTbFc2+Rs=
+      - Nqd4Y2Pq670VlrWCiZX67ZiUXeCoWESG+RzWrtNK5fo=
       ocp-aad-session-key:
-      - W6wylkuwmfypG1_0s0R_8N0SUW7bf4ygbPZ9mVRQ_4NG5svbDZXXCI1Wp-wvkgyFcPAnnyZx-GPnaVq48pi9-B7sbSVNx3FjS8eYMxZ9CS5KMqX85aaHNV2Uv66JxJSrDCX66bo5W1DBdA3x0x638JJhxlXdyKtez05na3EAPBI.zQdFFH9GyDnV2RgOMX7ONDqAt4bRXVkTHC7qGi2KcXk
+      - VNkvWNxlughzk29p9RoBPB4FHvrYERslx4DeB-3h9cdTxU6IdIhgNkBB7S5UlYPmbnwRGGIsh8UdtGjqo37Cegp2MPwyONP7eA9L3a8_dKfFeSxN0iIqyGjUgCi5qSpELNH6N20sFAiuNmE1-LO3p4jSxzUdx5jV4JssoDxqJSk.C4SK88epjdCg2Uz-v8qu4zXwLBxec_2QofitbGGhQbg
       pragma:
       - no-cache
       request-id:
-      - 0e100b3f-ed7c-4ec7-84b0-7ff2b4878b5d
+      - c3ff4596-406d-4c8a-9e27-e898279003c9
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2296,12 +2312,12 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants/NzbHZHGu9kSRcNosJXy75u9Vovv3CJtPtnMxj8uH8EI?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants/mh-nMhpiS0KEHGY3NS7uSu9Vovv3CJtPtnMxj8uH8EI?api-version=1.6
   response:
     body:
       string: ''
@@ -2311,19 +2327,19 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Fri, 21 Aug 2020 06:28:13 GMT
+      - Tue, 23 Feb 2021 08:45:36 GMT
       duration:
-      - '3097304'
+      - '3601524'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - UCqg51CRwbFSVSpQdd+0eu2pZyuBt7dvQmjs73sOGao=
+      - p01X/F7l60M7JMeTd4lTtRWsh5t5VsJ4VJF4DT8uGA4=
       ocp-aad-session-key:
-      - U6HoLwxInTVWbZuc-tS9hoUt4dPxnKMj3MAV_CB7GehLf05I8O5h4zbkf4nbVgxXdWQ-hQZ7_3H_Bm180XpIs2TmwsCHwn6EjeiPt5Qi2WKE40R2SuKNgrvW-FFxwiZb2DmSKzBTzs0_Iv0SK5TLw8xt42d9bSNAIg50bYFqYAc.DBzWQkA6HdeVmY9C8PEZhsZ5_QPIy5beDO3FzUMjx68
+      - gLSCib4zm2wkQFWmp_I0noIO9ymeU_W3UrI4Di7ckflyO6CbAMfsygS14ke80snOSzLUjTMIn8YhFut6tgugCPzRNfH02PTD5alWG_BUcrJ-ggEUnaTG0b7uXn2qHOtg-TA92YUyAR6ECnJQ-tAIgA_IxsfqlaJkM78tYLwC37g.0VteT_wqkfuc5OzQ01aZGcGOgORAXpi_ELi5Cbyoh4E
       pragma:
       - no-cache
       request-id:
-      - b5d46aa5-8921-4220-8bb6-ecaca19157e1
+      - 08c6b275-0e54-4d75-a363-64769de15bcc
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2339,9 +2355,9 @@ interactions:
       message: No Content
 - request:
     body: '{"odata.type": "Microsoft.DirectoryServices.OAuth2PermissionGrant", "clientId":
-      "64c73637-ae71-44f6-9170-da2c257cbbe6", "consentType": "AllPrincipals", "resourceId":
+      "32a71f9a-621a-424b-841c-6637352eee4a", "consentType": "AllPrincipals", "resourceId":
       "fba255ef-08f7-4f9b-b673-318fcb87f042", "scope": "user_impersonation", "startTime":
-      "2020-08-21T06:28:13.670468", "expiryTime": "2021-08-21T06:28:13.670468"}'
+      "2021-02-23T08:45:36.619316", "expiryTime": "2022-02-23T08:45:36.619316"}'
     headers:
       Accept:
       - application/json
@@ -2358,15 +2374,15 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants/@Element","clientId":"64c73637-ae71-44f6-9170-da2c257cbbe6","consentType":"AllPrincipals","expiryTime":"2021-08-21T06:28:13.670468","objectId":"NzbHZHGu9kSRcNosJXy75u9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2020-08-21T06:28:13.670468"}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants/@Element","clientId":"32a71f9a-621a-424b-841c-6637352eee4a","consentType":"AllPrincipals","expiryTime":"2022-02-23T08:45:36.619316","objectId":"mh-nMhpiS0KEHGY3NS7uSu9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2021-02-23T08:45:36.619316"}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -2379,21 +2395,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:13 GMT
+      - Tue, 23 Feb 2021 08:45:36 GMT
       duration:
-      - '2993047'
+      - '3406165'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants/NzbHZHGu9kSRcNosJXy75u9Vovv3CJtPtnMxj8uH8EI
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants/mh-nMhpiS0KEHGY3NS7uSu9Vovv3CJtPtnMxj8uH8EI
       ocp-aad-diagnostics-server-name:
-      - fVk//gv0KFVnwkHJSpUdlarxtRvDXmerXdKmXx+vA/U=
+      - Di/JcYzC6RA0nEYUk94b7MkejxeEu1vMBxkIifstNlg=
       ocp-aad-session-key:
-      - PszX1gfg8p2rFdyfdI2_YY3hdDoCxMkcmPN_yE9Bsg5f1uyO7ha2gFkQ92AogTexwwLDeywo6VXViH6wapTRc2MrzhB9MNYa37qJ7jcpF3twjAf6ana5CY2DHhEz3PmD6bexsK1M4VENnlYy4P0iU-cG8c1gNCkWQ1R8IEmb_dw.o8keqqKigu1LQ2Cwf-nI4n_zf0IBIfjB3Pwy9yq5B0Q
+      - yVdJgoeo0_ExAge5W8ZpF1Wz2TJKnYVfN5encpZ_RCbg7sy77UyJ1VbSye8JZS4SHubPzEwSiHzJNFUpSHldCKVrW5g0r4SxNBEIGHROSdq_Flt0K8-fB3HgMRkW_0aKoBnzNgpSPQhxTlqJ3eGWarWzRTzsOJrOfDEtcq4_D2U.G9Yyhcs9ICxEmFqq2Eo8NKg7NsJDN97RhsNhSPliF_c
       pragma:
       - no-cache
       request-id:
-      - 03a5dc05-d31d-4cb7-8707-f0a056eb8911
+      - 16e46300-63f3-4099-96ae-23c3f258c234
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2421,12 +2437,12 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -2442,19 +2458,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:14 GMT
+      - Tue, 23 Feb 2021 08:45:36 GMT
       duration:
-      - '2124042'
+      - '2201607'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - fP4NK2gNaIdDNhBv8pKeGATgIpn16XzVoGGpzH0I8Co=
+      - PMyx6F55oKWgcz75MZ4aKcuCZ0zt3e2UaPG0R2xXNVI=
       ocp-aad-session-key:
-      - L7TX7-yImCV-V2Uhv4w22TD5fL-if6CCpmPPNX6BleSb6-cQQFD0n6hd1H_gqUKR3mEAlOFhbh-U-z1vt7a-HXUbjc3OHyYYyZUKHAQkak7Q6Lh1CCeWFlUXkedOAkIcoyaRCYSbpSvYj-IiEKNSH09Idoqlsj6O_2rqZr83HCI.Tv7wBefQRid59po3rIjLO25SOdstLZsxp6EANYo1ocM
+      - AVxQgFG9q85T10vJmMZ4N1rz5DkeABLAjLWgYxrOtiCU1ZPdcGOwMS_6CG8zXNXUdQdTWIXnNRLMIRKeKSRsI01p-mBpGYISbiciI9BI-GKbtGp9-IGqBI9NPGROjkZs_B88J6jT9xae8HwTzn5BweVmzpacTTc5QZx1azp1yAQ.JCU70KWvFHyoWx2FkV-MZVEjOBlUcP1Y_8fOeA7jEdI
       pragma:
       - no-cache
       request-id:
-      - 872eaaec-d342-4062-8422-3e46df9a7b5a
+      - a98abef7-051a-4b04-895e-41cce4ab1d77
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2482,44 +2498,44 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a30a4689-338b-4f07-9b4f-d7af2ded5a12","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"b5e22543-b770-45de-bffb-9246b51b25fe","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2021-08-21T06:27:56.96504Z","keyId":"2197cada-aa78-47b4-a229-20f138077dcc","startDate":"2020-08-21T06:27:56.96504Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"},{"id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2022-02-23T08:45:19.356502Z","keyId":"51069578-2878-4b11-8c54-efd3bc482403","startDate":"2021-02-23T08:45:19.356502Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"},{"id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2394'
+      - '2396'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:14 GMT
+      - Tue, 23 Feb 2021 08:45:37 GMT
       duration:
-      - '2269166'
+      - '2361705'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - iBLPAV+mEu1yabKxR7hiHLRXeq9pAO/IjS9ArC3QLLk=
+      - NNF6SU7oblm2gmtiFVxJ4lF5Yr+vPdeEUYWyFEInbKo=
       ocp-aad-session-key:
-      - 945qMeuqWdfmD1ySVedvIyQ1iX_7FYhqHHaAp9uZvwu3_NHX-gZNmFkklAF3cCWNU6q8BW39gTWU-QL_LP3YAD7dlZvCsYjRR8QOFd7fhAAcqIqv7RH20BV9-4bqzgZqc_NF8ge_im-eFdxMZ9q9PapTqIOtLJPD5CpXqEAxgz8.CH0GLYiIwMGsDXg9HNMXbVVYkQWF_0TB0NxfQIKhlKc
+      - zW2hdLsve_t9C_rbWJJSCROMU5A170xkb9BzcaWqcNaOyIsXOoYCnWCnRJhBEfRaFui6QNsMsJpwtCcJQsAFhj7iDwoZ5eONCNoJlN9QU-5xBRj5vbsP62anQn0SyMsnX4dA3Ey8_nhk_RxtSotQCpBqQ2Yp6ax2GpaBhA0mDEs.WVn75EWfEsNfdfO_3hDyboSAsH7spgAkA3_MJhmn7hA
       pragma:
       - no-cache
       request-id:
-      - 6b27a312-65ee-4b14-ae25-041f0835d259
+      - 98bcabcb-9ce3-4123-b268-1c23b78cb21f
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2547,44 +2563,44 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/a30a4689-338b-4f07-9b4f-d7af2ded5a12?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/b5e22543-b770-45de-bffb-9246b51b25fe?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a30a4689-338b-4f07-9b4f-d7af2ded5a12","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"b5e22543-b770-45de-bffb-9246b51b25fe","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2021-08-21T06:27:56.96504Z","keyId":"2197cada-aa78-47b4-a229-20f138077dcc","startDate":"2020-08-21T06:27:56.96504Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"},{"id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2022-02-23T08:45:19.356502Z","keyId":"51069578-2878-4b11-8c54-efd3bc482403","startDate":"2021-02-23T08:45:19.356502Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[{"resourceAppId":"00000002-0000-0000-c000-000000000000","resourceAccess":[{"id":"a42657d6-7f20-40e3-b6f0-cee03008a62a","type":"Scope"},{"id":"311a71cc-e848-46a1-bdf8-97ff7156d8e6","type":"Scope"}]}],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2391'
+      - '2393'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:15 GMT
+      - Tue, 23 Feb 2021 08:45:37 GMT
       duration:
-      - '2224525'
+      - '2380492'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - uw2DI55YPxO27iCQ9gmp7jkFjvTBnlg/TMjn48ai3jY=
+      - TCjJ0/W0yFtK2qY/SYMmX8RfXQpUtjzYIdBQwB6JrRg=
       ocp-aad-session-key:
-      - IOHTDDYYuvl4B7aHFDBrv5_tA5N9o16-ze6AddjdgufSVvnSBZzkFggIwMnS19KvnMOpBrwPsvCbzHbLBEKdgDbCuTRoFGyvKiqNxjPV_o4LyZ5ywkk79wmIiXp-nLn_K7xEYpZKysfQHtXtfMLNr_QrIv23ZtVK2fTWlkVgpsA.g8JtxX-35IDrbQa6W5ZlM1Kor_dzuQA2P_miZgfjRNI
+      - JsOPEvhTBx74N0X92XdPivCYIwp8m8nYmrlcj8gAkqGMbLLW1Uu3NjZ84p60kwdZDnRle7Mqr0NPWgl4QnD87ked-UrmCxHP-4V0-dp1P_RvJhEegn9JDe2Er-JC6288T7oTI7MVeDVPTlI_dCK-XLeJkeG4ki4-Xl7iI-zmhyw.Jid6XRrTYIpuRQVc-6fVOvSs7GmvHvC6i75daSXvslI
       pragma:
       - no-cache
       request-id:
-      - 3cd6a5c8-f02e-4de7-bed0-ddd3b0c6502d
+      - 3b6062d7-bb22-43fc-8267-e2adb1fdd389
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2616,12 +2632,12 @@ interactions:
       ParameterSetName:
       - --id --api
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: PATCH
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/a30a4689-338b-4f07-9b4f-d7af2ded5a12?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/b5e22543-b770-45de-bffb-9246b51b25fe?api-version=1.6
   response:
     body:
       string: ''
@@ -2631,19 +2647,19 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Fri, 21 Aug 2020 06:28:16 GMT
+      - Tue, 23 Feb 2021 08:45:39 GMT
       duration:
-      - '3814877'
+      - '4984349'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - ltdErb/EUtDqqofgNqOFJZSK42vqehyhW+MdcYj4hS4=
+      - Hdntwjzps/WyG2RJNaiHocFk5JY1BOzRhjElKs8ZEEE=
       ocp-aad-session-key:
-      - NVN7plrpRjYMdhzCqymfHLCbidnwP6c7n8qAfsmUBQF1ROHQGf2n6UPgB5XURGu1GCBswrziNGjzC2ruMf1OssZBqLYz-8LMaKVVGxurzINttZyKhEOvMi5jVsnJUtdXN18pd3a8fNgEm6hltA-fKS2IiANHU36TRjOH1lSfyR0.LTUlnIPq9eVLWFgghB6T9YwnvC1tnzogUC7lhXqa6g0
+      - BvfZWWKFzmbuYr3z-1vU_2e_TOb_zY-4Vw2mEWOpJrvDBc1YIyeSBiNjEFM0OHEbSlZThyCtx6UyKP3V2kjGVgXv3MH67syAPDj3Gk6huAPnO9RLTCyxfgBQcVJBERKIYVP6UY6gi18Hpm1TTGhK70AFaD_u80F3CigJ0a6XGg8.NDgN2qXPIkKlK9grjGpmte0ZnQt5qdy8yiC3sHvCCZo
       pragma:
       - no-cache
       request-id:
-      - 504b626b-4c06-4f49-93cf-6497f7e87ccb
+      - 52b16522-1e54-48b8-af15-0541fdf8c5fc
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2671,19 +2687,19 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"64c73637-ae71-44f6-9170-da2c257cbbe6","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"32a71f9a-621a-424b-841c-6637352eee4a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"cli-app-000001","appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"cli-app-000001","errorUrl":null,"homepage":"https://cli-app-000001","informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","a929150b-3dde-4fd6-a64c-f9cf898c4150"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
+        cli-app-000001","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["http://cli-app-000001","5b91ffae-ddfc-4f85-94e2-78cbb12c92f2"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -2696,19 +2712,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:16 GMT
+      - Tue, 23 Feb 2021 08:45:39 GMT
       duration:
-      - '2385556'
+      - '2324829'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - h41duery3CPm5kxowuKN7pvEekwLyNG/wkcjkTUIbY0=
+      - +tQU6bkptA6UkxTQOtXdS6NvW1vsWTKwyBitItXzfmI=
       ocp-aad-session-key:
-      - hjWsV8xvZ2PppciFIh-1C5qQYsRY7dvn1DAx6DtwvqGNOvijtnSQACpgNuZMoz6W-LwPmBUvCvhWd8drN7HcCVd3Je0RyJ5V__8M0SZb_Qlo4UFBL1mAT4azgki08FwHjg4wb_Sq3vxAKr9lGM2RN2fUWf52aF-UplP1VPoz83g.xnPILrILmm-HVrPKZX317OnWmMLIDOunDQHrGF9DeZc
+      - XTUuXdMRniD6UVk-obcbRC7x4DakImEzIew6uO94M1haLiReBr9HaGxCrRXPh_yfMMzDVNzfGlVau431xDiraXHln8oCouXbj8aH_WshJlWIupeNKr_gWIriA_1XtTmsV57NIurJ-O5a1TP3-CaYFtoq3Qw2CRQRGYBTYOeMMEg.VcNO-kn9k_IMH3KTgLpnw89xcPNOcJE--9wK2dCnGQ4
       pragma:
       - no-cache
       request-id:
-      - 528d5935-ea52-40d3-a415-98541edb945a
+      - 8900c4e7-a910-4b19-94a5-c9245b65be5b
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2736,12 +2752,73 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27%29&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/oauth2PermissionGrants?$filter=clientId%20eq%20%2732a71f9a-621a-424b-841c-6637352eee4a%27&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#oauth2PermissionGrants","value":[{"clientId":"32a71f9a-621a-424b-841c-6637352eee4a","consentType":"AllPrincipals","expiryTime":"2022-02-23T08:45:36.619316","objectId":"mh-nMhpiS0KEHGY3NS7uSu9Vovv3CJtPtnMxj8uH8EI","principalId":null,"resourceId":"fba255ef-08f7-4f9b-b673-318fcb87f042","scope":"user_impersonation","startTime":"2021-02-23T08:45:36.619316"}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '448'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Tue, 23 Feb 2021 08:45:40 GMT
+      duration:
+      - '2237415'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - Reodj4ETwzAIEG9bAGgIKy/AA22XZQWRS32yerIvqDA=
+      ocp-aad-session-key:
+      - mAo42YaSpdxSFmFmmbDBTA9zqg_eaSmKqeW1DAE3V-nKeikutJ8NcXqwmk9VUyVBRmvyHMOOfNV0IY7dq0TUYMzGTFt-ZUnXAxmaBG3wKThm3HegxMz4pxT-JWKWZJM5rnw0XYOZ7E5nysOg-A6b6o-QI_rDUfMxsmSZ-CEJbxI.-nzzZlTsgpu-putFPR_Um-pXLFpxrqwiae4uevhOxgM
+      pragma:
+      - no-cache
+      request-id:
+      - 2bd5a7ae-59a1-4608-9651-0b74ed594a72
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-ms-resource-unit:
+      - '2'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app permission list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -2757,19 +2834,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:17 GMT
+      - Tue, 23 Feb 2021 08:45:40 GMT
       duration:
-      - '2125918'
+      - '2210516'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - dMQIMqTNmvClkFrJur55SvaXYOP0//qg9V+JHwyJ2DU=
+      - pYxAs6uRV9G7teIG+DAqKE78BW6nu84EW6uPau3nnR8=
       ocp-aad-session-key:
-      - F_AimgtkSw71oBuOscLhtIravv5UbN_DN2etCqeRaNktNsAombc5aBGETYEBYPSouzi-lwTWLKH3HK8HY9TrxxL3wy9OslktcDruBtGdBQA2vfU_BQAev3Yvu7mCPPiZI2rVmKvKpzcGGv4-4I0H96P9UiHhF21Ev2p5Zc0tTYM.tH6GlFtVFjjKstRAAk4KBnLNChGOeJaFSiZlhCFdUfI
+      - FR0DBgEGTzRfkWVG83Hrt7ihoZhnItHMpBRh-VDxxuo6hWaSu6pS6SbhO1d7eh0lNFicUbKPIb77DjPMSRdnyoT9dIGYYYLwR4gdbgXAjKUkNLxTKJPYdXLIs1dnkhZ9YhZO5q-6snXbPtJa3lGKmeNCNVJUlRhQoPKVVllpCzM.xbz85my5D6K4VT-Ls7Cldzq4R_5c82ePcjvzAnvBOpU
       pragma:
       - no-cache
       request-id:
-      - 14f35bd5-45c5-4812-82b2-36e2b4d7e2cd
+      - 855cd564-1d8d-482c-90d9-0b77d6540f01
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2797,44 +2874,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%27a929150b-3dde-4fd6-a64c-f9cf898c4150%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a30a4689-338b-4f07-9b4f-d7af2ded5a12","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"b5e22543-b770-45de-bffb-9246b51b25fe","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2021-08-21T06:27:56.96504Z","keyId":"2197cada-aa78-47b4-a229-20f138077dcc","startDate":"2020-08-21T06:27:56.96504Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2022-02-23T08:45:19.356502Z","keyId":"51069578-2878-4b11-8c54-efd3bc482403","startDate":"2021-02-23T08:45:19.356502Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2197'
+      - '2199'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:17 GMT
+      - Tue, 23 Feb 2021 08:45:41 GMT
       duration:
-      - '2656869'
+      - '3112523'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - wa7XLTE+/p7laYRXAZUltYgvhndklofPlRXpYDhC3dg=
+      - DnFI4n/Dvcsv832Sl4Vmf81GaSCzBuS87NsMMcTtNug=
       ocp-aad-session-key:
-      - Q0z-0X9DvmLBQmgllsSYJEhyRvK7W9GeEUZebDEf-e_ylc8swnupQakAkNm2a99YBWw2zi4TzDsO-0eYRTzdAK40IGAklwIhA3_PWOkaDLhdFZ52l-o1UW5fuh7MtgEjAY5HnKBmm0hILqrqAhsQg2kJNBk4cDvcPtD1KAG5wX8.xMP8_CiXNxeOwVV35vvkBXlylgRnEQGZrRfoHUA__vQ
+      - JatLxHBfmJ5AAmXmrKaDD1TaxcMvwyIoUWF_lOcKWVbw9gb-OCgEueLWF_njPcjqVrMLwe5UT44lQ-YS7porQkFxkJaU2tJFoywQEyldq_CfdnUDlhmxWcLsQngmGhQxT1x-sBC8eJ5k6D2qiWutIpn0J5IH6QjMODdFAkCl4Q8.zoUhEjQk1UY8R1grZY1jpde0TmUDbdEf7tgLGDMY5H8
       pragma:
       - no-cache
       request-id:
-      - 00b65988-9ea6-4d35-b108-88ad560b887a
+      - 1047c52f-80c9-4757-b2f6-18300f8f90bc
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2862,44 +2939,44 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.8.5 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
-        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.10.1
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/a30a4689-338b-4f07-9b4f-d7af2ded5a12?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/b5e22543-b770-45de-bffb-9246b51b25fe?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"a30a4689-338b-4f07-9b4f-d7af2ded5a12","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"a929150b-3dde-4fd6-a64c-f9cf898c4150","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/a30a4689-338b-4f07-9b4f-d7af2ded5a12/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"b5e22543-b770-45de-bffb-9246b51b25fe","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
         the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        cli-app-000001","id":"5a70fe9f-831e-488b-a70a-8615c45b78b2","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
         the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
-        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2021-08-21T06:27:56.96504Z","keyId":"2197cada-aa78-47b4-a229-20f138077dcc","startDate":"2020-08-21T06:27:56.96504Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
+        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2022-02-23T08:45:19.356502Z","keyId":"51069578-2878-4b11-8c54-efd3bc482403","startDate":"2021-02-23T08:45:19.356502Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
       cache-control:
       - no-cache
       content-length:
-      - '2194'
+      - '2196'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 21 Aug 2020 06:28:18 GMT
+      - Tue, 23 Feb 2021 08:45:41 GMT
       duration:
-      - '2344072'
+      - '2354619'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 7/al7S0Qh57bz+89nP+mnwDwdim1hKdV5Sukqtc2xmA=
+      - +tQU6bkptA6UkxTQOtXdS6NvW1vsWTKwyBitItXzfmI=
       ocp-aad-session-key:
-      - yROStmYG6MIpU0mut9xn-8zE4cTSxH_XKk_u00hlnq-UYA5NOiAY18Cv8OCdKb_QoGBg39ZX-txRnIYKSFtVy6dDVkCm99B0jbgBFlYhb26vtxwt47Lj8z9peAk-ew8PJpFowFKF6nV1Iqu1MW_2qBEktQ3XwOu0OdM2FCWMfY0.XC_Cvf8W4zY3oQK5ejj8_tt4WeWTx8WUcKJ3Z-D9370
+      - z8b5Q7G-3mwelCPwxqaIYukKT1V6Sqs6Ht2xOZkihkNejSH-CSDdyI0GaPQ9LGRUPPRuswf-iAw4W7yIZygoEhu3dsmQpTHzAtUfRGzwubIFaYfMAWRsyj1-U9x2u0xf3VxFDXChKg38mZPX3Z3uf1kMnCF407g9cGYp2txBP6Q.Y_5QvwhyUyRLXm5E_V_Vh5dchyYvrYZHlQX6873EsIo
       pragma:
       - no-cache
       request-id:
-      - 57ce124f-12ef-4b49-a859-6f6957251f80
+      - 12a68df1-6b7f-46ca-b9a6-6204f3b7e079
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -2913,4 +2990,187 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27%29&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '121'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Tue, 23 Feb 2021 08:45:41 GMT
+      duration:
+      - '2157333'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - 3bYdhj473qmlaqiTzBylRvE6xFmnQz8ro+SXkyNnc5Y=
+      ocp-aad-session-key:
+      - u8JWF2xAo2gQHyCMM2FpIXZ5PRggd6HT7nMbGsj0IAKP4Espb0_dTbwcB7NMfv9TR9oWQOqB4px10XuIetalSwDo1OUKwZ3wHjDYQHNZzbaupaYdMZDqHRytqM-8wAT9J-DSev8AO2oy5hv25U7WOnBBsSyBRbFrmq-cMv48miQ.oJTulZ8wJBqLDG_FJDoHHs30DVio7JyfXsGnEyyOyFg
+      pragma:
+      - no-cache
+      request-id:
+      - c94339d3-8957-4c9e-906b-0aa0dc522275
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-ms-resource-unit:
+      - '2'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=appId%20eq%20%275b91ffae-ddfc-4f85-94e2-78cbb12c92f2%27&api-version=1.6
+  response:
+    body:
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"b5e22543-b770-45de-bffb-9246b51b25fe","deletionTimestamp":null,"acceptMappedClaims":null,"addIns":[],"appId":"5b91ffae-ddfc-4f85-94e2-78cbb12c92f2","applicationTemplateId":null,"appRoles":[],"availableToOtherTenants":false,"displayName":"cli-app-000001","errorUrl":null,"groupMembershipClaims":null,"homepage":"https://cli-app-000001","identifierUris":["http://cli-app-000001"],"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"isDeviceOnlyAuthSupported":null,"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"logo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/logo","logoUrl":null,"mainLogo@odata.mediaEditLink":"directoryObjects/b5e22543-b770-45de-bffb-9246b51b25fe/Microsoft.DirectoryServices.Application/mainLogo","oauth2AllowIdTokenImplicitFlow":true,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access cli-app-000001 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        cli-app-000001","id":"61dde3fa-d94f-42c0-9230-7d297ce42185","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access cli-app-000001 on your behalf.","userConsentDisplayName":"Access
+        cli-app-000001","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"optionalClaims":null,"orgRestrictions":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[{"customKeyIdentifier":"//5yAGIAYQBjAA==","endDate":"2022-02-23T08:45:19.356502Z","keyId":"51069578-2878-4b11-8c54-efd3bc482403","startDate":"2021-02-23T08:45:19.356502Z","value":null}],"publicClient":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null,"signInAudience":"AzureADMyOrg","tokenEncryptionKeyId":null}]}'
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      content-length:
+      - '2199'
+      content-type:
+      - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
+      dataserviceversion:
+      - 3.0;
+      date:
+      - Tue, 23 Feb 2021 08:45:42 GMT
+      duration:
+      - '2270138'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - p01X/F7l60M7JMeTd4lTtRWsh5t5VsJ4VJF4DT8uGA4=
+      ocp-aad-session-key:
+      - H_Eh3jTQ3CLEJ-VQntAY-bw8B_GlJuoM7_g0SlXbHZRHmXaXNHKRqv5iljrzPsQ7MWKzh4PBKU-vEdBl7WPHcyPGzi7LWfXl67nYgRoITXc1oxqjy_uJcFKIhgxu99s5XXI1LBeq-rn33uYtFPyDG7gNO9j-a-Tu0b7P2C9UYmk.qvVy8ikJ3MJXPN232IDDFXn7eo_tlQ5FHVVbRLCne28
+      pragma:
+      - no-cache
+      request-id:
+      - a9a8f73d-dbdc-41bb-9143-73607742faab
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-ms-resource-unit:
+      - '2'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - ad app delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - python/3.8.7 (Windows-10-10.0.19041-SP0) msrest/0.6.18 msrest_azure/0.6.3
+        azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.19.1
+      accept-language:
+      - en-US
+    method: DELETE
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/b5e22543-b770-45de-bffb-9246b51b25fe?api-version=1.6
+  response:
+    body:
+      string: ''
+    headers:
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - no-cache
+      date:
+      - Tue, 23 Feb 2021 08:45:43 GMT
+      duration:
+      - '4594060'
+      expires:
+      - '-1'
+      ocp-aad-diagnostics-server-name:
+      - Gpeq5rc81qxTCgR76cfx2XrVQr18ZbLqfwuAnkxg0B4=
+      ocp-aad-session-key:
+      - PImTjTDllEIdLKPmXMk6XcVC6owA-W_1g0E1V9ov2zxuw250lqmqwHurDtsoseYT20cJ1PKnjMEH3OSyWQHGrt_wYbXsOSTiVZSONvnH26T9ziknfUl2XuXGHE388qjZnV8zS_ZOfEKQ-CiSUc2imgckAqS-rBVu9mRG5SKwcmc.6IM10IWyLELBgfb5_zcS09e70HxSanupzRmy1gFxohE
+      pragma:
+      - no-cache
+      request-id:
+      - 77f03b8a-98ad-417c-86e0-f9abb57c5204
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-aspnet-version:
+      - 4.0.30319
+      x-ms-dirapi-data-contract-version:
+      - '1.6'
+      x-ms-resource-unit:
+      - '1'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 204
+      message: No Content
 version: 1


### PR DESCRIPTION
**Description**<!--Mandatory-->

Close https://github.com/Azure/azure-cli/issues/16862: `az ad app permission grant` fails with ResourceNotFoundError

When calling `az ad app permission list/grant` on an App without associated Service Principal, CLI fails with with a raw error.

This PR refines the error message to **tell the user to create a Service Principal instead**.

**Testing Guide**
```powershell
$appId=$(az ad app create --display-name testapp0223 --query appId --output tsv)
az ad app permission add --id $appId --api 00000002-0000-0000-c000-000000000000 --api-permissions 311a71cc-e848-46a1-bdf8-97ff7156d8e6=Scope
az ad app permission grant --id $appId --api 00000002-0000-0000-c000-000000000000
```

Before:
```
Operation failed with status: 'Not Found'. Details: 404 Client Error: Not Found for url: 
https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/oauth2PermissionGrants?
$filter=clientId%20eq%20%273e192ff9-5cdc-45eb-9deb-d195cf7f5f2c%27&api-version=1.6
```

After:
```
Service principal with appId or objectId '3e192ff9-5cdc-45eb-9deb-d195cf7f5f2c' doesn't 
exist. If '3e192ff9-5cdc-45eb-9deb-d195cf7f5f2c' is an appId, make sure an associated 
service principal is created for the app. To create one, run `az ad sp create --id 
3e192ff9-5cdc-45eb-9deb-d195cf7f5f2c`.
```
