### PR TITLE
[ACR] Fix #17618: Update credential add/update handling for tasks created using --auth-mode

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -633,7 +633,7 @@ examples:
   - name: Create a Linux task from a public GitHub repository which builds the hello-world image with both a git commit and pull request trigger enabled. Note that this task does not use Source Registry (MyRegistry), so we can explicitly set Auth mode as None for it.
     text: |
         az acr task create -t hello-world:{{.Run.ID}} -n hello-world -r MyRegistry  -f Dockerfile \\
-            --auth-mode None -c https://github.com/Azure-Samples/acr-build-helloworld-node.git \\
+            --no-push true --auth-mode None -c https://github.com/Azure-Samples/acr-build-helloworld-node.git \\
             --pull-request-trigger-enabled true --git-access-token 000000000000000000000000000000000
   - name: Create a Windows task from a public GitHub repository which builds the Azure Container Builder image on Amd64 architecture with only base image trigger enabled.
     text: |

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -593,7 +593,10 @@ def acr_task_credential_add(cmd,
         cmd, registry_name, resource_group_name, TASK_NOT_SUPPORTED)
 
     existingCreds = client.get_details(resource_group_name, registry_name, task_name).credentials
-    existingCreds = {} if not existingCreds else existingCreds.custom_registries
+    if not existingCreds or not existingCreds.custom_registries
+        existingCreds = {}
+    else:
+        existingCreds = existingCreds.custom_registries
 
     if login_server in existingCreds:
         raise CLIError("Login server '{}' already exists. You cannot add it again.".format(login_server))
@@ -629,7 +632,10 @@ def acr_task_credential_update(cmd,
         cmd, registry_name, resource_group_name, TASK_NOT_SUPPORTED)
 
     existingCreds = client.get_details(resource_group_name, registry_name, task_name).credentials
-    existingCreds = {} if not existingCreds else existingCreds.custom_registries
+    if not existingCreds or not existingCreds.custom_registries
+        existingCreds = {}
+    else:
+        existingCreds = existingCreds.custom_registries
 
     if login_server not in existingCreds:
         raise CLIError("Login server '{}' not found.".format(login_server))

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -593,7 +593,7 @@ def acr_task_credential_add(cmd,
         cmd, registry_name, resource_group_name, TASK_NOT_SUPPORTED)
 
     existingCreds = client.get_details(resource_group_name, registry_name, task_name).credentials
-    if not existingCreds or not existingCreds.custom_registries
+    if not existingCreds or not existingCreds.custom_registries:
         existingCreds = {}
     else:
         existingCreds = existingCreds.custom_registries
@@ -632,7 +632,7 @@ def acr_task_credential_update(cmd,
         cmd, registry_name, resource_group_name, TASK_NOT_SUPPORTED)
 
     existingCreds = client.get_details(resource_group_name, registry_name, task_name).credentials
-    if not existingCreds or not existingCreds.custom_registries
+    if not existingCreds or not existingCreds.custom_registries:
         existingCreds = {}
     else:
         existingCreds = existingCreds.custom_registries


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fixes https://github.com/Azure/azure-cli/issues/17618.
Fixes the sample for creating a task with `--auth-mode None`.

**Testing Guide**
<!--Example commands with explanations.-->

1. Create task a valid `--auth-mode` value.
`az acr task create -t hello-world:{{.Run.ID}} -n hello-world -r MyRegistry  -f Dockerfile \
            --no-push true --auth-mode None -c https://github.com/Azure-Samples/acr-build-helloworld-node.git \
            --git-access-token 000000000000000000000000000000000 --assign-identity`
2. Add custom registry credential 
`az acr task credential add --login-server myotherregistry.azurecr.io --use-identity [system]`

Previously, `az acr task credential add` and `az acr task credential update` crashed. 

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
