### PR TITLE
[sqlvm] Make SqlServerLicenseType as optional

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sqlvm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sqlvm/custom.py
@@ -170,7 +170,7 @@ def aglistener_update(instance, sql_virtual_machine_instances=None):
 
 
 # pylint: disable=too-many-arguments, too-many-locals, line-too-long, too-many-boolean-expressions
-def sqlvm_create(client, cmd, sql_virtual_machine_name, resource_group_name, sql_server_license_type,
+def sqlvm_create(client, cmd, sql_virtual_machine_name, resource_group_name, sql_server_license_type=None,
                  location=None, sql_image_sku=None, enable_auto_patching=None, sql_management_mode="LightWeight",
                  day_of_week=None, maintenance_window_starting_hour=None, maintenance_window_duration=None,
                  enable_auto_backup=None, enable_encryption=False, retention_period=None, storage_account_url=None,


### PR DESCRIPTION
Make SqlServerLicenseType optional

**Description**<!--Mandatory-->
Making SqlServerLicenseType optional. We are preventing users to assign license type for their resource in mooncake cloud. In other clouds, if they dont provide license type, we will throw an error in our pre requisite check.

**Testing Guide**
az sql vm create -n sqlvm -g myresourcegroup -l eastus

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
