### PR TITLE
[ACR] 'az acr connected-registry install info/renew-credentials': Provide connection string in installation command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -412,7 +412,7 @@ def _get_install_info(cmd,
         cred_client = cf_acr_token_credentials(cmd.cli_ctx)
         poller = acr_token_credential_generate(
             cmd, cred_client, registry_name, sync_token_name,
-            password1=True, password2=True, resource_group_name=resource_group_name)
+            password1=True, password2=False, resource_group_name=resource_group_name)
         credentials = LongRunningOperation(cmd.cli_ctx)(poller)
         sync_username = credentials.username
         sync_password = credentials.passwords[0].value

--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -394,20 +394,12 @@ def _get_install_info(cmd,
                       registry_name,
                       regenerate_credentials,
                       resource_group_name=None):
-    registry, resource_group_name = validate_managed_registry(
+    _, resource_group_name = validate_managed_registry(
         cmd, registry_name, resource_group_name)
     connected_registry = acr_connected_registry_show(
         cmd, client, connected_registry_name, registry_name, resource_group_name)
     parent_gateway_endpoint = connected_registry.parent.sync_properties.gateway_endpoint
-    parent_id = connected_registry.parent.id
     sync_token_name = connected_registry.parent.sync_properties.token_id.split('/tokens/')[1]
-    if parent_id:
-        parent = parent_id.split('/connectedRegistries/')[1]
-        parent = acr_connected_registry_show(
-            cmd, client, parent, registry_name, resource_group_name)
-        parent_registry_endpoint = parent.login_server.host
-    else:
-        parent_registry_endpoint = registry.login_server
 
     connected_registry_login_server = "<connected registry login server. " + \
         "More info at https://aka.ms/acr/connected-registry>"
@@ -421,10 +413,7 @@ def _get_install_info(cmd,
             password1=True, password2=True, resource_group_name=resource_group_name)
         credentials = LongRunningOperation(cmd.cli_ctx)(poller)
         sync_username = credentials.username
-        sync_password = {
-            "password1": credentials.passwords[0].value,
-            "password2": credentials.passwords[1].value
-        }
+        sync_password = credentials.passwords[0].value
         logger.warning('Please store your generated credentials safely.')
     else:
         sync_username = sync_token_name
@@ -432,14 +421,11 @@ def _get_install_info(cmd,
 
     logger.warning("Value 'ACR_SYNC_TOKEN_USERNAME' has been deprecated and will be removed in a future release."
                    " Use 'ACR_SYNC_TOKEN_NAME' instead.")
+    connection_string = "ConnectedRegistryName=%s;" % connected_registry_name + \
+        "SyncTokenName=%s;SyncTokenPassword=%s;" % (sync_username, sync_password) + \
+        "ParentGatewayEndpoint=%s;ParentEndpointProtocol=https" % parent_gateway_endpoint
     return {
-        "ACR_REGISTRY_NAME": connected_registry_name,
-        "ACR_REGISTRY_LOGIN_SERVER": connected_registry_login_server,
-        "ACR_SYNC_TOKEN_NAME": sync_username,
-        "ACR_SYNC_TOKEN_USERNAME": sync_username,
-        "ACR_SYNC_TOKEN_PASSWORD": sync_password,
-        "ACR_PARENT_GATEWAY_ENDPOINT": parent_gateway_endpoint,
-        "ACR_PARENT_LOGIN_SERVER": parent_registry_endpoint,
-        "ACR_PARENT_PROTOCOL": "https"
+        "ACR_REGISTRY_CONNECTION_STRING": connection_string,
+        "ACR_REGISTRY_LOGIN_SERVER": connected_registry_login_server
     }
 # endregion

--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -401,8 +401,8 @@ def _get_install_info(cmd,
     parent_gateway_endpoint = connected_registry.parent.sync_properties.gateway_endpoint
     if parent_gateway_endpoint is None or parent_gateway_endpoint == '':
         parent_gateway_endpoint = "<parent gateway endpoint>"
-    if parent_gateway_endpoint.endswith(".data.azurecr.io") \
-       or parent_gateway_endpoint.endswith(".data.azurecr-test.io"):
+    parent_id = connected_registry.parent.id
+    if parent_id:
         parent_endpoint_protocol = "https"
     else:
         parent_endpoint_protocol = "<http or https>"
@@ -425,10 +425,9 @@ def _get_install_info(cmd,
     else:
         sync_username = sync_token_name
         sync_password = "<sync token password>"
-        connection_string_sync_password = sync_password
 
     connection_string = "ConnectedRegistryName=%s;" % connected_registry_name + \
-        "SyncTokenName=%s;SyncTokenPassword=%s;" % (sync_username, connection_string_sync_password) + \
+        "SyncTokenName=%s;SyncTokenPassword=%s;" % (sync_username, sync_password) + \
         "ParentGatewayEndpoint=%s;ParentEndpointProtocol=%s" % (parent_gateway_endpoint, parent_endpoint_protocol)
     return {
         "ACR_REGISTRY_CONNECTION_STRING": connection_string,

--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -394,12 +394,20 @@ def _get_install_info(cmd,
                       registry_name,
                       regenerate_credentials,
                       resource_group_name=None):
-    _, resource_group_name = validate_managed_registry(
+    registry, resource_group_name = validate_managed_registry(
         cmd, registry_name, resource_group_name)
     connected_registry = acr_connected_registry_show(
         cmd, client, connected_registry_name, registry_name, resource_group_name)
     parent_gateway_endpoint = connected_registry.parent.sync_properties.gateway_endpoint
+    parent_id = connected_registry.parent.id
     sync_token_name = connected_registry.parent.sync_properties.token_id.split('/tokens/')[1]
+    if parent_id:
+        parent = parent_id.split('/connectedRegistries/')[1]
+        parent = acr_connected_registry_show(
+            cmd, client, parent, registry_name, resource_group_name)
+        parent_registry_endpoint = parent.login_server.host
+    else:
+        parent_registry_endpoint = registry.login_server
 
     connected_registry_login_server = "<connected registry login server. " + \
         "More info at https://aka.ms/acr/connected-registry>"
@@ -413,19 +421,33 @@ def _get_install_info(cmd,
             password1=True, password2=True, resource_group_name=resource_group_name)
         credentials = LongRunningOperation(cmd.cli_ctx)(poller)
         sync_username = credentials.username
-        sync_password = credentials.passwords[0].value
+        sync_password = {
+            "password1": credentials.passwords[0].value,
+            "password2": credentials.passwords[1].value
+        }
+        connection_string_sync_password = sync_password["password1"]
         logger.warning('Please store your generated credentials safely.')
     else:
         sync_username = sync_token_name
         sync_password = "<sync token password>"
+        connection_string_sync_password = sync_password
 
-    logger.warning("Value 'ACR_SYNC_TOKEN_USERNAME' has been deprecated and will be removed in a future release."
-                   " Use 'ACR_SYNC_TOKEN_NAME' instead.")
+    logger.warning("Value 'ACR_REGISTRY_NAME', 'ACR_SYNC_TOKEN_NAME', 'ACR_SYNC_TOKEN_USERNAME', "
+                   "'ACR_SYNC_TOKEN_PASSWORD', 'ACR_PARENT_GATEWAY_ENDPOINT', "
+                   "'ACR_PARENT_LOGIN_SERVER', and 'ACR_PARENT_PROTOCOL' are going to be deprecated and "
+                   "will be removed in a future release. Use 'ACR_REGISTRY_CONNECTION_STRING' instead.")
     connection_string = "ConnectedRegistryName=%s;" % connected_registry_name + \
-        "SyncTokenName=%s;SyncTokenPassword=%s;" % (sync_username, sync_password) + \
+        "SyncTokenName=%s;SyncTokenPassword=%s;" % (sync_username, connection_string_sync_password) + \
         "ParentGatewayEndpoint=%s;ParentEndpointProtocol=https" % parent_gateway_endpoint
     return {
-        "ACR_REGISTRY_CONNECTION_STRING": connection_string,
-        "ACR_REGISTRY_LOGIN_SERVER": connected_registry_login_server
+        "ACR_REGISTRY_NAME": connected_registry_name,
+        "ACR_REGISTRY_LOGIN_SERVER": connected_registry_login_server,
+        "ACR_SYNC_TOKEN_NAME": sync_username,
+        "ACR_SYNC_TOKEN_USERNAME": sync_username,
+        "ACR_SYNC_TOKEN_PASSWORD": sync_password,
+        "ACR_PARENT_GATEWAY_ENDPOINT": parent_gateway_endpoint,
+        "ACR_PARENT_LOGIN_SERVER": parent_registry_endpoint,
+        "ACR_PARENT_PROTOCOL": "https",
+        "ACR_REGISTRY_CONNECTION_STRING": connection_string
     }
 # endregion

--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -401,9 +401,13 @@ def _get_install_info(cmd,
     parent_gateway_endpoint = connected_registry.parent.sync_properties.gateway_endpoint
     if parent_gateway_endpoint is None or parent_gateway_endpoint == '':
         parent_gateway_endpoint = "<parent gateway endpoint>"
+    if parent_gateway_endpoint.endswith(".data.azurecr.io") or parent_gateway_endpoint.endswith(".data.azurecr-test.io"):
+        parent_endpoint_protocol = "https"
+    else:
+        parent_endpoint_protocol = "<http or https>"
     sync_token_name = connected_registry.parent.sync_properties.token_id.split('/tokens/')[1]
 
-    connected_registry_login_server = "<connected registry login server. " + \
+    connected_registry_login_server = "<Optional: connected registry login server. " + \
         "More info at https://aka.ms/acr/connected-registry>"
 
     if regenerate_credentials:
@@ -424,7 +428,7 @@ def _get_install_info(cmd,
 
     connection_string = "ConnectedRegistryName=%s;" % connected_registry_name + \
         "SyncTokenName=%s;SyncTokenPassword=%s;" % (sync_username, connection_string_sync_password) + \
-        "ParentGatewayEndpoint=%s;ParentEndpointProtocol=https" % parent_gateway_endpoint
+        "ParentGatewayEndpoint=%s;ParentEndpointProtocol=%s" % (parent_gateway_endpoint, parent_endpoint_protocol)
     return {
         "ACR_REGISTRY_CONNECTION_STRING": connection_string,
         "ACR_REGISTRY_LOGIN_SERVER": connected_registry_login_server

--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -401,7 +401,8 @@ def _get_install_info(cmd,
     parent_gateway_endpoint = connected_registry.parent.sync_properties.gateway_endpoint
     if parent_gateway_endpoint is None or parent_gateway_endpoint == '':
         parent_gateway_endpoint = "<parent gateway endpoint>"
-    if parent_gateway_endpoint.endswith(".data.azurecr.io") or parent_gateway_endpoint.endswith(".data.azurecr-test.io"):
+    if parent_gateway_endpoint.endswith(".data.azurecr.io") \
+       or parent_gateway_endpoint.endswith(".data.azurecr-test.io"):
         parent_endpoint_protocol = "https"
     else:
         parent_endpoint_protocol = "<http or https>"

--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -402,10 +402,12 @@ def _get_install_info(cmd,
     if parent_gateway_endpoint is None or parent_gateway_endpoint == '':
         parent_gateway_endpoint = "<parent gateway endpoint>"
     parent_id = connected_registry.parent.id
+    # if parent_id is not none, parent is a connected registry
     if parent_id:
-        parent_endpoint_protocol = "https"
-    else:
         parent_endpoint_protocol = "<http or https>"
+    # if parent_id is none, parent is a cloud registry
+    else:
+        parent_endpoint_protocol = "https"
     sync_token_name = connected_registry.parent.sync_properties.token_id.split('/tokens/')[1]
 
     connected_registry_login_server = "<Optional: connected registry login server. " + \


### PR DESCRIPTION
**Description**<!--Mandatory-->
Change the output into connection string for acr connected-registry install command.
Remove old output vars, and check the parent gateway endpoint to use a place holder for an empty string (dynamic parent login server).

**Testing Guide**
az acr connected-registry install info -n -r
az acr connected-registry install renew-credentials -n -r

**History Notes**

[ACR] BREAKING CHANGE: az acr connected-registry install info: Replace keys ACR_REGISTRY_NAME, ACR_SYNC_TOKEN_NAME, ACR_SYNC_TOKEN_PASSWORD, ACR_PARENT_GATEWAY_ENDPOINT, and ACR_PARENT_PROTOCOL with a new connected string key, ACR_REGISTRY_CONNECTION_STRING.
[ACR] BREAKING CHANGE: az acr connected-registry install renew-credentials: Replace keys ACR_REGISTRY_NAME, ACR_SYNC_TOKEN_NAME, ACR_SYNC_TOKEN_PASSWORD, ACR_PARENT_GATEWAY_ENDPOINT, and ACR_PARENT_PROTOCOL with a new connected string key, ACR_REGISTRY_CONNECTION_STRING.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
