### PR TITLE
{Core} --add option in Generic Update Operation: add warning info and help info

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -374,6 +374,7 @@ def register_global_subscription_argument(cli_ctx):
     cli_ctx.register_event(EVENT_INVOKER_PRE_LOAD_ARGUMENTS, add_subscription_parameter)
 
 
+ge_update_arg_ref = 'https://aka.ms/AAby4o3'
 add_usage = '--add property.listProperty <key=value, string or JSON string>'
 set_usage = '--set property1.property2=<value>'
 remove_usage = '--remove property.list <indexToRemove> OR --remove propertyToRemove'
@@ -524,6 +525,7 @@ def add_properties(instance, argument_values, force_string):
         raise ValueError
 
     dict_entry = {}
+    json_parse_fail_args = []
     for argument in argument_values:
         if '=' in argument:
             # consecutive key=value entries get added to the same dictionary
@@ -542,12 +544,14 @@ def add_properties(instance, argument_values, force_string):
                 try:
                     argument = shell_safe_json_parse(argument)
                 except (ValueError, CLIError):
-                    pass
+                    json_parse_fail_args.append(argument)
+
             list_to_add_to.append(argument)
 
     # if only key=value pairs used, must check at the end to append the dictionary
     if dict_entry:
         list_to_add_to.append(dict_entry)
+    return json_parse_fail_args
 
 
 def remove_properties(instance, argument_values):

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -545,7 +545,8 @@ def add_properties(instance, argument_values, force_string):
                 try:
                     argument = shell_safe_json_parse(argument)
                     if isinstance(argument, list):
-                        json_parse_warning.append(InvalidArgumentValueError('{} is a json array which may not conform to the property\'s format'.format(argument)))
+                        json_parse_warning.append(InvalidArgumentValueError(
+                            '{} is a json array which may not conform to the property\'s format'.format(argument)))
                 except (ValueError, CLIError) as err:
                     json_parse_warning.append(err)
 

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -546,7 +546,8 @@ def add_properties(instance, argument_values, force_string):
                     argument = shell_safe_json_parse(argument)
                     if isinstance(argument, list):
                         json_parse_warning.append(InvalidArgumentValueError(
-                            '{} is a json array which may not conform to the property\'s format'.format(argument)))
+                            '{} is a json array which may not conform to the property\'s format.'.format(argument),
+                            recommendation="Read more in {}".format(generic_update_arg_ref)))
                 except (ValueError, CLIError) as err:
                     json_parse_warning.append(err)
 

--- a/src/azure-cli-core/azure/cli/core/commands/command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/commands/command_operation.py
@@ -168,7 +168,7 @@ class GenericUpdateCommandOperation(BaseCommandOperation):     # pylint: disable
         from knack.util import CLIError
         from azure.cli.core.commands import cached_get, cached_put, _is_poller
         from azure.cli.core.util import find_child_item, augment_no_wait_handler_args
-        from azure.cli.core.commands.arm import add_usage, remove_usage, set_usage, \
+        from azure.cli.core.commands.arm import add_usage, remove_usage, set_usage,\
             add_properties, remove_properties, set_properties
         from msrest.serialization import SerializationError
 

--- a/src/azure-cli-core/azure/cli/core/commands/command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/commands/command_operation.py
@@ -247,8 +247,8 @@ class GenericUpdateCommandOperation(BaseCommandOperation):     # pylint: disable
                                     setter_arg_name=self.setter_arg_name, **setterargs)
         except SerializationError:
             if json_parse_warning:
-                logger.warning("'--add' option value: %s. If you want to pass a JSON string, "
-                               "read more in %s", ' '.join([e.error_msg for e in json_parse_warning]), generic_update_arg_ref)
+                logger.warning("'--add' option value: %s. If you want to pass a JSON string, read more in %s",
+                               ' '.join([e.error_msg for e in json_parse_warning]), generic_update_arg_ref)
             raise
         if supports_no_wait and no_wait_enabled:
             return None
@@ -307,8 +307,8 @@ class GenericUpdateCommandOperation(BaseCommandOperation):     # pylint: disable
         arguments['properties_to_add'] = CLICommandArgument(
             'properties_to_add', options_list=['--add'], nargs='+',
             action=self.OrderedArgsAction, default=[],
-            help='Add an object to a list of objects by specifying a path and '
-                 'key value pairs.  Example: {}. Read more in reference docs: {}'.format(add_usage, generic_update_arg_ref),
+            help='Add an object to a list of objects by specifying a path and key value pairs.  Example: {}. '
+                 'Read more in reference docs: {}'.format(add_usage, generic_update_arg_ref),
             metavar='LIST KEY=VALUE', arg_group=group_name
         )
         arguments['properties_to_remove'] = CLICommandArgument(

--- a/src/azure-cli-core/azure/cli/core/commands/command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/commands/command_operation.py
@@ -168,7 +168,7 @@ class GenericUpdateCommandOperation(BaseCommandOperation):     # pylint: disable
         from knack.util import CLIError
         from azure.cli.core.commands import cached_get, cached_put, _is_poller
         from azure.cli.core.util import find_child_item, augment_no_wait_handler_args
-        from azure.cli.core.commands.arm import add_usage, remove_usage, set_usage, generic_update_arg_ref, \
+        from azure.cli.core.commands.arm import add_usage, remove_usage, set_usage, \
             add_properties, remove_properties, set_properties
         from msrest.serialization import SerializationError
 
@@ -247,8 +247,8 @@ class GenericUpdateCommandOperation(BaseCommandOperation):     # pylint: disable
                                     setter_arg_name=self.setter_arg_name, **setterargs)
         except SerializationError:
             if json_parse_warning:
-                logger.warning("'--add' option value: %s. If you want to pass a JSON string, read more in %s",
-                               ' '.join([e.error_msg for e in json_parse_warning]), generic_update_arg_ref)
+                logger.warning('--add option value: %s',
+                               ' '.join([e.error_msg + " ".join(e.recommendations) for e in json_parse_warning]))
             raise
         if supports_no_wait and no_wait_enabled:
             return None


### PR DESCRIPTION
resolve #17610  #17586
The --add option in generic update operation is very hard to use, so more information about the generic update arguments is added to the help text. 
If option value is JSON string and its format is wrong, the error message should help users to fix it. Two cases are in consideration:
1, The JSON string is not escaped or has the wrong format: show the JSON parse error
2, The JSON string is parsed as a JSON array: in most case, --add option should pass a JSON Object instead of a JSON array. Passing a list may cause DeserializationError

## Help text
Add links(https://docs.microsoft.com/en-us/cli/azure/use-cli-effectively?view=azure-cli-latest#generic-update-arguments) to the documentation page of cli generic update arguments
**Before**
![image](https://user-images.githubusercontent.com/81600993/114843149-1d1a6f80-9e0c-11eb-82d3-3a805bcfacd8.png)

**After**
![image](https://user-images.githubusercontent.com/81600993/114861877-6d033180-9e20-11eb-90ca-7b218e1232bd.png)

## Error message
Add hints of the cause of error
**Before**
![image](https://user-images.githubusercontent.com/81600993/114843094-0c69f980-9e0c-11eb-8513-cba099767d1d.png)

**After**
![image](https://user-images.githubusercontent.com/81600993/114861837-607ed900-9e20-11eb-9b52-d868fdb44ef4.png)

![image](https://user-images.githubusercontent.com/81600993/114861658-1e559780-9e20-11eb-90fa-e200b4cb34cc.png)

