### PR TITLE
{Misc} Drop `six` from core

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -12,8 +12,6 @@ import os
 import sys
 import timeit
 
-import six
-
 from knack.cli import CLI
 from knack.commands import CLICommandsLoader
 from knack.completion import ARGCOMPLETE_ENV_NAME
@@ -780,7 +778,7 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
 
         kwargs['deprecate_info'] = Deprecated.ensure_new_style_deprecation(self.cli_ctx, kwargs, 'command')
 
-        if operation and not isinstance(operation, six.string_types):
+        if operation and not isinstance(operation, str):
             raise TypeError("Operation must be a string. Got '{}'".format(operation))
         if handler and not callable(handler):
             raise TypeError("Handler must be a callable. Got '{}'".format(operation))
@@ -856,7 +854,7 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
                 op = getattr(op, part)
             if isinstance(op, types.FunctionType):
                 return op
-            return six.get_method_function(op)
+            return op.__func__
         except (ValueError, AttributeError):
             raise ValueError("The operation '{}' is invalid.".format(operation))
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -17,7 +17,6 @@ import sys
 import time
 import copy
 from importlib import import_module
-import six
 
 # pylint: disable=unused-import
 from azure.cli.core.commands.constants import (
@@ -713,7 +712,7 @@ class AzCliCommandInvoker(CommandInvoker):
         except Exception as ex:  # pylint: disable=broad-except
             if cmd_copy.exception_handler:
                 return cmd_copy.exception_handler(ex)
-            six.reraise(*sys.exc_info())
+            raise
 
     def _run_jobs_serially(self, jobs, ids):
         results, exceptions = [], []

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -587,7 +587,7 @@ def _cli_generic_update_command(context, name, getter_op, setter_op, setter_arg_
 
 def _cli_wait_command(context, name, getter_op, custom_command=False, **kwargs):
 
-    if not isinstance(getter_op, string_types):
+    if not isinstance(getter_op, str):
         raise ValueError("Getter operation must be a string. Got '{}'".format(type(getter_op)))
 
     factory = _get_client_factory(name, custom_command=custom_command, **kwargs)
@@ -718,7 +718,7 @@ def _cli_wait_command(context, name, getter_op, custom_command=False, **kwargs):
 
 def _cli_show_command(context, name, getter_op, custom_command=False, **kwargs):
 
-    if not isinstance(getter_op, string_types):
+    if not isinstance(getter_op, str):
         raise ValueError("Getter operation must be a string. Got '{}'".format(type(getter_op)))
 
     factory = _get_client_factory(name, custom_command=custom_command, **kwargs)

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -10,7 +10,6 @@ from collections import OrderedDict
 import copy
 import json
 import re
-from six import string_types
 
 from azure.cli.core import AzCommandsLoader, EXCLUDED_PARAMS
 from azure.cli.core.commands import LongRunningOperation, _is_poller, cached_get, cached_put
@@ -413,11 +412,11 @@ def _cli_generic_update_command(context, name, getter_op, setter_op, setter_arg_
                                 child_arg_name='item_name', custom_function_op=None, **kwargs):
     if not isinstance(context, AzCommandsLoader):
         raise TypeError("'context' expected type '{}'. Got: '{}'".format(AzCommandsLoader.__name__, type(context)))
-    if not isinstance(getter_op, string_types):
+    if not isinstance(getter_op, str):
         raise TypeError("Getter operation must be a string. Got '{}'".format(getter_op))
-    if not isinstance(setter_op, string_types):
+    if not isinstance(setter_op, str):
         raise TypeError("Setter operation must be a string. Got '{}'".format(setter_op))
-    if custom_function_op and not isinstance(custom_function_op, string_types):
+    if custom_function_op and not isinstance(custom_function_op, str):
         raise TypeError("Custom function operation must be a string. Got '{}'".format(
             custom_function_op))
 

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -13,7 +13,7 @@ import zipfile
 import traceback
 import hashlib
 from subprocess import check_output, STDOUT, CalledProcessError
-from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
+from urllib.parse import urlparse
 
 from pkg_resources import parse_version
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_add_resourcegroup_transform.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_add_resourcegroup_transform.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-from six import StringIO
+from io import StringIO
 from azure.cli.core.commands.transform import _parse_id, _add_resource_group
 
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -6,7 +6,7 @@
 import mock
 import unittest
 import difflib
-from six import StringIO
+from io import StringIO
 from collections import namedtuple
 from azure.cli.core import AzCommandsLoader, MainCommandsLoader
 from azure.cli.core.commands import AzCliCommand

--- a/src/azure-cli-core/azure/cli/core/tests/test_storage_validators.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_storage_validators.py
@@ -5,7 +5,7 @@
 
 import argparse
 import unittest
-from six import StringIO
+from io import StringIO
 
 from azure.cli.core.commands.validators import (validate_key_value_pairs, validate_tag,
                                                 validate_tags)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -15,8 +15,7 @@ import ssl
 import re
 import logging
 
-import six
-from six.moves.urllib.request import urlopen  # pylint: disable=import-error
+from urllib.request import urlopen
 from knack.log import get_logger
 from knack.util import CLIError, to_snake_case
 
@@ -344,8 +343,8 @@ def _get_local_versions():
 
 def get_az_version_string(use_cache=False):  # pylint: disable=too-many-statements
     from azure.cli.core.extension import get_extensions, EXTENSIONS_DIR, DEV_EXTENSION_SOURCES, EXTENSIONS_SYS_DIR
-
-    output = six.StringIO()
+    import io
+    output = io.StringIO()
     versions = _get_local_versions()
 
     # get the versions from pypi
@@ -528,7 +527,7 @@ def b64encode(s):
     :return: base64 encoded string
     :rtype: str
     """
-    encoded = base64.b64encode(six.b(s))
+    encoded = base64.b64encode(s.encode("latin-1"))
     return encoded if encoded is str else encoded.decode('latin-1')
 
 
@@ -887,7 +886,7 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
                         value = getattr(endpoints, p)
                     except CloudEndpointNotSetException:
                         continue
-                    if isinstance(value, six.string_types) and url.lower().startswith(value.lower()):
+                    if isinstance(value, str) and url.lower().startswith(value.lower()):
                         resource = value
                         break
         if resource:


### PR DESCRIPTION
**Description**<!--Mandatory-->

Because of the deprecation of Python 2 support (https://github.com/Azure/azure-cli/pull/11363), drop `six`.
