### PR TITLE
[AppService] Bugfix: Handle if only single publish profile is returned

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1056,7 +1056,7 @@ def _fill_ftp_publishing_url(cmd, webapp, resource_group_name, name, slot=None):
     try:
         url = next(p['publishUrl'] for p in profiles if p['publishMethod'] == 'FTP')
         setattr(webapp, 'ftpPublishingUrl', url)
-    except StopIteration as e:
+    except StopIteration:
         pass
     return webapp
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2000,14 +2000,6 @@ def list_publishing_credentials(cmd, resource_group_name, name, slot=None):
     return content.result()
 
 
-def _convert_publish_profile_from_xml(profile):
-    new = {}
-    for key in profile:
-        # strip the leading '@' xmltodict put in for attributes
-        new[key.lstrip('@')] = profile[key]
-    return new
-
-
 def list_publish_profiles(cmd, resource_group_name, name, slot=None, xml=False):
     import xmltodict
 
@@ -2021,12 +2013,14 @@ def list_publish_profiles(cmd, resource_group_name, name, slot=None, xml=False):
         profiles = xmltodict.parse(full_xml, xml_attribs=True)['publishData']['publishProfile']
         converted = []
 
-        if isinstance(profiles, list):
-            for profile in profiles:
-                new = _convert_publish_profile_from_xml(profile)
-                converted.append(new)
-        else:
-            new = _convert_publish_profile_from_xml(profiles)
+        if not isinstance(profiles, list):
+            profiles = [profiles]
+
+        for profile in profiles:
+            new = {}
+            for key in profile:
+                # strip the leading '@' xmltodict put in for attributes
+                new[key.lstrip('@')] = profile[key]
             converted.append(new)
         return converted
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1083,7 +1083,7 @@ def _add_fx_version(cmd, resource_group_name, name, custom_image_name, slot=None
     web_app = get_webapp(cmd, resource_group_name, name, slot)
     if not web_app:
         raise CLIError("'{}' app doesn't exist in resource group {}".format(name, resource_group_name))
-    linux_fx = fx_version if web_app.reserved else None
+    linux_fx = fx_version if (web_app.reserved or not web_app.is_xenon) else None
     windows_fx = fx_version if web_app.is_xenon else None
     return update_site_configs(cmd, resource_group_name, name,
                                linux_fx_version=linux_fx, windows_fx_version=windows_fx, slot=slot)


### PR DESCRIPTION
**Description**<!--Mandatory-->
In some apps with only single publish profile, API doesn't return a list and`az webapp deployment source config-zip` breaks

**Testing Guide**
Run `az webapp deployment source config-zip` on a webapp that only has a single publish profile, the command will error out.
The behaviour will not be changed if the webapp has multiple publish profiles

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
