### PR TITLE
[AppService] az appservice: Add function to retrieve users github personal access token

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
@@ -37,6 +37,13 @@ FUNCTIONS_NO_V2_REGIONS = {
     "USSec West",
     "USSec East"
 }
+GITHUB_OAUTH_CLIENT_ID = "8d8e1f6000648c575489"
+GITHUB_OAUTH_REDIRECT_URI = "http://localhost:3000/TokenAuthorize"
+GITHUB_OAUTH_SCOPES = [
+    "admin:repo_hook",
+    "repo",
+    "workflow"
+]
 
 
 class FUNCTIONS_STACKS_API_KEYS():

--- a/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
@@ -38,7 +38,6 @@ FUNCTIONS_NO_V2_REGIONS = {
     "USSec East"
 }
 GITHUB_OAUTH_CLIENT_ID = "8d8e1f6000648c575489"
-GITHUB_OAUTH_REDIRECT_URI = "http://localhost:3000/TokenAuthorize"
 GITHUB_OAUTH_SCOPES = [
     "admin:repo_hook",
     "repo",

--- a/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
@@ -46,8 +46,9 @@ def get_github_access_token(cmd, scope_list=None):
         interval = int(parsed_response['interval'][0])
         expires_in_seconds = int(parsed_response['expires_in'][0])
 
-        logger.warning("Please go to '%s' and enter the user code '%s' to activate and retrieve your github personal access token",
-            verification_uri, user_code)
+        navigate_to_msg = 'Please navigate to {0} and enter the user code {1} to activate and ' \
+                          'retrieve your github personal access token'.format(verification_uri, user_code)
+        logger.warning(navigate_to_msg)
 
         timeout = time.time() + expires_in_seconds
         logger.warning("Waiting up to '%s' minutes for activation", str(expires_in_seconds // 60))

--- a/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
@@ -45,10 +45,8 @@ def get_github_access_token(cmd, scope_list=None):
         verification_uri = parsed_response['verification_uri'][0]
         interval = int(parsed_response['interval'][0])
         expires_in_seconds = int(parsed_response['expires_in'][0])
-
-        navigate_to_msg = 'Please navigate to {0} and enter the user code {1} to activate and ' \
-                          'retrieve your github personal access token'.format(verification_uri, user_code)
-        logger.warning(navigate_to_msg)
+        logger.warning('Please navigate to %s and enter the user code %s to activate and '
+                       'retrieve your github personal access token', verification_uri, user_code)
 
         timeout = time.time() + expires_in_seconds
         logger.warning("Waiting up to '%s' minutes for activation", str(expires_in_seconds // 60))

--- a/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
@@ -11,6 +11,11 @@ from ._constants import (GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_REDIRECT_URI, GITH
 
 logger = get_logger(__name__)
 
+'''
+This function opens a web browser to prompt for github login
+then spins up a server on localhost:3000 to listen for callback
+to receive access token
+'''
 def get_github_access_token(cmd, scope_list=None):
     import os
     random_state = os.urandom(5).hex()
@@ -30,8 +35,7 @@ def get_github_access_token(cmd, scope_list=None):
         authorize_url += _scope_string
     logger.warning('Opening OAuth URL')
 
-    # Get code to exchange for access token
-    access_code = _start_http_server(random_state, authorize_url)
+    access_code = _start_http_server(random_state, authorize_url)  # use localhost to get code to exchange for access token
 
     if access_code:
         client = web_client_factory(cmd.cli_ctx)

--- a/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
@@ -1,0 +1,85 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from knack.util import CLIError
+from knack.log import get_logger
+
+from ._client_factory import web_client_factory
+from ._constants import (GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_REDIRECT_URI, GITHUB_OAUTH_SCOPES)
+
+logger = get_logger(__name__)
+
+def get_github_access_token(cmd, scope_list=None):
+    import os
+    random_state = os.urandom(5).hex()
+
+    authorize_url = 'https://github.com/login/oauth/authorize?' \
+                    'client_id={}&state={}&redirect_uri={}'.format(
+                        GITHUB_OAUTH_CLIENT_ID, random_state, GITHUB_OAUTH_REDIRECT_URI)
+    if scope_list:
+        for scope in scope_list:
+            if scope not in GITHUB_OAUTH_SCOPES:
+                raise ValidationError("Requested github oauth scope is invalid")
+        _scope_string = "&scope="
+        for i in range(len(scope_list)):
+            if i != 0:
+                _scope_string += "+"
+            _scope_string += scope_list[i]
+        authorize_url += _scope_string
+    logger.warning('Opening OAuth URL')
+
+    # Get code to exchange for access token
+    access_code = _start_http_server(random_state, authorize_url)
+
+    if access_code:
+        client = web_client_factory(cmd.cli_ctx)
+        response = client.generate_github_access_token_for_appservice_cli_async(access_code, random_state)
+
+        if response.access_token:
+            return response.access_token
+    return None
+
+
+def _start_http_server(random_state, authorize_url):
+    ip = '127.0.0.1'
+    port = 3000
+    
+    import http.server
+    import webbrowser
+    import socketserver
+    import urllib.parse as urlparse
+
+    class Server(socketserver.TCPServer):
+        allow_reuse_address = True
+
+    class CallBackHandler(http.server.BaseHTTPRequestHandler):
+        access_token = None
+        
+        def do_GET(self):
+            parsed_params = urlparse.parse_qs(urlparse.urlparse(self.path).query)
+            received_state = parsed_params.get('state', [None])[0]
+            received_code = parsed_params.get('code', [None])[0]
+
+            if (self.path.startswith('/TokenAuthorize') and received_state and received_code and (random_state == received_state)):
+                CallBackHandler.received_code = received_code
+                self.send_response(200)
+                self.send_header("Content-type", "text/html")
+                self.end_headers()
+                self.wfile.write('GitHub account authenticated. You may close this tab'.encode('utf-8'))
+            else:
+                self.send_response(200)
+                self.send_header("Content-type", "text/html")
+                self.end_headers()
+                self.wfile.write('Unable to authenticate GitHub account. Please close this tab'.encode('utf-8'))
+
+    try:
+        server = Server((ip, port), CallBackHandler)
+        webbrowser.open(authorize_url)
+        logger.warning('Listening at port: {}'.format(port))
+        server.handle_request()
+    except Exception as e:
+        raise CLIError('Socket error: {}. Please try again, or provide personal access token'.format(e))
+
+    return CallBackHandler.received_code if hasattr(CallBackHandler, 'received_code') else None

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -289,6 +289,7 @@ def load_arguments(self, _):
             c.argument('repository_type', help='repository type',
                        arg_type=get_enum_type(['git', 'mercurial', 'vsts', 'github', 'externalgit', 'localgit']))
             c.argument('git_token', help='Git access token required for auto sync')
+            c.argument('github_action', options_list=['--github-action'], help='If using github action, default to False')
         with self.argument_context(scope + ' identity') as c:
             c.argument('scope', help="The scope the managed identity has access to")
             c.argument('role', help="Role name or id the managed identity will be assigned")

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -61,7 +61,9 @@ from ._create_util import (zip_contents_from_dir, get_runtime_version_details, c
                            detect_os_form_src, get_current_stack_from_runtime, generate_default_app_name)
 from ._constants import (FUNCTIONS_STACKS_API_JSON_PATHS, FUNCTIONS_STACKS_API_KEYS,
                          FUNCTIONS_LINUX_RUNTIME_VERSION_REGEX, FUNCTIONS_WINDOWS_RUNTIME_VERSION_REGEX,
-                         NODE_EXACT_VERSION_DEFAULT, RUNTIME_STACKS, FUNCTIONS_NO_V2_REGIONS, PUBLIC_CLOUD)
+                         NODE_EXACT_VERSION_DEFAULT, RUNTIME_STACKS, FUNCTIONS_NO_V2_REGIONS, PUBLIC_CLOUD,
+                         GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_REDIRECT_URI)
+from ._github_oauth import (get_github_access_token)
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1561,7 +1561,7 @@ def config_source_control(cmd, resource_group_name, name, repo_url, repository_t
                           manual_integration=None, git_token=None, slot=None, cd_app_type=None,
                           app_working_dir=None, nodejs_task_runner=None, python_framework=None,
                           python_version=None, cd_account_create=None, cd_project_url=None, test=None,
-                          slot_swap=None, private_repo_username=None, private_repo_password=None):
+                          slot_swap=None, private_repo_username=None, private_repo_password=None, github_action=None):
     client = web_client_factory(cmd.cli_ctx)
     location = _get_location_from_webapp(client, resource_group_name, name)
 
@@ -1602,7 +1602,7 @@ def config_source_control(cmd, resource_group_name, name, repo_url, repository_t
 
     source_control = SiteSourceControl(location=location, repo_url=repo_url, branch=branch,
                                        is_manual_integration=manual_integration,
-                                       is_mercurial=(repository_type != 'git'))
+                                       is_mercurial=(repository_type != 'git'), is_git_hub_action=bool(github_action))
 
     # SCC config can fail if previous commands caused SCMSite shutdown, so retry here.
     for i in range(5):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -61,9 +61,7 @@ from ._create_util import (zip_contents_from_dir, get_runtime_version_details, c
                            detect_os_form_src, get_current_stack_from_runtime, generate_default_app_name)
 from ._constants import (FUNCTIONS_STACKS_API_JSON_PATHS, FUNCTIONS_STACKS_API_KEYS,
                          FUNCTIONS_LINUX_RUNTIME_VERSION_REGEX, FUNCTIONS_WINDOWS_RUNTIME_VERSION_REGEX,
-                         NODE_EXACT_VERSION_DEFAULT, RUNTIME_STACKS, FUNCTIONS_NO_V2_REGIONS, PUBLIC_CLOUD,
-                         GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_REDIRECT_URI)
-from ._github_oauth import (get_github_access_token)
+                         NODE_EXACT_VERSION_DEFAULT, RUNTIME_STACKS, FUNCTIONS_NO_V2_REGIONS, PUBLIC_CLOUD)
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -118,6 +118,7 @@ pbr==5.3.1
 portalocker==1.7.1
 psutil==5.8.0
 pycparser==2.19
+PyGithub==1.38
 PyJWT==1.7.1
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -118,6 +118,7 @@ pbr==5.3.1
 portalocker==1.7.1
 psutil==5.8.0
 pycparser==2.19
+PyGithub==1.38
 PyJWT==1.7.1
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -117,6 +117,7 @@ pbr==5.3.1
 portalocker==1.7.1
 psutil==5.8.0
 pycparser==2.19
+PyGithub==1.38
 PyJWT==1.7.1
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -137,6 +137,7 @@ DEPENDENCIES = [
     'jsmin~=2.2.2',
     'jsondiff==1.2.0',
     'packaging~=20.9',
+    'PyGithub==1.38',
     'pytz==2019.1',
     'scp~=0.13.2',
     'semver==2.13.0',


### PR DESCRIPTION
**Description**<!--Mandatory-->

- Add function `get_github_access_token` to help users retrieve github access token easier
- Following doc: https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow

![image](https://user-images.githubusercontent.com/14339314/115771008-6a9e5b80-a37b-11eb-967d-8d59d96f2682.png)

![image](https://user-images.githubusercontent.com/14339314/115771150-93beec00-a37b-11eb-84fd-f5415b8e696f.png)

![image](https://user-images.githubusercontent.com/14339314/115771162-9883a000-a37b-11eb-92af-2ce3139bebac.png)



**Testing Guide**
This is not exposed in a command yet, as I'm not sure what command to put it under. We will be using this function in webapp commands in the future, and static webapps have use cases as well

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
