### PR TITLE
[AppService] Fixes #16087:az webapp config ssl create  setting --name parameter as required.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export_features.json
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export_features.json
@@ -1,11 +1,11 @@
 {
   "Color": "Red",
   "Region": "West US",
-  "FeatureManagement": {
+  "feature_management": {
     "Beta": false,
     "Percentage": true,
     "Timestamp": {
-      "EnabledFor": [
+      "enabled_for": [
         {
           "Name": "Local Tests",
           "Parameters": {

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export_features_prop.json
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/export_features_prop.json
@@ -1,4 +1,4 @@
-#Tue Feb 23 09:35:27 China Standard Time 2021
+#Wed Feb 24 19:42:12 India Standard Time 2021
 Color=Red
 Region=West US
 feature-management.FalseFeature=false

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -233,6 +233,10 @@ def load_arguments(self, _):
             c.argument('key_vault_certificate_name', help='The name of the certificate in Key Vault')
         with self.argument_context(scope + ' config ssl create') as c:
             c.argument('hostname', help='The custom domain name')
+            c.argument('name', options_list=['--name', '-n'],
+                       help='Name of the web app. If left unspecified, a name will be randomly generated. You can configure the default using --defaults web=<name>`.')
+            c.argument('resource-group', options_list=['--resource-group', '-g'],
+                       help='Name of resource group. You can configure the default group using `az configure --default-group=<name>`.')
         with self.argument_context(scope + ' config ssl show') as c:
             c.argument('certificate_name', help='The name of the certificate')
         with self.argument_context(scope + ' config hostname') as c:


### PR DESCRIPTION
**Description**<!--Mandatory-->
 -Marked '--name' as a required parameter.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
