### PR TITLE
{CI} Bump `azdev` to 0.1.31

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -13,7 +13,7 @@ steps:
       chmod +x env/bin/activate
       . env/bin/activate
       python -m pip install -U pip
-      pip install azdev==0.1.30
+      pip install azdev==0.1.31
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then


### PR DESCRIPTION
**Description**<!--Mandatory-->

Bump `azdev` to 0.1.31 to adopt https://github.com/Azure/azure-cli-dev-tools/pull/294 and fix `pylint`.
