### PR TITLE
{Role} `ad sp create-for-rbac`: Retry Service Principal creation for "must in the local tenant" error

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1457,10 +1457,14 @@ def create_service_principal_for_rbac(
                 aad_sp = _create_service_principal(cmd.cli_ctx, app_id, resolve_app=False)
                 break
             except Exception as ex:  # pylint: disable=broad-except
+                err_msg = str(ex)
                 if retry_time < _RETRY_TIMES and (
-                        ' does not reference ' in str(ex) or ' does not exist ' in str(ex)):
+                        ' does not reference ' in err_msg or
+                        ' does not exist ' in err_msg or
+                        'service principal being created must in the local tenant' in err_msg):
+                    logger.warning("Creating service principal failed with error '%s'. Retrying: %s/%s",
+                                   err_msg, retry_time + 1, _RETRY_TIMES)
                     time.sleep(5)
-                    logger.warning('Retrying service principal creation: %s/%s', retry_time + 1, _RETRY_TIMES)
                 else:
                     logger.warning(
                         "Creating service principal failed for appid '%s'. Trace followed:\n%s",

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -325,9 +325,13 @@ class CreateForRbacScenarioTest(ScenarioTest):
             finally:
                 self.cmd('ad sp delete --id {name}')
 
+    @mock.patch('azure.cli.command_modules.role.custom._auth_client_factory')
+    @mock.patch('azure.cli.command_modules.role.custom._graph_client_factory')
     @mock.patch('azure.cli.command_modules.role.custom._create_service_principal')
     @mock.patch('azure.cli.command_modules.role.custom.create_application')
-    def test_create_for_rbac_retry(self, create_application_mock, create_service_principal_mock):
+    def test_create_for_rbac_retry(self, create_application_mock, create_service_principal_mock,
+                                   graph_client_factory_mock, auth_client_factory_mock):
+        graph_client_factory_mock.return_value.config.tenant_id = '00000001-0000-0000-0000-000000000000'
         create_application_mock.return_value.app_id = '00000000-0000-0000-0000-000000000000'
         create_service_principal_mock.side_effect = [
             # Mock replication exceptions

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -338,8 +338,7 @@ class CreateForRbacScenarioTest(ScenarioTest):
             # Success
             mock.MagicMock()
         ]
-        with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
-            self.cmd('ad sp create-for-rbac --skip-assignment')
+        self.cmd('ad sp create-for-rbac --skip-assignment')
 
 
 class GraphGroupScenarioTest(ScenarioTest):

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -325,6 +325,22 @@ class CreateForRbacScenarioTest(ScenarioTest):
             finally:
                 self.cmd('ad sp delete --id {name}')
 
+    @mock.patch('azure.cli.command_modules.role.custom._create_service_principal')
+    @mock.patch('azure.cli.command_modules.role.custom.create_application')
+    def test_create_for_rbac_retry(self, create_application_mock, create_service_principal_mock):
+        create_application_mock.return_value.app_id = '00000000-0000-0000-0000-000000000000'
+        create_service_principal_mock.side_effect = [
+            # Mock replication exceptions
+            Exception("The appId '00000000-0000-0000-0000-000000000000' of the service principal "
+                      "does not reference a valid application object."),
+            Exception("When using this permission, the backing application of the service principal being "
+                      "created must in the local tenant"),
+            # Success
+            mock.MagicMock()
+        ]
+        with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
+            self.cmd('ad sp create-for-rbac --skip-assignment')
+
 
 class GraphGroupScenarioTest(ScenarioTest):
 


### PR DESCRIPTION
## Description

Fix #14767

The retry-able check logic is firstly added by #1499:

https://github.com/Azure/azure-cli/blob/f0dcfcf5eb8413496ad7f3d4f871045d5386a099/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py#L492

It was later changed by #2567 (not sure why the change):

https://github.com/Azure/azure-cli/blob/67d44a187229f4b3872b8fc1401144492a778f18/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py#L508

This PR simply adds another retry-able check for 

> When using this permission, the backing application of the service principal being created must in the local tenant

just like what https://github.com/microsoft/onefuzz/pull/716 does.

## Testing Guide

With new Knack (https://github.com/microsoft/knack/pull/228):

```
> pytest src\azure-cli\azure\cli\command_modules\role\tests\latest\test_graph.py::CreateForRbacScenarioTest::test_create_for_rbac_retry --override-ini log_cli=true

--------------------------------------- live log call ---------------------------------------
WARNING  cli.azure.cli.command_modules.role.custom:custom.py:1466 Creating service principal failed with error 'The appId '00000000-0000-0000-0000-000000000000' of the service principal does not reference a valid application object.'. Retrying: 1/36
WARNING  cli.azure.cli.command_modules.role.custom:custom.py:1466 Creating service principal failed with error 'When using this permission, the backing application of the service principal being created must in the local tenant'. Retrying: 2/36
WARNING  cli.azure.cli.command_modules.role.custom:custom.py:1505 The output includes credentials that you must protect. Be sure that you do not include these credentials in your code or check the credentials into your source control. For more information, see https://aka.ms/azadsp-cli
PASSED                                                                                 [100%]
```

## Additional Context

As https://github.com/Azure/azure-cli/pull/2567#pullrequestreview-28002303 pointed out, this is indeed very ugly. 