### PR TITLE
{Telemetry} Add telemetry info of extension even when install fail

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -85,6 +85,17 @@ def _validate_whl_extension(ext_file):
     check_version_compatibility(azext_metadata)
 
 
+def _get_extension_info_from_source(source):
+    url_parse_result = urlparse(source)
+    is_url = (url_parse_result.scheme == 'http' or url_parse_result.scheme == 'https')
+    whl_filename = os.path.basename(url_parse_result.path) if is_url else os.path.basename(source)
+    parsed_filename = WHEEL_INFO_RE(whl_filename)
+    # Extension names can have - but .whl format changes it to _ (PEP 0427). Undo this.
+    extension_name = parsed_filename.groupdict().get('name').replace('_', '-') if parsed_filename else None
+    extension_version = parsed_filename.groupdict().get('ver') if parsed_filename else None
+    return extension_name, extension_version
+
+
 def _add_whl_ext(cli_ctx, source, ext_sha256=None, pip_extra_index_urls=None, pip_proxy=None, system=None):  # pylint: disable=too-many-statements
     cli_ctx.get_progress_controller().add(message='Analyzing')
     if not source.endswith('.whl'):
@@ -296,6 +307,7 @@ def add_extension(cmd=None, source=None, extension_name=None, index_url=None, ye
     if extension_name:
         cmd_cli_ctx.get_progress_controller().add(message='Searching')
         ext = None
+        set_extension_management_detail(extension_name, version)
         try:
             ext = get_extension(extension_name)
         except ExtensionNotInstalledException:
@@ -322,12 +334,12 @@ def add_extension(cmd=None, source=None, extension_name=None, index_url=None, ye
             else:
                 err = "No matching extensions for '{}'. Use --debug for more information.".format(extension_name)
             raise CLIError(err)
-
+    ext_name, ext_version = _get_extension_info_from_source(source)
+    set_extension_management_detail(extension_name if extension_name else ext_name, ext_version)
     extension_name = _add_whl_ext(cli_ctx=cmd_cli_ctx, source=source, ext_sha256=ext_sha256,
                                   pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, system=system)
     try:
         ext = get_extension(extension_name)
-        _augment_telemetry_with_ext_info(extension_name, ext)
         if extension_name and ext.experimental:
             logger.warning("The installed extension '%s' is experimental and not covered by customer support. "
                            "Please use with discretion.", extension_name)
@@ -383,6 +395,8 @@ def update_extension(cmd=None, extension_name=None, index_url=None, pip_extra_in
         cur_version = ext.get_version()
         try:
             download_url, ext_sha256 = resolve_from_index(extension_name, cur_version=cur_version, index_url=index_url, target_version=version, cli_ctx=cmd_cli_ctx)
+            _, ext_version = _get_extension_info_from_source(download_url)
+            set_extension_management_detail(extension_name, ext_version)
         except NoExtensionCandidatesError as err:
             logger.debug(err)
             msg = "Extension {} with version {} not found.".format(extension_name, version) if version else "No updates available for '{}'. Use --debug for more information.".format(extension_name)
@@ -401,8 +415,6 @@ def update_extension(cmd=None, extension_name=None, index_url=None, pip_extra_in
                          pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy)
             logger.debug('Deleting backup of old extension at %s', backup_dir)
             shutil.rmtree(backup_dir)
-            # This gets the metadata for the extension *after* the update
-            _augment_telemetry_with_ext_info(extension_name)
         except Exception as err:
             logger.error('An error occurred whilst updating.')
             logger.error(err)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Existing code will only add `Context.Default.AzureCLI.ExtensionManagementDetail` after the extension is installed. This PR extracts extension name and version from source url and add to telemetry so that these data will be sent by telemetry even when the install of extension fails.

**Testing Guide**
<!--Example commands with explanations.-->
In a virtual env, downgrade pip: `python -m pip -U pip==18.0`.

Run `az extension add -s https://azurecliext.blob.core.windows.net/release/azure_cli_ml-1.21.0-py3-none-any.whl -y`. 

The install will fail, check the telemetry record in `~/.azure/telemetry/cache`, you should see `"Context.Default.AzureCLI.ExtensionManagementDetail": "azure-cli-ml@1.21.0"`.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
