### PR TITLE
{ACR} Improve the way to get az version in acr

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -123,16 +123,8 @@ def _get_docker_status_and_version(ignore_errors, yes):
 
 # Get current CLI version
 def _get_cli_version():
-    from pkg_resources import working_set
-
-    # working_set.by_key is a dictionary with component names as key
-    cli_component_name = "azure-cli"
-    cli_version = "not found"
-
-    if cli_component_name in working_set.by_key:
-        cli_version = working_set.by_key[cli_component_name].version
-
-    logger.warning('Azure CLI version: %s', cli_version)
+    from azure.cli.core import __version__ as core_version
+    logger.warning('Azure CLI version: %s', core_version)
 
 
 # Get helm versions


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Use `from pkg_resources import working_set` is slow (see #14905). And with PR #17432, in MSI installed Azure CLI, we cannot rely on `dist-info` to get package versions.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
