### PR TITLE
[ACR] az acr connected-registry create: Removing ancestors active validation.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -90,11 +90,6 @@ def acr_connected_registry_create(cmd,  # pylint: disable=too-many-locals, too-m
                            "when the connected registry parent '{}' mode is '{}'. ".format(parent_name, parent.mode) +
                            "For more information on connected registries " +
                            "please visit https://aka.ms/acr/connected-registry.")
-        msg = "Can't create the registry '{}'. The ancestor connected ".format(connected_registry_name) +\
-              "registry activation status is not '{}'. ".format(ConnectedRegistryActivationStatus.ACTIVE.value) +\
-              "Please install the parent connected registry and try again. For more information on connected " +\
-              "registries, please visit https://aka.ms/acr/connected-registry."
-        _check_ancestors_are_active(family_tree, parent.id, msg)
         _update_ancestor_permissions(cmd, family_tree, resource_group_name, registry_name, parent.id,
                                      connected_registry_name, repositories, mode, False)
 
@@ -469,14 +464,6 @@ def _get_install_info(cmd,
         "ACR_REGISTRY_LOGIN_SERVER": connected_registry_login_server
     }
 # endregion
-
-
-def _check_ancestors_are_active(family_tree, parent_id, msg):
-    while parent_id and not parent_id.isspace():
-        ancestor = family_tree[parent_id]["connectedRegistry"]
-        if ancestor.activation.status != ConnectedRegistryActivationStatus.ACTIVE.value:
-            raise CLIError(msg)
-        parent_id = ancestor.parent.id
 
 
 def _update_ancestor_permissions(cmd,


### PR DESCRIPTION
**Description**<!--Mandatory-->
The PR #17566 was merged before all comments were resolved. I need to remove a validation check from the command before release. 

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
