### PR TITLE
{Role} `az ad sp create-for-rbac`: Fix "One or more properties contains invalid values"

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -588,7 +588,7 @@ def list_apps(cmd, app_id=None, display_name=None, identifier_uri=None, query_fi
 
     result = client.applications.list(filter=(' and '.join(sub_filters)))
     if sub_filters or include_all:
-        return result
+        return list(result)
 
     result = list(itertools.islice(result, 101))
     if len(result) == 101:
@@ -1415,7 +1415,6 @@ def create_service_principal_for_rbac(
         existing_sps = list(graph_client.service_principals.list(filter=query_exp))
         if existing_sps:
             app_display_name = existing_sps[0].display_name
-            name = existing_sps[0].service_principal_names[0]
 
     app_start_date = datetime.datetime.now(TZ_UTC)
     app_end_date = app_start_date + relativedelta(years=years or 1)


### PR DESCRIPTION
Fix [IcM 232405459](https://portal.microsofticm.com/imp/v3/incidents/details/232405459/home): Running az ad sp create-for-rbac results in failure

## Symptom

`az ad sp create-for-rbac` fails with:

```
Error: One or more properties contains invalid values.
```

## Cause
For example:

```
ad sp create-for-rbac -n sp-prod --skip-assignment
```

CLI first checks the existence of the Service Principal by searching for Service Principal whose `servicePrincipalNames` contains `http://sp-prod`:

https://github.com/Azure/azure-cli/blob/50ccb24528eb36529d1432808f3ff385cc4c04aa/src/azure-cli/azure/cli/command_modules/role/custom.py#L1414

Normally, the result will look like:

```
"servicePrincipalNames": [
  "http://sp-prod",
  "1f440000-0000-0000-0000-000000000000"
]
```

Under some unknown cases, in AAD's response of a Service Principal, **the order is reversed**:

```
"servicePrincipalNames":[
  "1f440000-0000-0000-0000-000000000000",
  "http://sp-prod"
]
```

So CLI uses the 1st item `1f440000-0000-0000-0000-000000000000` as `name`:

https://github.com/Azure/azure-cli/blob/50ccb24528eb36529d1432808f3ff385cc4c04aa/src/azure-cli/azure/cli/command_modules/role/custom.py#L1418

Then CLI uses `name` (`1f440000-0000-0000-0000-000000000000`) as `identifierUri` to create an Application:

https://github.com/Azure/azure-cli/blob/50ccb24528eb36529d1432808f3ff385cc4c04aa/src/azure-cli/azure/cli/command_modules/role/custom.py#L1437-L1440

It first checks whether there is an Application whose `identifierUris` contains `1f440000-0000-0000-0000-000000000000`:

https://github.com/Azure/azure-cli/blob/50ccb24528eb36529d1432808f3ff385cc4c04aa/src/azure-cli/azure/cli/command_modules/role/custom.py#L784

This will certainly fail as `1f440000-0000-0000-0000-000000000000` is the `appId`, not `identifierUri`:

```
> az ad app show --id 1f440000-0000-0000-0000-000000000000
{
  "appId": "1f440000-0000-0000-0000-000000000000",
  ...
  "identifierUris": [
    "http://sp-prod"
  ],
  ...
```

So CLI will use `1f440000-0000-0000-0000-000000000000` as a `identifierUri` to create a new Application:

https://github.com/Azure/azure-cli/blob/50ccb24528eb36529d1432808f3ff385cc4c04aa/src/azure-cli/azure/cli/command_modules/role/custom.py#L820-L822

This is why `PUT` is called, instead of `PATCH`. This will certainly fail as `1f440000-0000-0000-0000-000000000000` is not a valid `identifierUri` (should start with `http://`).

## Change

As the query for searching Service Principal already uses `name` (`http://sp-prod`):

https://github.com/Azure/azure-cli/blob/50ccb24528eb36529d1432808f3ff385cc4c04aa/src/azure-cli/azure/cli/command_modules/role/custom.py#L1414

there is simply no need to re-set `name` to the first item:

https://github.com/Azure/azure-cli/blob/50ccb24528eb36529d1432808f3ff385cc4c04aa/src/azure-cli/azure/cli/command_modules/role/custom.py#L1418

In other words, `name` already has correct value (`http://sp-prod`).

## Temporary mitigation

As the Service Principal's response is not always consistent, the user should delete the old Application with `az ad app delete` and run `az ad sp create-for-rbac` from scratch (without existing Service Principal and Application.)