### PR TITLE
[ARM] az bicep: Replace datetime APIs that are not available in Python 3.6

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -38,6 +38,7 @@ _config_dir = get_config_dir()
 _bicep_installation_dir = os.path.join(_config_dir, "bin")
 _bicep_version_check_file_path = os.path.join(_config_dir, "bicepVersionCheck.json")
 _bicep_version_check_cache_ttl = timedelta(minutes=10)
+_bicep_version_check_time_format = "%Y-%m-%dT%H:%M:%S.%f"
 
 _logger = get_logger(__name__)
 
@@ -149,7 +150,7 @@ def _load_bicep_version_check_result_from_cache():
         with open(_bicep_version_check_file_path, "r") as version_check_file:
             version_check_data = json.load(version_check_file)
             latest_release_tag = version_check_data["latestReleaseTag"]
-            last_check_time = datetime.fromisoformat(version_check_data["lastCheckTime"])
+            last_check_time = datetime.strptime(version_check_data["lastCheckTime"], _bicep_version_check_time_format)
             cache_expired = datetime.now() - last_check_time > _bicep_version_check_cache_ttl
 
             return latest_release_tag, cache_expired
@@ -160,7 +161,7 @@ def _load_bicep_version_check_result_from_cache():
 def _refresh_bicep_version_check_cache(lastest_release_tag):
     with open(_bicep_version_check_file_path, "w+") as version_check_file:
         version_check_data = {
-            "lastCheckTime": datetime.now().isoformat(timespec="microseconds"),
+            "lastCheckTime": datetime.now().strftime(_bicep_version_check_time_format),
             "latestReleaseTag": lastest_release_tag,
         }
         json.dump(version_check_data, version_check_file)


### PR DESCRIPTION
**Description**<!--Mandatory-->
`fromiosformat` and `isoformat` are not available in Python 3.6. This is causing failures for some Bicep users using Azure CLI. The PR updates the Bicep version check code to use Python 3.6 compatible APIs.

Closes https://github.com/Azure/bicep/issues/2243.
Closes https://github.com/Azure/azure-cli/issues/17665.

**Testing Guide**
```
az bicep version
```
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
