### PR TITLE
{Packaging} Upgrade pip version in bundled Python

### DIFF
--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -83,6 +83,7 @@ if not exist %PYTHON_DIR% (
     popd
 )
 set PYTHON_EXE=%PYTHON_DIR%\python.exe
+%PYTHON_EXE% -m pip install --upgrade pip==21.0.1
 
 robocopy %PYTHON_DIR% %BUILDING_DIR% /s /NFL /NDL
 

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -33,6 +33,8 @@ $PYTHON_SRC_DIR/*/configure --srcdir $PYTHON_SRC_DIR/* --prefix $WORKDIR/python_
 make
 make install
 
+$WORKDIR/python_env/bin/python3 -m pip install --upgrade pip==21.0.1
+
 export PATH=$PATH:$WORKDIR/python_env/bin
 
 find ${WORKDIR}/src/ -name setup.py -type f | xargs -I {} dirname {} | grep -v azure-cli-testsdk | xargs pip3 install --no-deps


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Upgrade pip version to `21.0.1` in bundled Python to solve some extension install/usage issues like https://github.com/Azure/azure-cli/issues/16858

`az devops login` will use CLI's pip to install `keyring` in extension directory and it depends on `cryptography`. On Ubuntu, it can be solved by upgrading pip as shown in this [comment](https://github.com/Azure/azure-cli/issues/16858#issuecomment-776266256).


**Testing Guide**
<!--Example commands with explanations.-->
The package built with the change can be downloaded [here](https://dev.azure.com/azure-sdk/public/_build/results?buildId=753108&view=results). Install the package and test installing an extension that depends on `cryptography` with no upper bound on Ubuntu. For instance:
`az extension add --source https://azurecliext.blob.core.windows.net/release/azure_cli_ml-1.21.0-py3-none-any.whl -y`

I have also tested installing all available extensions on Windows 10 and Ubuntu 20.04. No regression found.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
