### PR TITLE
[Core] Add spinner progress bar for long running operation

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -115,12 +115,12 @@ class AzCli(CLI):
         import uuid
         self.data['headers']['x-ms-client-request-id'] = str(uuid.uuid1())
 
-    def get_progress_controller(self, det=False):
+    def get_progress_controller(self, det=False, spinner=None):
         import azure.cli.core.commands.progress as progress
         if not self.progress_controller:
             self.progress_controller = progress.ProgressHook()
 
-        self.progress_controller.init_progress(progress.get_progress_view(det))
+        self.progress_controller.init_progress(progress.get_progress_view(det, spinner=spinner))
         return self.progress_controller
 
     def get_cli_version(self):

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -950,7 +950,7 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
         from msrest.exceptions import ClientException
 
         correlation_message = ''
-        self.cli_ctx.get_progress_controller().begin()
+        self.progress_bar.begin()
         correlation_id = None
 
         cli_logger = get_logger()  # get CLI logger which has the level set through command lines

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -981,7 +981,7 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
                 self.progress_bar.update_progress()
                 self._delay()
             except KeyboardInterrupt:
-                self.cli_ctx.get_progress_controller().stop()
+                self.progress_bar.stop()
                 logger.error('Long-running operation wait cancelled.  %s', correlation_message)
                 raise
 
@@ -989,7 +989,7 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
             result = poller.result()
         except ClientException as client_exception:
             from azure.cli.core.commands.arm import handle_long_running_operation_exception
-            self.cli_ctx.get_progress_controller().stop()
+            self.progress_bar.stop()
             handle_long_running_operation_exception(client_exception)
 
         self.progress_bar.end()

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -30,7 +30,7 @@ from azure.cli.core.util import (
     get_command_type_kwarg, read_file_content, get_arg_list, poller_classes)
 from azure.cli.core.local_context import LocalContextAction
 import azure.cli.core.telemetry as telemetry
-
+from azure.cli.core.commands.progress import IndeterminateProgressBar
 
 from knack.arguments import CLICommandArgument
 from knack.commands import CLICommand, CommandGroup, PREVIEW_EXPERIMENTAL_CONFLICT_ERROR
@@ -869,7 +869,8 @@ class AzCliCommandInvoker(CommandInvoker):
 
 
 class LongRunningOperation:  # pylint: disable=too-few-public-methods
-    def __init__(self, cli_ctx, start_msg='', finish_msg='', poller_done_interval_ms=1000.0):
+    def __init__(self, cli_ctx, start_msg='', finish_msg='', poller_done_interval_ms=500.0,
+                 progress_bar=None):
 
         self.cli_ctx = cli_ctx
         self.start_msg = start_msg
@@ -877,6 +878,7 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
         self.poller_done_interval_ms = poller_done_interval_ms
         self.deploy_dict = {}
         self.last_progress_report = datetime.datetime.now()
+        self.progress_bar = progress_bar if progress_bar is not None else IndeterminateProgressBar(cli_ctx)
 
     def _delay(self):
         time.sleep(self.poller_done_interval_ms / 1000.0)
@@ -949,15 +951,17 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
 
         correlation_message = ''
         self.cli_ctx.get_progress_controller().begin()
+        self.progress_bar.start_time = datetime.datetime.utcnow()
         correlation_id = None
 
         cli_logger = get_logger()  # get CLI logger which has the level set through command lines
         is_verbose = any(handler.level <= logs.INFO for handler in cli_logger.handlers)
+
         telemetry.poll_start()
         poll_flag = False
         while not poller.done():
             poll_flag = True
-            self.cli_ctx.get_progress_controller().add(message='Running')
+
             try:
                 # pylint: disable=protected-access
                 correlation_id = json.loads(
@@ -975,6 +979,7 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
                 except Exception as ex:  # pylint: disable=broad-except
                     logger.warning('%s during progress reporting: %s', getattr(type(ex), '__name__', type(ex)), ex)
             try:
+                self.progress_bar.update_progress()
                 self._delay()
             except KeyboardInterrupt:
                 self.cli_ctx.get_progress_controller().stop()
@@ -988,9 +993,10 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
             self.cli_ctx.get_progress_controller().stop()
             handle_long_running_operation_exception(client_exception)
 
-        self.cli_ctx.get_progress_controller().end()
+        self.progress_bar.end()
         if poll_flag:
             telemetry.poll_end()
+
         return result
 
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -951,7 +951,6 @@ class LongRunningOperation:  # pylint: disable=too-few-public-methods
 
         correlation_message = ''
         self.cli_ctx.get_progress_controller().begin()
-        self.progress_bar.start_time = datetime.datetime.utcnow()
         correlation_id = None
 
         cli_logger = get_logger()  # get CLI logger which has the level set through command lines

--- a/src/azure-cli-core/azure/cli/core/commands/progress.py
+++ b/src/azure-cli-core/azure/cli/core/commands/progress.py
@@ -185,6 +185,12 @@ class IndeterminateProgressBar:
                 stream=sys.stderr,
                 hide_cursor=False))
 
+    def begin(self):
+        self.hook.begin()
+        
+    def stop(self):
+        self.hook.stop()
+
     def update_progress(self):
         self.hook.add(message=self.message)
 

--- a/src/azure-cli-core/azure/cli/core/commands/progress.py
+++ b/src/azure-cli-core/azure/cli/core/commands/progress.py
@@ -103,10 +103,10 @@ class ProgressHook:
 
 class IndeterminateStandardOut(ProgressViewBase):
     """ custom output for progress reporting """
-    def __init__(self, out=None):
+    def __init__(self, out=None, spinner=None):
         super(IndeterminateStandardOut, self).__init__(
             out if out else sys.stderr)
-        self.spinner = None
+        self.spinner = spinner
 
     def write(self, args):
         """
@@ -166,8 +166,27 @@ class DeterminateStandardOut(ProgressViewBase):
         self.out.flush()
 
 
-def get_progress_view(determinant=False, outstream=sys.stderr):
+def get_progress_view(determinant=False, outstream=sys.stderr, spinner=None):
     """ gets your view """
     if determinant:
         return DeterminateStandardOut(out=outstream)
-    return IndeterminateStandardOut(out=outstream)
+    return IndeterminateStandardOut(out=outstream, spinner=spinner)
+
+
+class IndeterminateProgressBar:
+    """ Define progress bar update view """
+    def __init__(self, cli_ctx, message="Running"):
+        self.cli_ctx = cli_ctx
+        self.message = message
+        self.hook = self.cli_ctx.get_progress_controller(
+            det=False,
+            spinner=humanfriendly.Spinner(  # pylint: disable=no-member
+                label='Running',
+                stream=sys.stderr,
+                hide_cursor=False))
+
+    def update_progress(self):
+        self.hook.add(message=self.message)
+
+    def end(self):
+        self.hook.end()

--- a/src/azure-cli-core/azure/cli/core/commands/progress.py
+++ b/src/azure-cli-core/azure/cli/core/commands/progress.py
@@ -187,7 +187,7 @@ class IndeterminateProgressBar:
 
     def begin(self):
         self.hook.begin()
-        
+
     def stop(self):
         self.hook.stop()
 

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -412,7 +412,7 @@ class TestCustom(unittest.TestCase):
         ])
 
         # Act.
-        result = _what_if_deploy_arm_template_core(cmd, mock.MagicMock(), True, ["create", "igNoRE"])
+        result = _what_if_deploy_arm_template_core(cmd.cli_ctx, mock.MagicMock(), True, ["create", "igNoRE"])
 
         # Assert.
         self.assertEqual(1, len(result.changes))


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR is one part for progress bar project.
As we already in beta version for several months, I plan to move indeterminate progress bar with spinner to all long running operation in azure cli as shown below:
![image](https://user-images.githubusercontent.com/49508232/110723287-c50dad80-824e-11eb-8e35-2f056a0493ac.png)

But I have to mention for commands like `network vnet create`, which is long running operation, but not hornor CLI `LongRunningOperation` class, will not have progress bar.

**Testing Guide**
<!--Example commands with explanations.-->
`az storage account create`
`az vm create`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
