### PR TITLE
[RDBMS] Allowing DB server private access from different subscription

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_client_factory.py
@@ -355,9 +355,9 @@ def cf_postgres_flexible_db(cli_ctx, _):
     return get_postgresql_flexible_management_client(cli_ctx).databases
 
 
-def resource_client_factory(cli_ctx, **_):
-    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES)
+def resource_client_factory(cli_ctx, subscription_id=None):
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES, subscription_id=subscription_id)
 
 
-def network_client_factory(cli_ctx):
-    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_NETWORK)
+def network_client_factory(cli_ctx, subscription_id=None):
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_NETWORK, subscription_id=subscription_id)

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -262,7 +262,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements
                            validator=retention_validator)
                 c.argument('version', default='12', options_list=['--version'],
                            help='Server major version.')
-                c.argument('zone', options_list=['--zone, -z'],
+                c.argument('zone', options_list=['--zone', '-z'],
                            help='Availability zone into which to provision the resource.')
             elif command_group == 'mysql':
                 c.argument('tier', default='Burstable',
@@ -275,7 +275,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements
                            help='The number of days a backup is retained. Range of 7 to 35 days. Default is 7 days.')
                 c.argument('version', default='5.7', options_list=['--version'],
                            help='Server major version.')
-                c.argument('zone', options_list=['--zone, -z'],
+                c.argument('zone', options_list=['--zone', '-z'],
                            help='Availability zone into which to provision the resource.')
                 c.argument('iops', type=int, options_list=['--iops'],
                            help='Number of IOPS to be allocated for this server. You will get certain amount of free IOPS based '
@@ -289,7 +289,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements
                        help='Resource ID of an existing subnet. Please note that the subnet will be delegated to Microsoft.DBforPostgreSQL/flexibleServers/Microsoft.DBforMySQL/flexibleServers.After delegation, this subnet cannot be used for any other type of Azure resources.')
             c.argument('server_name', options_list=['--name', '-n'], arg_type=server_name_setter_arg_type)
             c.argument('location', arg_type=get_location_type(self.cli_ctx))
-            c.argument('administrator_login', default=generate_username(), options_list=['--admin-user, -u'], arg_group='Authentication', arg_type=administrator_login_setter_arg_type,
+            c.argument('administrator_login', default=generate_username(), options_list=['--admin-user', '-u'], arg_group='Authentication', arg_type=administrator_login_setter_arg_type,
                        help='Administrator username for the server. Once set, it cannot be changed. ')
             c.argument('administrator_login_password', options_list=['--admin-password', '-p'],
                        help='The password of the administrator. Minimum 8 characters and maximum 128 characters. Password must contain characters from three of the following categories: English uppercase letters, English lowercase letters, numbers, and non-alphanumeric characters.',

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
@@ -583,7 +583,7 @@ def database_create_func(client, resource_group_name=None, server_name=None, dat
         charset = 'utf8'
         collation = 'utf8_general_ci'
         logger.warning("Creating database with utf8 charset and utf8_general_ci collation")
-    elif charset or collation:
+    elif (not charset and collation) or (charset and not collation):
         raise RequiredArgumentMissingError("charset and collation have to be input together.")
 
     parameters = {

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -361,7 +361,7 @@ def database_create_func(client, resource_group_name=None, server_name=None, dat
         charset = 'utf8'
         collation = 'en_US.utf8'
         logger.warning("Creating database with utf8 charset and en_US.utf8 collation")
-    elif charset or collation:
+    elif (not charset and collation) or (charset and not collation):
         raise RequiredArgumentMissingError("charset and collation have to be input together.")
 
     parameters = {

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -17,7 +17,7 @@ DEFAULT_VNET_ADDRESS_PREFIX = '10.0.0.0/16'
 DEFAULT_SUBNET_PREFIX = '10.0.0.0/24'
 
 
-# pylint: disable=too-many-locals, too-many-statements
+# pylint: disable=too-many-locals, too-many-statements, too-many-branches
 def prepare_vnet(cmd, server_name, vnet, subnet, resource_group_name, loc, delegation_service_name, vnet_address_pref, subnet_address_pref):
     Delegation, Subnet, VirtualNetwork, AddressSpace, ServiceEndpoint = cmd.get_models('Delegation', 'Subnet', 'VirtualNetwork',
                                                                                        'AddressSpace', 'ServiceEndpointPropertiesFormat',
@@ -171,7 +171,7 @@ def _create_vnet_subnet_delegation(nw_client, resource_group, vnet_name, subnet_
         vnet_exist = _get_resource(nw_client.virtual_networks, resource_group, vnet_name)
         if not vnet_exist:
             logger.warning('The Vnet does not exist. Creating new vnet "%s" in resource group "%s"',
-                        vnet_name, resource_group)
+                           vnet_name, resource_group)
             nw_client.virtual_networks.begin_create_or_update(resource_group,
                                                               vnet_name,
                                                               VirtualNetwork(name=vnet_name,

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands.py
@@ -444,7 +444,7 @@ class FlexibleServerVnetServerMgmtScenarioTest(RdbmsScenarioTest):
                  .format(database_engine, resource_group, restore_server), checks=NoneCheck())
 
         # Wait until vnet can be detached from the deleted server
-        time.sleep(5 * 60)
+        time.sleep(15 * 60)
 
     def _test_flexible_server_vnet_server_mgmt_delete(self, resource_group):
         self.cmd('az group delete --name {} --yes --no-wait'.format(resource_group), checks=NoneCheck())
@@ -639,7 +639,7 @@ class FlexibleServerReplicationMgmtScenarioTest(RdbmsScenarioTest):  # pylint: d
                      JMESPathCheck('sourceServerId', result['id']),
                      JMESPathCheck('replicaCapacity', '0')])
 
-        time.sleep(5 * 60)
+        time.sleep(15 * 60)
 
     def _test_flexible_server_replica_list(self, database_engine, resource_group, master_server):
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands_mysql.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands_mysql.py
@@ -57,7 +57,7 @@ class MySqlFlexibleServerMgmtScenarioTest(FlexibleServerMgmtScenarioTest):
     @pytest.mark.dependency(name="test_mysql_flexible_server_mgmt_prepare")
     def test_mysql_flexible_server_mgmt_prepare(self):
         self.cmd('az group create --location {} --name {}'.format('mysql_location', self.resource_group))
-        self.cmd('az {} flexible-server create -l {} -g {} -n {} --public-access none'.format('mysql', 'francecentral', self.resource_group, self.server))
+        self.cmd('az {} flexible-server create -l {} -g {} -n {} --public-access none'.format('mysql', mysql_location, self.resource_group, self.server))
 
     @AllowLargeResponse()
     @pytest.mark.order(2)

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands_mysql.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands_mysql.py
@@ -54,103 +54,103 @@ class MySqlFlexibleServerMgmtScenarioTest(FlexibleServerMgmtScenarioTest):
         self.location = mysql_location
 
     @pytest.mark.order(1)
+    @pytest.mark.dependency(name="test_mysql_flexible_server_mgmt_prepare")
     def test_mysql_flexible_server_mgmt_prepare(self):
-        self.cmd('az group create --location {} --name {}'.format(mysql_location, self.resource_group))
-        self.cmd('az {} flexible-server create -l {} -g {} -n {} --public-access none'.format('mysql', mysql_location, self.resource_group, self.server))
+        self.cmd('az group create --location {} --name {}'.format('mysql_location', self.resource_group))
+        self.cmd('az {} flexible-server create -l {} -g {} -n {} --public-access none'.format('mysql', 'francecentral', self.resource_group, self.server))
 
     @AllowLargeResponse()
     @pytest.mark.order(2)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_mgmt_prepare'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_create(self):
         self._test_flexible_server_create('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(3)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_create'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_update_password(self):
         self._test_flexible_server_update_password('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(4)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_update_password'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_update_storage(self):
         self._test_flexible_server_update_storage('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(5)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_update_storage'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_update_backup_retention(self):
         self._test_flexible_server_update_backup_retention('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(6)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_update_backup_retention'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_update_scale_up(self):
         self._test_flexible_server_update_scale_up('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(7)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_update_scale_up'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_update_scale_down(self):
         self._test_flexible_server_update_scale_down('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_update_scale_down'])
+    @pytest.mark.order(8)
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_update_mmw(self):
         self._test_flexible_server_update_mmw('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
-    @pytest.mark.order(8)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_update_mmw'])
+    @pytest.mark.order(9)
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_update_tag(self):
         self._test_flexible_server_update_tag('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
-    @pytest.mark.order(9)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_update_tag'])
+    @pytest.mark.order(10)
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_restart(self):
         self._test_flexible_server_restart('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(10)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_restart'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_stop(self):
         self._test_flexible_server_stop('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(11)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_stop'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_start(self):
         self._test_flexible_server_start('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(12)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_start'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_list(self):
         self._test_flexible_server_list('mysql', self.resource_group)
         self._test_flexible_server_connection_string('mysql', self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(13)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_list'])
     def test_mysql_flexible_server_list_skus(self):
         self._test_flexible_server_list_skus('mysql', self.location)
 
     @AllowLargeResponse()
     @pytest.mark.order(14)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_list_skus'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_restore(self):
         self._test_flexible_server_restore('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(15)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_restore'])
     def test_mysql_flexible_server_create_non_default_tiers(self):
         self._test_flexible_server_create_non_default_tiers('mysql', self.resource_group)
 
     @AllowLargeResponse()
     @pytest.mark.order(16)
-    @pytest.mark.depends(on=['MySqlFlexibleServerMgmtScenarioTest::test_mysql_flexible_server_create_non_default_tiers'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_mgmt_prepare"])
     def test_mysql_flexible_server_delete(self):
         self.cmd('az group delete --name {} --yes --no-wait'.format(self.resource_group))
 
@@ -172,25 +172,25 @@ class MySqlFlexibleServerIopsMgmtScenarioTest(FlexibleServerIopsMgmtScenarioTest
 
     @AllowLargeResponse()
     @pytest.mark.order(2)
-    @pytest.mark.depends(on=['MySqlFlexibleServerIopsMgmtScenarioTest::test_mysql_flexible_server_iops_prepare'])
+    @pytest.mark.dependency(name="test_mysql_flexible_server_iops_create")
     def test_mysql_flexible_server_iops_create(self):
         self._test_flexible_server_iops_create('mysql', self.resource_group, self.server_1, self.server_2, self.server_3)
 
     @AllowLargeResponse()
     @pytest.mark.order(3)
-    @pytest.mark.depends(on=['MySqlFlexibleServerIopsMgmtScenarioTest::test_mysql_flexible_server_iops_create'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_iops_create"])
     def test_mysql_flexible_server_iops_scale_up(self):
         self._test_flexible_server_iops_scale_up('mysql', self.resource_group, self.server_1, self.server_2, self.server_3)
 
     @AllowLargeResponse()
     @pytest.mark.order(4)
-    @pytest.mark.depends(on=['MySqlFlexibleServerIopsMgmtScenarioTest::test_mysql_flexible_server_iops_scale_up'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_iops_create"])
     def test_mysql_flexible_server_iops_scale_down(self):
         self._test_flexible_server_iops_scale_down('mysql', self.resource_group, self.server_1, self.server_2, self.server_3)
 
     @AllowLargeResponse()
     @pytest.mark.order(5)
-    @pytest.mark.depends(on=['MySqlFlexibleServerIopsMgmtScenarioTest::test_mysql_flexible_server_iops_scale_down'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_iops_create"])
     def test_mysql_flexible_server_iops_delete(self):
         self.cmd('az group delete --name {} --yes --no-wait'.format(self.resource_group))
 
@@ -214,25 +214,25 @@ class MySqlFlexibleServerVnetServerMgmtScenarioTest(FlexibleServerVnetServerMgmt
     @unittest.skip("Service is temporarily busy and the operation cannot be performed. Please try again later.")
     @AllowLargeResponse()
     @pytest.mark.order(2)
-    @pytest.mark.depends(on=['MySqlFlexibleServerVnetServerMgmtScenarioTest::test_mysql_flexible_server_vnet_server_prepare'])
+    @pytest.mark.dependency(name="test_mysql_flexible_server_vnet_server_create")
     def test_mysql_flexible_server_vnet_server_create(self):
         self._test_flexible_server_vnet_server_create('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(3)
-    @pytest.mark.depends(on=['MySqlFlexibleServerVnetServerMgmtScenarioTest::test_mysql_flexible_server_vnet_server_create'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_vnet_server_create"])
     def test_mysql_flexible_server_vnet_server_update_scale_up(self):
         self._test_flexible_server_vnet_server_update_scale_up('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(4)
-    @pytest.mark.depends(on=['MySqlFlexibleServerVnetServerMgmtScenarioTest::test_mysql_flexible_server_vnet_server_update_scale_up'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_vnet_server_create"])
     def test_mysql_flexible_server_vnet_server_restore(self):
         self._test_flexible_server_vnet_server_restore('mysql', self.resource_group, self.server, self.restore_server)
 
     @AllowLargeResponse()
     @pytest.mark.order(5)
-    @pytest.mark.depends(on=['MySqlFlexibleServerVnetServerMgmtScenarioTest::test_mysql_flexible_server_vnet_server_restore'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_vnet_server_create"])
     def test_mysql_flexible_server_vnet_server_delete(self):
         self._test_flexible_server_vnet_server_delete('mysql', self.resource_group, self.server, self.restore_server)
 
@@ -248,30 +248,31 @@ class MySqlFlexibleServerProxyResourceMgmtScenarioTest(FlexibleServerProxyResour
 
     @AllowLargeResponse()
     @pytest.mark.order(1)
+    @pytest.mark.dependency(name="test_mysql_flexible_server_proxy_resource_mgmt_prepare")
     def test_mysql_flexible_server_proxy_resource_mgmt_prepare(self):
         self.cmd('az group create --location {} --name {}'.format(mysql_location, self.resource_group))
         self.cmd('az {} flexible-server create -l {} -g {} -n {} --public-access none'.format('mysql', mysql_location, self.resource_group, self.server))
 
     @AllowLargeResponse()
     @pytest.mark.order(2)
-    @pytest.mark.depends(on=['MySqlFlexibleServerProxyResourceMgmtScenarioTest::test_mysql_flexible_server_proxy_resource_mgmt_prepare'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_proxy_resource_mgmt_prepare"])
     def test_mysql_flexible_server_firewall_rule_mgmt(self):
         self._test_firewall_rule_mgmt('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(3)
-    @pytest.mark.depends(on=['MySqlFlexibleServerProxyResourceMgmtScenarioTest::test_mysql_flexible_server_firewall_rule_mgmt'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_proxy_resource_mgmt_prepare"])
     def test_mysql_flexible_server_parameter_mgmt(self):
         self._test_parameter_mgmt('mysql', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(4)
-    @pytest.mark.depends(on=['MySqlFlexibleServerProxyResourceMgmtScenarioTest:test_mysql_flexible_server_parameter_mgmt'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_proxy_resource_mgmt_prepare"])
     def test_mysql_flexible_server_database_mgmt(self):
         self._test_database_mgmt('mysql', self.resource_group, self.server)
 
     @pytest.mark.order(5)
-    @pytest.mark.depends(on=['MySqlFlexibleServerProxyResourceMgmtScenarioTest::test_mysql_flexible_server_database_mgmt'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_proxy_resource_mgmt_prepare"])
     def test_mysql_flexible_server_proxy_resource_mgmt_delete(self):
         self._test_flexible_server_proxy_resource_mgmt_delete(self.resource_group)
 
@@ -301,6 +302,7 @@ class MySqlFlexibleServerReplicationMgmtScenarioTest(FlexibleServerReplicationMg
 
     @AllowLargeResponse()
     @pytest.mark.order(1)
+    @pytest.mark.dependency(name="test_mysql_flexible_server_replica_prepare")
     def test_mysql_flexible_server_replica_prepare(self):
         self.cmd('az group create --location {} --name {}'.format(mysql_location, self.resource_group))
         self.cmd('{} flexible-server create -g {} --name {} -l {} --storage-size {} --public-access none'
@@ -308,31 +310,31 @@ class MySqlFlexibleServerReplicationMgmtScenarioTest(FlexibleServerReplicationMg
 
     @AllowLargeResponse()
     @pytest.mark.order(2)
-    @pytest.mark.depends(on=['MySqlFlexibleServerReplicationMgmtScenarioTest::test_mysql_flexible_server_replica_prepare'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_replica_prepare"])
     def test_mysql_flexible_server_replica_create(self):
         self._test_flexible_server_replica_create('mysql', self.resource_group, self.master_server, self.replicas)
 
     @AllowLargeResponse()
     @pytest.mark.order(3)
-    @pytest.mark.depends(on=['MySqlFlexibleServerReplicationMgmtScenarioTest::test_mysql_flexible_server_replica_create'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_replica_prepare"])
     def test_mysql_flexible_server_replica_list(self):
         self._test_flexible_server_replica_list('mysql', self.resource_group, self.master_server)
 
     @AllowLargeResponse()
     @pytest.mark.order(4)
-    @pytest.mark.depends(on=['MySqlFlexibleServerReplicationMgmtScenarioTest::test_mysql_flexible_server_replica_list'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_replica_prepare"])
     def test_mysql_flexible_server_replica_stop(self):
         self._test_flexible_server_replica_stop('mysql', self.resource_group, self.master_server, self.replicas)
 
     @AllowLargeResponse()
     @pytest.mark.order(5)
-    @pytest.mark.depends(on=['MySqlFlexibleServerReplicationMgmtScenarioTest::test_mysql_flexible_server_replica_stop'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_replica_prepare"])
     def test_mysql_flexible_server_replica_delete_source(self):
         self._test_flexible_server_replica_delete_source('mysql', self.resource_group, self.master_server, self.replicas)
 
     @AllowLargeResponse()
     @pytest.mark.order(6)
-    @pytest.mark.depends(on=['MySqlFlexibleServerReplicationMgmtScenarioTest::test_mysql_flexible_server_replica_delete_source'])
+    @pytest.mark.dependency(depends=["test_mysql_flexible_server_replica_prepare"])
     def test_mysql_flexible_server_replica_delete(self):
         self._test_flexible_server_replica_delete('mysql', self.resource_group, self.replicas)
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands_postgres.py
@@ -53,110 +53,107 @@ class PostgresFlexibleServerMgmtScenarioTest(FlexibleServerMgmtScenarioTest):
         self.location = postgres_location
 
     @pytest.mark.order(1)
+    @pytest.mark.dependency(name="test_postgres_flexible_server_mgmt_prepare")
     def test_postgres_flexible_server_mgmt_prepare(self):
         self.cmd('az group create --location {} --name {}'.format(postgres_location, self.resource_group))
         self.cmd('az {} flexible-server create -l {} -g {} -n {} --public-access none'.format('postgres', postgres_location, self.resource_group, self.server))
 
     @AllowLargeResponse()
     @pytest.mark.order(2)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_mgmt_prepare'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_create(self):
         self._test_flexible_server_create('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(3)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_create'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_update_password(self):
         self._test_flexible_server_update_password('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(4)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_update_password'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_update_storage(self):
         self._test_flexible_server_update_storage('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(5)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_update_storage'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_update_backup_retention(self):
         self._test_flexible_server_update_backup_retention('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(6)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_update_backup_retention'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_update_scale_up(self):
         self._test_flexible_server_update_scale_up('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(7)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_update_scale_up'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_update_scale_down(self):
         self._test_flexible_server_update_scale_down('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(8)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_update_scale_down'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_update_mmw(self):
         self._test_flexible_server_update_mmw('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(9)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_update_mmw'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_update_tag(self):
         self._test_flexible_server_update_tag('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(10)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_update_tag'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_restart(self):
         self._test_flexible_server_restart('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(11)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_restart'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_stop(self):
         self._test_flexible_server_stop('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(12)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_stop'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_start(self):
         self._test_flexible_server_start('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(13)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_start'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_list(self):
         self._test_flexible_server_list('postgres', self.resource_group)
         self._test_flexible_server_connection_string('postgres', self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(14)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_list'])
     def test_postgres_flexible_server_list_skus(self):
         self._test_flexible_server_list_skus('postgres', self.location)
 
     @AllowLargeResponse()
     @pytest.mark.order(15)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_list_skus'])
     def test_postgres_flexible_server_create_non_default_tiers_select_zone(self):
         self._test_flexible_server_create_non_default_tiers('postgres', self.resource_group)
 
     @AllowLargeResponse()
     @pytest.mark.order(16)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_create_non_default_tiers_select_zone'])
     def test_postgres_flexible_server_create_different_version(self):
         self._test_flexible_server_create_different_version('postgres', self.resource_group)
 
     @AllowLargeResponse()
     @pytest.mark.order(17)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_create_different_version'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_mgmt_prepare"])
     def test_postgres_flexible_server_restore(self):
         self._test_flexible_server_restore('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(18)
-    @pytest.mark.depends(on=['PostgresFlexibleServerMgmtScenarioTest::test_postgres_flexible_server_restore'])
     def test_postgres_flexible_server_delete(self):
         self.cmd('az group delete --name {} --yes --no-wait'.format(self.resource_group))
 
@@ -176,61 +173,60 @@ class PostgresFlexibleServerHighAvailabilityMgmt(FlexibleServerHighAvailabilityM
 
     @AllowLargeResponse()
     @pytest.mark.order(2)
-    @pytest.mark.depends(on=['PostgresFlexibleServerHighAvailabilityMgmt::test_postgres_flexible_server_high_availability_prepare'])
+    @pytest.mark.dependency(name="test_postgres_flexible_server_high_availability_prepare")
     def test_postgres_flexible_server_high_availability_create(self):
         self._test_flexible_server_high_availability_create('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(3)
-    @pytest.mark.depends(on=['PostgresFlexibleServerHighAvailabilityMgmt::test_postgres_flexible_server_high_availability_create'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_high_availability_prepare"])
     def test_postgres_flexible_server_high_availability_disable(self):
         self._test_flexible_server_high_availability_disable('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(4)
-    @pytest.mark.depends(on=['PostgresFlexibleServerHighAvailabilityMgmt::test_postgres_flexible_server_high_availability_disable'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_high_availability_prepare"])
     def test_postgres_flexible_server_high_availability_enable(self):
         self._test_flexible_server_high_availability_enable('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(5)
-    @pytest.mark.depends(on=['PostgresFlexibleServerHighAvailabilityMgmt::test_postgres_flexible_server_high_availability_enable'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_high_availability_prepare"])
     def test_postgres_flexible_server_high_availability_update_scale_up(self):
         self._test_flexible_server_high_availability_update_scale_up('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(6)
-    @pytest.mark.depends(on=['PostgresFlexibleServerHighAvailabilityMgmt::test_postgres_flexible_server_high_availability_update_scale_up'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_high_availability_prepare"])
     def test_postgres_flexible_server_high_availability_update_parameter(self):
         self._test_flexible_server_high_availability_update_parameter('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(7)
-    @pytest.mark.depends(on=['PostgresFlexibleServerHighAvailabilityMgmt::test_postgres_flexible_server_high_availability_update_parameter'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_high_availability_prepare"])
     def test_postgres_flexible_server_high_availability_restart(self):
         self._test_flexible_server_high_availability_restart('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(8)
-    @pytest.mark.depends(on=['PostgresFlexibleServerHighAvailabilityMgmt::test_postgres_flexible_server_high_availability_restart'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_high_availability_prepare"])
     def test_postgres_flexible_server_high_availability_stop(self):
         self._test_flexible_server_high_availability_stop('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(9)
-    @pytest.mark.depends(on=['PostgresFlexibleServerHighAvailabilityMgmt::test_postgres_flexible_server_high_availability_stop'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_high_availability_prepare"])
     def test_postgres_flexible_server_high_availability_start(self):
         self._test_flexible_server_high_availability_start('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(10)
-    @pytest.mark.depends(on=['PostgresFlexibleServerHighAvailabilityMgmt::test_postgres_flexible_server_high_availability_start'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_high_availability_prepare"])
     def test_postgres_flexible_server_high_availability_restore(self):
         self._test_flexible_server_high_availability_restore('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(11)
-    @pytest.mark.depends(on=['PostgresFlexibleServerHighAvailabilityMgmt::test_postgres_flexible_server_high_availability_restore'])
     def test_postgres_flexible_server_high_availability_delete(self):
         self._test_flexible_server_high_availability_delete(self.resource_group)
 
@@ -253,55 +249,55 @@ class PostgresFlexibleServerVnetServerMgmtScenarioTest(FlexibleServerVnetServerM
     @unittest.skip("Takes too long. Need to re-record.")
     @AllowLargeResponse()
     @pytest.mark.order(2)
-    @pytest.mark.depends(on=['PostgresFlexibleServerVnetServerMgmtScenarioTest::test_postgres_flexible_server_vnet_server_prepare'])
+    @pytest.mark.dependency(name="test_postgres_flexible_server_vnet_server_create")
     def test_postgres_flexible_server_vnet_server_create(self):
         self._test_flexible_server_vnet_server_create('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(3)
-    @pytest.mark.depends(on=['PostgresFlexibleServerVnetServerMgmtScenarioTest::test_postgres_flexible_server_vnet_server_create'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_vnet_server_create"])
     def test_postgres_flexible_server_vnet_server_update_scale_up(self):
         self._test_flexible_server_vnet_server_update_scale_up('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(4)
-    @pytest.mark.depends(on=['PostgresFlexibleServerVnetServerMgmtScenarioTest::test_postgres_flexible_server_vnet_server_update_scale_up'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_vnet_server_create"])
     def test_postgres_flexible_server_vnet_server_restore(self):
         self._test_flexible_server_vnet_server_restore('postgres', self.resource_group, self.server, self.restore_server)
 
     @AllowLargeResponse()
     @pytest.mark.order(5)
-    @pytest.mark.depends(on=['PostgresFlexibleServerVnetServerMgmtScenarioTest::test_postgres_flexible_server_vnet_server_restore'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_vnet_server_create"])
     def test_postgres_flexible_server_vnet_server_delete(self):
         self._test_flexible_server_vnet_server_delete('postgres', self.resource_group, self.server, self.restore_server)
 
     @unittest.skip("Takes too long. Need to re-record.")
     @AllowLargeResponse()
     @pytest.mark.order(6)
-    @pytest.mark.depends(on=['PostgresFlexibleServerVnetServerMgmtScenarioTest::test_postgres_flexible_server_vnet_server_prepare'])
+    @pytest.mark.dependency(name="test_postgres_flexible_server_vnet_ha_server_create")
     def test_postgres_flexible_server_vnet_ha_server_create(self):
         self._test_flexible_server_vnet_ha_server_create('postgres', self.resource_group, self.server_2)
 
     @AllowLargeResponse()
     @pytest.mark.order(7)
-    @pytest.mark.depends(on=['PostgresFlexibleServerVnetServerMgmtScenarioTest::test_postgres_flexible_server_vnet_ha_server_create'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_vnet_ha_server_create"])
     def test_postgres_flexible_server_vnet_ha_server_update_scale_up(self):
         self._test_flexible_server_vnet_server_update_scale_up('postgres', self.resource_group, self.server_2)
 
     @AllowLargeResponse()
     @pytest.mark.order(8)
-    @pytest.mark.depends(on=['PostgresFlexibleServerVnetServerMgmtScenarioTest::test_postgres_flexible_server_vnet_ha_server_update_scale_up'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_vnet_ha_server_create"])
     def test_postgres_flexible_server_vnet_ha_server_restore(self):
         self._test_flexible_server_vnet_server_restore('postgres', self.resource_group, self.server_2, self.restore_server_2)
 
     @AllowLargeResponse()
     @pytest.mark.order(9)
-    @pytest.mark.depends(on=['PostgresFlexibleServerVnetServerMgmtScenarioTest::test_postgres_flexible_server_vnet_ha_server_restore'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_vnet_ha_server_create"])
     def test_postgres_flexible_server_vnet_ha_server_delete(self):
         self._test_flexible_server_vnet_server_delete('postgres', self.resource_group, self.server_2, self.restore_server_2)
 
     @pytest.mark.order(10)
-    @pytest.mark.depends(on=['PostgresFlexibleServerVnetServerMgmtScenarioTest::test_postgres_flexible_server_vnet_ha_server_delete', 'PostgresFlexibleServerVnetServerMgmtScenarioTest::test_postgres_flexible_server_vnet_server_delete'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_vnet_ha_server_create"])
     def test_postgres_flexible_server_vnet_server_mgmt_delete(self):
         self._test_flexible_server_vnet_server_mgmt_delete(self.resource_group)
 
@@ -317,30 +313,31 @@ class PostgresFlexibleServerProxyResourceMgmtScenarioTest(FlexibleServerProxyRes
 
     @AllowLargeResponse()
     @pytest.mark.order(1)
+    @pytest.mark.dependency(name="test_postgres_flexible_server_proxy_resource_mgmt_prepare")
     def test_postgres_flexible_server_proxy_resource_mgmt_prepare(self):
         self.cmd('az group create --location {} --name {}'.format(postgres_location, self.resource_group))
         self.cmd('az {} flexible-server create -l {} -g {} -n {} --public-access none'.format('postgres', postgres_location, self.resource_group, self.server))
 
     @AllowLargeResponse()
     @pytest.mark.order(2)
-    @pytest.mark.depends(on=['PostgresFlexibleServerProxyResourceMgmtScenarioTest::test_postgres_flexible_server_proxy_resource_mgmt_prepare'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_proxy_resource_mgmt_prepare"])
     def test_postgres_flexible_server_firewall_rule_mgmt(self):
         self._test_firewall_rule_mgmt('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(3)
-    @pytest.mark.depends(on=['PostgresFlexibleServerProxyResourceMgmtScenarioTest::test_postgres_flexible_server_firewall_rule_mgmt'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_proxy_resource_mgmt_prepare"])
     def test_postgres_flexible_server_parameter_mgmt(self):
         self._test_parameter_mgmt('postgres', self.resource_group, self.server)
 
     @AllowLargeResponse()
     @pytest.mark.order(4)
-    @pytest.mark.depends(on=['PostgresFlexibleServerProxyResourceMgmtScenarioTest::test_postgres_flexible_server_parameter_mgmt'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_proxy_resource_mgmt_prepare"])
     def test_postgres_flexible_server_database_mgmt(self):
         self._test_database_mgmt('postgres', self.resource_group, self.server)
 
     @pytest.mark.order(5)
-    @pytest.mark.depends(on=['PostgresFlexibleServerProxyResourceMgmtScenarioTest::test_postgres_flexible_server_database_mgmt'])
+    @pytest.mark.dependency(depends=["test_postgres_flexible_server_proxy_resource_mgmt_prepare"])
     def test_postgres_flexible_server_proxy_resource_mgmt_delete(self):
         self._test_flexible_server_proxy_resource_mgmt_delete(self.resource_group)
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
PG and MySQL servers can allow private access to VNET from different subscription

az postgres flexible-server create -g test-rg -n test-server --subnet /subscriptions/<different_subscription_id>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vneet_name>/subnets/<subnet_name>

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
