### PR TITLE
{Packaging} Bump bcrypt and PyNaCl

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -18,9 +18,9 @@ steps:
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then
-        azdev setup -c $CLI_REPO_PATH
+        azdev setup -c $CLI_REPO_PATH --debug
       else
-        azdev setup -c $CLI_REPO_PATH -r $CLI_EXT_REPO_PATH
+        azdev setup -c $CLI_REPO_PATH -r $CLI_EXT_REPO_PATH --debug
       fi
     displayName: 'Azdev Setup'
     env:

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -89,7 +89,7 @@ azure-storage-common==1.4.2
 azure-synapse-accesscontrol==0.2.0
 azure-synapse-artifacts==0.3.0
 azure-synapse-spark==0.2.0
-bcrypt==3.1.7
+bcrypt==3.2.0
 certifi==2019.6.16
 cffi==1.14.4
 chardet==3.0.4
@@ -117,7 +117,7 @@ portalocker==1.7.1
 psutil==5.7.2
 pycparser==2.19
 PyJWT==1.7.1
-PyNaCl==1.3.0
+PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0
 pytz==2019.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -90,7 +90,7 @@ azure-storage-common==1.4.2
 azure-synapse-accesscontrol==0.2.0
 azure-synapse-artifacts==0.3.0
 azure-synapse-spark==0.2.0
-bcrypt==3.1.7
+bcrypt==3.2.0
 certifi==2019.6.16
 cffi==1.14.4
 chardet==3.0.4
@@ -118,7 +118,7 @@ portalocker==1.7.1
 psutil==5.7.2
 pycparser==2.19
 PyJWT==1.7.1
-PyNaCl==1.3.0
+PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0
 pytz==2019.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -17,7 +17,6 @@ azure-graphrbac==0.60.0
 azure-identity==1.5.0
 azure-keyvault-administration==4.0.0b3
 azure-keyvault==1.1.0
-azure-keyvault==1.1.0
 azure-loganalytics==0.1.0
 azure-mgmt-advisor==2.0.1
 azure-mgmt-apimanagement==0.2.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -90,7 +90,7 @@ azure-storage-common==1.4.2
 azure-synapse-accesscontrol==0.2.0
 azure-synapse-artifacts==0.3.0
 azure-synapse-spark==0.2.0
-bcrypt==3.1.7
+bcrypt==3.2.0
 certifi==2019.6.16
 cffi==1.14.4
 chardet==3.0.4
@@ -117,7 +117,7 @@ portalocker==1.7.1
 psutil==5.7.2
 pycparser==2.19
 PyJWT==1.7.1
-PyNaCl==1.3.0
+PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 pypiwin32==223
 pyreadline==2.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -17,7 +17,6 @@ azure-graphrbac==0.60.0
 azure-identity==1.5.0
 azure-keyvault-administration==4.0.0b3
 azure-keyvault==1.1.0
-azure-keyvault==1.1.0
 azure-loganalytics==0.1.0
 azure-mgmt-advisor==2.0.1
 azure-mgmt-apimanagement==0.2.0


### PR DESCRIPTION
**Description**<!--Mandatory-->

Per #16611, bump versions:

- [bcrypt 3.2](https://pypi.org/project/bcrypt/3.2.0/)
- [PyNaCl 1.4](https://pypi.org/project/PyNaCl/1.4.0/)

so that they can be installed on Windows with Python 3.9, without the dependency on **Microsoft Visual C++**.