### PR TITLE
{pylint} Disable more checkers to comply with pylint 2.8.0

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -13,7 +13,7 @@ steps:
       chmod +x env/bin/activate
       . env/bin/activate
       python -m pip install -U pip
-      pip install azdev==0.1.31
+      pip install azdev==0.1.32
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then

--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -13,7 +13,7 @@ steps:
       chmod +x env/bin/activate
       . env/bin/activate
       python -m pip install -U pip
-      pip install azdev==0.1.30
+      pip install azdev==0.1.31
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then

--- a/pylintrc
+++ b/pylintrc
@@ -4,18 +4,42 @@ reports=no
 
 [MESSAGES CONTROL]
 # For all codes, run 'pylint --list-msgs' or go to 'https://pylint.readthedocs.io/en/latest/reference_guide/features.html'
-# locally-disabled: Warning locally suppressed using disable-msg
 # cyclic-import: because of https://github.com/PyCQA/pylint/issues/850
+# import-outside-toplevel: Lazy import to improve performance
+# locally-disabled: Warning locally suppressed using disable-msg
 # too-many-arguments: Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
 disable=
-    missing-docstring,
-    locally-disabled,
-    fixme,
+    arguments-out-of-order,
+    bad-option-value,
+    consider-using-generator,
+    consider-using-with,
     cyclic-import,
-    too-many-arguments,
-    invalid-name,
     duplicate-code,
-    bad-option-value
+    fixme,
+    import-outside-toplevel,
+    inconsistent-return-statements,
+    invalid-name,
+    invalid-str-returned,
+    locally-disabled,
+    missing-docstring,
+    missing-kwoa,
+    no-else-break,
+    no-else-continue,
+    no-member,
+    no-value-for-parameter,
+    raise-missing-from,
+    self-assigning-variable,
+    subprocess-run-check,
+    super-with-arguments,
+    too-many-arguments,
+    too-many-function-args,
+    too-many-lines,
+    unnecessary-comprehension,
+    unrecognized-inline-option,
+    unused-import,
+    use-a-generator,
+    using-constant-test,
+    wrong-import-order,
 
 [FORMAT]
 max-line-length=120


### PR DESCRIPTION
Require https://github.com/Azure/azure-cli-dev-tools/pull/295

## Context

The old `pylint` 2.3.0 is

- not compatible with the latest `astroid` (https://github.com/Azure/azure-cli-dev-tools/pull/294)
- not compatible with Python 3.9 (https://github.com/Azure/azure-cli/pull/17368) 

## Change

- Use the latest `azdev` with `pylint` bumped to 2.8.0
- Disable new [checkers](http://pylint.pycqa.org/en/latest/technical_reference/features.html) of the new `pylint` 

## TODO

All these newly disabled checkers should be fixed one by one in their dedicated PRs:

- [ ] arguments-out-of-order
- [ ] bad-option-value
- [ ] consider-using-generator
- [ ] consider-using-with
- [ ] duplicate-code
- [ ] inconsistent-return-statements
- [ ] invalid-name
- [ ] invalid-str-returned
- [ ] missing-kwoa
- [ ] no-else-break
- [ ] no-else-continue
- [ ] no-member
- [ ] no-value-for-parameter
- [ ] raise-missing-from
- [ ] self-assigning-variable
- [ ] subprocess-run-check
- [ ] super-with-arguments
- [ ] too-many-function-args
- [ ] too-many-lines
- [ ] unnecessary-comprehension
- [ ] unrecognized-inline-option
- [ ] unused-import
- [ ] use-a-generator
- [ ] using-constant-test
- [ ] wrong-import-order

## Additional information

The list of failed checkers are acquired by running `pylint` with `--msg-template='{symbol}'`:

```
python -m pylint d:\cli\azure-cli\src\azure-cli\azure\cli d:\cli\azure-cli\src\azure-cli-core\azure\cli\core d:\cli\azure-cli\src\azure-cli-telemetry\azure\cli\telemetry d:\cli\azure-cli\src\azure-cli-testsdk\azure\cli\testsdk d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\acr d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\acs d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\advisor d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\ams d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\apim d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\appconfig d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\appservice d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\aro d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\backup d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\batch d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\batchai d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\billing d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\botservice d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\cdn d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\cloud d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\cognitiveservices d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\config d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\configure d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\consumption d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\container d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\cosmosdb d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\databoxedge d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\deploymentmanager d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\dla d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\dls d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\dms d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\eventgrid d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\eventhubs d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\extension d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\feedback d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\find d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\hdinsight d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\interactive d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\iot d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\keyvault d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\kusto d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\lab d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\managedservices d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\maps d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\monitor d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\natgateway d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\netappfiles d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\network d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\policyinsights d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\privatedns d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\profile d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\rdbms d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\redis d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\relay d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\reservations d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\resource d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\role d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\search d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\security d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\servicebus d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\servicefabric d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\signalr d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\sql d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\sqlvm d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\storage d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\synapse d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\util d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\vm --ignore vendored_sdks,privates --rcfile=D:\cli\azure-cli\pylintrc --jobs 8 --msg-template='{symbol}'
```