### PR TITLE
{Packaging} Remove aio and dist-info folders in MSI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,11 +180,16 @@ jobs:
   displayName: Test Windows MSI
 
   dependsOn: BuildWindowsMSI
-  # condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
-  condition: false
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
   pool:
     vmImage: 'vs2017-win2016'
   steps:
+  - task: DownloadPipelineArtifact@1
+    displayName: 'Download Build Artifacts'
+    inputs:
+      TargetPath: '$(Build.ArtifactStagingDirectory)/metadata'
+      artifactName: metadata
+  
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build Artifacts'
     inputs:
@@ -196,16 +201,25 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        $InstallArgs = @(
-          "/I"
-          '"$env:SYSTEM_ARTIFACTSDIRECTORY/msi/Microsoft Azure CLI.msi"'
-          "/norestart"
-          "/L*v"
-          ".\install_logs.txt"
-        )
-        Start-Process "msiexec.exe" -ArgumentList $InstallArgs -Wait -NoNewWindow
+        # Elevate as Admin
+        if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {  
+          $arguments = "& '" +$myinvocation.mycommand.definition + "'"
+          Start-Process powershell -Verb runAs -ArgumentList $arguments
+          Break
+        }
+        $pre_installed_version=az version --query '\"azure-cli\"' -o tsv
+        $to_be_installed_version=Get-Content $(System.ArtifactsDirectory)/metadata/version
+        if ($pre_installed_version -eq $to_be_installed_version){
+          $reinstall_option="REINSTALL=ALL REINSTALLMODE=emus"
+        }else {
+          $reinstall_option=""
+        }
+        Start-Process "msiexec.exe" -ArgumentList "/i `"$env:SYSTEM_ARTIFACTSDIRECTORY\msi\Microsoft Azure CLI.msi`" $reinstall_option /q /norestart /l*v .\install_logs.txt" -Wait -NoNewWindow
         Get-Content .\install_logs.txt
-
+        $installed_version=az version --query '\"azure-cli\"' -o tsv
+        if ($installed_version -ne $to_be_installed_version){
+          Exit 1
+        }
         az --version
         az self-test
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,6 +207,7 @@ jobs:
           Start-Process powershell -Verb runAs -ArgumentList $arguments
           Break
         }
+        az --version
         $pre_installed_version=az version --query '\"azure-cli\"' -o tsv
         $to_be_installed_version=Get-Content $(System.ArtifactsDirectory)/metadata/version
         if ($pre_installed_version -eq $to_be_installed_version){

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,24 +201,36 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        # Elevate as Admin
         if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {  
+          # Start another Powershell process as Admin and execute this script again
           $arguments = "& '" +$myinvocation.mycommand.definition + "'"
           Start-Process powershell -Verb runAs -ArgumentList $arguments
+          # Stop if the PowerShell is not run as Admin
           Break
         }
+        # The following are executed by elevated PowerShell
         az --version
+
+        $InstallArgs = @(
+          "/i"
+          "`"$env:SYSTEM_ARTIFACTSDIRECTORY\msi\Microsoft Azure CLI.msi`""
+          "/q"
+          "/norestart"
+          "/l*v"
+          ".\install_logs.txt"
+        )
         $pre_installed_version=az version --query '\"azure-cli\"' -o tsv
         $to_be_installed_version=Get-Content $(System.ArtifactsDirectory)/metadata/version
         if ($pre_installed_version -eq $to_be_installed_version){
-          $reinstall_option="REINSTALL=ALL REINSTALLMODE=emus"
-        }else {
-          $reinstall_option=""
+          # See https://docs.microsoft.com/windows/win32/msi/reinstallmode about options of REINSTALLMODE
+          $reinstall_option="REINSTALL=ALL REINSTALLMODE=emus" 
+          $InstallArgs += $reinstall_option
         }
-        Start-Process "msiexec.exe" -ArgumentList "/i `"$env:SYSTEM_ARTIFACTSDIRECTORY\msi\Microsoft Azure CLI.msi`" $reinstall_option /q /norestart /l*v .\install_logs.txt" -Wait -NoNewWindow
+        Start-Process "msiexec.exe" -ArgumentList $InstallArgs -Wait -NoNewWindow
         Get-Content .\install_logs.txt
         $installed_version=az version --query '\"azure-cli\"' -o tsv
         if ($installed_version -ne $to_be_installed_version){
+          echo "The MSI failed to install."
           Exit 1
         }
         az --version

--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -83,7 +83,7 @@ if not exist %PYTHON_DIR% (
     popd
 )
 set PYTHON_EXE=%PYTHON_DIR%\python.exe
-%PYTHON_EXE% -m pip install --upgrade pip==21.0.1
+%PYTHON_EXE% -m pip install --upgrade pip==21.0.1 setuptools==52.0.0
 
 robocopy %PYTHON_DIR% %BUILDING_DIR% /s /NFL /NDL
 
@@ -146,9 +146,25 @@ for /f %%f in ('dir /b /s *.pyc') do (
 )
 popd
 
+:: Remove __pycache__
+echo remove pycache
 for /d /r %BUILDING_DIR%\Lib\site-packages\pip %%d in (__pycache__) do (
     if exist %%d rmdir /s /q "%%d"
 )
+
+:: Remove aio
+echo remove aio
+for /d /r %BUILDING_DIR%\Lib\site-packages\azure\mgmt %%d in (aio) do (
+    if exist %%d rmdir /s /q "%%d"
+)
+
+:: Remove dist-info
+echo remove dist-info
+pushd %BUILDING_DIR%\Lib\site-packages
+for /d %%d in ("*.dist-info") do (
+    if exist %%d rmdir /s /q "%%d"
+)
+popd
 
 if %errorlevel% neq 0 goto ERROR
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`azure-cli` does not use `aio` files in azure management SDKs. `dist-info` is not used in MSI for installation or update. Remove them in this PR.

This PR also adds back the MSI test task to resolve #9270

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
