### PR TITLE
[Style] Define theme for Cloud Shell

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,5 +56,5 @@
 /src/azure-cli/azure/cli/command_modules/sql/ @jaredmoo @Juliehzl @evelyn-ys
 /src/azure-cli/azure/cli/command_modules/storage/ @Juliehzl @jsntcy @zhoxing-ms @evelyn-ys
 /src/azure-cli/azure/cli/command_modules/synapse/ @idear1203 @sunsw1994 @aim-for-better
-/src/azure-cli/azure/cli/command_modules/util/ @jiasli @Juliehzl @zhoxing-ms
+/src/azure-cli/azure/cli/command_modules/util/ @jiasli @Juliehzl @zhoxing-ms @evelyn-ys
 /src/azure-cli/azure/cli/command_modules/vm/ @qwordy @houk-ms @yungezz

--- a/src/azure-cli-core/azure/cli/core/tests/test_style.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_style.py
@@ -7,7 +7,7 @@ import sys
 import unittest
 from unittest import mock
 
-from azure.cli.core.style import Style, Theme, format_styled_text, print_styled_text, _is_modern_terminal
+from azure.cli.core.style import Style, Theme, format_styled_text, print_styled_text, _rgb_hex
 
 
 class TestStyle(unittest.TestCase):
@@ -33,7 +33,7 @@ class TestStyle(unittest.TestCase):
             (Style.WARNING, "Bright Yellow: Warning message indicator\n"),
         ]
         formatted = format_styled_text(styled_text)
-        excepted = """\x1b[39mWhite: Primary text color
+        excepted = """\x1b[0mWhite: Primary text color
 \x1b[90mBright Black: Secondary text color
 \x1b[95mBright Magenta: Important text color
 \x1b[94mBright Blue: Commands, parameters, and system inputs
@@ -41,19 +41,19 @@ class TestStyle(unittest.TestCase):
 \x1b[91mBright Red: Error message indicator
 \x1b[92mBright Green: Success message indicator
 \x1b[93mBright Yellow: Warning message indicator
-\x1b[39m"""
+\x1b[0m"""
         self.assertEqual(formatted, excepted)
 
         # Test str input
         styled_text = "Primary text color"
         formatted = format_styled_text(styled_text)
-        excepted = "\x1b[39mPrimary text color\x1b[39m"
+        excepted = "\x1b[0mPrimary text color\x1b[0m"
         self.assertEqual(formatted, excepted)
 
         # Test tuple input
         styled_text = (Style.PRIMARY, "Primary text color")
         formatted = format_styled_text(styled_text)
-        excepted = "\x1b[39mPrimary text color\x1b[39m"
+        excepted = "\x1b[0mPrimary text color\x1b[0m"
         self.assertEqual(formatted, excepted)
 
     def test_format_styled_text_on_error(self):
@@ -111,9 +111,9 @@ class TestStyle(unittest.TestCase):
             (Style.SECONDARY, "Bright Black: Secondary text color\n"),
         ]
         formatted = format_styled_text(styled_text)
-        excepted = """\x1b[39mWhite: Primary text color
+        excepted = """\x1b[0mWhite: Primary text color
 \x1b[90mBright Black: Secondary text color
-\x1b[39m"""
+\x1b[0m"""
         self.assertEqual(formatted, excepted)
 
         # Color is turned off via param
@@ -156,16 +156,13 @@ class TestStyle(unittest.TestCase):
         print_styled_text("test text 1", "test text 2")
         mock_print.assert_called_with("test text 1", "test text 2", file=sys.stderr)
 
+    def test_rgb_hex(self):
 
-class TestUtils(unittest.TestCase):
+        result = _rgb_hex("#13A10E")
+        self.assertEqual(result, '\x1b[38;2;19;161;14m')
 
-    def test_is_modern_terminal(self):
-        with mock.patch.dict("os.environ", clear=True):
-            self.assertEqual(_is_modern_terminal(), False)
-        with mock.patch.dict("os.environ", WT_SESSION='c25cb945-246a-49e5-b37a-1e4b6671b916'):
-            self.assertEqual(_is_modern_terminal(), True)
-        with mock.patch.dict("os.environ", TERM_PROGRAM='vscode'):
-            self.assertEqual(_is_modern_terminal(), True)
+        result = _rgb_hex("3A96DD")
+        self.assertEqual(result, '\x1b[38;2;58;150;221m')
 
 
 if __name__ == '__main__':

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1266,3 +1266,9 @@ def get_parent_proc_name():
         parent_proc_name = _get_parent_proc_name()
         setattr(get_parent_proc_name, "return_value", parent_proc_name)
     return getattr(get_parent_proc_name, "return_value")
+
+
+def is_modern_terminal():
+    """In addition to knack.util.is_modern_terminal, detect Cloud Shell."""
+    import knack.util
+    return knack.util.is_modern_terminal() or in_cloud_console()

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -48,11 +48,10 @@ DEPENDENCIES = [
     'azure-common~=1.1',
     'azure-core==1.12.0',
     'azure-mgmt-core>=1.2.0,<2.0.0',
-    'colorama~=0.4.1',
     'cryptography>=3.2,<3.4',
     'humanfriendly>=4.7,<10.0',
     'jmespath',
-    'knack~=0.8.0',
+    'knack~=0.8.1',
     'msal>=1.10.0,<2.0.0',
     # Dependencies of the vendored subscription SDK
     # https://github.com/Azure/azure-sdk-for-python/blob/ab12b048ddf676fe0ccec16b2167117f0609700d/sdk/resources/azure-mgmt-resource/setup.py#L82-L86

--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -192,17 +192,17 @@ def demo_style(cmd, theme=None):  # pylint: disable=unused-argument
     print_styled_text()
 
     print_styled_text("[Available styles]\n")
-    placeholder = '{:19s}: {}\n'
+    placeholder = '████ {:8s}: {}\n'
     styled_text = [
         (Style.PRIMARY, placeholder.format("White", "Primary text color")),
-        (Style.SECONDARY, placeholder.format("Bright Black", "Secondary text color")),
-        (Style.IMPORTANT, placeholder.format("Bright/Dark Magent", "Important text color")),
+        (Style.SECONDARY, placeholder.format("Grey", "Secondary text color")),
+        (Style.IMPORTANT, placeholder.format("Magenta", "Important text color")),
         (Style.ACTION, placeholder.format(
-            "Bright/Dark Blue", "Commands, parameters, and system inputs. (White in legacy powershell terminal.)")),
-        (Style.HYPERLINK, placeholder.format("Bright/Dark Cyan", "Hyperlink")),
-        (Style.ERROR, placeholder.format("Bright/Dark Red", "Error message indicator")),
-        (Style.SUCCESS, placeholder.format("Bright/Dark Green", "Success message indicator")),
-        (Style.WARNING, placeholder.format("Bright/Dark Yellow", "Warning message indicator")),
+            "Blue", "Commands, parameters, and system inputs (White in legacy powershell terminal)")),
+        (Style.HYPERLINK, placeholder.format("Cyan", "Hyperlink")),
+        (Style.ERROR, placeholder.format("Red", "Error message indicator")),
+        (Style.SUCCESS, placeholder.format("Green", "Success message indicator")),
+        (Style.WARNING, placeholder.format("Yellow", "Warning message indicator")),
     ]
     print_styled_text(styled_text)
 
@@ -260,6 +260,15 @@ def demo_style(cmd, theme=None):  # pylint: disable=unused-argument
         (Style.PRIMARY, ". To switch to another subscription, run "),
         (Style.ACTION, "az account set --subscription"),
         (Style.PRIMARY, " <subscription ID>\n"),
-        (Style.WARNING, "WARNING: The subscription has been disabled!")
+        (Style.WARNING, "WARNING: The subscription has been disabled!\n")
     ]
     print_styled_text(styled_text)
+
+    print_styled_text("[logs]\n")
+
+    # Print logs
+    logger.debug("This is a debug log entry.")
+    logger.info("This is a info log entry.")
+    logger.warning("This is a warning log entry.")
+    logger.error("This is a error log entry.")
+    logger.critical("This is a critical log entry.")

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -105,7 +105,7 @@ isodate==0.6.0
 Jinja2==2.11.3
 jmespath==0.9.5
 jsmin==2.2.2
-knack==0.8.0
+knack==0.8.1
 MarkupSafe==1.1.1
 mock==4.0.2
 msal==1.10.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -105,7 +105,7 @@ isodate==0.6.0
 Jinja2==2.11.3
 jmespath==0.9.5
 jsmin==2.2.2
-knack==0.8.0
+knack==0.8.1
 MarkupSafe==1.1.1
 mock==4.0.2
 msal==1.10.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -104,7 +104,7 @@ isodate==0.6.0
 Jinja2==2.11.3
 jmespath==0.9.5
 jsmin==2.2.2
-knack==0.8.0
+knack==0.8.1
 MarkupSafe==1.1.1
 mock==4.0.2
 msal==1.10.0


### PR DESCRIPTION
Depends on https://github.com/microsoft/knack/pull/238

## Description

In Cloud Shell, `SECONDARY` test's color Bright Black (`#555753`) in the color palette **violates** the required Contrast Ratio of **4.5:1**

- In Bash, `#555753` on `#000000` background has Contrast Ratio of [2.87:1](https://webaim.org/resources/contrastchecker/?fcolor=555753&bcolor=000000)
- In PowerShell, `#555753` on `#092457` background has Contrast Ratio of [2.05:1](https://webaim.org/resources/contrastchecker/?fcolor=555753&bcolor=092457)

## Changes

- Hardcoding RGB values of Cloud Shell-specific theme, as users can't change the color palette of Cloud Shell
- Make `SECONDARY` text's Bight Black lighter
- Refine other colors to make them more pleasing

Cloud Shell theme:

| Style | color
| - | -
| PRIMARY  | `#ffffff`
| SECONDARY| `#bcbcbc`
| IMPORTANT| `#f887ff`
| ACTION   | `#6cb0ff`
| HYPERLINK| `#72d7d8`
| ERROR    | `#f55d5c`
| SUCCESS  | `#70d784`
| WARNING  | `#fbd682`

## Testing Guide

```
az demo style --theme cloud-shell
```

## Before & After in Bash

### Demo style - `az demo style`

![1-1](https://user-images.githubusercontent.com/4003950/110610354-1b380d80-81c9-11eb-9a96-738935c41480.png)
![image](https://user-images.githubusercontent.com/4003950/110772222-57856f80-8296-11eb-8aa7-95af4b4c0a8b.png)

### Error handling - `az group lsit`

![2-1](https://user-images.githubusercontent.com/4003950/110610937-add8ac80-81c9-11eb-8057-1d83559c0b99.png)
![2-2](https://user-images.githubusercontent.com/4003950/110610933-aca77f80-81c9-11eb-9af7-af878ad24286.png)

## Before & After in PowerShell

### Demo style - `az demo style`

![image](https://user-images.githubusercontent.com/4003950/110772606-c06ce780-8296-11eb-8870-cf3406098444.png)
![image](https://user-images.githubusercontent.com/4003950/110772423-8e5b8580-8296-11eb-8119-7bf60688548d.png)

### Error handling - `az group lsit`

![4-1](https://user-images.githubusercontent.com/4003950/110611686-6a327280-81ca-11eb-9a6d-345e5f6d18a8.png)
![4-2](https://user-images.githubusercontent.com/4003950/110611832-8c2bf500-81ca-11eb-9757-73bc63b0e915.png)
