### PR TITLE
{Compute} Update function of auto_shutdown_vm

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -1003,13 +1003,15 @@ def auto_shutdown_vm(cmd, resource_group_name, vm_name, off=None, email=None, we
         raise CLIError('usage error: --time is a required parameter')
     daily_recurrence = {'time': time}
     notification_settings = None
-    if webhook:
+    if email:
+        if not webhook:
+            raise CLIError('usage error: --webhook is a required parameter')
         notification_settings = {
-            'emailRecipient': email,
-            'webhookUrl': webhook,
-            'timeInMinutes': 30,
-            'status': 'Enabled'
-        }
+                'emailRecipient': email,
+                'webhookUrl': webhook,
+                'timeInMinutes': 30,
+                'status': 'Enabled'
+            }
     schedule = Schedule(status='Enabled',
                         target_resource_id=vm_id,
                         daily_recurrence=daily_recurrence,

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -1005,12 +1005,12 @@ def auto_shutdown_vm(cmd, resource_group_name, vm_name, off=None, email=None, we
     notification_settings = None
     if email:
         if not webhook:
-            raise CLIError('usage error: --webhook is a required parameter')
+            raise CLIError('usage error: --webhook is a required parameter when --email exists')
         notification_settings = {
-                'emailRecipient': email,
-                'webhookUrl': webhook,
-                'timeInMinutes': 30,
-                'status': 'Enabled'
+            'emailRecipient': email,
+            'webhookUrl': webhook,
+            'timeInMinutes': 30,
+            'status': 'Enabled'
             }
     schedule = Schedule(status='Enabled',
                         target_resource_id=vm_id,

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -1003,15 +1003,15 @@ def auto_shutdown_vm(cmd, resource_group_name, vm_name, off=None, email=None, we
         raise CLIError('usage error: --time is a required parameter')
     daily_recurrence = {'time': time}
     notification_settings = None
-    if email:
-        if not webhook:
-            raise CLIError('usage error: --webhook is a required parameter when --email exists')
+    if email and not webhook:
+        raise CLIError('usage error: --webhook is a required parameter when --email exists')
+    if webhook:
         notification_settings = {
             'emailRecipient': email,
             'webhookUrl': webhook,
             'timeInMinutes': 30,
             'status': 'Enabled'
-            }
+        }
     schedule = Schedule(status='Enabled',
                         target_resource_id=vm_id,
                         daily_recurrence=daily_recurrence,


### PR DESCRIPTION
Description

Resolve #16824

[Compute] When users use --email but don't use --webhook, remind users that these two parameters need to be set together.

Testing Guide

History Notes

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

