### PR TITLE
[ARM] Fix #17379: bicep auto install results in invalid json output from deployment

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -30,7 +30,7 @@ def run_bicep_command(args, auto_install=True, check_upgrade=True):
 
     if not installed:
         if auto_install:
-            ensure_bicep_installation()
+            ensure_bicep_installation(stdout=False)
         else:
             raise FileOperationError('Bicep CLI not found. Install it now by running "az bicep install".')
     elif check_upgrade:
@@ -49,7 +49,7 @@ def run_bicep_command(args, auto_install=True, check_upgrade=True):
     return _run_command(installation_path, args)
 
 
-def ensure_bicep_installation(release_tag=None):
+def ensure_bicep_installation(release_tag=None, stdout=True):
     system = platform.system()
     installation_path = _get_bicep_installation_path(system)
 
@@ -68,18 +68,25 @@ def ensure_bicep_installation(release_tag=None):
 
     try:
         release_tag = release_tag if release_tag else get_bicep_latest_release_tag()
-        if release_tag:
-            print(f"Installing Bicep CLI {release_tag}...")
-        else:
-            print("Installing Bicep CLI...")
+        if stdout:
+            if release_tag:
+                print(f"Installing Bicep CLI {release_tag}...")
+            else:
+                print("Installing Bicep CLI...")
 
         request = urlopen(_get_bicep_download_url(system, release_tag))
         with open(installation_path, "wb") as f:
             f.write(request.read())
 
         os.chmod(installation_path, os.stat(installation_path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-
-        print(f'Successfully installed Bicep CLI to "{installation_path}".')
+        
+        if stdout:
+            print(f'Successfully installed Bicep CLI to "{installation_path}".')
+        else:
+            _logger.info(
+                'Successfully installed Bicep CLI to %s',
+                installation_path,
+            )
     except IOError as err:
         raise ClientRequestError(f"Error while attempting to download Bicep CLI: {err}")
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -79,7 +79,7 @@ def ensure_bicep_installation(release_tag=None, stdout=True):
             f.write(request.read())
 
         os.chmod(installation_path, os.stat(installation_path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        
+
         if stdout:
             print(f'Successfully installed Bicep CLI to "{installation_path}".')
         else:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Added a conditional during Bicep CLI installation to send install messages to logger for an "auto install" while still printing messages to stdout for a manual install (az bicep install)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARM] Fix #17379: bicep auto install results in invalid json output from deployment

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
