### PR TITLE
[ARM] BREAKING CHANGE: az bicep build/decompile: Change the --files parameter to --file

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2334,26 +2334,24 @@ short-summary: Upgrade Bicep CLI to the latest version.
 
 helps['bicep build'] = """
 type: command
-short-summary: Build one or more Bicep files.
+short-summary: Build a Bicep file.
 examples:
   - name: Build a Bicep file.
-    text: az bicep build --files {bicep_file}
-  - name: Build multiple Bicep files.
-    text: az bicep build --files {bicep_file1} {bicep_file2}
-  - name: Build a Bicep file and prints all output to stdout.
-    text: az bicep build --files {bicep_file} --stdout
-  - name: Build multiple Bicep files and prints all output to stdout.
-    text: az bicep build --files {bicep_file1} {bicep_file2} --stdout
+    text: az bicep build --file {bicep_file}
+  - name: Build a Bicep file and print all output to stdout.
+    text: az bicep build --file {bicep_file} --stdout
+  - name: Build a Bicep file and save the result to the specified directory.
+    text: az bicep build --file {bicep_file} --outdir {out_dir}
+  - name: Build a Bicep file and save the result to the specified file.
+    text: az bicep build --file {bicep_file} --outfile {out_file}
 """
 
 helps['bicep decompile'] = """
 type: command
-short-summary: Attempt to decompile one or more ARM template files to Bicep files
+short-summary: Attempt to decompile an ARM template file to a Bicep file.
 examples:
   - name: Decompile an ARM template file.
-    text: az bicep decompile --files {json_template_file}
-  - name: Decompile multiple ARM template files.
-    text: az bicep decompile --files {json_template_file1} {json_template_file2}
+    text: az bicep decompile --file {json_template_file}
 """
 
 helps['bicep version'] = """

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -574,7 +574,7 @@ def load_arguments(self, _):
 
     with self.argument_context('bicep build') as c:
         c.argument('file', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
-                                                     type=file_type, help="The path to the Bicep file to build in the file system."))
+                                                    type=file_type, help="The path to the Bicep file to build in the file system."))
         c.argument('outdir', arg_type=CLIArgumentType(options_list=['--outdir'], completer=DirectoriesCompleter(),
                                                       help="When set, saves the output at the specified directory."))
         c.argument('outfile', arg_type=CLIArgumentType(options_list=['--outfile'], completer=FilesCompleter(),
@@ -584,7 +584,7 @@ def load_arguments(self, _):
 
     with self.argument_context('bicep decompile') as c:
         c.argument('file', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
-                                                     type=file_type, help="The path to the ARM template to decompile in the file system."))
+                                                    type=file_type, help="The path to the ARM template to decompile in the file system."))
 
     with self.argument_context('bicep install') as c:
         c.argument('version', options_list=['--version', '-v'], help='The version of Bicep CLI to be installed. Default to the latest if not specified.')

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -573,17 +573,17 @@ def load_arguments(self, _):
         c.argument('resource_group', arg_type=resource_group_name_type)
 
     with self.argument_context('bicep build') as c:
-        c.argument('files', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
+        c.argument('file', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
                                                      type=file_type, help="The path to the Bicep file to build in the file system."))
         c.argument('outdir', arg_type=CLIArgumentType(options_list=['--outdir'], completer=DirectoriesCompleter(),
                                                       help="When set, saves the output at the specified directory."))
         c.argument('outfile', arg_type=CLIArgumentType(options_list=['--outfile'], completer=FilesCompleter(),
-                                                      help="When set, saves the output as the specified file path."))
+                                                       help="When set, saves the output as the specified file path."))
         c.argument('stdout', arg_type=CLIArgumentType(options_list=['--stdout'], action='store_true',
                                                       help="When set, prints all output to stdout instead of corresponding files."))
 
     with self.argument_context('bicep decompile') as c:
-        c.argument('files', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
+        c.argument('file', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
                                                      type=file_type, help="The path to the ARM template to decompile in the file system."))
 
     with self.argument_context('bicep install') as c:

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -7,6 +7,7 @@
 # pylint: disable=too-many-locals, too-many-statements, line-too-long
 def load_arguments(self, _):
     from argcomplete.completers import FilesCompleter
+    from argcomplete.completers import DirectoriesCompleter
 
     from azure.mgmt.resource.locks.models import LockLevel
     from azure.mgmt.resource.managedapplications.models import ApplicationLockLevel
@@ -572,14 +573,18 @@ def load_arguments(self, _):
         c.argument('resource_group', arg_type=resource_group_name_type)
 
     with self.argument_context('bicep build') as c:
-        c.argument('files', arg_type=CLIArgumentType(nargs="+", options_list=['--files', '-f'], completer=FilesCompleter(),
-                                                     type=file_type, help="Space separated Bicep file paths in the file system."))
+        c.argument('files', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
+                                                     type=file_type, help="The path to the Bicep file to build in the file system."))
+        c.argument('outdir', arg_type=CLIArgumentType(options_list=['--outdir'], completer=DirectoriesCompleter(),
+                                                      help="When set, saves the output at the specified directory."))
+        c.argument('outfile', arg_type=CLIArgumentType(options_list=['--outfile'], completer=FilesCompleter(),
+                                                      help="When set, saves the output as the specified file path."))
         c.argument('stdout', arg_type=CLIArgumentType(options_list=['--stdout'], action='store_true',
                                                       help="When set, prints all output to stdout instead of corresponding files."))
 
     with self.argument_context('bicep decompile') as c:
-        c.argument('files', arg_type=CLIArgumentType(nargs="+", options_list=['--files', '-f'], completer=FilesCompleter(),
-                                                     type=file_type, help="Space separated ARM template paths in the file system."))
+        c.argument('files', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
+                                                     type=file_type, help="The path to the ARM template to decompile in the file system."))
 
     with self.argument_context('bicep install') as c:
         c.argument('version', options_list=['--version', '-v'], help='The version of Bicep CLI to be installed. Default to the latest if not specified.')

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -49,7 +49,8 @@ from ._bicep import (
     is_bicep_file,
     ensure_bicep_installation,
     get_bicep_latest_release_tag,
-    get_bicep_available_release_tags
+    get_bicep_available_release_tags,
+    validate_bicep_target_scope
 )
 
 logger = get_logger(__name__)
@@ -479,7 +480,7 @@ def _deploy_arm_template_at_subscription_scope(cmd,
                                                template_file=None, template_uri=None, parameters=None,
                                                deployment_name=None, deployment_location=None, validate_only=False,
                                                no_wait=False, no_prompt=False, template_spec=None, query_string=None):
-    deployment_properties = _prepare_deployment_properties_unmodified(cmd, template_file=template_file,
+    deployment_properties = _prepare_deployment_properties_unmodified(cmd, 'subscription', template_file=template_file,
                                                                       template_uri=template_uri, parameters=parameters,
                                                                       mode='Incremental',
                                                                       no_prompt=no_prompt,
@@ -562,7 +563,7 @@ def _deploy_arm_template_at_resource_group(cmd,
                                            deployment_name=None, mode=None, rollback_on_error=None,
                                            validate_only=False, no_wait=False,
                                            aux_subscriptions=None, aux_tenants=None, no_prompt=False, template_spec=None, query_string=None):
-    deployment_properties = _prepare_deployment_properties_unmodified(cmd, template_file=template_file,
+    deployment_properties = _prepare_deployment_properties_unmodified(cmd, 'resourceGroup', template_file=template_file,
                                                                       template_uri=template_uri,
                                                                       parameters=parameters, mode=mode,
                                                                       rollback_on_error=rollback_on_error,
@@ -644,7 +645,7 @@ def _deploy_arm_template_at_management_group(cmd,
                                              template_file=None, template_uri=None, parameters=None,
                                              deployment_name=None, deployment_location=None, validate_only=False,
                                              no_wait=False, no_prompt=False, template_spec=None, query_string=None):
-    deployment_properties = _prepare_deployment_properties_unmodified(cmd, template_file=template_file,
+    deployment_properties = _prepare_deployment_properties_unmodified(cmd, 'managementGroup', template_file=template_file,
                                                                       template_uri=template_uri,
                                                                       parameters=parameters, mode='Incremental',
                                                                       no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
@@ -720,7 +721,7 @@ def _deploy_arm_template_at_tenant_scope(cmd,
                                          template_file=None, template_uri=None, parameters=None,
                                          deployment_name=None, deployment_location=None, validate_only=False,
                                          no_wait=False, no_prompt=False, template_spec=None, query_string=None):
-    deployment_properties = _prepare_deployment_properties_unmodified(cmd, template_file=template_file,
+    deployment_properties = _prepare_deployment_properties_unmodified(cmd, 'tenant', template_file=template_file,
                                                                       template_uri=template_uri,
                                                                       parameters=parameters, mode='Incremental',
                                                                       no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,)
@@ -759,7 +760,7 @@ def what_if_deploy_arm_template_at_resource_group(cmd, resource_group_name,
                                                   aux_tenants=None, result_format=None,
                                                   no_pretty_print=None, no_prompt=False,
                                                   exclude_change_types=None, template_spec=None, query_string=None):
-    what_if_properties = _prepare_deployment_what_if_properties(cmd, template_file, template_uri,
+    what_if_properties = _prepare_deployment_what_if_properties(cmd, 'resourceGroup', template_file, template_uri,
                                                                 parameters, mode, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, aux_tenants=aux_tenants,
                                                     plug_pipeline=(template_uri is None and template_spec is None))
@@ -773,7 +774,7 @@ def what_if_deploy_arm_template_at_subscription_scope(cmd,
                                                       deployment_name=None, deployment_location=None,
                                                       result_format=None, no_pretty_print=None, no_prompt=False,
                                                       exclude_change_types=None, template_spec=None, query_string=None):
-    what_if_properties = _prepare_deployment_what_if_properties(cmd, template_file, template_uri, parameters,
+    what_if_properties = _prepare_deployment_what_if_properties(cmd, 'subscription', template_file, template_uri, parameters,
                                                                 DeploymentMode.incremental, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
     what_if_poller = mgmt_client.what_if_at_subscription_scope(deployment_name, what_if_properties, deployment_location)
@@ -786,7 +787,7 @@ def what_if_deploy_arm_template_at_management_group(cmd, management_group_id=Non
                                                     deployment_name=None, deployment_location=None,
                                                     result_format=None, no_pretty_print=None, no_prompt=False,
                                                     exclude_change_types=None, template_spec=None, query_string=None):
-    what_if_properties = _prepare_deployment_what_if_properties(cmd, template_file, template_uri, parameters,
+    what_if_properties = _prepare_deployment_what_if_properties(cmd, 'managementGroup', template_file, template_uri, parameters,
                                                                 DeploymentMode.incremental, result_format, no_prompt, template_spec=template_spec, query_string=query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
     what_if_poller = mgmt_client.what_if_at_management_group_scope(management_group_id, deployment_name,
@@ -800,7 +801,7 @@ def what_if_deploy_arm_template_at_tenant_scope(cmd,
                                                 deployment_name=None, deployment_location=None,
                                                 result_format=None, no_pretty_print=None, no_prompt=False,
                                                 exclude_change_types=None, template_spec=None, query_string=None):
-    what_if_properties = _prepare_deployment_what_if_properties(cmd, template_file, template_uri, parameters,
+    what_if_properties = _prepare_deployment_what_if_properties(cmd, 'tenant', template_file, template_uri, parameters,
                                                                 DeploymentMode.incremental, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
     what_if_poller = mgmt_client.what_if_at_tenant_scope(deployment_name, deployment_location, what_if_properties)
@@ -869,7 +870,7 @@ def _prepare_template_uri_with_query_string(template_uri, input_query_string):
         raise InvalidArgumentValueError('Unable to parse parameter: {} .Make sure the value is formed correctly.'.format(input_query_string))
 
 
-def _prepare_deployment_properties_unmodified(cmd, template_file=None, template_uri=None, parameters=None,
+def _prepare_deployment_properties_unmodified(cmd, deployment_scope, template_file=None, template_uri=None, parameters=None,
                                               mode=None, rollback_on_error=None, no_prompt=False, template_spec=None, query_string=None):
     cli_ctx = cmd.cli_ctx
     DeploymentProperties, TemplateLink, OnErrorDeployment = get_sdk(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES,
@@ -901,6 +902,10 @@ def _prepare_deployment_properties_unmodified(cmd, template_file=None, template_
         )
         template_obj = _remove_comments_from_json(template_content, file_path=template_file)
 
+        if is_bicep_file(template_file):
+            template_schema = template_obj.get('$schema', '')
+            validate_bicep_target_scope(template_schema, deployment_scope)
+
     if rollback_on_error == '':
         on_error_deployment = OnErrorDeployment(type='LastSuccessful')
     elif rollback_on_error:
@@ -917,13 +922,13 @@ def _prepare_deployment_properties_unmodified(cmd, template_file=None, template_
     return properties
 
 
-def _prepare_deployment_what_if_properties(cmd, template_file, template_uri, parameters,
+def _prepare_deployment_what_if_properties(cmd, deployment_scope, template_file, template_uri, parameters,
                                            mode, result_format, no_prompt, template_spec, query_string):
     DeploymentWhatIfProperties, DeploymentWhatIfSettings = get_sdk(cmd.cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES,
                                                                    'DeploymentWhatIfProperties', 'DeploymentWhatIfSettings',
                                                                    mod='models')
 
-    deployment_properties = _prepare_deployment_properties_unmodified(cmd=cmd, template_file=template_file, template_uri=template_uri,
+    deployment_properties = _prepare_deployment_properties_unmodified(cmd, deployment_scope, template_file=template_file, template_uri=template_uri,
                                                                       parameters=parameters, mode=mode, no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
     deployment_what_if_properties = DeploymentWhatIfProperties(template=deployment_properties.template, template_link=deployment_properties.template_link,
                                                                parameters=deployment_properties.parameters, mode=deployment_properties.mode,

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3194,15 +3194,19 @@ def upgrade_bicep_cli(cmd):
     ensure_bicep_installation(release_tag=latest_release_tag)
 
 
-def build_bicep_file(cmd, files, stdout=None):
+def build_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None):
+    args = ["build", file]
+    if outdir:
+        args += ["--outdir", outdir]
+    if outfile:
+        args += ["--outfile", outfile]
     if stdout:
-        print(run_bicep_command(["build"] + files + ["--stdout"]))
-    else:
-        run_bicep_command(["build"] + files)
+        args += ["--stdout"]
+    run_bicep_command(args)
 
 
-def decompile_bicep_file(cmd, files):
-    run_bicep_command(["decompile"] + files)
+def decompile_bicep_file(cmd, file):
+    run_bicep_command(["decompile", file])
 
 
 def show_bicep_cli_version(cmd):

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/policy_definition_deploy_mg.bicep
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/policy_definition_deploy_mg.bicep
@@ -1,3 +1,5 @@
+targetScope = 'managementGroup'
+
 resource policyDef 'Microsoft.Authorization/policyDefinitions@2018-05-01' = {
   name: 'policy-for-bicep-test'
   properties: {

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/policy_definition_deploy_sub.bicep
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/policy_definition_deploy_sub.bicep
@@ -1,0 +1,17 @@
+targetScope = 'subscription'
+
+resource policyDef 'Microsoft.Authorization/policyDefinitions@2018-05-01' = {
+  name: 'policy-for-bicep-test'
+  properties: {
+    policyType: 'Custom'
+    policyRule: {
+      if: {
+        field: 'location'
+        equals: 'westus2'
+      }
+      then: {
+        effect: 'deny'
+      }
+    }
+  }
+}

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/role_definition_deploy_tenant.bicep
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/role_definition_deploy_tenant.bicep
@@ -1,3 +1,5 @@
+targetScope = 'tenant'
+
 resource roleDef 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' = {
   name: '0cb07228-4614-4814-ac1a-c4e39793ce58'
   properties: {

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -3302,7 +3302,7 @@ class DeploymentWithBicepScenarioTest(LiveScenarioTest):
     def test_subscription_level_deployment_with_bicep(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         self.kwargs.update({
-            'tf': os.path.join(curr_dir, 'policy_definition_deploy.bicep').replace('\\', '\\\\'),
+            'tf': os.path.join(curr_dir, 'policy_definition_deploy_sub.bicep').replace('\\', '\\\\'),
         })
 
         self.cmd('deployment sub validate --location westus --template-file "{tf}"', checks=[
@@ -3320,7 +3320,7 @@ class DeploymentWithBicepScenarioTest(LiveScenarioTest):
     def test_management_group_level_deployment_with_bicep(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         self.kwargs.update({
-            'tf': os.path.join(curr_dir, 'policy_definition_deploy.bicep').replace('\\', '\\\\'),
+            'tf': os.path.join(curr_dir, 'policy_definition_deploy_mg.bicep').replace('\\', '\\\\'),
             'mg': self.create_random_name('azure-cli-management', 30)
         })
 
@@ -3341,7 +3341,7 @@ class DeploymentWithBicepScenarioTest(LiveScenarioTest):
     def test_tenent_level_deployment_with_bicep(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         self.kwargs.update({
-            'tf': os.path.join(curr_dir, 'role_definition_deploy.bicep').replace('\\', '\\\\')
+            'tf': os.path.join(curr_dir, 'role_definition_deploy_tenant.bicep').replace('\\', '\\\\')
         })
 
         self.cmd('deployment tenant validate --location WestUS --template-file "{tf}"', checks=[

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
@@ -29,7 +29,7 @@ class TestBicep(unittest.TestCase):
     @mock.patch("azure.cli.command_modules.resource._bicep.get_bicep_latest_release_tag")
     @mock.patch("azure.cli.command_modules.resource._bicep._get_bicep_installed_version")
     @mock.patch("os.path.isfile")
-    def test_run_bicep_command_check_upgrade(
+    def test_run_bicep_command_check_version(
         self,
         isfile_stub,
         _get_bicep_installed_version_stub,
@@ -42,7 +42,7 @@ class TestBicep(unittest.TestCase):
         _get_bicep_installed_version_stub.return_value = "1.0.0"
         get_bicep_latest_release_tag_stub.return_value = "v2.0.0"
 
-        run_bicep_command(["--version"], check_upgrade=True)
+        run_bicep_command(["--version"], check_version=True)
 
         warning_mock.assert_called_once_with(
             'A new Bicep release is available: %s. Upgrade now by running "az bicep upgrade".',


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
- Closes #17390: Bicep related live test issue.
- Closes https://github.com/Azure/bicep/issues/1562: Validate scope when deploying a bicep file with Azure CLI.
- Partially addresses https://github.com/Azure/bicep/issues/2055: Bicep errors if I've hit my github api rate limit.
- Changes the `--files` parameter to `--file` to only take one file for the `az bicep build/decompile` commands, because we removed the support of multi-file compiling/decompiling support from Bicep CLI.

**Testing Guide**
`az bicep build/decompile --file {bicep_file}`

**History Notes**
[ARM] BREAKING CHANGE: az bicep build: Change the parameter --files to --file
[ARM] BREAKING CHANGE: az bicep decompile: Change the parameter --files to --file
[ARM] az bicep build: Add a parameter --outdir for specifying the output directory
[ARM] az bicep build: Add a parameter --outfile for specifying the output file path
[ARM] Fix an issue where checking version upgrade for Bicep CLI throws exception if GitHub API rate limit is hit

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
