### PR TITLE
[Interactive] Fix #16931: Fix `KeyError` in `az interactive --update`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /scripts/live_test @qwordy
 /src/azure-cli-testsdk/ @jsntcy @jiasli @kairu-ms @qwordy
 /src/azure-cli-core/ @jiasli @Juliehzl @fengzhou-msft @evelyn-ys @jsntcy @houk-ms
-/src/azure-cli-core/azure/cli/core/extension/ @msyyc
+/src/azure-cli-core/azure/cli/core/extension/ @msyyc @fengzhou-msft
 /src/azure-cli/azure/cli/command_modules/acr/ @djyou @fengzhou-msft @yungezz
 /src/azure-cli/azure/cli/command_modules/acs/ @rjtsdl @fengzhou-msft
 /src/azure-cli/azure/cli/command_modules/advisor/ @Prasanna-Padmanabhan

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -715,11 +715,9 @@ def get_command_type_kwarg(custom_command=False):
 
 def reload_module(module):
     # reloading the imported module to update
-    try:
+    if module in sys.modules:
         from importlib import reload
-    except ImportError:
-        pass  # for python 2
-    reload(sys.modules[module])
+        reload(sys.modules[module])
 
 
 def get_default_admin_username():


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Resolve #16931

`interactive` is written in a special way that it is an `azure-cli` module, but it will install the `interative` extension for starting an interactive shell. With the use of [command index](https://github.com/Azure/azure-cli/pull/13294), `interactive` command group only loads the `interactive` module and not `azext_interactive` module as the extension has 0 command. That's why `reload_module` will throw `KeyError` when trying to reload `azext_interactive` after updated. 

This PR adds check whether the module is already imported before reloading it.

**Testing Guide**
<!--Example commands with explanations.-->
1. Install an old version of `interactive`
`az extension add --upgrade -n interactive --version 0.4.3`
2. Run the command to update `interactive`
`az interactive --update`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
