### PR TITLE
{Core} Fix: `test_credscache_good_error_on_file_corruption` fails when run in parallel with other tests

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -113,6 +113,7 @@ def _load_tokens_from_file(file_path):
             raise CLIError("Failed to load token files. If you have a repro, please log an issue at "
                            "https://github.com/Azure/azure-cli/issues. At the same time, you can clean "
                            "up by running 'az account clear' and then 'az login'. (Inner Error: {})".format(ex))
+    logger.debug("'%s' is not a file or doesn't exist.", file_path)
     return []
 
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -1787,8 +1787,9 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(token_type, token_entry2['tokenType'])
 
     @mock.patch('azure.cli.core._profile.get_file_json', autospec=True)
-    def test_credscache_good_error_on_file_corruption(self, mock_read_file):
-        mock_read_file.side_effect = ValueError('a bad error for you')
+    @mock.patch('os.path.isfile', autospec=True, return_value=True)
+    def test_credscache_good_error_on_file_corruption(self, isfile_mock, get_file_json_mock):
+        get_file_json_mock.side_effect = ValueError('a bad error for you')
         cli = DummyCli()
 
         # action


### PR DESCRIPTION
## Symptom

Fix: `test_credscache_good_error_on_file_corruption` fails when run in parallel with other tests

CI failure:

https://dev.azure.com/azure-sdk/playground/_build/results?buildId=806624&view=logs&j=abe8eae2-a613-5a65-3eeb-3e8a13573181&t=ff49c02d-6a40-524c-c9b1-98f6bb13c7f4&l=2248

```
__________ TestProfile.test_credscache_good_error_on_file_corruption ___________
[gw0] linux -- Python 3.8.8 /home/vsts/work/1/s/env/bin/python
self = <azure.cli.core.tests.test_profile.TestProfile testMethod=test_credscache_good_error_on_file_corruption>
get_file_json_mock = <function get_file_json at 0x7f723502fee0>

    @mock.patch('azure.cli.core._profile.get_file_json', autospec=True)
    def test_credscache_good_error_on_file_corruption(self, get_file_json_mock):
        get_file_json_mock.side_effect = ValueError('a bad error for you')
        cli = DummyCli()
    
        # action
        creds_cache = CredsCache(cli, async_persist=False)
    
        # assert
        with self.assertRaises(CLIError) as context:
>           creds_cache.load_adal_token_cache()
E           AssertionError: CLIError not raised

src/azure-cli-core/azure/cli/core/tests/test_profile.py:1799: AssertionError
```

## Root cause

The test `test_credscache_good_error_on_file_corruption` assumes `~/.azure/accessTokens.json` exists when it is run. If there is no `~/.azure/accessTokens.json`,

https://github.com/Azure/azure-cli/blob/50ccb24528eb36529d1432808f3ff385cc4c04aa/src/azure-cli-core/azure/cli/core/_profile.py#L109

evaluates to `False`, thus bypassing the code under test, causing failure.

This can also be repoed by deleting `~/.azure/accessTokens.json` and only running `test_credscache_good_error_on_file_corruption`:

```
pytest src/azure-cli-core/azure/cli/core/tests/test_profile.py::TestProfile::test_credscache_good_error_on_file_corruption -o log_cli_level=DEBUG
```

⚠ In parallel testing, the existence of `~/.azure/accessTokens.json` is not guaranteed, so the failure.

## Change

Also patch `os.path.isfile` to make the test isolated from the underlying file system.
