### PR TITLE
[BACKUP] az backup vault create: Add tags as an optional argument

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -76,7 +76,7 @@ def load_arguments(self, _):
         c.argument('location', validator=get_default_location_from_resource_group)
 
     with self.argument_context('backup vault create') as c:
-        c.argument('tags', type=file_type, help='JSON encoded tags. Use the show command with JSON output to see tags format. Modify the values accordingly using a file editor and pass here.', completer=FilesCompleter())
+        c.argument('tags', type=file_type, help='JSON encoded tags. Use the show command with JSON output to see tags format. Modify the values accordingly using a file editor and pass the file path here.', completer=FilesCompleter())
 
     with self.argument_context('backup vault backup-properties set') as c:
         c.argument('backup_storage_redundancy', arg_type=get_enum_type(['GeoRedundant', 'LocallyRedundant']), help='Sets backup storage properties for a Recovery Services vault.')

--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -75,6 +75,9 @@ def load_arguments(self, _):
         c.argument('vault_name', vault_name_type, options_list=['--name', '-n'], id_part='name')
         c.argument('location', validator=get_default_location_from_resource_group)
 
+    with self.argument_context('backup vault create') as c:
+        c.argument('tags', type=file_type, help='JSON encoded tags. Use the show command with JSON output to see tags format. Modify the values accordingly using a file editor and pass here.', completer=FilesCompleter())
+
     with self.argument_context('backup vault backup-properties set') as c:
         c.argument('backup_storage_redundancy', arg_type=get_enum_type(['GeoRedundant', 'LocallyRedundant']), help='Sets backup storage properties for a Recovery Services vault.')
         c.argument('soft_delete_feature_state', arg_type=get_enum_type(['Enable', 'Disable']), help='Set soft-delete feature state for a Recovery Services Vault.')

--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -12,7 +12,7 @@ from knack.arguments import CLIArgumentType
 import azure.cli.core.commands.arm  # pylint: disable=unused-import
 from azure.cli.core.commands.parameters import \
     (get_resource_name_completion_list, file_type, get_three_state_flag,
-     get_enum_type)
+     get_enum_type, tags_type)
 from azure.cli.core.commands.validators import get_default_location_from_resource_group
 from azure.cli.command_modules.backup._validators import \
     (datetime_type)
@@ -76,7 +76,7 @@ def load_arguments(self, _):
         c.argument('location', validator=get_default_location_from_resource_group)
 
     with self.argument_context('backup vault create') as c:
-        c.argument('tags', type=file_type, help='JSON encoded tags. Use the show command with JSON output to see tags format. Modify the values accordingly using a file editor and pass the file path here.', completer=FilesCompleter())
+        c.argument('tags', arg_type=tags_type)
 
     with self.argument_context('backup vault backup-properties set') as c:
         c.argument('backup_storage_redundancy', arg_type=get_enum_type(['GeoRedundant', 'LocallyRedundant']), help='Sets backup storage properties for a Recovery Services vault.')

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -95,11 +95,12 @@ password_length = 15
 # pylint: disable=too-many-function-args
 
 
-def create_vault(client, vault_name, resource_group_name, location):
+def create_vault(client, vault_name, resource_group_name, location, tags=None):
     vault_sku = Sku(name=SkuName.standard)
     vault_properties = VaultProperties()
-
-    vault = Vault(location=location, sku=vault_sku, properties=vault_properties)
+    if tags is not None:
+        tags = _get_or_read_json(tags)
+    vault = Vault(location=location, sku=vault_sku, properties=vault_properties, tags=tags)
     return client.create_or_update(resource_group_name, vault_name, vault)
 
 

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -98,8 +98,6 @@ password_length = 15
 def create_vault(client, vault_name, resource_group_name, location, tags=None):
     vault_sku = Sku(name=SkuName.standard)
     vault_properties = VaultProperties()
-    if tags is not None:
-        tags = _get_or_read_json(tags)
     vault = Vault(location=location, sku=vault_sku, properties=vault_properties, tags=tags)
     return client.create_or_update(resource_group_name, vault_name, vault)
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
Added tags as an optional argument to az backup vault create command. Now the users will be able to create vaults with tags by giving space-separated tags as command-line arguments.

**Testing Guide**
az backup vault create -n {vault_name} --location {location_name} -g {rg_name} --tags DeleteBy=12-9999 Owner=akneema

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
