### PR TITLE
[Storage] Refine error message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -177,14 +177,17 @@ def validate_client_parameters(cmd, namespace):
 
     # if account name is specified but no key, attempt to query
     if n.account_name and not n.account_key and not n.sas_token:
-        logger.warning('There are no credentials provided in your command and environment, we will query for the '
-                       'account key inside your storage account. \nPlease provide --connection-string, '
-                       '--account-key or --sas-token as credentials, or use `--auth-mode login` if you '
-                       'have required RBAC roles in your command. For more information about RBAC roles '
-                       'in storage, visit '
-                       'https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli. \n'
-                       'Setting the corresponding environment variables can avoid inputting credentials in '
-                       'your command. Please use --help to get more information.')
+        message = """
+There are no credentials provided in your command and environment, we will query for account key for your storage account.
+It is recommended to provide --connection-string, --account-key or --sas-token in your command as credentials.
+"""
+        if hasattr(n, 'auth_mode') or hasattr(n, 'token_credential'):
+            message += """
+You also can add `--auth-mode login` in your command to use Azure Active Directory (Azure AD) for authorization if your login account is assigned required RBAC roles.
+For more information about RBAC roles in storage, visit https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli.
+"""
+        logger.warning('{}In addition, setting the corresponding environment variables can avoid inputting credentials '
+                       'in your command. Please use --help to get more information about environment variable usage.'.format(message))
         try:
             n.account_key = _query_account_key(cmd.cli_ctx, n.account_name)
         except Exception as ex:  # pylint: disable=broad-except

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -186,8 +186,9 @@ It is recommended to provide --connection-string, --account-key or --sas-token i
 You also can add `--auth-mode login` in your command to use Azure Active Directory (Azure AD) for authorization if your login account is assigned required RBAC roles.
 For more information about RBAC roles in storage, visit https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli.
 """
-        logger.warning('{}\nIn addition, setting the corresponding environment variables can avoid inputting credentials '
-                       'in your command. Please use --help to get more information about environment variable usage.'.format(message))
+        logger.warning('%s\nIn addition, setting the corresponding environment variables can avoid inputting '
+                       'credentials in your command. Please use --help to get more information about environment '
+                       'variable usage.', message)
         try:
             n.account_key = _query_account_key(cmd.cli_ctx, n.account_name)
         except Exception as ex:  # pylint: disable=broad-except

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -181,12 +181,12 @@ def validate_client_parameters(cmd, namespace):
 There are no credentials provided in your command and environment, we will query for account key for your storage account.
 It is recommended to provide --connection-string, --account-key or --sas-token in your command as credentials.
 """
-        if hasattr(n, 'auth_mode') or hasattr(n, 'token_credential'):
+        if 'auth_mode' in cmd.arguments:
             message += """
 You also can add `--auth-mode login` in your command to use Azure Active Directory (Azure AD) for authorization if your login account is assigned required RBAC roles.
 For more information about RBAC roles in storage, visit https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-cli.
 """
-        logger.warning('{}In addition, setting the corresponding environment variables can avoid inputting credentials '
+        logger.warning('{}\nIn addition, setting the corresponding environment variables can avoid inputting credentials '
                        'in your command. Please use --help to get more information about environment variable usage.'.format(message))
         try:
             n.account_key = _query_account_key(cmd.cli_ctx, n.account_name)

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
@@ -41,9 +41,10 @@ class MockLoader(object):
 
 
 class MockCmd(object):
-    def __init__(self, ctx):
+    def __init__(self, ctx, arguments={}):
         self.cli_ctx = ctx
         self.loader = MockLoader(self.cli_ctx)
+        self.arguments = arguments
 
     def get_models(self, *attr_args, **kwargs):
         return get_sdk(self.cli_ctx, ResourceType.DATA_STORAGE, *attr_args, **kwargs)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix issue #16272 and #16853
For command without --auth-mode support, we will not expose related warning message anymore to avoid confuse users.
![image](https://user-images.githubusercontent.com/49508232/114157241-041a4600-9956-11eb-8c12-6b82097f4239.png)

For command support `--auth-mode`, it will still print out related message.
![image](https://user-images.githubusercontent.com/49508232/114378402-404de080-9bba-11eb-9e71-d182f9edf31b.png)

But for command liek
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
