### PR TITLE
[Core] Display allowed values in error message when enum validation fails

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -497,8 +497,8 @@ class AzCliCommandParser(CLICommandParser):
             else:
                 # `command_source` indicates command values have been parsed, value is an argument
                 parameter = action.option_strings[0] if action.option_strings else action.dest
-                error_msg = "{prog}: '{value}' is not a valid value for '{param}'. Allowed values: {choice}.".format(
-                    prog=self.prog, value=value, param=parameter, choice=', '.join(sorted([str(x) for x in action.choices])))
+                error_msg = "{prog}: '{value}' is not a valid value for '{param}'. Allowed values: {choices}.".format(
+                    prog=self.prog, value=value, param=parameter, choices=', '.join([str(x) for x in action.choices]))
                 candidates = difflib.get_close_matches(value, action.choices, cutoff=0.7)
                 az_error = InvalidArgumentValueError(error_msg)
 

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -497,8 +497,8 @@ class AzCliCommandParser(CLICommandParser):
             else:
                 # `command_source` indicates command values have been parsed, value is an argument
                 parameter = action.option_strings[0] if action.option_strings else action.dest
-                error_msg = "{prog}: '{value}' is not a valid value for '{param}'.".format(
-                    prog=self.prog, value=value, param=parameter)
+                error_msg = "{prog}: '{value}' is not a valid value for '{param}'. Allowed values: {choice}.".format(
+                    prog=self.prog, value=value, param=parameter, choice=', '.join(sorted([str(x) for x in action.choices])))
                 candidates = difflib.get_close_matches(value, action.choices, cutoff=0.7)
                 az_error = InvalidArgumentValueError(error_msg)
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When the enum validation fails, error message would show the allowed values to improve user experience
Before:
![image](https://user-images.githubusercontent.com/81600993/114133997-82b4ba80-9939-11eb-84bb-3e4327d1e9e3.png)
After:
![image](https://user-images.githubusercontent.com/81600993/114133776-2782c800-9939-11eb-80c7-acf055fe2ea2.png)

The case in which the candiate list is shown along with the best match candidate:
![image](https://user-images.githubusercontent.com/81600993/114134192-e939d880-9939-11eb-994e-79fd534171e4.png)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
