### PR TITLE
{Feedback} Explain what `az feedback` does

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@
 /src/azure-cli/azure/cli/command_modules/dms/ @temandr @binuj
 /src/azure-cli/azure/cli/command_modules/eventhubs/ @v-ajnava
 /src/azure-cli/azure/cli/command_modules/extension/ @fengzhou-msft @msyyc
+/src/azure-cli/azure/cli/command_modules/feedback/ @fengzhou-msft @jiasli
 /src/azure-cli/azure/cli/command_modules/hdinsight/ @aim-for-better @Juliehzl @kairu-ms
 /src/azure-cli/azure/cli/command_modules/iot/ @digimaun
 /src/azure-cli/azure/cli/command_modules/keyvault/ @fengzhou-msft @yungezz @houk-ms

--- a/src/azure-cli/azure/cli/command_modules/feedback/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/feedback/_help.py
@@ -9,5 +9,9 @@ from knack.help_files import helps  # pylint: disable=unused-import
 
 helps['feedback'] = """
 type: command
-short-summary: Send feedback to the Azure CLI Team!
+short-summary: Send feedback to the Azure CLI Team. 
+long-summary: >-
+    This command is interactive. If possible, it launches the default
+    web browser to open GitHub issue creation page with the body auto-generated and pre-filled.
+    You will have a chance to edit the issue body before submitting it.
 """

--- a/src/azure-cli/azure/cli/command_modules/feedback/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/feedback/_help.py
@@ -9,7 +9,7 @@ from knack.help_files import helps  # pylint: disable=unused-import
 
 helps['feedback'] = """
 type: command
-short-summary: Send feedback to the Azure CLI Team. 
+short-summary: Send feedback to the Azure CLI Team.
 long-summary: >-
     This command is interactive. If possible, it launches the default
     web browser to open GitHub issue creation page with the body auto-generated and pre-filled.


### PR DESCRIPTION
**Description**<!--Mandatory-->
Fix #17393

The current `az feedback` help message is very vague.

```
> az feedback -h

Command
    az feedback : Send feedback to the Azure CLI Team!
```

This PR refines the help message to explicitly explain what `az feedback` does.

**Testing Guide**

```
> az feedback -h

Command
    az feedback : Send feedback to the Azure CLI Team.
        This command is interactive. If possible, it launches the default web browser to open GitHub
        issue creation page with the body auto-generated and pre-filled. You will have a chance to
        edit the issue body before submitting it.
```
