### PR TITLE
{Core} Fix get_msal_token for beta by directly using MSAL

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_identity.py
+++ b/src/azure-cli-core/azure/cli/core/_identity.py
@@ -104,7 +104,8 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         return msal_app
 
     @property
-    def _msal_app(self):
+    def msal_app(self):
+        """ Get the MSAL ClientApplication to directly interact with MSAL. """
         if not self._msal_app_instance:
             # Build the authority in MSAL style, like https://login.microsoftonline.com/your_tenant
             msal_authority = "{}/{}".format(self.authority, self.tenant_id)
@@ -305,15 +306,15 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         return credential, cloud_shell_identity_info
 
     def logout_user(self, user):
-        accounts = self._msal_app.get_accounts(user)
+        accounts = self.msal_app.get_accounts(user)
         logger.info('Before account removal:')
         logger.info(json.dumps(accounts))
 
         # `accounts` are the same user in all tenants, log out all of them
         for account in accounts:
-            self._msal_app.remove_account(account)
+            self.msal_app.remove_account(account)
 
-        accounts = self._msal_app.get_accounts(user)
+        accounts = self.msal_app.get_accounts(user)
         logger.info('After account removal:')
         logger.info(json.dumps(accounts))
 
@@ -323,25 +324,25 @@ class Identity:  # pylint: disable=too-many-instance-attributes
 
     def logout_all(self):
         # TODO: Support multi-authority logout
-        accounts = self._msal_app.get_accounts()
+        accounts = self.msal_app.get_accounts()
         logger.info('Before account removal:')
         logger.info(json.dumps(accounts))
 
         for account in accounts:
-            self._msal_app.remove_account(account)
+            self.msal_app.remove_account(account)
 
-        accounts = self._msal_app.get_accounts()
+        accounts = self.msal_app.get_accounts()
         logger.info('After account removal:')
         logger.info(json.dumps(accounts))
         # remove service principal secrets
         self._msal_secret_store.remove_all_cached_creds()
 
     def get_user(self, user=None):
-        accounts = self._msal_app.get_accounts(user) if user else self._msal_app.get_accounts()
+        accounts = self.msal_app.get_accounts(user) if user else self.msal_app.get_accounts()
         return accounts
 
     def get_user_credential(self, username):
-        accounts = self._msal_app.get_accounts(username)
+        accounts = self.msal_app.get_accounts(username)
 
         # TODO: Confirm with MSAL team that username can uniquely identify the account
         if not accounts:

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -766,7 +766,7 @@ class Profile:
                 logger.warning(result['error_description'])
 
             # Retry login with VM SSH as resource
-            result = app.acquire_token_interactive(scopes, prompt='select_account')
+            result = app.acquire_token_interactive(scopes, prompt='select_account', data=data)
 
             if 'error' in result:
                 from azure.cli.core.credential import aad_error_handler

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -635,18 +635,6 @@ class Profile:
         """get access token for current user account, used by vsts and iot module"""
         return self.get_access_token_for_scopes(username, tenant, *resource_to_scopes(resource))
 
-    def get_msal_token(self, scopes, data):
-        """
-        This is added for vmssh feature with backward compatible interface.
-        data contains token_type (ssh-cert), key_id and JWK.
-        """
-        account = self.get_subscription()
-        username = account[_USER_ENTITY][_USER_NAME]
-        subscription_id = account[_SUBSCRIPTION_ID]
-        credential, _, _ = self.get_login_credentials(subscription_id=subscription_id)
-        certificate = credential.get_token(*scopes, data=data)
-        return username, certificate.token
-
     @staticmethod
     def _try_parse_msi_account_name(account):
         user_name = account[_USER_ENTITY].get(_USER_NAME)
@@ -762,45 +750,16 @@ class Profile:
 
     def get_msal_token(self, scopes, data):
         """
-        This is added only for vmssh feature.
-        It is a temporary solution and will deprecate after MSAL adopted completely.
+        This is added for VM SSH feature with backward compatible interface.
+        data contains token_type (ssh-cert), key_id and JWK.
         """
-        from msal import ClientApplication
-        import posixpath
         account = self.get_subscription()
         username = account[_USER_ENTITY][_USER_NAME]
         tenant = account[_TENANT_ID] or 'common'
-        _, refresh_token, _, _ = self.get_refresh_token()
-        authority = posixpath.join(self.cli_ctx.cloud.endpoints.active_directory, tenant)
-        app = ClientApplication(_CLIENT_ID, authority=authority)
-        result = app.acquire_token_by_refresh_token(refresh_token, scopes, data=data)
+        app = Identity(authority=self._authority, tenant_id=tenant).msal_app
+        msal_accounts = app.get_accounts(username)[0]
+        result = app.acquire_token_silent_with_error(scopes, msal_accounts, data=data)
         return username, result["access_token"]
-
-    def get_refresh_token(self, resource=None,
-                          subscription=None):
-        account = self.get_subscription(subscription)
-        user_type = account[_USER_ENTITY][_USER_TYPE]
-        username_or_sp_id = account[_USER_ENTITY][_USER_NAME]
-        resource = resource or self.cli_ctx.cloud.endpoints.active_directory_resource_id
-
-        # Use ARM as the default scopes
-        if not scopes:
-            scopes = resource_to_scopes(self.cli_ctx.cloud.endpoints.active_directory_resource_id)
-
-        if subscription and tenant:
-            raise CLIError("Please specify only one of subscription and tenant, not both")
-
-        account = self.get_subscription(subscription)
-        identity_credential = self._create_identity_credential(account, tenant)
-
-        from azure.cli.core.credential import CredentialAdaptor, _convert_token_entry
-        auth = CredentialAdaptor(identity_credential)
-        token = auth.get_token(*scopes)
-        # (tokenType, accessToken, tokenEntry)
-        cred = 'Bearer', token.token, _convert_token_entry(token)
-        return (cred,
-                None if tenant else str(account[_SUBSCRIPTION_ID]),
-                str(tenant if tenant else account[_TENANT_ID]))
 
     def refresh_accounts(self, subscription_finder=None):
         subscriptions = self.load_cached_subscriptions()

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -107,7 +107,6 @@ jsmin==2.2.2
 knack==0.8.0rc2
 MarkupSafe==1.1.1
 mock==4.0.2
-msal==1.9.0
 msrest==0.6.21
 msrestazure==0.6.3
 oauthlib==3.0.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -107,7 +107,6 @@ jsmin==2.2.2
 knack==0.8.0rc2
 MarkupSafe==1.1.1
 mock==4.0.2
-msal==1.9.0
 msrest==0.6.21
 msrestazure==0.6.3
 oauthlib==3.0.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -106,7 +106,6 @@ jsmin==2.2.2
 knack==0.8.0rc2
 MarkupSafe==1.1.1
 mock==4.0.2
-msal==1.9.0
 msrest==0.6.21
 msrestazure==0.6.3
 oauthlib==3.0.1


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix `get_msal_token` for beta. 

The current beta talks to Azure Identity to get VM SSH cert (#16596).

Due to Azure Identity's 

- removal of passing `kwargs` (`data`) to `get_token` for user account (https://github.com/Azure/azure-sdk-for-python/pull/16323#discussion_r566565254)
- rejection of passing `kwargs` (`data`) to `get_token` for service principal (https://github.com/Azure/azure-sdk-for-python/pull/16397)

Azure CLI now directly interacts with MSAL to retrieve the SSH certificate.

The process can be further improved by adopting #17072, #17093.

