### PR TITLE
{Config} Redirect users from `az configure` to `az config`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/config/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/config/_help.py
@@ -9,13 +9,14 @@ from knack.help_files import helps  # pylint: disable=unused-import
 helps['config'] = """
 type: group
 short-summary: Manage Azure CLI configuration.
+long-summary: Available since Azure CLI 2.10.0.
 """
 
 helps['config set'] = """
 type: command
 short-summary: Set a configuration.
 long-summary: |
-    For available configuration options, see https://docs.microsoft.com/en-us/cli/azure/azure-cli-configuration.
+    For available configuration options, see https://docs.microsoft.com/cli/azure/azure-cli-configuration.
     By default without specifying --local, the configuration will be saved to `~/.azure/config`.
 examples:
   - name: Disable color with `core.no_color`.

--- a/src/azure-cli/azure/cli/command_modules/configure/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/_help.py
@@ -35,6 +35,7 @@ short-summary: Show the contents of a specific object in the cache.
 helps['configure'] = """
 type: command
 short-summary: Manage Azure CLI configuration. This command is interactive.
+long-summary: For automation scenarios or to set all available options, use the new `az config`.
 parameters:
   - name: --defaults -d
     short-summary: >


### PR DESCRIPTION
**Description**<!--Mandatory-->

1. Users are complaining `az config` can't be found: https://github.com/MicrosoftDocs/azure-docs-cli/issues/2469, https://github.com/MicrosoftDocs/azure-docs-cli/issues/2465
2. Redirect users from `az configure` to `az config`

**Testing Guide**

```
az configure --help
az config --help
```

**Additional Context**

Another issue https://github.com/Azure/azure-cli/issues/17261 is opened to instruct user to upgrade to the latest version if a command (group) is not found.