### PR TITLE
{KeyVault} Replace `_token_retriever` with `get_raw_token`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_completers.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_completers.py
@@ -8,7 +8,7 @@ from azure.cli.core._profile import Profile
 
 
 def _get_token(cli_ctx, server, resource, scope):  # pylint: disable=unused-argument
-    return Profile(cli_ctx=cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
+    return Profile(cli_ctx=cli_ctx).get_raw_token(resource)[0]
 
 
 def get_keyvault_name_completion_list(resource_name):

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1543,7 +1543,7 @@ def _get_keyvault_client(cli_ctx):
     version = str(get_api_version(cli_ctx, ResourceType.DATA_KEYVAULT))
 
     def _get_token(server, resource, scope):  # pylint: disable=unused-argument
-        return Profile(cli_ctx=cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
+        return Profile(cli_ctx=cli_ctx).get_raw_token(resource)[0]
 
     return KeyVaultClient(KeyVaultAuthentication(_get_token), api_version=version)
 

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
@@ -1671,7 +1671,7 @@ def _get_keyVault_not_arm_client(cli_ctx):
     version = str(get_api_version(cli_ctx, ResourceType.DATA_KEYVAULT))
 
     def get_token(server, resource, scope):  # pylint: disable=unused-argument
-        return Profile(cli_ctx=cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
+        return Profile(cli_ctx=cli_ctx).get_raw_token(resource)[0]
 
     client = KeyVaultClient(KeyVaultAuthentication(get_token), api_version=version)
     return client

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -106,7 +106,7 @@ def create_keyvault_data_plane_client(cli_ctx):
     version = str(get_api_version(cli_ctx, ResourceType.DATA_KEYVAULT))
 
     def get_token(server, resource, scope):  # pylint: disable=unused-argument
-        return Profile(cli_ctx=cli_ctx).get_login_credentials(resource)[0]._token_retriever()  # pylint: disable=protected-access
+        return Profile(cli_ctx=cli_ctx).get_raw_token(resource)[0]
 
     from azure.keyvault import KeyVaultAuthentication, KeyVaultClient
     return KeyVaultClient(KeyVaultAuthentication(get_token), api_version=version)


### PR DESCRIPTION
Split from #17738

**Description**<!--Mandatory-->

As pointed out by #15854, calling the protected method `_token_retriever` is simply wrong. 

This PR replaces `_token_retriever` with `azure.cli.core._profile.Profile.get_raw_token`, as provided by https://github.com/Azure/azure-cli/issues/15805#issuecomment-722914070.

This is also the approach adopted by `azure.cli.command_modules.keyvault._client_factory.keyvault_data_plane_factory`:

https://github.com/Azure/azure-cli/blob/1eed07797b9877fac1703555d25ead43b295376b/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py#L128-L137
On the other hand, instead of implementing its own keyvault client factory, **appconfig** directly uses  `azure.cli.command_modules.keyvault._client_factory.keyvault_data_plane_factory` (#15826):

https://github.com/Azure/azure-cli/blob/7a5538f0d062f3fde2950dc3f310735807ec7bd4/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py#L300-L301

Other command modules may follow the same approach, but I will defer this decision to @houk-ms.
