### PR TITLE
{Core} Fix `test_open_page_in_browser` on WSL

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -16,7 +16,7 @@ from azure.cli.core.util import \
     (get_file_json, truncate_text, shell_safe_json_parse, b64_to_hex, hash_string, random_string,
      open_page_in_browser, can_launch_browser, handle_exception, ConfiguredDefaultSetter, send_raw_request,
      should_disable_connection_verify, parse_proxy_resource_id, get_az_user_agent, get_az_rest_user_agent,
-     _get_parent_proc_name)
+     _get_parent_proc_name, is_wsl)
 from azure.cli.core.mock import DummyCli
 
 
@@ -151,11 +151,13 @@ class TestUtils(unittest.TestCase):
 
     @mock.patch('webbrowser.open', autospec=True)
     @mock.patch('subprocess.Popen', autospec=True)
-    def test_open_page_in_browser(self, sunprocess_open_mock, webbrowser_open_mock):
+    def test_open_page_in_browser(self, subprocess_open_mock, webbrowser_open_mock):
         platform = sys.platform.lower()
         open_page_in_browser('http://foo')
-        if platform == 'darwin':
-            sunprocess_open_mock.assert_called_once_with(['open', 'http://foo'])
+        if is_wsl():
+            subprocess_open_mock.assert_called_once_with(['powershell.exe', '-Command', 'Start-Process "http://foo"'])
+        elif platform == 'darwin':
+            subprocess_open_mock.assert_called_once_with(['open', 'http://foo'])
         else:
             webbrowser_open_mock.assert_called_once_with('http://foo', 2)
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -643,7 +643,7 @@ def open_page_in_browser(url):
         try:
             # https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe
             # Ampersand (&) should be quoted
-            return subprocess.call(['powershell.exe', '-Command', 'Start-Process "{}"'.format(url)])
+            return subprocess.Popen(['powershell.exe', '-Command', 'Start-Process "{}"'.format(url)])
         except OSError:  # WSL might be too old  # FileNotFoundError introduced in Python 3
             pass
     elif platform_name == 'darwin':


### PR DESCRIPTION
**Description**<!--Mandatory-->

`src/azure-cli-core/azure/cli/core/tests/test_util.py::TestUtils::test_open_page_in_browser` fails on WSL:

```py
_mock_self = <MagicMock name='open' spec='function' id='139689703216128'>, args = ('http://foo', 2), kwargs = {}
self = <MagicMock name='open' spec='function' id='139689703216128'>
msg = "Expected 'open' to be called once. Called 0 times."

    def assert_called_once_with(_mock_self, *args, **kwargs):
        """assert that the mock was called exactly once and that that call was
        with the specified arguments."""
        self = _mock_self
        if not self.call_count == 1:
            msg = ("Expected '%s' to be called once. Called %s times.%s"
                   % (self._mock_name or 'mock',
                      self.call_count,
                      self._calls_repr()))
>           raise AssertionError(msg)
E           AssertionError: Expected 'open' to be called once. Called 0 times.

env38/lib/python3.8/site-packages/mock/mock.py:925: AssertionError
```

Now fix it!