### PR TITLE
{Core} Hotfix: Fix inifite extension install loop

### DIFF
--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -220,6 +220,11 @@ class ManualInterrupt(UserFault):
     pass
 
 
+class NoTTYError(UserFault):
+    """ No tty available for prompt. """
+    pass
+
+
 # ARM template related error types
 class InvalidTemplateError(UserFault):
     """ ARM template validation fails. It could be caused by incorrect template files or parameters """

--- a/src/azure-cli-core/azure/cli/core/extension/dynamic_install.py
+++ b/src/azure-cli-core/azure/cli/core/extension/dynamic_install.py
@@ -65,7 +65,7 @@ def _get_all_extensions(cmd_chain, ext_set=None):
     return ext_set
 
 
-def _search_in_extension_commands(cli_ctx, command_str):
+def _search_in_extension_commands(cli_ctx, command_str, allow_prefix_match=False):
     """Search the command in an extension commands dict which mimics a prefix tree.
     If the value of the dict item is a string, then the key represents the end of a complete command
     and the value is the name of the extension that the command belongs to.
@@ -95,6 +95,8 @@ def _search_in_extension_commands(cli_ctx, command_str):
         except KeyError:
             return None
     # command_str is prefix of one or more complete commands.
+    if not allow_prefix_match:
+        return None
     all_exts = _get_all_extensions(cmd_chain)
     return list(all_exts) if all_exts else None
 
@@ -137,7 +139,8 @@ def _check_value_in_extensions(cli_ctx, parser, args, no_prompt):  # pylint: dis
     from azure.cli.core.azclierror import NoTTYError
     exit_code = 2
     command_str = roughly_parse_command(args[1:])
-    ext_name = _search_in_extension_commands(cli_ctx, command_str)
+    allow_prefix_match = args[-1] == '-h' or args[-1] == '--help'
+    ext_name = _search_in_extension_commands(cli_ctx, command_str, allow_prefix_match=allow_prefix_match)
     # ext_name is a list if the input command matches the prefix of one or more extension commands,
     # for instance: `az blueprint` when running `az blueprint -h`
     # ext_name is a str if the input command matches a complete command of an extension,

--- a/src/azure-cli-core/azure/cli/core/extension/dynamic_install.py
+++ b/src/azure-cli-core/azure/cli/core/extension/dynamic_install.py
@@ -1,0 +1,232 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import azure.cli.core.telemetry as telemetry
+from azure.cli.core.commands import AzCliCommandInvoker
+from azure.cli.core.azclierror import CommandNotFoundError
+from knack.log import get_logger
+
+logger = get_logger(__name__)
+
+
+def _get_extension_command_tree(cli_ctx):
+    from azure.cli.core._session import EXT_CMD_TREE
+    import os
+    VALID_SECOND = 3600 * 24 * 10
+    if not cli_ctx:
+        return None
+    EXT_CMD_TREE.load(os.path.join(cli_ctx.config.config_dir, 'extensionCommandTree.json'), VALID_SECOND)
+    if not EXT_CMD_TREE.data:
+        import posixpath
+        import requests
+        from azure.cli.core.util import should_disable_connection_verify
+        try:
+            azmirror_endpoint = cli_ctx.cloud.endpoints.azmirror_storage_account_resource_id if cli_ctx and \
+                cli_ctx.cloud.endpoints.has_endpoint_set('azmirror_storage_account_resource_id') else None
+            url = posixpath.join(azmirror_endpoint, 'extensions', 'extensionCommandTree.json') if \
+                azmirror_endpoint else 'https://aka.ms/azExtCmdTree'
+            response = requests.get(
+                url,
+                verify=(not should_disable_connection_verify()),
+                timeout=10)
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.info("Request failed for extension command tree: %s", str(ex))
+            return None
+        if response.status_code == 200:
+            EXT_CMD_TREE.data = response.json()
+            EXT_CMD_TREE.save_with_retry()
+        else:
+            logger.info("Error when retrieving extension command tree. Response code: %s", response.status_code)
+            return None
+    return EXT_CMD_TREE
+
+
+def _get_all_extensions(cmd_chain, ext_set=None):
+    """Find all the extension names in cmd_chain (dict of extension command subtree).
+    An example of cmd_chain may look like (a command sub tree of the 'aks' command group):
+    {
+        "create": "aks-preview",
+        "update": "aks-preview",
+        "app": {
+            "up": "deploy-to-azure"
+        },
+        "use-dev-spaces": "dev-spaces"
+    }
+    Then the resulting ext_set is {'aks-preview', 'deploy-to-azure', 'dev-spaces'}
+    """
+    ext_set = set() if ext_set is None else ext_set
+    for key in cmd_chain:
+        if isinstance(cmd_chain[key], str):
+            ext_set.add(cmd_chain[key])
+        else:
+            _get_all_extensions(cmd_chain[key], ext_set)
+    return ext_set
+
+
+def _search_in_extension_commands(cli_ctx, command_str):
+    """Search the command in an extension commands dict which mimics a prefix tree.
+    If the value of the dict item is a string, then the key represents the end of a complete command
+    and the value is the name of the extension that the command belongs to.
+    An example of the dict read from extensionCommandTree.json:
+    {
+        "aks": {
+            "create": "aks-preview",
+            "update": "aks-preview",
+            "app": {
+                "up": "deploy-to-azure"
+            },
+            "use-dev-spaces": "dev-spaces"
+        },
+        ...
+    }
+    """
+    if not command_str:
+        return None
+    cmd_chain = _get_extension_command_tree(cli_ctx)
+    if not cmd_chain:
+        return None
+    for part in command_str.split():
+        try:
+            if isinstance(cmd_chain[part], str):
+                return cmd_chain[part]
+            cmd_chain = cmd_chain[part]
+        except KeyError:
+            return None
+    # command_str is prefix of one or more complete commands.
+    all_exts = _get_all_extensions(cmd_chain)
+    return list(all_exts) if all_exts else None
+
+
+def _get_extension_run_after_dynamic_install_config(cli_ctx):
+    default_value = True
+    run_after_extension_installed = cli_ctx.config.getboolean('extension',
+                                                              'run_after_dynamic_install',
+                                                              default_value) if cli_ctx else default_value
+    return run_after_extension_installed
+
+
+def get_extension_use_dynamic_install_config(cli_ctx):
+    default_value = 'yes_prompt'
+    use_dynamic_install = cli_ctx.config.get(
+        'extension', 'use_dynamic_install', default_value).lower() if cli_ctx else default_value
+    if use_dynamic_install not in ['no', 'yes_prompt', 'yes_without_prompt']:
+        use_dynamic_install = default_value
+    return use_dynamic_install
+
+
+def check_value_in_extensions(parser, args, no_prompt):  # pylint: disable=too-many-statements, too-many-locals
+    """Check if the command args can be found in extension commands.
+       Exit command if the error is caused by an extension not installed.
+       Otherwise return.
+    """
+    # Check if the command is from an extension
+    from azure.cli.core.util import roughly_parse_command
+    from azure.cli.core.azclierror import NoTTYError
+    exit_code = 2
+    command_str = roughly_parse_command(args[1:])
+    # self.cli_ctx is None when self.prog is beyond 'az', such as 'az iot'.
+    # use cli_ctx from cli_help which is not lost.
+    cli_ctx = parser.cli_ctx or (parser.cli_help.cli_ctx if parser.cli_help else None)
+    ext_name = _search_in_extension_commands(cli_ctx, command_str)
+    # ext_name is a list if the input command matches the prefix of one or more extension commands,
+    # for instance: `az blueprint` when running `az blueprint -h`
+    # ext_name is a str if the input command matches a complete command of an extension,
+    # for instance: `az blueprint create`
+    if isinstance(ext_name, list):
+        if len(ext_name) > 1:
+            from knack.prompting import prompt_choice_list, NoTTYException
+            prompt_msg = "The command requires the latest version of one of the following " \
+                "extensions. You need to pick one to install:"
+            try:
+                choice_idx = prompt_choice_list(prompt_msg, ext_name)
+                ext_name = ext_name[choice_idx]
+                no_prompt = True
+            except NoTTYException:
+                tty_err_msg = "{}{}\nUnable to prompt for selection as no tty available. Please update or " \
+                    "install the extension with 'az extension add --upgrade -n <extension-name>'." \
+                    .format(prompt_msg, ext_name)
+                az_error = NoTTYError(tty_err_msg)
+                az_error.print_error()
+                az_error.send_telemetry()
+                parser.exit(exit_code)
+        else:
+            ext_name = ext_name[0]
+    if not ext_name:
+        return
+
+    # If a valid command has parser error, it may be caused by CLI running on a profile that is
+    # not 'latest' and the command is not supported in that profile. If this command exists in an extension,
+    # CLI will try to download the extension and rerun the command. But the parser will fail again and try to
+    # install the extension and rerun the command infinitely. So we need to check if the latest version of the
+    # extension is already installed and return if yes as the error is not caused by extension not installed.
+    from azure.cli.core.extension import get_extension, ExtensionNotInstalledException
+    from azure.cli.core.extension._resolve import resolve_from_index, NoExtensionCandidatesError
+    try:
+        ext = get_extension(ext_name)
+    except ExtensionNotInstalledException:
+        pass
+    else:
+        try:
+            resolve_from_index(ext_name, cur_version=ext.version, cli_ctx=cli_ctx)
+        except NoExtensionCandidatesError:
+            return
+
+    telemetry.set_command_details(command_str,
+                                  parameters=AzCliCommandInvoker._extract_parameter_names(args),  # pylint: disable=protected-access
+                                  extension_name=ext_name)
+    run_after_extension_installed = _get_extension_run_after_dynamic_install_config(cli_ctx)
+    prompt_info = ""
+    if no_prompt:
+        logger.warning('The command requires the extension %s. It will be installed first.', ext_name)
+        install_ext = True
+    else:  # yes_prompt
+        from knack.prompting import prompt_y_n, NoTTYException
+        prompt_msg = 'The command requires the extension {}. Do you want to install it now?'.format(ext_name)
+        if run_after_extension_installed:
+            prompt_msg = '{} The command will continue to run after the extension is installed.' \
+                .format(prompt_msg)
+        NO_PROMPT_CONFIG_MSG = "Run 'az config set extension.use_dynamic_install=" \
+            "yes_without_prompt' to allow installing extensions without prompt."
+        try:
+            install_ext = prompt_y_n(prompt_msg, default='y')
+            if install_ext:
+                prompt_info = " with prompt"
+                logger.warning(NO_PROMPT_CONFIG_MSG)
+        except NoTTYException:
+            tty_err_msg = "The command requires the extension {}. " \
+                          "Unable to prompt for extension install confirmation as no tty " \
+                          "available. {}".format(ext_name, NO_PROMPT_CONFIG_MSG)
+            az_error = NoTTYError(tty_err_msg)
+            az_error.print_error()
+            az_error.send_telemetry()
+            parser.exit(exit_code)
+
+    print_error = True
+    if install_ext:
+        from azure.cli.core.extension.operations import add_extension
+        add_extension(cli_ctx=cli_ctx, extension_name=ext_name, upgrade=True)
+        if run_after_extension_installed:
+            import subprocess
+            import platform
+            exit_code = subprocess.call(args, shell=platform.system() == 'Windows')
+            # In this case, error msg is for telemetry recording purpose only.
+            # From UX perspective, the command will rerun in subprocess. Whether it succeeds or fails,
+            # mesages will be shown from the subprocess and this process should not print more message to
+            # interrupt that.
+            print_error = False
+            error_msg = ("Extension {} dynamically installed{} and commands will be "
+                         "rerun automatically.").format(ext_name, prompt_info)
+        else:
+            error_msg = 'Extension {} installed{}. Please rerun your command.' \
+                .format(ext_name, prompt_info)
+    else:
+        error_msg = "The command requires the latest version of extension {ext_name}. " \
+            "To install, run 'az extension add --upgrade -n {ext_name}'.".format(
+                ext_name=ext_name)
+    az_error = CommandNotFoundError(error_msg)
+    if print_error:
+        az_error.print_error()
+    az_error.send_telemetry()
+    parser.exit(exit_code)

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -320,7 +320,7 @@ def add_extension(cmd=None, source=None, extension_name=None, index_url=None, ye
                 logger.warning("Extension '%s' %s is already installed.", extension_name, ext.get_version())
                 if version and version == ext.get_version():
                     return
-                logger.warning("It will be overriden with version {}.".format(version) if version else "It will be updated if available.")
+                logger.warning("It will be overridden with version {}.".format(version) if version else "It will be updated if available.")
                 update_extension(cmd=cmd, extension_name=extension_name, index_url=index_url, pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, cli_ctx=cli_ctx, version=version)
                 return
             logger.warning("Overriding development version of '%s' with production version.", extension_name)

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -293,15 +293,14 @@ class AzCliCommandParser(CLICommandParser):
             cli_ctx = self.cli_ctx or (self.cli_help.cli_ctx if self.cli_help else None)
 
             command_name_inferred = self.prog
+            use_dynamic_install = 'no'
             if not self.command_source:
-                from azure.cli.core.extension.dynamic_install import get_extension_use_dynamic_install_config, \
-                    check_value_in_extensions
+                from azure.cli.core.extension.dynamic_install import try_install_extension
                 candidates = []
                 args = self.prog.split() + self._raw_arguments
-                use_dynamic_install = get_extension_use_dynamic_install_config(cli_ctx)
-                if use_dynamic_install != 'no':
-                    # The function will exit if the parse error is caused by the extension for the command not installed
-                    check_value_in_extensions(self, args, use_dynamic_install == 'yes_without_prompt')
+                # Check if the command is from an extension. If yes, try to fix by installing the extension, then exit.
+                # The command will be rerun in another process.
+                use_dynamic_install = try_install_extension(self, args)
                 # parser has no `command_source`, value is part of command itself
                 error_msg = "'{value}' is misspelled or not recognized by the system.".format(value=value)
                 az_error = CommandNotFoundError(error_msg)

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -312,8 +312,8 @@ class AzCliCommandParser(CLICommandParser):
             else:
                 # `command_source` indicates command values have been parsed, value is an argument
                 parameter = action.option_strings[0] if action.option_strings else action.dest
-                error_msg = "{prog}: '{value}' is not a valid value for '{param}'.".format(
-                    prog=self.prog, value=value, param=parameter)
+                error_msg = "{prog}: '{value}' is not a valid value for '{param}'. Allowed values: {choices}.".format(
+                    prog=self.prog, value=value, param=parameter, choices=', '.join([str(x) for x in action.choices]))
                 az_error = InvalidArgumentValueError(error_msg)
                 candidates = difflib.get_close_matches(value, action.choices, cutoff=0.7)
 

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -284,197 +284,6 @@ class AzCliCommandParser(CLICommandParser):
         self._namespace, self._raw_arguments = super().parse_known_args(args=args, namespace=namespace)
         return self._namespace, self._raw_arguments
 
-    def _get_extension_command_tree(self):
-        from azure.cli.core._session import EXT_CMD_TREE
-        import os
-        VALID_SECOND = 3600 * 24 * 10
-        # self.cli_ctx is None when self.prog is beyond 'az', such as 'az iot'.
-        # use cli_ctx from cli_help which is not lost.
-        cli_ctx = self.cli_ctx or (self.cli_help.cli_ctx if self.cli_help else None)
-        if not cli_ctx:
-            return None
-        EXT_CMD_TREE.load(os.path.join(cli_ctx.config.config_dir, 'extensionCommandTree.json'), VALID_SECOND)
-        if not EXT_CMD_TREE.data:
-            import posixpath
-            import requests
-            from azure.cli.core.util import should_disable_connection_verify
-            try:
-                azmirror_endpoint = cli_ctx.cloud.endpoints.azmirror_storage_account_resource_id if cli_ctx and \
-                    cli_ctx.cloud.endpoints.has_endpoint_set('azmirror_storage_account_resource_id') else None
-                url = posixpath.join(azmirror_endpoint, 'extensions', 'extensionCommandTree.json') if \
-                    azmirror_endpoint else 'https://aka.ms/azExtCmdTree'
-                response = requests.get(
-                    url,
-                    verify=(not should_disable_connection_verify()),
-                    timeout=10)
-            except Exception as ex:  # pylint: disable=broad-except
-                logger.info("Request failed for extension command tree: %s", str(ex))
-                return None
-            if response.status_code == 200:
-                EXT_CMD_TREE.data = response.json()
-                EXT_CMD_TREE.save_with_retry()
-            else:
-                logger.info("Error when retrieving extension command tree. Response code: %s", response.status_code)
-                return None
-        return EXT_CMD_TREE
-
-    def _get_all_extensions(self, cmd_chain, ext_set=None):
-        """Find all the extension names in cmd_chain (dict of extension command subtree).
-        An example of cmd_chain may look like (a command sub tree of the 'aks' command group):
-        {
-            "create": "aks-preview",
-            "update": "aks-preview",
-            "app": {
-                "up": "deploy-to-azure"
-            },
-            "use-dev-spaces": "dev-spaces"
-        }
-        Then the resulting ext_set is {'aks-preview', 'deploy-to-azure', 'dev-spaces'}
-        """
-        ext_set = set() if ext_set is None else ext_set
-        for key in cmd_chain:
-            if isinstance(cmd_chain[key], str):
-                ext_set.add(cmd_chain[key])
-            else:
-                self._get_all_extensions(cmd_chain[key], ext_set)
-        return ext_set
-
-    def _search_in_extension_commands(self, command_str):
-        """Search the command in an extension commands dict which mimics a prefix tree.
-        If the value of the dict item is a string, then the key represents the end of a complete command
-        and the value is the name of the extension that the command belongs to.
-        An example of the dict read from extensionCommandTree.json:
-        {
-            "aks": {
-                "create": "aks-preview",
-                "update": "aks-preview",
-                "app": {
-                    "up": "deploy-to-azure"
-                },
-                "use-dev-spaces": "dev-spaces"
-            },
-            ...
-        }
-        """
-        if not command_str:
-            return None
-        cmd_chain = self._get_extension_command_tree()
-        if not cmd_chain:
-            return None
-        for part in command_str.split():
-            try:
-                if isinstance(cmd_chain[part], str):
-                    return cmd_chain[part]
-                cmd_chain = cmd_chain[part]
-            except KeyError:
-                return None
-        # command_str is prefix of one or more complete commands.
-        all_exts = self._get_all_extensions(cmd_chain)
-        return list(all_exts) if all_exts else None
-
-    def _get_extension_use_dynamic_install_config(self):
-        cli_ctx = self.cli_ctx or (self.cli_help.cli_ctx if self.cli_help else None)
-        default_value = 'yes_prompt'
-        use_dynamic_install = cli_ctx.config.get(
-            'extension', 'use_dynamic_install', default_value).lower() if cli_ctx else default_value
-        if use_dynamic_install not in ['no', 'yes_prompt', 'yes_without_prompt']:
-            use_dynamic_install = default_value
-        return use_dynamic_install
-
-    def _get_extension_run_after_dynamic_install_config(self):
-        cli_ctx = self.cli_ctx or (self.cli_help.cli_ctx if self.cli_help else None)
-        default_value = True
-        run_after_extension_installed = cli_ctx.config.getboolean('extension',
-                                                                  'run_after_dynamic_install',
-                                                                  default_value) if cli_ctx else default_value
-        return run_after_extension_installed
-
-    def _check_value_in_extensions(self, cli_ctx, args, no_prompt):  # pylint: disable=too-many-statements
-        """Check if the command args can be found in extension commands.
-        """
-        # Check if the command is from an extension
-        from azure.cli.core.util import roughly_parse_command
-        from azure.cli.core.azclierror import NoTTYError
-        exit_code = 2
-        command_str = roughly_parse_command(args[1:])
-        ext_name = self._search_in_extension_commands(command_str)
-        # ext_name is a list if the input command matches the prefix of one or more extension commands,
-        # for instance: `az blueprint` when running `az blueprint -h`
-        # ext_name is a str if the input command matches a complete command of an extension,
-        # for instance: `az blueprint create`
-        if isinstance(ext_name, list):
-            if len(ext_name) > 1:
-                from knack.prompting import prompt_choice_list, NoTTYException
-                prompt_msg = "The command requires the latest version of one of the following " \
-                    "extensions. You need to pick one to install:"
-                try:
-                    choice_idx = prompt_choice_list(prompt_msg, ext_name)
-                    ext_name = ext_name[choice_idx]
-                except NoTTYException:
-                    tty_err_msg = "{}{}\nUnable to prompt for selection as no tty available. Please update or " \
-                        "install the extension with 'az extension add --upgrade -n <extension-name>'." \
-                        .format(prompt_msg, ext_name)
-                    az_error = NoTTYError(tty_err_msg)
-                    az_error.print_error()
-                    az_error.send_telemetry()
-                    self.exit(exit_code)
-            else:
-                ext_name = ext_name[0]
-        if not ext_name:
-            return
-
-        telemetry.set_command_details(command_str,
-                                      parameters=AzCliCommandInvoker._extract_parameter_names(args),  # pylint: disable=protected-access
-                                      extension_name=ext_name)
-        run_after_extension_installed = self._get_extension_run_after_dynamic_install_config()
-        prompt_info = ""
-        if no_prompt:
-            logger.warning('The command requires the extension %s. It will be installed first.', ext_name)
-            install_ext = True
-        else:  # yes_prompt
-            from knack.prompting import prompt_y_n, NoTTYException
-            prompt_msg = 'The command requires the extension {}. Do you want to install it now?'.format(ext_name)
-            if run_after_extension_installed:
-                prompt_msg = '{} The command will continue to run after the extension is installed.' \
-                    .format(prompt_msg)
-            NO_PROMPT_CONFIG_MSG = "Run 'az config set extension.use_dynamic_install=" \
-                "yes_without_prompt' to allow installing extensions without prompt."
-            try:
-                install_ext = prompt_y_n(prompt_msg, default='y')
-                if install_ext:
-                    prompt_info = " with prompt"
-                    logger.warning(NO_PROMPT_CONFIG_MSG)
-            except NoTTYException:
-                tty_err_msg = "The command requires the extension {}. " \
-                              "Unable to prompt for extension install confirmation as no tty " \
-                              "available. {}".format(ext_name, NO_PROMPT_CONFIG_MSG)
-                az_error = NoTTYError(tty_err_msg)
-                az_error.print_error()
-                az_error.send_telemetry()
-                self.exit(exit_code)
-
-        if install_ext:
-            from azure.cli.core.extension.operations import add_extension
-            add_extension(cli_ctx=cli_ctx, extension_name=ext_name, upgrade=True)
-            if run_after_extension_installed:
-                import subprocess
-                import platform
-                exit_code = subprocess.call(args, shell=platform.system() == 'Windows')
-                error_msg = ("Extension {} dynamically installed{} and commands will be "
-                             "rerun automatically.").format(ext_name, prompt_info)
-            else:
-                error_msg = 'Extension {} installed{}. Please rerun your command.' \
-                    .format(ext_name, prompt_info)
-        else:
-            error_msg = "The command requires the latest version of extension {ext_name}. " \
-                "To install, run 'az extension add --upgrade -n {ext_name}'.".format(
-                    ext_name=ext_name)
-        az_error = CommandNotFoundError(error_msg)
-        if exit_code != 0:
-            az_error.print_error()
-        az_error.send_telemetry()
-        self.exit(exit_code)
-
     def _check_value(self, action, value):  # pylint: too-many-locals, too-many-branches
         # Override to customize the error message when a argument is not among the available choices
         # converted value must be one of the choices (if specified)
@@ -485,12 +294,14 @@ class AzCliCommandParser(CLICommandParser):
 
             command_name_inferred = self.prog
             if not self.command_source:
+                from azure.cli.core.extension.dynamic_install import get_extension_use_dynamic_install_config, \
+                    check_value_in_extensions
                 candidates = []
                 args = self.prog.split() + self._raw_arguments
-                use_dynamic_install = self._get_extension_use_dynamic_install_config()
+                use_dynamic_install = get_extension_use_dynamic_install_config(cli_ctx)
                 if use_dynamic_install != 'no':
                     # The function will exit if the parse error is caused by the extension for the command not installed
-                    self._check_value_in_extensions(cli_ctx, args, use_dynamic_install == 'yes_without_prompt')
+                    check_value_in_extensions(self, args, use_dynamic_install == 'yes_without_prompt')
                 # parser has no `command_source`, value is part of command itself
                 error_msg = "'{value}' is misspelled or not recognized by the system.".format(value=value)
                 az_error = CommandNotFoundError(error_msg)

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -9,7 +9,6 @@ import argparse
 import argcomplete
 
 import azure.cli.core.telemetry as telemetry
-from azure.cli.core.azlogging import CommandLoggerContext
 from azure.cli.core.extension import get_extension
 from azure.cli.core.commands import ExtensionCommandSource
 from azure.cli.core.commands import AzCliCommandInvoker
@@ -390,7 +389,93 @@ class AzCliCommandParser(CLICommandParser):
                                                                   default_value) if cli_ctx else default_value
         return run_after_extension_installed
 
-    def _check_value(self, action, value):  # pylint: disable=too-many-statements, too-many-locals, too-many-branches
+    def _check_value_in_extensions(self, cli_ctx, args, no_prompt):  # pylint: disable=too-many-statements
+        """Check if the command args can be found in extension commands.
+        """
+        # Check if the command is from an extension
+        from azure.cli.core.util import roughly_parse_command
+        from azure.cli.core.azclierror import NoTTYError
+        exit_code = 2
+        command_str = roughly_parse_command(args[1:])
+        ext_name = self._search_in_extension_commands(command_str)
+        # ext_name is a list if the input command matches the prefix of one or more extension commands,
+        # for instance: `az blueprint` when running `az blueprint -h`
+        # ext_name is a str if the input command matches a complete command of an extension,
+        # for instance: `az blueprint create`
+        if isinstance(ext_name, list):
+            if len(ext_name) > 1:
+                from knack.prompting import prompt_choice_list, NoTTYException
+                prompt_msg = "The command requires the latest version of one of the following " \
+                    "extensions. You need to pick one to install:"
+                try:
+                    choice_idx = prompt_choice_list(prompt_msg, ext_name)
+                    ext_name = ext_name[choice_idx]
+                except NoTTYException:
+                    tty_err_msg = "{}{}\nUnable to prompt for selection as no tty available. Please update or " \
+                        "install the extension with 'az extension add --upgrade -n <extension-name>'." \
+                        .format(prompt_msg, ext_name)
+                    az_error = NoTTYError(tty_err_msg)
+                    az_error.print_error()
+                    az_error.send_telemetry()
+                    self.exit(exit_code)
+            else:
+                ext_name = ext_name[0]
+        if not ext_name:
+            return
+
+        telemetry.set_command_details(command_str,
+                                      parameters=AzCliCommandInvoker._extract_parameter_names(args),  # pylint: disable=protected-access
+                                      extension_name=ext_name)
+        run_after_extension_installed = self._get_extension_run_after_dynamic_install_config()
+        prompt_info = ""
+        if no_prompt:
+            logger.warning('The command requires the extension %s. It will be installed first.', ext_name)
+            install_ext = True
+        else:  # yes_prompt
+            from knack.prompting import prompt_y_n, NoTTYException
+            prompt_msg = 'The command requires the extension {}. Do you want to install it now?'.format(ext_name)
+            if run_after_extension_installed:
+                prompt_msg = '{} The command will continue to run after the extension is installed.' \
+                    .format(prompt_msg)
+            NO_PROMPT_CONFIG_MSG = "Run 'az config set extension.use_dynamic_install=" \
+                "yes_without_prompt' to allow installing extensions without prompt."
+            try:
+                install_ext = prompt_y_n(prompt_msg, default='y')
+                if install_ext:
+                    prompt_info = " with prompt"
+                    logger.warning(NO_PROMPT_CONFIG_MSG)
+            except NoTTYException:
+                tty_err_msg = "The command requires the extension {}. " \
+                              "Unable to prompt for extension install confirmation as no tty " \
+                              "available. {}".format(ext_name, NO_PROMPT_CONFIG_MSG)
+                az_error = NoTTYError(tty_err_msg)
+                az_error.print_error()
+                az_error.send_telemetry()
+                self.exit(exit_code)
+
+        if install_ext:
+            from azure.cli.core.extension.operations import add_extension
+            add_extension(cli_ctx=cli_ctx, extension_name=ext_name, upgrade=True)
+            if run_after_extension_installed:
+                import subprocess
+                import platform
+                exit_code = subprocess.call(args, shell=platform.system() == 'Windows')
+                error_msg = ("Extension {} dynamically installed{} and commands will be "
+                             "rerun automatically.").format(ext_name, prompt_info)
+            else:
+                error_msg = 'Extension {} installed{}. Please rerun your command.' \
+                    .format(ext_name, prompt_info)
+        else:
+            error_msg = "The command requires the latest version of extension {ext_name}. " \
+                "To install, run 'az extension add --upgrade -n {ext_name}'.".format(
+                    ext_name=ext_name)
+        az_error = CommandNotFoundError(error_msg)
+        if exit_code != 0:
+            az_error.print_error()
+        az_error.send_telemetry()
+        self.exit(exit_code)
+
+    def _check_value(self, action, value):  # pylint: too-many-locals, too-many-branches
         # Override to customize the error message when a argument is not among the available choices
         # converted value must be one of the choices (if specified)
         if action.choices is not None and value not in action.choices:  # pylint: disable=too-many-nested-blocks
@@ -398,127 +483,46 @@ class AzCliCommandParser(CLICommandParser):
             # use cli_ctx from cli_help which is not lost.
             cli_ctx = self.cli_ctx or (self.cli_help.cli_ctx if self.cli_help else None)
 
-            caused_by_extension_not_installed = False
             command_name_inferred = self.prog
-            error_msg = None
-            use_dynamic_install = 'no'
             if not self.command_source:
                 candidates = []
                 args = self.prog.split() + self._raw_arguments
                 use_dynamic_install = self._get_extension_use_dynamic_install_config()
                 if use_dynamic_install != 'no':
-                    # Check if the command is from an extension
-                    from azure.cli.core.util import roughly_parse_command
-                    command_str = roughly_parse_command(args[1:])
-                    ext_name = self._search_in_extension_commands(command_str)
-                    # The input command matches the prefix of one or more extension commands
-                    if isinstance(ext_name, list):
-                        if len(ext_name) > 1:
-                            from knack.prompting import prompt_choice_list, NoTTYException
-                            prompt_msg = "The command requires the latest version of one of the following " \
-                                "extensions. You need to pick one to install:"
-                            try:
-                                choice_idx = prompt_choice_list(prompt_msg, ext_name)
-                                ext_name = ext_name[choice_idx]
-                                use_dynamic_install = 'yes_without_prompt'
-                            except NoTTYException:
-                                error_msg = "{}{}\nUnable to prompt for selection as no tty available. Please " \
-                                    "update or install the extension with 'az extension add --upgrade -n " \
-                                    "<extension-name>'.".format(prompt_msg, ext_name)
-                                logger.error(error_msg)
-                                telemetry.set_user_fault(error_msg)
-                                self.exit(2)
-                        else:
-                            ext_name = ext_name[0]
-
-                    if ext_name:
-                        caused_by_extension_not_installed = True
-                        telemetry.set_command_details(command_str,
-                                                      parameters=AzCliCommandInvoker._extract_parameter_names(args),  # pylint: disable=protected-access
-                                                      extension_name=ext_name)
-                        run_after_extension_installed = self._get_extension_run_after_dynamic_install_config()
-                        prompt_info = ""
-                        if use_dynamic_install == 'yes_without_prompt':
-                            logger.warning('The command requires the extension %s. '
-                                           'It will be installed first.', ext_name)
-                            go_on = True
-                        else:
-                            from knack.prompting import prompt_y_n, NoTTYException
-                            prompt_msg = 'The command requires the extension {}. ' \
-                                'Do you want to install it now?'.format(ext_name)
-                            if run_after_extension_installed:
-                                prompt_msg = '{} The command will continue to run after the extension is installed.' \
-                                    .format(prompt_msg)
-                            NO_PROMPT_CONFIG_MSG = "Run 'az config set extension.use_dynamic_install=" \
-                                "yes_without_prompt' to allow installing extensions without prompt."
-                            try:
-                                go_on = prompt_y_n(prompt_msg, default='y')
-                                if go_on:
-                                    prompt_info = " with prompt"
-                                    logger.warning(NO_PROMPT_CONFIG_MSG)
-                            except NoTTYException:
-                                error_msg = "The command requires the extension {}. " \
-                                            "Unable to prompt for extension install confirmation as no tty " \
-                                            "available. {}".format(ext_name, NO_PROMPT_CONFIG_MSG)
-                                go_on = False
-                        if go_on:
-                            from azure.cli.core.extension.operations import add_extension
-                            add_extension(cli_ctx=cli_ctx, extension_name=ext_name, upgrade=True)
-                            if run_after_extension_installed:
-                                import subprocess
-                                import platform
-                                exit_code = subprocess.call(args, shell=platform.system() == 'Windows')
-                                error_msg = ("Extension {} dynamically installed{} and commands will be "
-                                             "rerun automatically.").format(ext_name, prompt_info)
-                                telemetry.set_user_fault(error_msg)
-                                self.exit(exit_code)
-                            else:
-                                with CommandLoggerContext(logger):
-                                    error_msg = 'Extension {} installed{}. Please rerun your command.' \
-                                        .format(ext_name, prompt_info)
-                                    logger.error(error_msg)
-                                    telemetry.set_user_fault(error_msg)
-                                self.exit(2)
-                        else:
-                            error_msg = "The command requires the latest version of extension {ext_name}. " \
-                                "To install, run 'az extension add --upgrade -n {ext_name}'.".format(
-                                    ext_name=ext_name) if not error_msg else error_msg
-                if not error_msg:
-                    # parser has no `command_source`, value is part of command itself
-                    error_msg = "'{value}' is misspelled or not recognized by the system.".format(value=value)
+                    # The function will exit if the parse error is caused by the extension for the command not installed
+                    self._check_value_in_extensions(cli_ctx, args, use_dynamic_install == 'yes_without_prompt')
+                # parser has no `command_source`, value is part of command itself
+                error_msg = "'{value}' is misspelled or not recognized by the system.".format(value=value)
                 az_error = CommandNotFoundError(error_msg)
-                if not caused_by_extension_not_installed:
-                    candidates = difflib.get_close_matches(value, action.choices, cutoff=0.7)
-                    if candidates:
-                        # use the most likely candidate to replace the misspelled command
-                        args_inferred = [item if item != value else candidates[0] for item in args]
-                        command_name_inferred = ' '.join(args_inferred).split('-')[0]
-
+                candidates = difflib.get_close_matches(value, action.choices, cutoff=0.7)
+                if candidates:
+                    # use the most likely candidate to replace the misspelled command
+                    args_inferred = [item if item != value else candidates[0] for item in args]
+                    command_name_inferred = ' '.join(args_inferred).split('-')[0]
             else:
                 # `command_source` indicates command values have been parsed, value is an argument
                 parameter = action.option_strings[0] if action.option_strings else action.dest
                 error_msg = "{prog}: '{value}' is not a valid value for '{param}'.".format(
                     prog=self.prog, value=value, param=parameter)
-                candidates = difflib.get_close_matches(value, action.choices, cutoff=0.7)
                 az_error = InvalidArgumentValueError(error_msg)
+                candidates = difflib.get_close_matches(value, action.choices, cutoff=0.7)
 
             command_arguments = self._get_failure_recovery_arguments(action)
             if candidates:
                 az_error.set_recommendation("Did you mean '{}' ?".format(candidates[0]))
 
             # recommend a command for user
-            if not caused_by_extension_not_installed:
-                recommender = CommandRecommender(*command_arguments, error_msg, cli_ctx)
-                recommender.set_help_examples(self.get_examples(command_name_inferred))
-                recommendations = recommender.provide_recommendations()
-                if recommendations:
-                    az_error.set_aladdin_recommendation(recommendations)
+            recommender = CommandRecommender(*command_arguments, error_msg, cli_ctx)
+            recommender.set_help_examples(self.get_examples(command_name_inferred))
+            recommendations = recommender.provide_recommendations()
+            if recommendations:
+                az_error.set_aladdin_recommendation(recommendations)
 
-                # remind user to check extensions if we can not find a command to recommend
-                if isinstance(az_error, CommandNotFoundError) \
-                        and not az_error.recommendations and self.prog == 'az' \
-                        and use_dynamic_install == 'no':
-                    az_error.set_recommendation(EXTENSION_REFERENCE)
+            # remind user to check extensions if we can not find a command to recommend
+            if isinstance(az_error, CommandNotFoundError) \
+                    and not az_error.recommendations and self.prog == 'az' \
+                    and use_dynamic_install == 'no':
+                az_error.set_recommendation(EXTENSION_REFERENCE)
 
             az_error.print_error()
             az_error.send_telemetry()

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -259,7 +259,7 @@ class TestParser(unittest.TestCase):
         with mock.patch('logging.Logger.error', mock_log_error), \
                 mock.patch('azure.cli.core.extension.operations.add_extension', mock_add_extension), \
                 mock.patch('azure.cli.core.extension.dynamic_install._get_extension_command_tree', mock_ext_cmd_tree_load), \
-                mock.patch('azure.cli.core.extension.dynamic_install.get_extension_use_dynamic_install_config', return_value='yes_without_prompt'), \
+                mock.patch('azure.cli.core.extension.dynamic_install._get_extension_use_dynamic_install_config', return_value='yes_without_prompt'), \
                 mock.patch('azure.cli.core.extension.dynamic_install._get_extension_run_after_dynamic_install_config', return_value=False):
             with self.assertRaises(SystemExit):
                 parser.parse_args('test new-ext create --opt enum_2'.split())

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -258,9 +258,9 @@ class TestParser(unittest.TestCase):
         # test dynamic extension install
         with mock.patch('logging.Logger.error', mock_log_error), \
                 mock.patch('azure.cli.core.extension.operations.add_extension', mock_add_extension), \
-                mock.patch('azure.cli.core.parser.AzCliCommandParser._get_extension_command_tree', mock_ext_cmd_tree_load), \
-                mock.patch('azure.cli.core.parser.AzCliCommandParser._get_extension_use_dynamic_install_config', return_value='yes_without_prompt'), \
-                mock.patch('azure.cli.core.parser.AzCliCommandParser._get_extension_run_after_dynamic_install_config', return_value=False):
+                mock.patch('azure.cli.core.extension.dynamic_install._get_extension_command_tree', mock_ext_cmd_tree_load), \
+                mock.patch('azure.cli.core.extension.dynamic_install.get_extension_use_dynamic_install_config', return_value='yes_without_prompt'), \
+                mock.patch('azure.cli.core.extension.dynamic_install._get_extension_run_after_dynamic_install_config', return_value=False):
             with self.assertRaises(SystemExit):
                 parser.parse_args('test new-ext create --opt enum_2'.split())
             self.assertIn("Extension new-ext-name installed. Please rerun your command.", logger_msgs[5])


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR consolidates changes in https://github.com/Azure/azure-cli/pull/17474 and also has the [changes](https://github.com/Azure/azure-cli/pull/17698/commits/020cf2ae1052ff1a7a47b426db0cb815e97bf389) to only allow prefix match for help commands during dynamic extension install to resolve #17696.

**Testing Guide**
<!--Example commands with explanations.-->
`az account -s sub_id set`: not trigger extension install
`az devops --organization org project list`: not trigger extension install
`az devops`: not trigger extension install
`az devops -h`: trigger extension install
`az devops project list --organization org`: trigger extension install
`az devops project list`: trigger extension install


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
