### PR TITLE
[AppService]: fix #17207 - for az webapp log config 'level' always defaults to verbose

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2091,6 +2091,7 @@ def config_diagnostics(cmd, resource_group_name, name, level=None,
         fs_log = None
         blob_log = None
         level = level if application_logging != 'off' else False
+        level = True if level is None else level
         if application_logging in ['filesystem', 'off']:
             fs_log = FileSystemApplicationLogsConfig(level=level)
         if application_logging in ['azureblobstorage', 'off']:

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2090,10 +2090,9 @@ def config_diagnostics(cmd, resource_group_name, name, level=None,
     if application_logging:
         fs_log = None
         blob_log = None
-        level = application_logging != 'off'
+        level = level if application_logging != 'off' else False
         if application_logging in ['filesystem', 'off']:
             fs_log = FileSystemApplicationLogsConfig(level=level)
-        level = application_logging != 'off'
         if application_logging in ['azureblobstorage', 'off']:
             blob_log = AzureBlobStorageApplicationLogsConfig(level=level, retention_in_days=3,
                                                              sas_url=None)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
#17207 
**Testing Guide**
<!--Example commands with explanations.-->
`az webapp log config -n myapp --resource-group myrg --application-logging filesystem --level information`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
