### PR TITLE
[Core] Unify ADAL and MSAL error handler

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -23,7 +23,6 @@ from azure.cli.core._session import ACCOUNT
 from azure.cli.core.util import get_file_json, in_cloud_console, open_page_in_browser, can_launch_browser,\
     is_windows, is_wsl
 from azure.cli.core.cloud import get_active_cloud, set_cloud_subscription
-from azure.cli.core.adal_authentication import aad_exception_handler, adal_exception_handler
 
 logger = get_logger(__name__)
 
@@ -634,6 +633,7 @@ class Profile:
         result = app.acquire_token_by_refresh_token(refresh_token, scopes, data=data)
 
         if 'error' in result:
+            from azure.cli.core.adal_authentication import aad_exception_handler
             aad_exception_handler(result)
         return username, result["access_token"]
 
@@ -692,7 +692,7 @@ class Profile:
                                                                                    tenant_dest,
                                                                                    use_cert_sn_issuer)
             except adal.AdalError as ex:
-                from azure.cli.core.adal_authentication import aad_exception_handler
+                from azure.cli.core.adal_authentication import adal_exception_handler
                 adal_exception_handler(ex)
         return (creds,
                 None if tenant else str(account[_SUBSCRIPTION_ID]),

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -23,6 +23,7 @@ from azure.cli.core._session import ACCOUNT
 from azure.cli.core.util import get_file_json, in_cloud_console, open_page_in_browser, can_launch_browser,\
     is_windows, is_wsl
 from azure.cli.core.cloud import get_active_cloud, set_cloud_subscription
+from azure.cli.core.adal_authentication import aad_exception_handler
 
 logger = get_logger(__name__)
 
@@ -631,6 +632,9 @@ class Profile:
         authority = posixpath.join(self.cli_ctx.cloud.endpoints.active_directory, tenant)
         app = ClientApplication(_CLIENT_ID, authority=authority)
         result = app.acquire_token_by_refresh_token(refresh_token, scopes, data=data)
+
+        if 'error' in result:
+            aad_exception_handler(result)
         return username, result["access_token"]
 
     def get_refresh_token(self, resource=None,

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -674,17 +674,22 @@ class Profile:
             creds = self._get_token_from_cloud_shell(resource)
         else:
             tenant_dest = tenant if tenant else account[_TENANT_ID]
-            if user_type == _USER:
-                # User
-                creds = self._creds_cache.retrieve_token_for_user(username_or_sp_id,
-                                                                  tenant_dest, resource)
-            else:
-                # Service Principal
-                use_cert_sn_issuer = bool(account[_USER_ENTITY].get(_SERVICE_PRINCIPAL_CERT_SN_ISSUER_AUTH))
-                creds = self._creds_cache.retrieve_token_for_service_principal(username_or_sp_id,
-                                                                               resource,
-                                                                               tenant_dest,
-                                                                               use_cert_sn_issuer)
+            import adal
+            try:
+                if user_type == _USER:
+                    # User
+                    creds = self._creds_cache.retrieve_token_for_user(username_or_sp_id,
+                                                                      tenant_dest, resource)
+                else:
+                    # Service Principal
+                    use_cert_sn_issuer = bool(account[_USER_ENTITY].get(_SERVICE_PRINCIPAL_CERT_SN_ISSUER_AUTH))
+                    creds = self._creds_cache.retrieve_token_for_service_principal(username_or_sp_id,
+                                                                                   resource,
+                                                                                   tenant_dest,
+                                                                                   use_cert_sn_issuer)
+            except adal.AdalError as ex:
+                from azure.cli.core.adal_authentication import aad_exception_handler
+                aad_exception_handler(ex)
         return (creds,
                 None if tenant else str(account[_SUBSCRIPTION_ID]),
                 str(tenant if tenant else account[_TENANT_ID]))

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -633,8 +633,8 @@ class Profile:
         result = app.acquire_token_by_refresh_token(refresh_token, scopes, data=data)
 
         if 'error' in result:
-            from azure.cli.core.adal_authentication import aad_exception_handler
-            aad_exception_handler(result)
+            from azure.cli.core.adal_authentication import aad_error_handler
+            aad_error_handler(result)
         return username, result["access_token"]
 
     def get_refresh_token(self, resource=None,
@@ -692,8 +692,8 @@ class Profile:
                                                                                    tenant_dest,
                                                                                    use_cert_sn_issuer)
             except adal.AdalError as ex:
-                from azure.cli.core.adal_authentication import adal_exception_handler
-                adal_exception_handler(ex)
+                from azure.cli.core.adal_authentication import adal_error_handler
+                adal_error_handler(ex)
         return (creds,
                 None if tenant else str(account[_SUBSCRIPTION_ID]),
                 str(tenant if tenant else account[_TENANT_ID]))

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -23,7 +23,7 @@ from azure.cli.core._session import ACCOUNT
 from azure.cli.core.util import get_file_json, in_cloud_console, open_page_in_browser, can_launch_browser,\
     is_windows, is_wsl
 from azure.cli.core.cloud import get_active_cloud, set_cloud_subscription
-from azure.cli.core.adal_authentication import aad_exception_handler
+from azure.cli.core.adal_authentication import aad_exception_handler, adal_exception_handler
 
 logger = get_logger(__name__)
 
@@ -693,7 +693,7 @@ class Profile:
                                                                                    use_cert_sn_issuer)
             except adal.AdalError as ex:
                 from azure.cli.core.adal_authentication import aad_exception_handler
-                aad_exception_handler(ex)
+                adal_exception_handler(ex)
         return (creds,
                 None if tenant else str(account[_SUBSCRIPTION_ID]),
                 str(tenant if tenant else account[_TENANT_ID]))

--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -43,24 +43,9 @@ class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-meth
                 AdalAuthentication._log_hostname()
             raise err
         except adal.AdalError as err:
-            # pylint: disable=no-member
             if in_cloud_console():
                 AdalAuthentication._log_hostname()
-
-            err = (getattr(err, 'error_response', None) or {}).get('error_description') or str(err)
-            if 'AADSTS70008' in err:  # all errors starting with 70008 should be creds expiration related
-                raise CLIError("Credentials have expired due to inactivity. {}".format(
-                    "Please run 'az login'" if not in_cloud_console() else ''))
-            if 'AADSTS50079' in err:
-                raise CLIError("Configuration of your account was changed. {}".format(
-                    "Please run 'az login'" if not in_cloud_console() else ''))
-            if 'AADSTS50173' in err:
-                raise CLIError("The credential data used by CLI has been expired because you might have changed or "
-                               "reset the password. {}".format(
-                                   "Please clear browser's cookies and run 'az login'"
-                                   if not in_cloud_console() else ''))
-
-            raise CLIError(err)
+            aad_exception_handler(err)
         except requests.exceptions.SSLError as err:
             from .util import SSLERROR_TEMPLATE
             raise CLIError(SSLERROR_TEMPLATE.format(str(err)))
@@ -246,3 +231,19 @@ def _timestamp(dt):
     # https://docs.python.org/3/library/unittest.mock-examples.html#partial-mocking
     # https://williambert.online/2011/07/how-to-unit-testing-in-django-with-mocking-and-patching/
     return dt.timestamp()
+
+
+def aad_exception_handler(ex):
+    login_message = ("To re-authenticate, please {}. If the problem persists, "
+                     "please contact your tenant administrator."
+                     .format("refresh Azure Portal" if in_cloud_console() else "run `az login`"))
+
+    # https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-aadsts-error-codes
+    # Search for an error code at https://login.microsoftonline.com/error
+    try:
+        msg = ex.error_response['error_description']
+    except (KeyError, AttributeError):
+        msg = str(ex)
+
+    from azure.cli.core.azclierror import AuthenticationError
+    raise AuthenticationError(msg, login_message) from ex

--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -254,4 +254,6 @@ def adal_error_handler(err: adal.AdalError):
     except AttributeError:
         # In case of AdalError created as
         #   AdalError('More than one token matches the criteria. The result is ambiguous.')
-        raise CLIError(str(err))
+        # https://github.com/Azure/azure-cli/issues/15320
+        from azure.cli.core.azclierror import UnknownError
+        raise UnknownError(str(err), recommendation="Please run `az account clear`, then `az login`.")

--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -45,7 +45,7 @@ class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-meth
         except adal.AdalError as err:
             if in_cloud_console():
                 AdalAuthentication._log_hostname()
-            adal_exception_handler(err)
+            adal_error_handler(err)
         except requests.exceptions.SSLError as err:
             from .util import SSLERROR_TEMPLATE
             raise CLIError(SSLERROR_TEMPLATE.format(str(err)))
@@ -233,7 +233,7 @@ def _timestamp(dt):
     return dt.timestamp()
 
 
-def aad_exception_handler(error: dict):
+def aad_error_handler(error: dict):
     """ Handle the error from AAD server returned by ADAL or MSAL. """
     login_message = ("To re-authenticate, please {}. If the problem persists, "
                      "please contact your tenant administrator."
@@ -247,10 +247,10 @@ def aad_exception_handler(error: dict):
     raise AuthenticationError(msg, login_message)
 
 
-def adal_exception_handler(err: adal.AdalError):
+def adal_error_handler(err: adal.AdalError):
     """ Handle AdalError. """
     try:
-        aad_exception_handler(err.error_response)
+        aad_error_handler(err.error_response)
     except AttributeError:
         # In case of AdalError created as
         #   AdalError('More than one token matches the criteria. The result is ambiguous.')

--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -260,4 +260,8 @@ class RecommendationError(ClientError):
     """ The client error raised by `az next`. It is needed in `az next` to skip error records. """
     pass
 
+
+class AuthenticationError(ServiceError):
+    """ Raised when AAD authentication fails. """
+
 # endregion


### PR DESCRIPTION
## Description

Refine the error message reported by #16209, #16641, #17142.

In the current code, wrapping `adal.AdalError` and rephrasing the error message actually doesn't provide more information. Instead, it leaves the original server error unexposed.

| error code | CLI error  | server error |
| - | - | - |
| `AADSTS70008` | Credentials have expired due to inactivity. | https://login.microsoftonline.com/error?code=70008 | 
| `AADSTS50079`	| Configuration of your account was changed. | https://login.microsoftonline.com/error?code=50079
| `AADSTS50173` | The credential data used by CLI has been expired because you might have changed or reset the password. | https://login.microsoftonline.com/error?code=50173

This PR 

1. wraps `adal.AdalError` in `AuthenticationError` with the original server error unchanged
2. adds `az login` instruction as `recommendation`


## Testing Guide

### Test expired refresh token

1. Create a Conditional Access policy in AAD tenant to make the refresh token only valid for 1 hour.
    ![image](https://user-images.githubusercontent.com/4003950/108961619-915d5000-76b2-11eb-82e8-14fb8a8bdbc5.png)
2. `az login` with the user that is managed by the policy
3. After one hour, run `az group list` or `az account get-access-token`

## Error message

```
> az group list
AADSTS70043: The refresh token has expired or is invalid due to sign-in frequency checks by conditional access. The token was issued on 2021-02-23T05:06:57.0691981Z and the maximum allowed lifetime for this request is 3600.
Trace ID: 4999f039-c867-4cc2-ab32-7dc259780c00
Correlation ID: 6517ef89-dd65-47e1-b5fa-7193461fb78a
Timestamp: 2021-02-24 07:13:32Z
To re-authenticate, please run `az login`. If the problem persists, please contact your tenant administrator.

> az account get-access-token
AADSTS70043: The refresh token has expired or is invalid due to sign-in frequency checks by conditional access. The token was issued on 2021-02-23T05:06:57.0691981Z and the maximum allowed lifetime for this request is 3600.
Trace ID: ab764987-048b-4745-bc32-ba7d16840b00
Correlation ID: a2d45c9f-41de-4e18-8bf5-8368975c7561
Timestamp: 2021-02-24 06:54:48Z
To re-authenticate, please run `az login`. If the problem persists, please contact your tenant administrator.
```
