### PR TITLE
[Container] Fix #16499: az container create: fix handling of return value from network_profiles.create_or_update

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/container/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/container/custom.py
@@ -345,7 +345,7 @@ def _get_vnet_network_profile(cmd, location, resource_group_name, vnet, vnet_add
     )
 
     logger.info('Creating network profile "%s" in resource group "%s"', default_network_profile_name, resource_group_name)
-    network_profile = ncf.network_profiles.create_or_update(resource_group_name, default_network_profile_name, network_profile).result()
+    network_profile = ncf.network_profiles.create_or_update(resource_group_name, default_network_profile_name, network_profile)
 
     return network_profile.id
 


### PR DESCRIPTION
**Description**

This pull request fixes issue [16499](https://github.com/Azure/azure-cli/issues/16499)

The implementation of 'az container create' is expecting the wrong return value from NetworkProfilesOperations.create_or_update().

NetworkProfilesOperations.create_or_update() is documented here:

https://docs.microsoft.com/en-us/python/api/azure-mgmt-network/azure.mgmt.network.v2020_06_01.operations.networkprofilesoperations?view=azure-python#create-or-update-resource-group-name--network-profile-name--parameters----kwargs-

**Testing Guide**

As described in issue 16499, run a command similar to the following using an empty resource group:

`
az container create --registry-username reguser 
--location eastus 
--registry-password regpassword 
--name container-name 
--resource-group container-resource-group 
--image image:tag 
--vnet container-vnet 
--vnet-address-prefix 192.168.0.0/16 
--subnet container-subnet 192.168.0.0/24 
--subnet-address-prefix 10.0.0.0/24
`

The command will fail the first time it is run because the azure-cli is expecting a different return value. The command will create the vnet, subnet, and network profile before failing. This allows the command to succeed the second time it is run.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
