### PR TITLE
[AppService] Remove preview flag for Python 3.9  in functionapp create

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/resources/LinuxFunctionsStacks.json
+++ b/src/azure-cli/azure/cli/command_modules/appservice/resources/LinuxFunctionsStacks.json
@@ -250,7 +250,7 @@
                             "use32BitWorkerProcess": false,
                             "linuxFxVersion": "Python|3.9"
                         },
-                        "isPreview": true,
+                        "isPreview": false,
                         "isDeprecated": false,
                         "isHidden": false
                     }


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Azure Functions team plan to release Python 3.9 for GA. We want to remove the preview flag for python 3.9 in functionapp create --help.

**Testing Guide**
<!--Example commands with explanations.-->
Test with ```az functionapp create --help```. The help content contains
```
  --runtime-version                    : The version of the functions runtime stack. Allowed
                                           values for each --runtime are: node -> [8, 10, 12, 14
                                           (preview)], java -> [8, 11], powershell -> [7.0], python
                                           -> [3.6, 3.7, 3.8, 3.9].
```
**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AppService]  Remove preview flag for Python 3.9 in create function app command

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
