### PR TITLE
[FunctionApp] Fixed issue with zip deploy where local time was provided but UTC was expected

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -557,7 +557,7 @@ def upload_zip_to_storage(cmd, resource_group_name, name, src, slot=None):
     block_blob_service.create_blob_from_path(container_name, blob_name, src, validate_content=True,
                                              progress_callback=progress_callback)
 
-    now = datetime.datetime.now()
+    now = datetime.datetime.utcnow()
     blob_start = now - datetime.timedelta(minutes=10)
     blob_end = now + datetime.timedelta(weeks=520)
     BlobPermissions = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE, 'blob#BlobPermissions')


### PR DESCRIPTION

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Resolves https://github.com/Azure/azure-cli/issues/13070

There was an issue where during `az functionapp deployment source config-zip`, we were using the local machine's timezone but to create a SAS URI, but the method creating the uri expected UTC (or a timezone to be passed). This resulted in deployment failures for certain timezones because the SAS URI that was being generated was already expired.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[FunctionApp] Fixed issue with zip deploy where local time was provided but UTC was expected

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
