### PR TITLE
{Core} Add `__init__.py` to `azure.cli.core.sdk`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/sdk/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/sdk/__init__.py
@@ -1,0 +1,4 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Description**<!--Mandatory-->

`azure.cli.core.sdk` (added by #17671) doesn't have `__int__.py`, so it will not be included in the `whl` file, causing CI failure:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=855815&view=logs&jobId=c846b3e8-69b8-5dbd-1a39-4905d81e6a95&j=1e6fba43-bdcf-51f0-a062-3712c33fbb51&t=a1e787eb-ec67-5c3d-79ec-0c68f4f59d65

```
        # Prepare x-ms-client-request-id header, used by RequestIdPolicy
        if 'x-ms-client-request-id' in cli_ctx.data['headers']:
            client_kwargs['request_id'] = cli_ctx.data['headers']['x-ms-client-request-id']
    
        # Replace NetworkTraceLoggingPolicy to redact 'Authorization' and 'x-ms-authorization-auxiliary' headers.
        #   NetworkTraceLoggingPolicy: log raw network trace, with all headers.
>       from azure.cli.core.sdk.policies import SafeNetworkTraceLoggingPolicy
E       ModuleNotFoundError: No module named 'azure.cli.core.sdk'
```

This is because `setup.py` uses [`find_packages`](https://setuptools.readthedocs.io/en/latest/userguide/package_discovery.html#using-find-or-find-packages) to find packages to include in the `whl` file:

https://github.com/Azure/azure-cli/blob/672837983df7e6f4cb55fadd30ed375bfd53df21/src/azure-cli-core/setup.py#L91

Only folders with `__int__.py` are marked as a package.

Similar problem happened before: https://github.com/Azure/azure-cli/pull/15711#discussion_r523865234.
