### PR TITLE
{Misc} Drop `from __future__ import print_function`

### DIFF
--- a/doc/sphinx/__main__.py
+++ b/doc/sphinx/__main__.py
@@ -5,8 +5,6 @@
 # --------------------------------------------------------------------------------------------
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import os
 import sphinx
 

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -7,9 +7,6 @@
 
 # common utilities for scripts
 
-from __future__ import print_function
-
-
 def get_repo_root():
     """
     Returns the root path to this repository. The root is where .git folder is.

--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -14,7 +14,6 @@
 
 #pylint: disable=line-too-long
 
-from __future__ import print_function
 import os
 import sys
 import platform

--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -5,8 +5,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import sys
 import os
 from subprocess import check_call, CalledProcessError

--- a/scripts/dump_command_table.py
+++ b/scripts/dump_command_table.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import argparse
 import inspect
 import json

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -4,8 +4,6 @@
 # --------------------------------------------------------------------------------------------
 # pylint: disable=line-too-long
 
-from __future__ import print_function
-
 __version__ = "2.21.0"
 
 import os

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 import argparse
 
 from azure.cli.core.commands import ExtensionCommandSource

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import collections
 import errno
 import json

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -5,8 +5,6 @@
 
 # pylint: disable=too-many-lines
 
-from __future__ import print_function
-
 import argparse
 import datetime
 import json

--- a/src/azure-cli-core/azure/cli/core/commands/template_create.py
+++ b/src/azure-cli-core/azure/cli/core/commands/template_create.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 import platform
 
 from azure.cli.core.commands.arm import resource_exists

--- a/src/azure-cli-core/azure/cli/core/file_util.py
+++ b/src/azure-cli-core/azure/cli/core/file_util.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 from azure.cli.core._help import CliCommandHelpFile, CliGroupHelpFile
 
 from knack.log import get_logger

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import difflib
 
 import argparse

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import logging
 import shutil
 import inspect

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 # pylint: disable=too-many-lines
 
-from __future__ import print_function
 import sys
 import json
 import getpass

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -5,7 +5,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 

--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import re
 from knack.util import CLIError
 from knack.log import get_logger

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 import binascii
 import datetime
 import errno

--- a/src/azure-cli/azure/cli/command_modules/ams/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/_format.py
@@ -3,8 +3,5 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
-
 def get_sp_create_output_xml(result):
     return print('\n'.join(['<add key=\"{}\" value=\"{}\" />'.format(k, v) for k, v in result.items()]))

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 import threading
 import time
 import ast

--- a/src/azure-cli/azure/cli/command_modules/appservice/vsts_cd_provider.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/vsts_cd_provider.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 from sys import stderr
 from vsts_cd_manager.continuous_delivery_manager import ContinuousDeliveryManager
 from azure.cli.core._profile import Profile

--- a/src/azure-cli/azure/cli/command_modules/batchai/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/batchai/custom.py
@@ -4,8 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: disable=too-many-lines
-from __future__ import print_function
-
 import collections
 import copy
 import datetime

--- a/src/azure-cli/azure/cli/command_modules/batchai/tests/latest/test_batchai_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/batchai/tests/latest/test_batchai_scenario.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from __future__ import print_function
-
 import time
 import uuid
 from contextlib import contextmanager

--- a/src/azure-cli/azure/cli/command_modules/configure/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/custom.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 import json
 import os
 

--- a/src/azure-cli/azure/cli/command_modules/container/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/container/_format.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 from collections import OrderedDict
 
 

--- a/src/azure-cli/azure/cli/command_modules/deploymentmanager/tests/latest/test_deploymentmanager_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/deploymentmanager/tests/latest/test_deploymentmanager_scenario.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 import os
 import json
 import os

--- a/src/azure-cli/azure/cli/command_modules/dla/tests/latest/test_dla_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/dla/tests/latest/test_dla_commands.py
@@ -4,8 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: disable=line-too-long
-from __future__ import print_function
-
 try:
     import unittest.mock as mock
 except ImportError:

--- a/src/azure-cli/azure/cli/command_modules/dls/tests/latest/test_dls_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/dls/tests/latest/test_dls_commands.py
@@ -4,8 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: disable=line-too-long
-from __future__ import print_function
-
 import datetime
 import os
 import time

--- a/src/azure-cli/azure/cli/command_modules/feedback/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/feedback/custom.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 import os
 import re
 import math

--- a/src/azure-cli/azure/cli/command_modules/find/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/find/custom.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from __future__ import print_function
-
 from collections import namedtuple
 import hashlib
 import random

--- a/src/azure-cli/azure/cli/command_modules/iot/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/custom.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 # pylint: disable=no-self-use,no-member,line-too-long,too-few-public-methods,too-many-lines,too-many-arguments,too-many-locals
 
-from __future__ import print_function
 from enum import Enum
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/hybrid_2018_03_01/test_keyvault_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/hybrid_2018_03_01/test_keyvault_commands.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import os
 import time
 import unittest

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/hybrid_2020_09_01/test_keyvault_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/hybrid_2020_09_01/test_keyvault_commands.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import json
 import os
 import time

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_commands.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import json
 import os
 import pytest

--- a/src/azure-cli/azure/cli/command_modules/monitor/grammar/autoscale/AutoscaleConditionLexer.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/grammar/autoscale/AutoscaleConditionLexer.py
@@ -5,7 +5,6 @@
 # Generated from AutoscaleCondition.g4 by ANTLR 4.7.2
 # encoding: utf-8
 # pylint: disable=all
-from __future__ import print_function
 from antlr4 import *
 from io import StringIO
 import sys

--- a/src/azure-cli/azure/cli/command_modules/monitor/grammar/autoscale/AutoscaleConditionParser.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/grammar/autoscale/AutoscaleConditionParser.py
@@ -5,7 +5,6 @@
 # Generated from AutoscaleCondition.g4 by ANTLR 4.7.2
 # encoding: utf-8
 # pylint: disable=all
-from __future__ import print_function
 from antlr4 import *
 from io import StringIO
 import sys

--- a/src/azure-cli/azure/cli/command_modules/monitor/grammar/metric_alert/MetricAlertConditionLexer.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/grammar/metric_alert/MetricAlertConditionLexer.py
@@ -5,7 +5,6 @@
 # Generated from MetricAlertCondition.g4 by ANTLR 4.7.2
 # encoding: utf-8
 # pylint: disable=all
-from __future__ import print_function
 from antlr4 import *
 from io import StringIO
 import sys

--- a/src/azure-cli/azure/cli/command_modules/monitor/grammar/metric_alert/MetricAlertConditionParser.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/grammar/metric_alert/MetricAlertConditionParser.py
@@ -5,7 +5,6 @@
 # Generated from MetricAlertCondition.g4 by ANTLR 4.7.2
 # encoding: utf-8
 # pylint: disable=all
-from __future__ import print_function
 from antlr4 import *
 from io import StringIO
 import sys

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from __future__ import print_function
-
 from collections import Counter, OrderedDict
 
 from msrestazure.azure_exceptions import CloudError

--- a/src/azure-cli/azure/cli/command_modules/network/zone_file/make_zone_file.py
+++ b/src/azure-cli/azure/cli/command_modules/network/zone_file/make_zone_file.py
@@ -24,9 +24,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # pylint: skip-file
-from __future__ import print_function
-
-
 def make_zone_file(json_obj):
     """
     Generate the DNS zonefile, given a json-encoded description of the

--- a/src/azure-cli/azure/cli/command_modules/network/zone_file/record_processors.py
+++ b/src/azure-cli/azure/cli/command_modules/network/zone_file/record_processors.py
@@ -25,8 +25,6 @@
 # SOFTWARE.
 # pylint: skip-file
 
-from __future__ import print_function
-
 import copy
 
 

--- a/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: disable=line-too-long
-from __future__ import print_function
 from collections import Counter, OrderedDict
 from knack.log import get_logger
 from msrestazure.azure_exceptions import CloudError

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 from knack.log import get_logger
 from knack.prompting import prompt_pass, NoTTYException
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -6,7 +6,6 @@
 # pylint: disable=too-many-lines
 # pylint: disable=line-too-long
 
-from __future__ import print_function
 from collections import OrderedDict
 import codecs
 import json

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import base64
 import datetime
 import json

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 from ..azcopy.util import AzCopy, client_auth_for_azcopy, login_auth_for_azcopy, _generate_sas_token
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import os
 from datetime import datetime
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob_azure_stack.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import os
 from datetime import datetime
 

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -11,9 +11,6 @@
 # --------------------------------------------------------------------------
 
 # pylint: disable=no-self-use,too-many-lines
-from __future__ import print_function
-
-
 import json
 import os
 

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -5,7 +5,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 from codecs import open
 from setuptools import setup, find_packages
 import sys

--- a/tools/automation/coverage/run_command_coverage.py
+++ b/tools/automation/coverage/run_command_coverage.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import collections
 import json
 import os

--- a/tools/automation/tests/nose_helper.py
+++ b/tools/automation/tests/nose_helper.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
 from ..utilities.path import get_repo_root
 
 

--- a/tools/automation/tests/verify_package_versions.py
+++ b/tools/automation/tests/verify_package_versions.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import os
 import sys
 import argparse

--- a/tools/automation/tests/verify_readme_history.py
+++ b/tools/automation/tests/verify_readme_history.py
@@ -5,8 +5,6 @@
 
 """Verify the README and HISTORY files for each module so they format correctly on PyPI. """
 
-from __future__ import print_function
-
 import os
 import sys
 import argparse

--- a/tools/automation/utilities/display.py
+++ b/tools/automation/utilities/display.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import sys
 
 

--- a/tools/automation/verify/default_modules.py
+++ b/tools/automation/verify/default_modules.py
@@ -5,8 +5,6 @@
 
 """Verify the list of modules that should be included as part of the CLI install. """
 
-from __future__ import print_function
-
 import os
 import sys
 import json

--- a/tools/automation/verify/doc_source_map.py
+++ b/tools/automation/verify/doc_source_map.py
@@ -5,8 +5,6 @@
 
 """Verify the document source map. """
 
-from __future__ import print_function
-
 import os
 import sys
 import json

--- a/tools/automation/verify/verify_module_load_times.py
+++ b/tools/automation/verify/verify_module_load_times.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 from collections import OrderedDict
 import re
 from subprocess import check_output, STDOUT, CalledProcessError


### PR DESCRIPTION
**Description**<!--Mandatory-->

Because of the deprecation of Python 2 support (https://github.com/Azure/azure-cli/pull/11363), drop
 
```py
from __future__ import print_function
```

The regex used to remove the lines is:

```regex
from __future__ import print_function\n+
```
