### PR TITLE
[AppService] Fixes #17219: Fix ssl bind bug

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2584,14 +2584,14 @@ def _update_ssl_binding(cmd, resource_group_name, name, certificate_thumbprint, 
             if webapp_cert.thumbprint == certificate_thumbprint:
                 found_cert = webapp_cert
     if found_cert:
-        if len(webapp_cert.host_names) == 1 and not webapp_cert.host_names[0].startswith('*'):
+        if len(found_cert.host_names) == 1 and not found_cert.host_names[0].startswith('*'):
             return _update_host_name_ssl_state(cmd, resource_group_name, name, webapp,
-                                               webapp_cert.host_names[0], ssl_type,
+                                               found_cert.host_names[0], ssl_type,
                                                certificate_thumbprint, slot)
 
         query_result = list_hostnames(cmd, resource_group_name, name, slot)
         hostnames_in_webapp = [x.name.split('/')[-1] for x in query_result]
-        to_update = _match_host_names_from_cert(webapp_cert.host_names, hostnames_in_webapp)
+        to_update = _match_host_names_from_cert(found_cert.host_names, hostnames_in_webapp)
         for h in to_update:
             _update_host_name_ssl_state(cmd, resource_group_name, name, webapp,
                                         h, ssl_type, certificate_thumbprint, slot)


### PR DESCRIPTION
**Description**<!--Mandatory-->
Fix `az webapp config ssl bind` using the wrong ssl cert to bind

**Testing Guide**
If app has multiple ssl certs, `az webapp config ssl bind` uses the wrong one

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
