### PR TITLE
[AKS] az aks create: add enable-encryption-at-host parameter

### DIFF
--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -259,6 +259,9 @@ aks create:
     node_osdisk_diskencryptionset_id:
       rule_exclusions:
       - option_length_too_long
+    enable_encryption_at_host:
+      rule_exclusions:
+      - option_length_too_long
 aks enable-addons:
   parameters:
     workspace_resource_id:
@@ -275,6 +278,9 @@ aks nodepool add:
       rule_exclusions:
       - option_length_too_long
     node_public_ip_prefix_id:
+      rule_exclusions:
+      - option_length_too_long
+    enable_encryption_at_host:
       rule_exclusions:
       - option_length_too_long
 aks update:

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -437,6 +437,9 @@ parameters:
   - name: --enable-sgxquotehelper
     type: bool
     short-summary: Enable SGX quote helper for confcom addon.
+  - name: --enable-encryption-at-host
+    type: bool
+    short-summary: Enable EncryptionAtHost, default value is false.
 examples:
   - name: Create a Kubernetes cluster with an existing SSH public key.
     text: az aks create -g MyResourceGroup -n MyManagedCluster --ssh-key-value /path/to/publickey
@@ -474,6 +477,8 @@ examples:
     text: az aks create -g MyResourceGroup -n MyManagedCluster --node-osdisk-diskencryptionset-id <disk-encryption-set-resource-id>
   - name: Create a kubernetes cluster with ephemeral OS enabled.
     text: az aks create -g MyResourceGroup -n MyManagedCluster --node-osdisk-type Ephemeral --node-osdisk-size 48
+  - name: Create a kubernetes cluster with EncryptionAtHost enabled.
+    text: az aks create -g MyResourceGroup -n MyManagedCluster --enable-encryption-at-host
 """
 
 helps['aks update'] = """
@@ -786,9 +791,14 @@ parameters:
   - name: --max-surge
     type: string
     short-summary: Extra nodes used to speed upgrade. When specified, it represents the number or percent used, eg. 5 or 33%
+  - name: --enable-encryption-at-host
+    type: bool
+    short-summary: Enable EncryptionAtHost, default value is false.
 examples:
   - name: Create a nodepool in an existing AKS cluster with ephemeral os enabled.
     text: az aks nodepool add -g MyResourceGroup -n nodepool1 --cluster-name MyManagedCluster --node-osdisk-type Ephemeral --node-osdisk-size 48
+  - name: Create a nodepool with EncryptionAtHost enabled.
+    text: az aks nodepool add -g MyResourceGroup -n nodepool1 --cluster-name MyManagedCluster --enable-encryption-at-host
 """
 
 helps['aks nodepool delete'] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -220,6 +220,7 @@ def load_arguments(self, _):
         c.argument('enable_ahub', options_list=['--enable-ahub'])
         c.argument('node_osdisk_diskencryptionset_id', type=str, options_list=['--node-osdisk-diskencryptionset-id', '-d'])
         c.argument('aci_subnet_name')
+        c.argument('enable_encryption_at_host', options_list=['--enable-encryption-at-host'], action='store_true')
         c.argument('appgw_name', options_list=['--appgw-name'], arg_group='Application Gateway')
         c.argument('appgw_subnet_cidr', options_list=['--appgw-subnet-cidr'], arg_group='Application Gateway')
         c.argument('appgw_id', options_list=['--appgw-id'], arg_group='Application Gateway')
@@ -323,6 +324,7 @@ def load_arguments(self, _):
             c.argument('ppg', type=str, validator=validate_ppg)
             c.argument('max_surge', type=str, validator=validate_max_surge)
             c.argument('node_os_disk_type', arg_type=get_enum_type([CONST_OS_DISK_TYPE_MANAGED, CONST_OS_DISK_TYPE_EPHEMERAL]))
+            c.argument('enable_encryption_at_host', options_list=['--enable-encryption-at-host'], action='store_true')
 
     for scope in ['aks nodepool show', 'aks nodepool delete', 'aks nodepool scale', 'aks nodepool upgrade', 'aks nodepool update']:
         with self.argument_context(scope) as c:

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1899,6 +1899,7 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
                appgw_subnet_id=None,
                appgw_watch_namespace=None,
                enable_sgxquotehelper=False,
+               enable_encryption_at_host=False,
                no_wait=False,
                yes=False):
     _validate_ssh_key(no_ssh_key, ssh_key_value)
@@ -1930,6 +1931,7 @@ def aks_create(cmd, client, resource_group_name, name, ssh_key_value,  # pylint:
         availability_zones=zones,
         enable_node_public_ip=enable_node_public_ip,
         node_public_ip_prefix_id=node_public_ip_prefix_id,
+        enable_encryption_at_host=enable_encryption_at_host,
         max_pods=int(max_pods) if max_pods else None,
         type=vm_set_type,
         mode="System"
@@ -3408,6 +3410,7 @@ def aks_agentpool_add(cmd, client, resource_group_name, cluster_name, nodepool_n
                       labels=None,
                       max_surge=None,
                       mode="User",
+                      enable_encryption_at_host=False,
                       no_wait=False):
     instances = client.list(resource_group_name, cluster_name)
     for agentpool_profile in instances:
@@ -3453,6 +3456,7 @@ def aks_agentpool_add(cmd, client, resource_group_name, cluster_name, nodepool_n
         node_public_ip_prefix_id=node_public_ip_prefix_id,
         node_taints=taints_array,
         upgrade_settings=upgradeSettings,
+        enable_encryption_at_host=enable_encryption_at_host,
         mode=mode
     )
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
az aks create: add enable-encryption-at-host parameter

**Testing Guide**
<!--Example commands with explanations.-->
```console
docker run -v ${HOME}:/root -it andyzhangx/azure-cli:2.22.1
az aks create -g $RESOURCE_GROUP_NAME -n $CLUSTER_NAME --node-count 1 --node-vm-size Standard_DS2_v2 --generate-ssh-keys --kubernetes-version 1.20.2 --enable-encryption-at-host
az aks nodepool add --name nodepool2 --cluster-name $CLUSTER_NAME --resource-group $RESOURCE_GROUP_NAME --enable-encryption-at-host
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
