### PR TITLE
{SQL} Hotfix: az sql midb log-replay start: fix typo for one of the parameters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -4489,7 +4489,7 @@ def managed_db_log_replay_start(
     if auto_complete and not last_backup_name:
         raise CLIError('Please specify a last backup name when using auto complete flag.')
 
-    kwargs['auto_complete'] = auto_complete
+    kwargs['auto_complete_restore'] = auto_complete
     kwargs['last_backup_name'] = last_backup_name
 
     kwargs['storageContainerUri'] = storage_container_uri


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
We found out that command `log-replay start` was not working with `-a` flag because of bug. This pr is fixing typo ```auto_complete -> auto_complete_restore```

**Testing Guide**
<!--Example commands with explanations.-->


This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
