### PR TITLE
[Compute] add error message for `vm identity assign`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -672,7 +672,7 @@ def assign_vm_identity(cmd, resource_group_name, vm_name, assign_identity=None, 
         if external_identities:
             vm.identity.user_assigned_identities = {}
             if not cmd.supported_api_version(min_api='2018-06-01', resource_type=ResourceType.MGMT_COMPUTE):
-                raise CLIInternalError("usage error: user assigned identity is not available under current profile.",
+                raise CLIInternalError("Usage error: user assigned identity is not available under current profile.",
                                        "Please set the cloud's profile to latest with 'az cloud set --profile latest"
                                        " --name <cloud name>'")
             for identity in external_identities:

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -26,6 +26,7 @@ from six.moves.urllib.request import urlopen  # noqa, pylint: disable=import-err
 
 from knack.log import get_logger
 from knack.util import CLIError
+from azure.cli.core.azclierror import CLIInternalError
 
 from azure.cli.command_modules.vm._validators import _get_resource_group_from_vault_name
 from azure.cli.core.commands.validators import validate_file_or_dict
@@ -670,6 +671,8 @@ def assign_vm_identity(cmd, resource_group_name, vm_name, assign_identity=None, 
         vm.identity = VirtualMachineIdentity(type=identity_types)
         if external_identities:
             vm.identity.user_assigned_identities = {}
+            if not cmd.supported_api_version(min_api='2018-06-01', resource_type=ResourceType.MGMT_COMPUTE):
+                raise CLIInternalError("usage error: user assigned identity is not available under current profile. Please set the cloud's profile to latest with 'az cloud set --profile latest --name <cloud name>'")
             for identity in external_identities:
                 vm.identity.user_assigned_identities[identity] = UserAssignedIdentitiesValue()
 

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -673,7 +673,7 @@ def assign_vm_identity(cmd, resource_group_name, vm_name, assign_identity=None, 
             vm.identity.user_assigned_identities = {}
             if not cmd.supported_api_version(min_api='2018-06-01', resource_type=ResourceType.MGMT_COMPUTE):
                 raise CLIInternalError("Usage error: user assigned identity is not available under current profile.",
-                                       "Please set the cloud's profile to latest with 'az cloud set --profile latest"
+                                       "You can set the cloud's profile to latest with 'az cloud set --profile latest"
                                        " --name <cloud name>'")
             for identity in external_identities:
                 vm.identity.user_assigned_identities[identity] = UserAssignedIdentitiesValue()

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -672,7 +672,9 @@ def assign_vm_identity(cmd, resource_group_name, vm_name, assign_identity=None, 
         if external_identities:
             vm.identity.user_assigned_identities = {}
             if not cmd.supported_api_version(min_api='2018-06-01', resource_type=ResourceType.MGMT_COMPUTE):
-                raise CLIInternalError("usage error: user assigned identity is not available under current profile. Please set the cloud's profile to latest with 'az cloud set --profile latest --name <cloud name>'")
+                raise CLIInternalError("usage error: user assigned identity is not available under current profile.",
+                                       "Please set the cloud's profile to latest with 'az cloud set --profile latest"
+                                       " --name <cloud name>'")
             for identity in external_identities:
                 vm.identity.user_assigned_identities[identity] = UserAssignedIdentitiesValue()
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
resolve #17682 
**command**:
`az vm identity assign`

**result**
Before:
```
'NoneType' object is not callable
Traceback (most recent call last):
python3.8/site-packages/knack/cli.py, ln 215, in invoke
    cmd_![image](https://user-images.githubusercontent.com/81600993/114687941-d0209580-9d46-11eb-8237-6365b365ea73.png) = self.invocation.execute(args)
cli/core/commands/__init__.py, ln 654, in execute
    raise ex
cli/core/commands/__init__.py, ln 718, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
cli/core/commands/__init__.py, ln 711, in _run_job
    six.reraise(*sys.exc_info())
...
cli/command_modules/vm/custom.py, ln 648, in assign_vm_identity
    assign_identity_helper(cmd.cli_ctx, getter, setter, identity_role=identity_role_id, identity_scope=identity_scope)
cli/core/commands/arm.py, ln 1057, in assign_identity
    resource = setter(resource)
cli/command_modules/vm/custom.py, ln 642, in setter
    vm.identity.user_assigned_identities[identity] = VirtualMachineIdentityUserAssignedIdentitiesValue()
TypeError: 'NoneType' object is not callable
```
After
![image](https://user-images.githubusercontent.com/81600993/114687891-c26b1000-9d46-11eb-9cd7-326d3e86331e.png)

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
