### PR TITLE
{Core} Fix: In Cloud Shell, cross-tenant authentication fails for user or Service Principal account

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -561,7 +561,8 @@ class Profile:
                 if sub[_TENANT_ID] != account[_TENANT_ID]:
                     external_tenants_info.append(sub[_TENANT_ID])
 
-        if external_tenants_info and (identity_type or in_cloud_console()):
+        if external_tenants_info and \
+                (in_cloud_console() and account[_USER_ENTITY].get(_CLOUD_SHELL_ID) or identity_type):
             raise CLIError("Cross-tenant authentication is not supported by managed identity and Cloud Shell. "
                            "Please run `az login` with a user account or a service principal.")
 

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -563,7 +563,7 @@ class Profile:
 
         if external_tenants_info and \
                 (in_cloud_console() and account[_USER_ENTITY].get(_CLOUD_SHELL_ID) or identity_type):
-            raise CLIError("Cross-tenant authentication is not supported by managed identity and Cloud Shell. "
+            raise CLIError("Cross-tenant authentication is not supported by managed identity and Cloud Shell account. "
                            "Please run `az login` with a user account or a service principal.")
 
         if identity_type is None:


### PR DESCRIPTION
**Description**<!--Mandatory-->

In Cloud Shell, even if `az login` is run with user or Service Principal account, subsequent commands involving cross-tenant authentication fails:

```
$ az network vnet peering create --name myVnetAToMyVnetB --resource-group myResourceGroupA --vnet-name myVnetA --remote-vnet /subscriptions/414af076-009b-4282-9a0a-acf75bcb037e/resourceGroups/myResourceGroupB/providers/Microsoft.Network/VirtualNetworks/myVnetB --allow-vnet-access
Cross-tenant authentication is not supported by managed identity and Cloud Shell. Please run `az login` with 
a user account or a service principal.
```

**Cause**

This bug was introduced by #16797 where only `in_cloud_console()` is checked:

https://github.com/Azure/azure-cli/blob/039fa21db4fdf6dfb22958aaf1c3f614e1fc3b59/src/azure-cli-core/azure/cli/core/_profile.py#L564-L566

In fact, `_CLOUD_SHELL_ID` (`cloudShellID`) should _also_ be checked so that the error is only raised for Cloud Shell's Managed Identity account, instead of user or Service Principal account.

**Testing guide**

In Cloud Shell, run

```sh
az login
# Replace `414af076-009b-4282-9a0a-acf75bcb037e` with your own subscription ID in another tenant
az network vnet peering create --name myVnetAToMyVnetB --resource-group myResourceGroupA --vnet-name myVnetA --remote-vnet /subscriptions/414af076-009b-4282-9a0a-acf75bcb037e/resourceGroups/myResourceGroupB/providers/Microsoft.Network/VirtualNetworks/myVnetB --allow-vnet-access
```