### PR TITLE
[Upgrade] Fix 16952: Fix ImportError after upgrade

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -117,11 +117,13 @@ def upgrade_version(cmd, update_all=None, yes=None):  # pylint: disable=too-many
                     logger.warning(UPGRADE_MSG)
         elif installer == 'HOMEBREW':
             logger.debug("Update homebrew formulae")
-            exit_code = subprocess.call(['brew', 'update'])
+            az_env = os.environ.copy()
+            az_env['HOMEBREW_NO_INSTALL_CLEANUP'] = 1
+            exit_code = subprocess.call(['brew', 'update'], env=az_env)
             if exit_code == 0:
                 update_cmd = ['brew', 'upgrade', 'azure-cli']
                 logger.debug("Update azure cli with '%s'", " ".join(update_cmd))
-                exit_code = subprocess.call(update_cmd)
+                exit_code = subprocess.call(update_cmd, env=az_env)
         elif installer == 'PIP':
             pip_args = [sys.executable, '-m', 'pip', 'install', '--upgrade', 'azure-cli', '-vv',
                         '--disable-pip-version-check', '--no-cache-dir']

--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -117,13 +117,11 @@ def upgrade_version(cmd, update_all=None, yes=None):  # pylint: disable=too-many
                     logger.warning(UPGRADE_MSG)
         elif installer == 'HOMEBREW':
             logger.debug("Update homebrew formulae")
-            az_env = os.environ.copy()
-            az_env['HOMEBREW_NO_INSTALL_CLEANUP'] = "1"
-            exit_code = subprocess.call(['brew', 'update'], env=az_env)
+            exit_code = subprocess.call(['brew', 'update'])
             if exit_code == 0:
                 update_cmd = ['brew', 'upgrade', 'azure-cli']
                 logger.debug("Update azure cli with '%s'", " ".join(update_cmd))
-                exit_code = subprocess.call(update_cmd, env=az_env)
+                exit_code = subprocess.call(update_cmd)
         elif installer == 'PIP':
             pip_args = [sys.executable, '-m', 'pip', 'install', '--upgrade', 'azure-cli', '-vv',
                         '--disable-pip-version-check', '--no-cache-dir']
@@ -143,20 +141,23 @@ def upgrade_version(cmd, update_all=None, yes=None):  # pylint: disable=too-many
         telemetry.set_failure(err_msg)
         sys.exit(exit_code)
 
-    import azure.cli.core
+    # Avoid using python modules directly as they may have been changed due to upgrade.
+    # If you do need to use them, you may need to reload them and their dependent modules.
+    # Otherwise you may have such issue https://github.com/Azure/azure-cli/issues/16952
     import importlib
-    importlib.reload(azure.cli.core)
-    new_version = azure.cli.core.__version__
+    import json
+    importlib.reload(subprocess)
+    importlib.reload(json)
+
+    version_result = subprocess.check_output(['az', 'version', '-o', 'json'], shell=platform.system() == 'Windows')
+    version_json = json.loads(version_result)
+    new_version = version_json['azure-cli-core']
 
     if update_cli and new_version == local_version:
         err_msg = "CLI upgrade failed or aborted."
         logger.warning(err_msg)
         telemetry.set_failure(err_msg)
         sys.exit(1)
-
-    # Python is reinstalled in another versioned directory with Homebrew, subprocess needs to be reloaded
-    if installer == 'HOMEBREW' and exts:
-        importlib.reload(subprocess)
 
     if exts:
         logger.warning("Upgrading extensions")

--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -118,7 +118,7 @@ def upgrade_version(cmd, update_all=None, yes=None):  # pylint: disable=too-many
         elif installer == 'HOMEBREW':
             logger.debug("Update homebrew formulae")
             az_env = os.environ.copy()
-            az_env['HOMEBREW_NO_INSTALL_CLEANUP'] = 1
+            az_env['HOMEBREW_NO_INSTALL_CLEANUP'] = "1"
             exit_code = subprocess.call(['brew', 'update'], env=az_env)
             if exit_code == 0:
                 update_cmd = ['brew', 'upgrade', 'azure-cli']


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Resolve #16952

The issue was caused by reloading the `azure.cli.core` python module to get the new version after upgrade, it depends on modules in `knack`. The new loaded `azure.cli.core` depends on new code of a new `knack` version: `from knack.util import status_tag_messages`, but `knack.util` is not reloaded, causing the issue of `ImportError`.

There are two ways to solve this issue:
1. Reload all loaded modules in `sys.modules` starting with `knack` such as `knack.util`, `knack.log`. Note that `knack` and `knack.util` are 2 items in `sys.modules`, simply reloading `knack` will not fix the `ImportError` with `from knack.util import status_tag_messages`.
2. Use `subprocess` to get `az version` to avoid calling cached modules in the same Python Interpreter.

This PR uses the second method as it is more error-proofing and easier to maintain as `azure.cli.core` could rely on new modules in the future.

**Testing Guide**
<!--Example commands with explanations.-->
1. Create a clean virtual env and activate it
`python -m venv env-test`
2. Install the old version of `azure-cli`
`pip install azure-cli==2.17.1`
3. Modify this file to apply changes in this PR:
`env-test/lib/site-packages/azure/cli/command_modules/util/custom.py`
4. Run `az upgrade`


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
