### PR TITLE
{CI} Use `azdev test` for core and telemetry

### DIFF
--- a/.azure-pipelines/templates/automation_test.yml
+++ b/.azure-pipelines/templates/automation_test.yml
@@ -8,9 +8,13 @@ parameters:
   type: string
   default: latest
 - name: fullTest
-  displayName: 'Run full test?'
+  displayName: Run full test?
   type: boolean
   default: false
+- name: module
+  displayName: Run test for specific module
+  type: string
+  default: ''
 
 steps:
   - task: UsePythonVersion@0
@@ -26,7 +30,16 @@ steps:
       echo pythonVersion: ${{ parameters.pythonVersion }}
       echo profile: ${{ parameters.profile }}
       echo fullTest: ${{ parameters.fullTest }}
+      echo module: ${{ parameters.module }}
       echo Build.Reason: $(Build.Reason)
+
+      # Test specific module
+      module="${{ parameters.module }}"
+      if [[ -n $module ]]; then
+        echo "Running test for module '$module'"
+        azdev test --no-exitfirst --verbose --series $module
+        exit 0
+      fi
 
       if [[ "$(Build.Reason)" == "PullRequest" && "${{ parameters.fullTest }}" == 'False' ]]; then
         echo "Running incremental test"
@@ -35,6 +48,6 @@ steps:
         echo "Running full test"
         azdev test --no-exitfirst --profile ${{ parameters.profile }} --verbose --series
       fi
-    displayName: "Test on Profile ${{ parameters.profile }}"
+    displayName: "azdev test"
     env:
       ADO_PULL_REQUEST_LATEST_COMMIT: $(System.PullRequest.TargetBranch)

--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -21,7 +21,7 @@ steps:
       else
         azdev setup -c $CLI_REPO_PATH -r $CLI_EXT_REPO_PATH --debug
       fi
-    displayName: 'Azdev Setup'
+    displayName: 'azdev setup'
     env:
       CLI_REPO_PATH: ${{ parameters.CLIRepoPath }}
       CLI_EXT_REPO_PATH: ${{ parameters.CLIExtensionRepoPath }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -372,31 +372,39 @@ jobs:
 
     displayName: 'Test pip Install'
 
-- job: UnitTest
-  displayName: Unit Test for Core and Telemetry
+- job: TestCore
+  displayName: Unit Test for Core
   timeoutInMinutes: 10
-
   pool:
     vmImage: 'ubuntu-16.04'
   strategy:
     matrix:
       Python36:
         python.version: '3.6'
-        tox_env: 'py36'
       Python38:
         python.version: '3.8'
-        tox_env: 'py38'
   steps:
-    - task: UsePythonVersion@0
-      displayName: 'Use Python $(python.version)'
-      inputs:
-        versionSpec: '$(python.version)'
-    - bash: pip install --upgrade pip tox
-      displayName: 'Install pip and tox'
-    - bash: ./scripts/ci/unittest.sh
-      displayName: 'Run Unit Test'
-      env:
-        TOXENV: $(tox_env)
+    - template: .azure-pipelines/templates/automation_test.yml
+      parameters:
+        pythonVersion: '$(python.version)'
+        module: 'azure-cli-core'
+
+- job: TestTelemetry
+  displayName: Unit Test for Telemetry
+  timeoutInMinutes: 10
+  pool:
+    vmImage: 'ubuntu-16.04'
+  strategy:
+    matrix:
+      Python36:
+        python.version: '3.6'
+      Python38:
+        python.version: '3.8'
+  steps:
+    - template: .azure-pipelines/templates/automation_test.yml
+      parameters:
+        pythonVersion: '$(python.version)'
+        module: 'azure-cli-telemetry'
 
 - job: IntegrationTestAgainstProfiles
   displayName: Integration Test against Profiles
@@ -438,23 +446,6 @@ jobs:
       parameters:
         pythonVersion: '$(python.version)'
         profile: 'latest'
-
-- job: TestCore
-  displayName: Test Core
-  timeoutInMinutes: 120
-  pool:
-    vmImage: 'ubuntu-16.04'
-  strategy:
-    matrix:
-      Python36:
-        python.version: '3.6'
-      Python38:
-        python.version: '3.8'
-  steps:
-    - template: .azure-pipelines/templates/automation_test.yml
-      parameters:
-        pythonVersion: '$(python.version)'
-        module: 'azure-cli-core'
 
 - job: AutomationTest20200901
   displayName: Automation Test (Profile 2020-09-01)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -189,7 +189,7 @@ jobs:
     inputs:
       TargetPath: '$(Build.ArtifactStagingDirectory)/metadata'
       artifactName: metadata
-  
+
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build Artifacts'
     inputs:
@@ -201,7 +201,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {  
+        if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
           # Start another Powershell process as Admin and execute this script again
           $arguments = "& '" +$myinvocation.mycommand.definition + "'"
           Start-Process powershell -Verb runAs -ArgumentList $arguments
@@ -223,7 +223,7 @@ jobs:
         $to_be_installed_version=Get-Content $(System.ArtifactsDirectory)/metadata/version
         if ($pre_installed_version -eq $to_be_installed_version){
           # See https://docs.microsoft.com/windows/win32/msi/reinstallmode about options of REINSTALLMODE
-          $reinstall_option="REINSTALL=ALL REINSTALLMODE=emus" 
+          $reinstall_option="REINSTALL=ALL REINSTALLMODE=emus"
           $InstallArgs += $reinstall_option
         }
         Start-Process "msiexec.exe" -ArgumentList $InstallArgs -Wait -NoNewWindow
@@ -438,6 +438,23 @@ jobs:
       parameters:
         pythonVersion: '$(python.version)'
         profile: 'latest'
+
+- job: TestCore
+  displayName: Test Core
+  timeoutInMinutes: 120
+  pool:
+    vmImage: 'ubuntu-16.04'
+  strategy:
+    matrix:
+      Python36:
+        python.version: '3.6'
+      Python38:
+        python.version: '3.8'
+  steps:
+    - template: .azure-pipelines/templates/automation_test.yml
+      parameters:
+        pythonVersion: '$(python.version)'
+        module: 'azure-cli-core'
 
 - job: AutomationTest20200901
   displayName: Automation Test (Profile 2020-09-01)


### PR DESCRIPTION
**Description**<!--Mandatory-->

The current `Unit Test for Core and Telemetry` uses `tox` to run `pytest`, making that internal `pytest` uncontrollable.

This PR replaces `tox` with `azdev test` so that core and telemetry use the same test framework as other modules.
