### PR TITLE
{Core} Quick patch for `managed_by_tenants` missing from response

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -271,16 +271,7 @@ class Profile:
             if subscription_dict[_SUBSCRIPTION_NAME] != _TENANT_LEVEL_ACCOUNT_NAME:
                 if hasattr(s, 'home_tenant_id'):
                     subscription_dict[_HOME_TENANT_ID] = s.home_tenant_id
-                if hasattr(s, 'managed_by_tenants'):
-                    if s.managed_by_tenants is None:
-                        # managedByTenants is missing from the response. This is a known service issue:
-                        # https://github.com/Azure/azure-rest-api-specs/issues/9567
-                        # pylint: disable=line-too-long
-                        raise CLIError("Invalid profile is used for cloud '{cloud_name}'. "
-                                       "To configure the cloud profile, run `az cloud set --name {cloud_name} --profile <profile>(e.g. 2019-03-01-hybrid)`. "
-                                       "For more information about using Azure CLI with Azure Stack, see "
-                                       "https://docs.microsoft.com/azure-stack/user/azure-stack-version-profiles-azurecli2"
-                                       .format(cloud_name=self.cli_ctx.cloud.name))
+                if getattr(s, 'managed_by_tenants', None):
                     subscription_dict[_MANAGED_BY_TENANTS] = [{_TENANT_ID: t.tenant_id} for t in s.managed_by_tenants]
 
             consolidated.append(subscription_dict)

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -271,7 +271,7 @@ class Profile:
             if subscription_dict[_SUBSCRIPTION_NAME] != _TENANT_LEVEL_ACCOUNT_NAME:
                 if hasattr(s, 'home_tenant_id'):
                     subscription_dict[_HOME_TENANT_ID] = s.home_tenant_id
-                if getattr(s, 'managed_by_tenants', None):
+                if getattr(s, 'managed_by_tenants', None) is not None:
                     subscription_dict[_MANAGED_BY_TENANTS] = [{_TENANT_ID: t.tenant_id} for t in s.managed_by_tenants]
 
             consolidated.append(subscription_dict)


### PR DESCRIPTION
### Update: The rollback of ARM has completed at 2021-03-31 08:00 UTC. This quick patch is not longer needed.

## ⚠ WARNING

This PR is a **workaround** for an ongoing ARM incident. The ARM service team is investigating with highest priority. We will close this PR once ARM service is fixed.


## Symptom

`az login` fails with

```
Invalid profile is used for cloud 'AzureCloud'. To configure the cloud profile, 
run `az cloud set --name AzureCloud --profile <profile>(e.g. 2019-03-01-hybrid)`. 
For more information about using Azure CLI with Azure Stack, see 
https://docs.microsoft.com/azure-stack/user/azure-stack-version-profiles-azurecli2
```

or (Azure CLI versions smaller than `2.15.0`)

```
azure/cli/core/_profile.py, ln 276, in _normalize_properties
    subscription_dict[_MANAGED_BY_TENANTS] = [{_TENANT_ID: t.tenant_id} for t in s.managed_by_tenants]
TypeError: 'NoneType' object is not iterable
```

## Root Cause Analysis

1. Azure CLI started using [Subscriptions - List](https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/list) API `/subscriptions?api-version=2019-06-01` since Feb 2020 for public cloud `AzureCloud` (#11886). This call is made during `az login` to fetch the subscriptions.

2. Azure Stack returns the response for `/subscriptions?api-version=2019-06-01` with older API version `2016-06-01` format without `managedByTenants` property (https://github.com/Azure/azure-rest-api-specs/issues/9567).

3. Az CLI checks this explicitly and shows the above error message to the user implying "Invalid profile is used for Azure Stack cloud and the profile is set to `latest`, you need to change the API profile to something like `2019-03-01-hybrid`" (#15550).

4. Due to the ARM incident, now in public cloud `AzureCloud`, the `/subscriptions` API's response omits `managedByTenants` in some regions. As a consequence, the lack of `managedByTenants`    
   1. breaks [Azure Lighthouse](https://docs.microsoft.com/en-us/azure/lighthouse/) functionality
   2. makes Azure CLI think the Azure Stack issue (https://github.com/Azure/azure-rest-api-specs/issues/9567) is hit, so the user is presented with the above error message implying you are logged in to Azure Stack. This causes `az login` to fail.

## Changes in this PR

This PR provides a quick patch which bypasses the check on `managedByTenants` and thus bypasses the ARM service incident.

## Apply the quick patch

The following commands replaces the `_profile.py` file of Azure CLI installed on local machine or Azure DevOps agent:

```sh
# Ubuntu, `sudo` may be needed
curl https://raw.githubusercontent.com/Azure/azure-cli/fix-managed_by_tenants/src/azure-cli-core/azure/cli/core/_profile.py --output /opt/az/lib/python3.6/site-packages/azure/cli/core/_profile.py

# CentOS, `sudo` may be needed
curl https://raw.githubusercontent.com/Azure/azure-cli/fix-managed_by_tenants/src/azure-cli-core/azure/cli/core/_profile.py --output /usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/_profile.py

# Windows, "Run as administrator" may be needed
curl https://raw.githubusercontent.com/Azure/azure-cli/fix-managed_by_tenants/src/azure-cli-core/azure/cli/core/_profile.py --output "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\azure\cli\core\_profile.py"
```

## Remove the quick patch

After the ARM incident is fixed, the patch needs to be removed.

- Azure DevOps agent: Remove the above line from the script.
- Linux: The patch will be overwritten automatically when the next Azure CLI version is installed. You may also reinstall the current Azure CLI to get the patch removed.
- Windows ("Run as administrator" may be needed):
  ```
  del "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\azure\cli\core\_profile.py"
  ```

## Additional information

Microsoft internal tracking ticket for the ARM incident: [IcM 234164333](https://portal.microsofticm.com/imp/v3/incidents/details/234164333/home)
