### PR TITLE
{Packaging} Pin `azure-core` to 1.12.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -46,6 +46,7 @@ DEPENDENCIES = [
     'argcomplete~=1.8',
     'azure-cli-telemetry==1.0.6.*',
     'azure-common~=1.1',
+    'azure-core==1.12.0',
     'azure-mgmt-core>=1.2.0,<2.0.0',
     'colorama~=0.4.1',
     'cryptography>=3.2,<3.4',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -9,7 +9,7 @@ azure-cli-core==2.21.0
 azure-cli-telemetry==1.0.6
 azure-cli==2.21.0
 azure-common==1.1.22
-azure-core==1.10.0
+azure-core==1.12.0
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
 azure-functions-devops-build==0.0.22

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -9,7 +9,7 @@ azure-cli-core==2.21.0
 azure-cli-telemetry==1.0.6
 azure-cli==2.21.0
 azure-common==1.1.22
-azure-core==1.10.0
+azure-core==1.12.0
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
 azure-functions-devops-build==0.0.22

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -9,7 +9,7 @@ azure-cli-core==2.21.0
 azure-cli-telemetry==1.0.6
 azure-cli==2.21.0
 azure-common==1.1.22
-azure-core==1.10.0
+azure-core==1.12.0
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
 azure-functions-devops-build==0.0.22


### PR DESCRIPTION
**Description**<!--Mandatory-->

Temporary fix for https://github.com/Azure/azure-cli/issues/17625.

Starting from `azure-core` 1.13.0, `Authorization` header is now exposed in DEBUG log (https://github.com/Azure/azure-sdk-for-python/pull/17424).

Temporarily pin `azure-core` to 1.12.0 so that `Authorization` header is redacted.

**Testing Guide**
```
az storage account list --debug
```