### PR TITLE
{CI} Restore `az self-test`

### DIFF
--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -23,13 +23,13 @@ exit_code=0
 block_list='azure-cli-ml azure-iot'
 
 for ext in $output; do
+    echo
     # Use regex to detect if $ext is in $block_list
     if [[ $block_list =~ $ext ]]; then
-        echo "$ext is skipped"
+        echo "Skip extension: $ext"
         continue
     fi
 
-    echo
     echo "Verifying extension:" $ext
     az extension add -n $ext
     if [ $? != 0 ]

--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -18,8 +18,8 @@ export AZURE_CLI_DIAGNOSTICS_TELEMETRY=
 output=$(az extension list-available --query [].name -otsv)
 exit_code=0
 
-# TODO: Remove when ML extension is compatible with CLI 2.0.69 core
-# https://github.com/Azure/azure-cli-extensions/issues/826
+# azure-cli-ml: https://github.com/Azure/azure-cli-extensions/issues/826
+# azure-iot: https://github.com/Azure/azure-cli/pull/17456
 block_list='azure-cli-ml azure-iot'
 
 for ext in $output; do

--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -18,11 +18,14 @@ export AZURE_CLI_DIAGNOSTICS_TELEMETRY=
 output=$(az extension list-available --query [].name -otsv)
 exit_code=0
 
-for ext in $output; do
+# TODO: Remove when ML extension is compatible with CLI 2.0.69 core
+# https://github.com/Azure/azure-cli-extensions/issues/826
+block_list='azure-cli-ml azure-iot'
 
-    # TODO: Remove when ML extension is compatible with CLI 2.0.69 core
-    # https://github.com/Azure/azure-cli-extensions/issues/826
-    if [ $ext == 'azure-cli-ml' ]; then
+for ext in $output; do
+    # Use regex to detect if $ext is in $block_list
+    if [[ $block_list =~ $ext ]]; then
+        echo "$ext is skipped"
         continue
     fi
 
@@ -36,11 +39,11 @@ for ext in $output; do
     fi
 done
 
-#az self-test --debug
-#if [ $? != 0 ]
-#then
-#    exit_code=1
-#    echo "Failed to verify:" $ext
-#fi
+az self-test --debug
+if [ $? != 0 ]
+then
+    exit_code=1
+    echo "Failed to verify:" $ext
+fi
 
 exit $exit_code


### PR DESCRIPTION
## Symptom

CI failure https://dev.azure.com/azure-sdk/public/_build/results?buildId=801336&view=logs&j=34631516-3f1c-501b-e428-6ea670d20b1c&t=4ecab084-061a-520a-6791-4f5413067b6d&l=1816

```
  File "/opt/az/azcliextensions/arcappliance/azext_arcappliance/pkg/resource/logic/util.py", line 5, in <module>
    from jsonschema import validate, ValidationError
  File "/opt/az/azcliextensions/azure-iot/jsonschema/__init__.py", line 33, in <module>
    __version__ = get_distribution(__name__).version
  ...
  File "/opt/hostedtoolcache/Python/3.6.13/x64/lib/python3.6/site-packages/pkg_resources/__init__.py", line 784, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'jsonschema' distribution was not found and is required by the application
```

## Root cause

This can also be reproed locally. (You may need to rename `~/cliextensions/azure-iot` to `aazure-iot` to make it appear earlier than `arcappliance`, because `os.listdir`'s result is not sorted.)

```
az extension add -n azure-iot
az extension add -n arcappliance
az self-test
```

Same error problem can be reproed with only `azure-iot`.

❌ This doesn't work:

```py
import sys
import pkg_resources

sys.path.append(r'C:\Users\me\.azure\cliextensions\azure-iot')
print(pkg_resources.working_set.by_key.get('jsonschema'))
disk = pkg_resources.get_distribution('jsonschema')
```

```
None
Traceback (most recent call last):
  File "D:\cli\testproj\demo.py", line 8, in <module>
    print(pkg_resources.get_distribution('jsonschema'))
  ...
  File "D:\cli\py39\lib\site-packages\pkg_resources\__init__.py", line 772, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'jsonschema' distribution was not found and is required by the application
```

✔ This works:

```py
import sys

sys.path.append(r'C:\Users\me\.azure\cliextensions\azure-iot')

import pkg_resources
print(pkg_resources.working_set.by_key.get('jsonschema'))
print(pkg_resources.get_distribution('jsonschema'))
```

```
jsonschema 3.0.2
jsonschema 3.0.2
```

This is because the change on `sys.path` doesn't take effect if `pkg_resources` is already imported.

CLI imports `pkg_resources` first:

https://github.com/Azure/azure-cli/blob/0df58e9ab2e4c4e0986f2bb8ce4fa0e02c2b4bff/src/azure-cli-core/azure/cli/core/__init__.py#L625

Then it changes `sys.path`:

https://github.com/Azure/azure-cli/blob/0df58e9ab2e4c4e0986f2bb8ce4fa0e02c2b4bff/src/azure-cli-core/azure/cli/core/__init__.py#L337

As for why this issue doesn't happen when installed separately:

- When only loading `azure-iot`, `azure-iot/jsonschema/__init__.py` is not loaded at all (but the 🐛 is there). When `azure-iot` really uses `jsonschema`, `azure-iot/azext_iot/common/utility.py:415` has its _workaround_ to update `pkg_resources.working_set`:
    ```py
    def ensure_pkg_resources_entries():
        import pkg_resources

        from azure.cli.core.extension import get_extension_path
        from azext_iot.constants import EXTENSION_NAME

        extension_path = get_extension_path(EXTENSION_NAME)
        if extension_path not in pkg_resources.working_set.entries:
            pkg_resources.working_set.add_entry(extension_path)

        return
    ```
- When only loading `arcappliance`, it loads `arcappliance/jsonschema/__init__.py`, which uses the new `importlib.metadata` and works fine
- When they are installed together, both `azure-iot` and `arcappliance` are loaded to `sys.path`. If `azure-iot` is loaded first, `arcappliance` loads `jsonschema` from `azure-iot/jsonschema/__init__.py`, thus bypassing the workaround and hit the 🐛

ℹ The above conclusion is derived by adding 

```py
import traceback
traceback.print_stack()
```

to 

- `pkg_resources/__init__.py`
- `azure-iot/jsonschema/__init__.py`
- `arcappliance/jsonschema/__init__.py`

Then run `az self-test` to observe the result.

> Actually, `az self-test` should not load all extensions together

It is possible for CLI to load all extensions together - when command index has not been built yet.

## Proposed solution

Fix the `azure-iot` extension by using the latest `jsonschema` which uses `importlib.metadata`(https://github.com/Julian/jsonschema/commit/6a7155a854d57e3f13f9dec15f2ade0820dbca2a, https://github.com/Julian/jsonschema/commit/fe772c380c48eb14fc47bbd0a0c95888b9ea700a)

## Mitigation

This PR restores `az self-test` and blocks `azure-iot` until `jsonschema` is bumped to the latest version.

