### PR TITLE
[Core] Provide recommendation for JSON parsing error

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -512,11 +512,25 @@ def shell_safe_json_parse(json_or_dict_string, preserve_order=False, strict=True
         try:
             import ast
             return ast.literal_eval(json_or_dict_string)
-        except SyntaxError:
-            raise CLIError(json_ex)
-        except ValueError as ex:
+        except Exception as ex:
             logger.debug(ex)  # log the exception which could be a python dict parsing error.
-            raise CLIError(json_ex)  # raise json_ex error which is more readable and likely.
+
+            # Echo the JSON received by CLI
+            msg = "Failed to parse JSON: {}\nError detail: {}".format(json_or_dict_string, json_ex)
+
+            # Recommendation for all shells
+            from azure.cli.core.azclierror import InvalidArgumentValueError
+            recommendation = "The JSON may have been parsed by the shell. See " \
+                             "https://docs.microsoft.com/cli/azure/use-cli-effectively#quoting-issues"
+
+            # Recommendation especially for PowerShell
+            parent_proc = get_parent_proc_name().lower()
+            if parent_proc in ("powershell.exe", "pwsh.exe"):
+                recommendation += "\nPowerShell requires additional quoting rules. See " \
+                                  "https://github.com/Azure/azure-cli/blob/dev/doc/quoting-issues-with-powershell.md"
+
+            # Raise from json_ex error which is more likely to be the original error
+            raise InvalidArgumentValueError(msg, recommendation=recommendation) from json_ex
 
 
 def b64encode(s):
@@ -1222,7 +1236,8 @@ def _get_parent_proc_name():
     # Un-cached function to get parent process name.
     try:
         import psutil
-    except ImportError:
+    except ImportError as ex:
+        logger.debug(ex)
         return None
 
     import os

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -67,7 +67,7 @@ DEPENDENCIES = [
 
 # dependencies for specific OSes
 if not sys.platform.startswith('cygwin'):
-    DEPENDENCIES.append('psutil~=5.7')
+    DEPENDENCIES.append('psutil~=5.8')
 
 TESTS_REQUIRE = [
     'mock'

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -114,7 +114,7 @@ oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==1.7.1
-psutil==5.7.2
+psutil==5.8.0
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -115,7 +115,7 @@ oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==1.7.1
-psutil==5.7.2
+psutil==5.8.0
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -114,7 +114,7 @@ oauthlib==3.0.1
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==1.7.1
-psutil==5.7.2
+psutil==5.8.0
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0


### PR DESCRIPTION
## Description

We are seeing countless users complaining they have stumbled on [Quoting issues with PowerShell](https://github.com/Azure/azure-cli/blob/dev/doc/quoting-issues-with-powershell.md).

All issues received: https://github.com/Azure/azure-cli/issues?q=is%3Aissue+label%3A%22Shell+-+PowerShell%22

## Changes

This PR refines the error message of JSON parsing error:

- Echo the JSON received by CLI
- Provide recommendation for all shells
- Provide recommendation especially for PowerShell
- Use the new `InvalidArgumentValueError` to replace `CLIError`

## Testing Guide

Before:

```sh
# In powershell.exe or pwsh.exe
> az monitor diagnostic-settings create --logs '{"category":"QueryRuntimeStatistics"}'
Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
```

After:

```sh
# In powershell.exe or pwsh.exe
> az monitor diagnostic-settings create --logs '{"category":"QueryRuntimeStatistics"}'
Failed to parse JSON: {category:QueryRuntimeStatistics}
Error detail: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
The JSON may have been parsed by the shell. See https://docs.microsoft.com/cli/azure/use-cli-effectively#quoting-issues
PowerShell requires additional quoting rules. See https://github.com/Azure/azure-cli/blob/dev/doc/quoting-issues-with-powershell.md
```
