### PR TITLE
[Style] Allow configuring theme

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -103,8 +103,11 @@ class AzCli(CLI):
 
         self.progress_controller = None
 
-        if not self.enable_color:
-            format_styled_text.theme = 'none'
+        if self.enable_color:
+            theme = self.config.get('core', 'theme', fallback='dark')
+        else:
+            theme = 'none'
+        format_styled_text.theme = theme
 
     def refresh_request_id(self):
         """Assign a new random GUID as x-ms-client-request-id

--- a/src/azure-cli/azure/cli/command_modules/util/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/util/_params.py
@@ -40,4 +40,5 @@ def load_arguments(self, _):
         c.argument('yes', options_list=['--yes', '-y'], action='store_true', help='Do not prompt for checking release notes.')
 
     with self.argument_context('demo style') as c:
-        c.argument('theme', arg_type=get_enum_type(Theme), help='The theme to format styled text.', default='dark')
+        c.argument('theme', arg_type=get_enum_type(Theme),
+                   help='The theme to format styled text. If unspecified, the default theme is used.')

--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -174,7 +174,8 @@ def upgrade_version(cmd, update_all=None, yes=None):  # pylint: disable=too-many
 
 def demo_style(cmd, theme=None):  # pylint: disable=unused-argument
     from azure.cli.core.style import Style, print_styled_text, format_styled_text
-    format_styled_text.theme = theme
+    if theme:
+        format_styled_text.theme = theme
     print_styled_text("[How to call print_styled_text]")
     # Print an empty line
     print_styled_text()


### PR DESCRIPTION
**Description**<!--Mandatory-->

Allow configuring theme from `core.theme`.

**Testing Guide**

```powershell
# Change theme to dark
az config set core.theme=dark

# Run the demo
az demo style

# Observe the error recommendation
az group lsit


# Change theme to light
az config set core.theme=light

# Run the demo
az demo style

# Observe the error recommendation
az group lsit
```

![image](https://user-images.githubusercontent.com/4003950/108973745-af7d7d00-76bf-11eb-832c-fe5580a5f527.png)
