### PR TITLE
[Identity] CAE b3

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_msal_patch.py
+++ b/src/azure-cli-core/azure/cli/core/_msal_patch.py
@@ -1,0 +1,173 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+A temporary workaround for MSAL limitation
+https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/335
+
+After a successful sign-in, if the sign-in account already exists in the token
+cache, remove it first along with its tokens to prevent MSAL from returning
+cached access tokens from the previous session that may have been revoked.
+
+Otherwise, MSAL will return revoked access tokens, resulting in 401 failure
+which can't be handled by commands that don't support silent reauth.
+"""
+
+# pylint: skip-file
+# flake8: noqa
+
+import json
+import time
+
+from knack.log import get_logger
+
+from msal.oauth2cli.oauth2 import Client
+from msal.token_cache import decode_id_token, canonicalize, decode_part
+
+logger = get_logger(__name__)
+
+
+def patch_token_cache_add(callback):
+
+    def __add(self, event, now=None):
+        # event typically contains: client_id, scope, token_endpoint,
+        # response, params, data, grant_type
+        environment = realm = None
+        if "token_endpoint" in event:
+            _, environment, realm = canonicalize(event["token_endpoint"])
+        if "environment" in event:  # Always available unless in legacy test cases
+            environment = event["environment"]  # Set by application.py
+        response = event.get("response", {})
+        data = event.get("data", {})
+        access_token = response.get("access_token")
+        refresh_token = response.get("refresh_token")
+        id_token = response.get("id_token")
+        id_token_claims = (
+            decode_id_token(id_token, client_id=event["client_id"])
+            if id_token else {})
+        client_info = {}
+        home_account_id = None  # It would remain None in client_credentials flow
+        if "client_info" in response:  # We asked for it, and AAD will provide it
+            client_info = json.loads(decode_part(response["client_info"]))
+            home_account_id = "{uid}.{utid}".format(**client_info)
+        elif id_token_claims:  # This would be an end user on ADFS-direct scenario
+            client_info["uid"] = id_token_claims.get("sub")
+            home_account_id = id_token_claims.get("sub")
+
+        target = ' '.join(event.get("scope") or [])  # Per schema, we don't sort it
+
+        with self._lock:
+            now = int(time.time() if now is None else now)
+
+            if client_info and not event.get("skip_account_creation"):
+                account = {
+                    "home_account_id": home_account_id,
+                    "environment": environment,
+                    "realm": realm,
+                    "local_account_id": id_token_claims.get(
+                        "oid", id_token_claims.get("sub")),
+                    "username": id_token_claims.get("preferred_username")  # AAD
+                                or id_token_claims.get("upn")  # ADFS 2019
+                                or "",  # The schema does not like null
+                    "authority_type":
+                        self.AuthorityType.ADFS if realm == "adfs"
+                        else self.AuthorityType.MSSTS,
+                    # "client_info": response.get("client_info"),  # Optional
+                }
+
+                logger.debug("Remove existing account %r", account)
+                logger.debug("Calling %r", callback)
+                callback(account)
+                self.modify(self.CredentialType.ACCOUNT, account, account)
+
+            if id_token:
+                idt = {
+                    "credential_type": self.CredentialType.ID_TOKEN,
+                    "secret": id_token,
+                    "home_account_id": home_account_id,
+                    "environment": environment,
+                    "realm": realm,
+                    "client_id": event.get("client_id"),
+                    # "authority": "it is optional",
+                }
+                self.modify(self.CredentialType.ID_TOKEN, idt, idt)
+
+            if access_token:
+                expires_in = int(  # AADv1-like endpoint returns a string
+                    response.get("expires_in", 3599))
+                ext_expires_in = int(  # AADv1-like endpoint returns a string
+                    response.get("ext_expires_in", expires_in))
+                at = {
+                    "credential_type": self.CredentialType.ACCESS_TOKEN,
+                    "secret": access_token,
+                    "home_account_id": home_account_id,
+                    "environment": environment,
+                    "client_id": event.get("client_id"),
+                    "target": target,
+                    "realm": realm,
+                    "token_type": response.get("token_type", "Bearer"),
+                    "cached_at": str(now),  # Schema defines it as a string
+                    "expires_on": str(now + expires_in),  # Same here
+                    "extended_expires_on": str(now + ext_expires_in)  # Same here
+                }
+                if data.get("key_id"):  # It happens in SSH-cert or POP scenario
+                    at["key_id"] = data.get("key_id")
+                if "refresh_in" in response:
+                    refresh_in = response["refresh_in"]  # It is an integer
+                    at["refresh_on"] = str(now + refresh_in)  # Schema wants a string
+                self.modify(self.CredentialType.ACCESS_TOKEN, at, at)
+
+            if refresh_token:
+                rt = {
+                    "credential_type": self.CredentialType.REFRESH_TOKEN,
+                    "secret": refresh_token,
+                    "home_account_id": home_account_id,
+                    "environment": environment,
+                    "client_id": event.get("client_id"),
+                    "target": target,  # Optional per schema though
+                    "last_modification_time": str(now),  # Optional. Schema defines it as a string.
+                }
+                if "foci" in response:
+                    rt["family_id"] = response["foci"]
+                self.modify(self.CredentialType.REFRESH_TOKEN, rt, rt)
+
+            app_metadata = {
+                "client_id": event.get("client_id"),
+                "environment": environment,
+            }
+            if "foci" in response:
+                app_metadata["family_id"] = response.get("foci")
+            self.modify(self.CredentialType.APP_METADATA, app_metadata, app_metadata)
+
+    def obtain_token_by_refresh_token(self, token_item, scope=None,
+                                      rt_getter=lambda token_item: token_item["refresh_token"],
+                                      on_removing_rt=None,
+                                      on_updating_rt=None,
+                                      on_obtaining_tokens=None,
+                                      **kwargs):
+        resp = super(Client, self).obtain_token_by_refresh_token(
+            rt_getter(token_item)
+            if not isinstance(token_item, str) else token_item,
+            scope=scope,
+            also_save_rt=on_updating_rt is False,
+            on_obtaining_tokens=on_obtaining_tokens,
+            **kwargs)
+        if resp.get('error') == 'invalid_grant':
+            (on_removing_rt or self.on_removing_rt)(token_item)  # Discard old RT
+        RT = "refresh_token"
+        if on_updating_rt is not False and RT in resp:
+            (on_updating_rt or self.on_updating_rt)(token_item, resp[RT])
+        return resp
+
+    from unittest.mock import patch
+
+    # Temporary patch for https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/335
+    cm_add = patch('msal.token_cache.TokenCache._TokenCache__add', __add)
+
+    # Temporary patch for https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/339
+    cm_obtain_token_by_refresh_token = patch('msal.oauth2cli.oauth2.Client.obtain_token_by_refresh_token',
+                                             obtain_token_by_refresh_token)
+    cm_add.__enter__()
+    cm_obtain_token_by_refresh_token.__enter__()

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -536,24 +536,24 @@ class Profile:
             adal_cache = AdalCredentialCache()
             adal_cache.remove_cached_creds(user_or_sp)
 
-            logger.warning('Account %s has been logged out from Azure CLI.', user_or_sp)
+            logger.warning("Account '%s' has been logged out from Azure CLI.", user_or_sp)
         else:
             # https://english.stackexchange.com/questions/5302/log-in-to-or-log-into-or-login-to
-            logger.warning("Account %s was not logged in to Azure CLI.", user_or_sp)
+            logger.warning("Account '%s' was not logged in to Azure CLI.", user_or_sp)
 
         # Log out from MSAL cache
         identity = Identity(self._authority)
         accounts = identity.get_user(user_or_sp)
         if accounts:
-            logger.info("The credential of %s were found from MSAL encrypted cache.", user_or_sp)
+            logger.info("The credential of '%s' were found from MSAL encrypted cache.", user_or_sp)
             if clear_credential:
                 identity.logout_user(user_or_sp)
-                logger.warning("The credential of %s were cleared from MSAL encrypted cache. This account is "
+                logger.warning("The credential of '%s' were cleared from MSAL encrypted cache. This account is "
                                "also logged out from other SDK tools which use Azure CLI's credential "
                                "via Single Sign-On.", user_or_sp)
             else:
-                logger.warning('The credential of %s is still stored in MSAL encrypted cached. Other SDK tools may use '
-                               'Azure CLI\'s credential via Single Sign-On. '
+                logger.warning("The credential of '%s' is still stored in MSAL encrypted cached. Other SDK tools may "
+                               "use Azure CLI\'s credential via Single Sign-On. "
                                'To clear the credential, run `az logout --username %s --clear-credential`.',
                                user_or_sp, user_or_sp)
         else:
@@ -582,7 +582,7 @@ class Profile:
                     logger.warning(account['username'])
                 logger.warning('Other SDK tools may use Azure CLI\'s credential via Single Sign-On. '
                                'To clear all credentials, run `az account clear --clear-credential`. '
-                               'To clear one of them, run `az logout --username USERNAME` --clear-credential.')
+                               'To clear one of them, run `az logout --username USERNAME --clear-credential`.')
         else:
             logger.warning('No credential was not found from MSAL encrypted cache.')
 
@@ -888,11 +888,11 @@ class SubscriptionFinder:
         self.authority = self.cli_ctx.cloud.endpoints.active_directory
         self.adal_cache = kwargs.pop("adal_cache", None)
 
-        def create_arm_client_factory(credentials):
+        def create_arm_client_factory(credential):
             if arm_client_factory:
-                return arm_client_factory(credentials)
+                return arm_client_factory(credential)
             from azure.cli.core.profiles import ResourceType, get_api_version
-            from azure.cli.core.commands.client_factory import _prepare_client_kwargs_track2
+            from azure.cli.core.commands.client_factory import _prepare_mgmt_client_kwargs_track2
 
             client_type = self._get_subscription_client_class()
             if client_type is None:
@@ -900,11 +900,10 @@ class SubscriptionFinder:
                 raise CLIInternalError("Unable to get '{}' in profile '{}'"
                                        .format(ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS, cli_ctx.cloud.profile))
             api_version = get_api_version(cli_ctx, ResourceType.MGMT_RESOURCE_SUBSCRIPTIONS)
-            client_kwargs = _prepare_client_kwargs_track2(cli_ctx)
+            client_kwargs = _prepare_mgmt_client_kwargs_track2(cli_ctx, credential)
             # We don't need to change credential_scopes as 'scopes' is ignored by BasicTokenCredential anyway
-            client = client_type(credentials, api_version=api_version,
+            client = client_type(credential, api_version=api_version,
                                  base_url=self.cli_ctx.cloud.endpoints.resource_manager,
-                                 credential_scopes=resource_to_scopes(self._arm_resource_id),
                                  **client_kwargs)
             return client
 

--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -25,9 +25,10 @@ class AzCLIError(CLIError):
     """ Base class for all the AzureCLI defined error classes.
     DO NOT raise this error class in your codes. """
 
-    def __init__(self, error_msg, recommendation=None):
+    def __init__(self, error_msg, recommendation=None, original_error=None):
         # error message
         self.error_msg = error_msg
+        self.original_error = original_error
 
         # manual recommendations provided based on developers' knowledge
         self.recommendations = []
@@ -169,7 +170,32 @@ class BadRequestError(UserFault):
 
 class UnauthorizedError(UserFault):
     """ Unauthorized request: 401 error """
-    pass
+
+    def __init__(self, error_msg, recommendation=None, original_error=None):
+
+        def _extract_claims(challenge):
+            # Copied from azure.mgmt.core.policies._authentication._parse_claims_challenge
+            from azure.mgmt.core.policies._authentication import _parse_challenges
+            parsed_challenges = _parse_challenges(challenge)
+            if len(parsed_challenges) != 1 or "claims" not in parsed_challenges[0].parameters:
+                # no or multiple challenges, or no claims directive
+                return None
+
+            encoded_claims = parsed_challenges[0].parameters["claims"]
+            padding_needed = -len(encoded_claims) % 4
+            return encoded_claims + "=" * padding_needed
+
+        claims = _extract_claims(original_error.response.headers.get('WWW-Authenticate'))
+
+        from azure.cli.core.credential import _generate_login_command, _generate_login_message
+        # login_command = _generate_login_command(claims=claims)
+        login_message = _generate_login_message(claims=claims)
+
+        recommendation = (
+            "The access token has expired or been revoked by Continuous Access Evaluation. "
+            "Silent re-authentication will be attempted in the future.\n{}")
+        recommendation = recommendation.format(login_message)
+        super().__init__(error_msg, recommendation=recommendation, original_error=original_error)
 
 
 class ForbiddenError(UserFault):
@@ -259,7 +285,7 @@ class RecommendationError(ClientError):
     pass
 
 
-class AuthenticationError(ServiceError):
-    """ Raised when AAD authentication fails. """
+class AuthenticationError(AzCLIError):
+    """ Raised when credential.get_token fails. """
 
 # endregion

--- a/src/azure-cli-core/azure/cli/core/azlogging.py
+++ b/src/azure-cli-core/azure/cli/core/azlogging.py
@@ -51,12 +51,18 @@ class AzCliLogging(CLILogging):
 
     def configure(self, args):
         super(AzCliLogging, self).configure(args)
-        from knack.log import CliLogLevel
-        if self.log_level == CliLogLevel.DEBUG:
-            # As azure.core.pipeline.policies.http_logging_policy is a redacted version of
-            # azure.core.pipeline.policies._universal, disable azure.core.pipeline.policies.http_logging_policy
-            # when debug log is shown.
-            logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.CRITICAL)
+        if self.log_level:
+            # When invoked by pytest, configure() is skipped and log_level will not be set.
+            from knack.log import CliLogLevel
+            if self.log_level == CliLogLevel.DEBUG:
+                # As azure.core.pipeline.policies.http_logging_policy is a redacted version of
+                # azure.core.pipeline.policies._universal, disable azure.core.pipeline.policies.http_logging_policy
+                # when debug log is shown.
+                logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.CRITICAL)
+
+            if self.log_level <= CliLogLevel.WARNING:
+                # Disable warnings from Azure Identity
+                logging.getLogger("azure.identity").setLevel(logging.CRITICAL)
 
     def get_command_log_dir(self):
         return self.command_log_dir

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -298,7 +298,7 @@ AZURE_PUBLIC_CLOUD = Cloud(
     'AzureCloud',
     endpoints=CloudEndpoints(
         management='https://management.core.windows.net/',
-        resource_manager='https://management.azure.com/',
+        resource_manager='https://eastus2euap.management.azure.com/',
         sql_management='https://management.core.windows.net:8443/',
         batch_resource_id='https://batch.core.windows.net/',
         gallery='https://gallery.azure.com/',

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -298,7 +298,7 @@ AZURE_PUBLIC_CLOUD = Cloud(
     'AzureCloud',
     endpoints=CloudEndpoints(
         management='https://management.core.windows.net/',
-        resource_manager='https://eastus2euap.management.azure.com/',
+        resource_manager='https://management.azure.com/',
         sql_management='https://management.core.windows.net:8443/',
         batch_resource_id='https://batch.core.windows.net/',
         gallery='https://gallery.azure.com/',

--- a/src/azure-cli-core/azure/cli/core/tests/test_credential.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_credential.py
@@ -1,0 +1,30 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+
+from azure.cli.core.credential import _generate_login_command
+
+
+class TestUtils(unittest.TestCase):
+    def test_generate_login_command(self):
+        # No parameter is given
+        assert _generate_login_command() == 'az login'
+
+        base64_claims = "eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYxNzE3MjE1NiJ9fX0="
+        json_claims = '{"access_token":{"nbf":{"essential":true, "value":"1617172156"}}}'
+        expect = 'az login --claims eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6dHJ1ZSwgInZhbHVlIjoiMTYxNzE3MjE1NiJ9fX0='
+
+        # Base64 string is preserved
+        actual = _generate_login_command(claims=base64_claims)
+        assert actual == expect
+
+        # JSON string is converted to base64
+        actual = _generate_login_command(claims=json_claims)
+        assert actual == expect
+
+        # scopes
+        actual = _generate_login_command(scopes=["https://management.core.windows.net//.default"])
+        assert actual == 'az login --scope https://management.core.windows.net//.default'

--- a/src/azure-cli-core/azure/cli/core/tests/test_identity.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_identity.py
@@ -57,7 +57,7 @@ class TestIdentity(unittest.TestCase):
         current_dir = os.path.dirname(os.path.realpath(__file__))
         test_cert_file = os.path.join(current_dir, 'err_sp_cert.pem')
         # TODO: wrap exception
-        with self.assertRaisesRegex(ValueError, "Unable to load certificate."):
+        with self.assertRaisesRegex(ValueError, "Could not deserialize key data."):
             identity.login_with_service_principal_certificate("00000000-0000-0000-0000-000000000000", test_cert_file)
 
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -384,7 +384,7 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(output, subs)
 
     @mock.patch('azure.cli.core._profile.SubscriptionFinder._get_subscription_client_class', autospec=True)
-    @mock.patch.dict('os.environ')
+    @mock.patch.dict('os.environ', clear=True)
     def test_login_with_environment_credential_service_principal(self, get_client_class_mock):
         os.environ['AZURE_TENANT_ID'] = self.service_principal_tenant_id
         os.environ['AZURE_CLIENT_ID'] = self.service_principal_id
@@ -1616,7 +1616,7 @@ class TestProfile(unittest.TestCase):
         cli = DummyCli()
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock, use_global_creds_cache=False, async_persist=False)
-        sp_subscription1 = SubscriptionStub('sp-sub/3', 'foo-subname', self.state1, 'foo_tenant.onmicrosoft.com')
+        sp_subscription1 = SubscriptionStub('sp-sub/3', 'foo-subname', self.state1, 'footenant.onmicrosoft.com')
         consolidated = profile._normalize_properties(self.user1, deepcopy([self.subscription1]), False, None, None)
         consolidated += profile._normalize_properties('http://foo', [sp_subscription1], True)
         profile._set_subscriptions(consolidated)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -90,7 +90,7 @@ def handle_exception(ex):  # pylint: disable=too-many-locals, too-many-statement
                 error_msg = extract_common_error_message(ex)
             status_code = str(getattr(ex, 'status_code', 'Unknown Code'))
             AzCLIErrorType = get_error_type_by_status_code(status_code)
-            az_error = AzCLIErrorType(error_msg)
+            az_error = AzCLIErrorType(error_msg, original_error=ex)
 
         elif isinstance(ex, ValidationError):
             az_error = azclierror.ValidationError(error_msg)
@@ -103,7 +103,7 @@ def handle_exception(ex):  # pylint: disable=too-many-locals, too-many-statement
             if extract_common_error_message(ex):
                 error_msg = extract_common_error_message(ex)
             AzCLIErrorType = get_error_type_by_azure_error(ex)
-            az_error = AzCLIErrorType(error_msg)
+            az_error = AzCLIErrorType(error_msg, original_error=ex)
 
         elif isinstance(ex, AzureException):
             if is_azure_connection_error(error_msg):

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -47,13 +47,14 @@ DEPENDENCIES = [
     'argcomplete~=1.8',
     'azure-cli-telemetry==1.0.6.*',
     'azure-common~=1.1',
-    'azure-mgmt-core>=1.2.0,<2.0.0',
+    'azure-core==1.14.0b1',
+    'azure-mgmt-core==1.3.0b1',
     'colorama~=0.4.1',
     'cryptography>=3.2,<3.4',
     'humanfriendly>=4.7,<10.0',
     'jmespath',
     'knack==0.8.0rc2',
-    'azure-identity==1.5.0b2',
+    'azure-identity==1.6.0b3',
     # Dependencies of the vendored subscription SDK
     # https://github.com/Azure/azure-sdk-for-python/blob/ab12b048ddf676fe0ccec16b2167117f0609700d/sdk/resources/azure-mgmt-resource/setup.py#L82-L86
     'msrest>=0.5.0',

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -214,6 +214,8 @@ class LiveScenarioTest(IntegrationTestBase, CheckerMixin, unittest.TestCase):
         self.kwargs = {}
         self.test_resources_count = 0
 
+        patch_main_exception_handler(self)
+
     def cmd(self, command, checks=None, expect_failure=False):
         command = self._apply_kwargs(command)
         return execute(self.cli_ctx, command, expect_failure=expect_failure).assert_with_checks(checks)

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -214,6 +214,7 @@ class LiveScenarioTest(IntegrationTestBase, CheckerMixin, unittest.TestCase):
         self.kwargs = {}
         self.test_resources_count = 0
 
+    def setUp(self):
         patch_main_exception_handler(self)
 
     def cmd(self, command, checks=None, expect_failure=False):

--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -104,7 +104,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('clear_credential', clear_credential_type)
 
         with self.argument_context('account export-msal-cache') as c:
-            c.argument('path', help='The path to export the MSAL cache.')
+            c.argument('path', help='The path to export the MSAL cache.', default='~/.azure/msal.cache.snapshot.json')
 
 
 COMMAND_LOADER_CLS = ProfileCommandsLoader

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -98,12 +98,12 @@ examples:
 
 helps['account export-msal-cache'] = """
 type: command
-short-summary: Export MSAL cache, by default to `~/.azure/msal.cache.snapshot.json`.
+short-summary: Export MSAL cache in plain text.
 long-summary: >
-    The exported cache is unencrypted. It contains login information of all logged-in users. Make sure you protect
-    it safely.
+    The exported cache is unencrypted.
+    It contains login information of all logged-in users. Make sure you protect it safely.
 
-    You can mount the exported MSAL cache to a container at `~/.IdentityService/msal.cache`, so that Azure CLI
+    You can mount the exported MSAL cache to a container at '~/.IdentityService/msal.cache', so that Azure CLI
     inside the container can automatically authenticate.
 examples:
     - name: Export MSAL cache to the default path.

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -103,7 +103,7 @@ def set_active_subscription(cmd, subscription):
     profile.set_active_subscription(subscription)
 
 
-def account_clear(cmd, clear_credential=False):
+def account_clear(cmd, clear_credential=True):
     """Clear all stored subscriptions. To clear individual, use 'logout'"""
     if in_cloud_console():
         logger.warning(_CLOUD_CONSOLE_LOGOUT_WARNING)
@@ -190,7 +190,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
     return all_subscriptions
 
 
-def logout(cmd, username=None, clear_credential=False):
+def logout(cmd, username=None, clear_credential=True):
     """Log out to remove access to Azure subscriptions"""
     if in_cloud_console():
         logger.warning(_CLOUD_CONSOLE_LOGOUT_WARNING)

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_auth_e2e.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_auth_e2e.py
@@ -1,0 +1,62 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from time import sleep
+
+import jwt
+from azure.cli.core.azclierror import AuthenticationError
+from azure.cli.testsdk import LiveScenarioTest
+from msrestazure.azure_exceptions import CloudError
+
+ARM_URL = "https://eastus2euap.management.azure.com/"  # ARM canary
+ARM_RETRY_INTERVAL = 10
+
+
+class CAEScenarioTest(LiveScenarioTest):
+
+    def test_client_capabilities(self):
+        self.cmd('login')
+
+        # Verify the access token has CAE enabled
+        out = self.cmd('account get-access-token').get_output_in_json()
+        access_token = out['accessToken']
+        decoded = jwt.decode(access_token, verify=False, algorithms=['RS256'])
+        self.assertEqual(decoded['xms_cc'], ['CP1'])  # xms_cc: extension microsoft client capabilities
+        self.assertEqual(decoded['xms_ssm'], '1')  # xms_ssm: extension microsoft smart session management
+
+    def _test_revoke_session(self, command, expected_error, checks=None):
+        self.test_client_capabilities()
+
+        # Test access token is working
+        self.cmd(command)
+
+        self._revoke_sign_in_sessions()
+
+        # CAE is currently only available in canary endpoint
+        # with mock.patch.object(self.cli_ctx.cloud.endpoints, "resource_manager", ARM_URL):
+        exit_code = 0
+        with self.assertRaises(expected_error) as ex:
+            while exit_code == 0:
+                exit_code = self.cmd(command).exit_code
+                sleep(ARM_RETRY_INTERVAL)
+        if checks:
+            checks(ex.exception)
+
+    def test_revoke_session_track2(self):
+        def check_aad_error_code(ex):
+            self.assertIn('AADSTS50173', str(ex))
+
+        self._test_revoke_session("storage account list", AuthenticationError, check_aad_error_code)
+
+    def test_revoke_session_track1(self):
+        def check_arm_error(ex):
+            self.assertEqual(ex.status_code, 401)
+            self.assertIsNotNone(ex.response.headers["WWW-Authenticate"])
+
+        self._test_revoke_session('group list', CloudError, check_arm_error)
+
+    def _revoke_sign_in_sessions(self):
+        # Manually revoke sign in sessions
+        self.cmd('rest -m POST -u https://graph.microsoft.com/v1.0/me/revokeSignInSessions')

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -9,13 +9,12 @@ azure-cli-core==2.21.0.1
 azure-cli-telemetry==1.0.6
 azure-cli==2.21.0.1
 azure-common==1.1.22
-azure-core==1.10.0
+azure-core==1.14.0b1
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
 azure-functions-devops-build==0.0.22
 azure-graphrbac==0.60.0
-azure-identity==1.5.0b2
-azure-keyvault==1.1.0
+azure-identity==1.6.0b3
 azure-keyvault-administration==4.0.0b3
 azure-keyvault==1.1.0
 azure-loganalytics==0.1.0
@@ -35,7 +34,7 @@ azure-mgmt-consumption==2.0.0
 azure-mgmt-containerinstance==1.5.0
 azure-mgmt-containerregistry==3.0.0rc17
 azure-mgmt-containerservice==11.1.0
-azure-mgmt-core==1.2.1
+azure-mgmt-core==1.3.0b1
 azure-mgmt-cosmosdb==3.0.0
 azure-mgmt-databoxedge==0.2.0
 azure-mgmt-datalake-analytics==0.2.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -9,15 +9,13 @@ azure-cli-core==2.21.0.1
 azure-cli-telemetry==1.0.6
 azure-cli==2.21.0.1
 azure-common==1.1.22
-azure-core==1.10.0
+azure-core==1.14.0b1
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
 azure-functions-devops-build==0.0.22
 azure-graphrbac==0.60.0
-azure-identity==1.5.0b2
-azure-keyvault==1.1.0
+azure-identity==1.6.0b3
 azure-keyvault-administration==4.0.0b3
-azure-keyvault==1.1.0
 azure-keyvault==1.1.0
 azure-loganalytics==0.1.0
 azure-mgmt-advisor==2.0.1
@@ -36,7 +34,7 @@ azure-mgmt-consumption==2.0.0
 azure-mgmt-containerinstance==1.5.0
 azure-mgmt-containerregistry==3.0.0rc17
 azure-mgmt-containerservice==11.1.0
-azure-mgmt-core==1.2.1
+azure-mgmt-core==1.3.0b1
 azure-mgmt-cosmosdb==3.0.0
 azure-mgmt-databoxedge==0.2.0
 azure-mgmt-datalake-analytics==0.2.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -9,15 +9,13 @@ azure-cli-core==2.21.0.1
 azure-cli-telemetry==1.0.6
 azure-cli==2.21.0.1
 azure-common==1.1.22
-azure-core==1.10.0
+azure-core==1.14.0b1
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
 azure-functions-devops-build==0.0.22
 azure-graphrbac==0.60.0
-azure-identity==1.5.0b2
-azure-keyvault==1.1.0
+azure-identity==1.6.0b3
 azure-keyvault-administration==4.0.0b3
-azure-keyvault==1.1.0
 azure-keyvault==1.1.0
 azure-loganalytics==0.1.0
 azure-mgmt-advisor==2.0.1
@@ -36,7 +34,7 @@ azure-mgmt-consumption==2.0.0
 azure-mgmt-containerinstance==1.5.0
 azure-mgmt-containerregistry==3.0.0rc17
 azure-mgmt-containerservice==11.1.0
-azure-mgmt-core==1.2.1
+azure-mgmt-core==1.3.0b1
 azure-mgmt-cosmosdb==3.0.0
 azure-mgmt-databoxedge==0.2.0
 azure-mgmt-datalake-analytics==0.2.1


### PR DESCRIPTION
## Dependencies

CAE b3 support build upon

- `azure-core` 1.14.0b1
  - https://pypi.org/project/azure-core/1.14.0b1/
  - https://github.com/Azure/azure-sdk-for-python/tree/azure-core_1.14.0b1
- `azure-mgmt-core` 1.3.0b1
  - https://pypi.org/project/azure-mgmt-core/1.3.0b1/
  - https://github.com/Azure/azure-sdk-for-python/tree/azure-mgmt-core_1.3.0b1
- `azure-identity` 1.6.0b3
  - https://pypi.org/project/azure-identity/1.6.0b3/
  - https://github.com/Azure/azure-sdk-for-python/tree/azure-identity_1.6.0b3


This PR is a rework of https://github.com/Azure/azure-cli/pull/17070.

## Testing Guide

```powershell
# Log in with CAE enabled
> az login

# A successful command using Track 2 SDK
> az storage account list

# A successful command using Track 1 SDK
> az group list

# Get the access token
# Decode it at https://jwt.ms and check claims
#   - "xms_cc": ["CP1"]
#   - "xms_ssm": "1" 
> az account get-access-token

# Revoke the session
> az rest -m POST -u https://graph.microsoft.com/v1.0/me/revokeSignInSessions

# Wait several minute for the session revocation to propagate

# A failed command using Track 2 SDK
> az storage account list
AADSTS50173: The provided grant has expired due to it being revoked, a fresh auth token is needed. The user might have changed or reset their password. The grant was issued on '2021-04-08T07:28:53.6808518Z' and the TokensValidFrom date (before which tokens are not valid) for this user is '2021-04-08T07:29:09.0000000Z'.
Trace ID: 686ab9c1-9991-4bc1-b353-279b2ea2ab01
Correlation ID: d1731352-800d-4b95-ae15-5e1999ce5d0b
Timestamp: 2021-04-08 07:53:44Z
To re-authenticate, please run:
az logout
az login
If the problem persists, please contact your tenant administrator.

# A failed command using Track 1 SDK
> az group list
Authentication failed.
The access token has expired or been revoked by Continuous Access Evaluation. Silent re-authentication will be attempted in the future.
To re-authenticate, please run:
az logout
az login
If the problem persists, please contact your tenant administrator.
```

## Additional context

Due to MSAL caching issue https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/335, `az logout` is currently mandatory before calling `az login` again so that revoked access tokens can be purged from MSAL cache.