### PR TITLE
[AppService]  BREAKING CHANGE: Add support for az staticwebapp show; az staticwebapp create; az staticwebapp update

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2293,6 +2293,14 @@ helps['staticwebapp list'] = """
       text: az staticwebapp list
 """
 
+helps['staticwebapp browse'] = """
+    type: command
+    short-summary: Show details of a static app.
+    examples:
+    - name: Show static app in a subscription.
+      text: az staticwebapp browse -n MyStaticAppName
+"""
+
 helps['staticwebapp show'] = """
     type: command
     short-summary: Show details of a static app.

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2293,12 +2293,12 @@ helps['staticwebapp list'] = """
       text: az staticwebapp list
 """
 
-helps['staticwebapp browse'] = """
+helps['staticwebapp show'] = """
     type: command
     short-summary: Show details of a static app.
     examples:
     - name: Show static app in a subscription.
-      text: az staticwebapp browse -n MyStaticAppName
+      text: az staticwebapp show -n MyStaticAppName
 """
 
 helps['staticwebapp create'] = """
@@ -2307,6 +2307,15 @@ helps['staticwebapp create'] = """
     examples:
     - name: Create static app in a subscription.
       text: az staticwebapp create -n MyStaticAppName -g MyExistingRg
+       -s https://github.com/JohnDoe/my-first-static-web-app -l WestUs2 -b master
+"""
+
+helps['staticwebapp update'] = """
+    type: command
+    short-summary: Update a static app. Return the app updated.
+    examples:
+    - name: Update static app in a subscription.
+      text: az staticwebapp update -n MyStaticAppName -g MyExistingRg
        -s https://github.com/JohnDoe/my-first-static-web-app -l WestUs2 -b master
 """
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2315,8 +2315,7 @@ helps['staticwebapp update'] = """
     short-summary: Update a static app. Return the app updated.
     examples:
     - name: Update static app in a subscription.
-      text: az staticwebapp update -n MyStaticAppName -g MyExistingRg
-       -s https://github.com/JohnDoe/my-first-static-web-app -l WestUs2 -b master
+      text: az staticwebapp update -n MyStaticAppName -g MyExistingRg -b master
 """
 
 helps['staticwebapp disconnect'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2314,8 +2314,8 @@ helps['staticwebapp update'] = """
     type: command
     short-summary: Update a static app. Return the app updated.
     examples:
-    - name: Update static app in a subscription.
-      text: az staticwebapp update -n MyStaticAppName -g MyExistingRg -b master
+    - name: Update static app to standard sku.
+      text: az staticwebapp update -n MyStaticAppName --sku Standard
 """
 
 helps['staticwebapp disconnect'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2293,14 +2293,6 @@ helps['staticwebapp list'] = """
       text: az staticwebapp list
 """
 
-helps['staticwebapp browse'] = """
-    type: command
-    short-summary: Show details of a static app.
-    examples:
-    - name: Show static app in a subscription.
-      text: az staticwebapp browse -n MyStaticAppName
-"""
-
 helps['staticwebapp show'] = """
     type: command
     short-summary: Show details of a static app.

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -1029,19 +1029,8 @@ def load_arguments(self, _):
                         "of 'build' when your app location is set to '/app' will cause the content at '/app/build' to "
                         "be served.")
     with self.argument_context('staticwebapp update') as c:
-        c.argument('location', arg_type=get_location_type(self.cli_ctx))
         c.argument('tags', arg_type=tags_type)
         c.argument('sku', arg_type=static_web_app_sku_arg_type)
-        c.argument('app_location', options_list=['--app-location'],
-                   help="Location of your application code. For example, '/' represents the root of your app, "
-                        "while '/app' represents a directory called 'app'")
-        c.argument('api_location', options_list=['--api-location'],
-                   help="Location of your Azure Functions code. For example, '/api' represents a folder called 'api'.")
-        c.argument('app_artifact_location', options_list=['--app-artifact-location'],
-                   help="The path of your build output relative to your apps location. For example, setting a value "
-                        "of 'build' when your app location is set to '/app' will cause the content at '/app/build' to "
-                        "be served.")
-
 
 def _get_functionapp_runtime_versions():
     # set up functionapp create help menu

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -67,6 +67,11 @@ def load_arguments(self, _):
         help='The Isolated pricing tiers, e.g., I1 (Isolated Small), I2 (Isolated Medium), I3 (Isolated Large)',
         arg_type=get_enum_type(['I1', 'I2', 'I3']))
 
+    static_web_app_sku_arg_type = CLIArgumentType(
+        help = 'The pricing tiers for Static Web Spp, e.g., F1(Free), S1(Standard)',
+        arg_type=get_enum_type(['F1', 'FREE', 'S1'])
+    )
+
     functionapp_runtime_strings, functionapp_runtime_to_version_strings = _get_functionapp_runtime_versions()
 
     # use this hidden arg to give a command the right instance, that functionapp commands
@@ -1013,6 +1018,20 @@ def load_arguments(self, _):
     with self.argument_context('staticwebapp create') as c:
         c.argument('location', arg_type=get_location_type(self.cli_ctx))
         c.argument('tags', arg_type=tags_type)
+        c.argument('sku', arg_type=static_web_app_sku_arg_type)
+        c.argument('app_location', options_list=['--app-location'],
+                   help="Location of your application code. For example, '/' represents the root of your app, "
+                        "while '/app' represents a directory called 'app'")
+        c.argument('api_location', options_list=['--api-location'],
+                   help="Location of your Azure Functions code. For example, '/api' represents a folder called 'api'.")
+        c.argument('app_artifact_location', options_list=['--app-artifact-location'],
+                   help="The path of your build output relative to your apps location. For example, setting a value "
+                        "of 'build' when your app location is set to '/app' will cause the content at '/app/build' to "
+                        "be served.")
+    with self.argument_context('staticwebapp update') as c:
+        c.argument('location', arg_type=get_location_type(self.cli_ctx))
+        c.argument('tags', arg_type=tags_type)
+        c.argument('sku', arg_type=static_web_app_sku_arg_type)
         c.argument('app_location', options_list=['--app-location'],
                    help="Location of your application code. For example, '/' represents the root of your app, "
                         "while '/app' represents a directory called 'app'")

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -1032,6 +1032,7 @@ def load_arguments(self, _):
         c.argument('tags', arg_type=tags_type)
         c.argument('sku', arg_type=static_web_app_sku_arg_type)
 
+
 def _get_functionapp_runtime_versions():
     # set up functionapp create help menu
     KEYS = FUNCTIONS_STACKS_API_KEYS()

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -68,7 +68,7 @@ def load_arguments(self, _):
         arg_type=get_enum_type(['I1', 'I2', 'I3']))
 
     static_web_app_sku_arg_type = CLIArgumentType(
-        help='The pricing tiers for Static Web App, including: Free, Standard.',
+        help='The pricing tiers for Static Web App',
         arg_type=get_enum_type(['Free', 'Standard'])
     )
 
@@ -1024,6 +1024,11 @@ def load_arguments(self, _):
                         "while '/app' represents a directory called 'app'")
         c.argument('api_location', options_list=['--api-location'],
                    help="Location of your Azure Functions code. For example, '/api' represents a folder called 'api'.")
+        c.argument('app_artifact_location', options_list=['--app-artifact-location'],
+                   help="The path of your build output relative to your apps location. For example, setting a value "
+                        "of 'build' when your app location is set to '/app' will cause the content at '/app/build' to "
+                        "be served.",
+                   deprecate_info=c.deprecate(expiration='2.22.1'))
         c.argument('output_location', options_list=['--output-location'],
                    help="The path of your build output relative to your apps location. For example, setting a value "
                         "of 'build' when your app location is set to '/app' will cause the content at '/app/build' to "

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -69,7 +69,7 @@ def load_arguments(self, _):
 
     static_web_app_sku_arg_type = CLIArgumentType(
         help = 'The pricing tiers for Static Web Spp, e.g., F1(Free), S1(Standard)',
-        arg_type=get_enum_type(['F1', 'FREE', 'S1'])
+        arg_type=get_enum_type(['F1', 'Free', 'S1', 'Standard'])
     )
 
     functionapp_runtime_strings, functionapp_runtime_to_version_strings = _get_functionapp_runtime_versions()

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -68,7 +68,7 @@ def load_arguments(self, _):
         arg_type=get_enum_type(['I1', 'I2', 'I3']))
 
     static_web_app_sku_arg_type = CLIArgumentType(
-        help = 'The pricing tiers for Static Web Spp, e.g., F1(Free), S1(Standard)',
+        help='The pricing tiers for Static Web Spp, e.g., F1(Free), S1(Standard)',
         arg_type=get_enum_type(['F1', 'Free', 'S1', 'Standard'])
     )
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -68,7 +68,7 @@ def load_arguments(self, _):
         arg_type=get_enum_type(['I1', 'I2', 'I3']))
 
     static_web_app_sku_arg_type = CLIArgumentType(
-        help='The pricing tiers for Static Web Spp, including: Free, Standard.',
+        help='The pricing tiers for Static Web App, including: Free, Standard.',
         arg_type=get_enum_type(['Free', 'Standard'])
     )
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -68,8 +68,8 @@ def load_arguments(self, _):
         arg_type=get_enum_type(['I1', 'I2', 'I3']))
 
     static_web_app_sku_arg_type = CLIArgumentType(
-        help='The pricing tiers for Static Web Spp, e.g., F1(Free), S1(Standard)',
-        arg_type=get_enum_type(['F1', 'Free', 'S1', 'Standard'])
+        help='The pricing tiers for Static Web Spp, including: Free, Standard.',
+        arg_type=get_enum_type(['Free', 'Standard'])
     )
 
     functionapp_runtime_strings, functionapp_runtime_to_version_strings = _get_functionapp_runtime_versions()

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -1024,7 +1024,7 @@ def load_arguments(self, _):
                         "while '/app' represents a directory called 'app'")
         c.argument('api_location', options_list=['--api-location'],
                    help="Location of your Azure Functions code. For example, '/api' represents a folder called 'api'.")
-        c.argument('app_artifact_location', options_list=['--app-artifact-location'],
+        c.argument('output_location', options_list=['--output-location'],
                    help="The path of your build output relative to your apps location. For example, setting a value "
                         "of 'build' when your app location is set to '/app' will cause the content at '/app/build' to "
                         "be served.")

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -427,7 +427,6 @@ def load_command_table(self, _):
 
     with self.command_group('staticwebapp', custom_command_type=staticsite_sdk, is_preview=True) as g:
         g.custom_command('list', 'list_staticsites')
-        g.custom_command('browse', 'show_staticsite', deprecate_info=g.deprecate(redirect='staticwebapp show', expiration='2.22.1'))
         g.custom_show_command('show', 'show_staticsite')
         g.custom_command('create', 'create_staticsites', supports_no_wait=True)
         g.custom_command('delete', 'delete_staticsite', supports_no_wait=True, confirmation=True)

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -427,6 +427,7 @@ def load_command_table(self, _):
 
     with self.command_group('staticwebapp', custom_command_type=staticsite_sdk, is_preview=True) as g:
         g.custom_command('list', 'list_staticsites')
+        g.custom_command('browse', 'show_staticsite', deprecate_info=g.deprecate(redirect='staticwebapp show', expiration='2.22.1'))
         g.custom_show_command('show', 'show_staticsite')
         g.custom_command('create', 'create_staticsites', supports_no_wait=True)
         g.custom_command('delete', 'delete_staticsite', supports_no_wait=True, confirmation=True)

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -432,7 +432,7 @@ def load_command_table(self, _):
         g.custom_command('delete', 'delete_staticsite', supports_no_wait=True, confirmation=True)
         g.custom_command('disconnect', 'disconnect_staticsite', supports_no_wait=True)
         g.custom_command('reconnect', 'reconnect_staticsite', supports_no_wait=True)
-        g.custom_command('update', 'update_staticsites', supports_no_wait=True)
+        g.custom_command('update', 'update_staticsite', supports_no_wait=True)
 
     with self.command_group('staticwebapp environment', custom_command_type=staticsite_sdk, is_preview=True) as g:
         g.custom_command('list', 'list_staticsite_environments')

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -427,7 +427,7 @@ def load_command_table(self, _):
 
     with self.command_group('staticwebapp', custom_command_type=staticsite_sdk, is_preview=True) as g:
         g.custom_command('list', 'list_staticsites')
-        g.custom_command('show', 'show_staticsite')
+        g.custom_show_command('show', 'show_staticsite')
         g.custom_command('create', 'create_staticsites', supports_no_wait=True)
         g.custom_command('delete', 'delete_staticsite', supports_no_wait=True, confirmation=True)
         g.custom_command('disconnect', 'disconnect_staticsite', supports_no_wait=True)

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -427,11 +427,12 @@ def load_command_table(self, _):
 
     with self.command_group('staticwebapp', custom_command_type=staticsite_sdk, is_preview=True) as g:
         g.custom_command('list', 'list_staticsites')
-        g.custom_command('browse', 'show_staticsite')
+        g.custom_command('show', 'show_staticsite')
         g.custom_command('create', 'create_staticsites', supports_no_wait=True)
         g.custom_command('delete', 'delete_staticsite', supports_no_wait=True, confirmation=True)
         g.custom_command('disconnect', 'disconnect_staticsite', supports_no_wait=True)
         g.custom_command('reconnect', 'reconnect_staticsite', supports_no_wait=True)
+        g.custom_command('update', 'update_staticsites', supports_no_wait=True)
 
     with self.command_group('staticwebapp environment', custom_command_type=staticsite_sdk, is_preview=True) as g:
         g.custom_command('list', 'list_staticsite_environments')

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -221,31 +221,41 @@ def create_staticsites(cmd, resource_group_name, name, location,
                        static_site_envelope=staticsite_deployment_properties)
 
 
-def update_staticsites(cmd, resource_group_name, name, location,
-                       source, branch, token=None,
-                       app_location='.', api_location='.', app_artifact_location='.github/workflows',
-                       tags=None, no_wait=False, sku='Free'):
+def update_staticsites(cmd, name, resource_group_name=None, location=None,
+                       source=None, branch=None, token=None,
+                       app_location=None, api_location=None, app_artifact_location=None,
+                       tags=None, sku=None, no_wait=False):
     if not token:
         _raise_missing_token_suggestion()
+    
+    if not resource_group_name:
+        resource_group_name = _get_resource_group_name_of_staticsite(client, name)
+
+    existing_staticsite = show_staticsite(cmd, name, resource_group_name)
+
+    if not existing_staticsite:
+        raise CLIError("No static web app found with name {0}".format(name))
 
     StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription = cmd.get_models(
         'StaticSiteARMResource', 'StaticSiteBuildProperties', 'SkuDescription')
 
     build = StaticSiteBuildProperties(
-        app_location=app_location,
-        api_location=api_location,
-        app_artifact_location=app_artifact_location)
+        app_location=app_location or existing_staticsite.build_properties.app_location,
+        api_location=api_location or existing_staticsite.build_properties.api_location,
+        app_artifact_location=app_artifact_location or existing_staticsite.build_properties.app_artifact_location)
 
-    sku_def = SkuDescription(name=get_sku_name(sku), tier=get_sku_name(sku))
+    sku_def = None
+    if not sku:
+        sku_def = SkuDescription(name=get_sku_name(sku), tier=get_sku_name(sku))
 
     staticsite_deployment_properties = StaticSiteARMResource(
-        location=location,
-        tags=tags,
-        repository_url=source,
-        branch=branch,
-        repository_token=token,
+        location=location or existing_staticsite.location,
+        tags=tags or existing_staticsite.tags,
+        repository_url=source or existing_staticsite.repository_url,
+        branch=branch or existing_staticsite.branch,
+        repository_token=token or existing_staticsite.repository_token,
         build_properties=build,
-        sku=sku_def)
+        sku=sku_def or existing_staticsite)
 
     client = _get_staticsites_client_factory(cmd.cli_ctx)
     return sdk_no_wait(no_wait, client.update_static_site,

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -8,7 +8,7 @@ from azure.cli.core.util import sdk_no_wait
 from knack.util import CLIError
 from knack.log import get_logger
 
-from .utils import get_sku_name
+from .utils import normalize_sku_for_staticapp
 
 logger = get_logger(__name__)
 
@@ -204,7 +204,7 @@ def create_staticsites(cmd, resource_group_name, name, location,
         api_location=api_location,
         app_artifact_location=app_artifact_location)
 
-    sku_def = SkuDescription(name=get_sku_name(sku), tier=get_sku_name(sku))
+    sku_def = SkuDescription(name=normalize_sku_for_staticapp(sku), tier=normalize_sku_for_staticapp(sku))
 
     staticsite_deployment_properties = StaticSiteARMResource(
         location=location,
@@ -225,9 +225,6 @@ def update_staticsite(cmd, name, resource_group_name=None, location=None,
                        source=None, branch=None, token=None,
                        app_location=None, api_location=None, app_artifact_location=None,
                        tags=None, sku=None, no_wait=False):
-    if not token:
-        _raise_missing_token_suggestion()
-
     existing_staticsite = show_staticsite(cmd, name, resource_group_name)
     if not existing_staticsite:
         raise CLIError("No static web app found with name {0}".format(name))
@@ -236,13 +233,13 @@ def update_staticsite(cmd, name, resource_group_name=None, location=None,
         'StaticSiteARMResource', 'StaticSiteBuildProperties', 'SkuDescription')
 
     if existing_staticsite.build_properties is not None:
-        app_location=app_location or existing_staticsite.build_properties.app_location,
-        api_location=api_location or existing_staticsite.build_properties.api_location,
+        app_location=app_location or existing_staticsite.build_properties.app_location
+        api_location=api_location or existing_staticsite.build_properties.api_location
         app_artifact_location=app_artifact_location or existing_staticsite.build_properties.app_artifact_location 
 
     sku_def = None
     if sku is not None:
-        sku_def = SkuDescription(name=get_sku_name(sku), tier=get_sku_name(sku))
+        sku_def = SkuDescription(name=normalize_sku_for_staticapp(sku), tier=normalize_sku_for_staticapp(sku))
 
     staticsite_deployment_properties = StaticSiteARMResource(
         location=location or existing_staticsite.location,

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -222,9 +222,9 @@ def create_staticsites(cmd, resource_group_name, name, location,
 
 
 def update_staticsite(cmd, name, resource_group_name=None, location=None,
-                       source=None, branch=None, token=None,
-                       app_location=None, api_location=None, app_artifact_location=None,
-                       tags=None, sku=None, no_wait=False):
+                      source=None, branch=None, token=None,
+                      app_location=None, api_location=None, app_artifact_location=None,
+                      tags=None, sku=None, no_wait=False):
     existing_staticsite = show_staticsite(cmd, name, resource_group_name)
     if not existing_staticsite:
         raise CLIError("No static web app found with name {0}".format(name))
@@ -233,9 +233,14 @@ def update_staticsite(cmd, name, resource_group_name=None, location=None,
         'StaticSiteARMResource', 'StaticSiteBuildProperties', 'SkuDescription')
 
     if existing_staticsite.build_properties is not None:
-        app_location=app_location or existing_staticsite.build_properties.app_location
-        api_location=api_location or existing_staticsite.build_properties.api_location
-        app_artifact_location=app_artifact_location or existing_staticsite.build_properties.app_artifact_location 
+        app_location = app_location or existing_staticsite.build_properties.app_location
+        api_location = api_location or existing_staticsite.build_properties.api_location
+        app_artifact_location = app_artifact_location or existing_staticsite.build_properties.app_artifact_location
+
+    build = StaticSiteBuildProperties(
+        app_location=app_location,
+        api_location=api_location,
+        app_artifact_location=app_artifact_location)
 
     sku_def = None
     if sku is not None:
@@ -247,7 +252,7 @@ def update_staticsite(cmd, name, resource_group_name=None, location=None,
         repository_url=source or existing_staticsite.repository_url,
         branch=branch or existing_staticsite.branch,
         repository_token=token or existing_staticsite.repository_token,
-        build_properties=StaticSiteBuildProperties(app_location=app_location, api_location=api_location, app_artifact_location=app_artifact_location),
+        build_properties=build,
         sku=sku_def or existing_staticsite.sku)
 
     client = _get_staticsites_client_factory(cmd.cli_ctx)

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -227,6 +227,9 @@ def update_staticsite(cmd, name, source=None, branch=None, token=None,
     if not existing_staticsite:
         raise CLIError("No static web app found with name {0}".format(name))
 
+    if tags is not None:
+        existing_staticsite.tags = tags
+
     StaticSiteARMResource, SkuDescription = cmd.get_models('StaticSiteARMResource', 'SkuDescription')
 
     sku_def = None
@@ -235,7 +238,7 @@ def update_staticsite(cmd, name, source=None, branch=None, token=None,
 
     staticsite_deployment_properties = StaticSiteARMResource(
         location=existing_staticsite.location,
-        tags=tags or existing_staticsite.tags,
+        tags=existing_staticsite.tags,
         repository_url=source or existing_staticsite.repository_url,
         branch=branch or existing_staticsite.branch,
         repository_token=token or existing_staticsite.repository_token,

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -221,41 +221,30 @@ def create_staticsites(cmd, resource_group_name, name, location,
                        static_site_envelope=staticsite_deployment_properties)
 
 
-def update_staticsite(cmd, name, resource_group_name=None, location=None,
-                      source=None, branch=None, token=None,
-                      app_location=None, api_location=None, app_artifact_location=None,
+def update_staticsite(cmd, name, source=None, branch=None, token=None,
                       tags=None, sku=None, no_wait=False):
-    existing_staticsite = show_staticsite(cmd, name, resource_group_name)
+    existing_staticsite = show_staticsite(cmd, name)
     if not existing_staticsite:
         raise CLIError("No static web app found with name {0}".format(name))
 
     StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription = cmd.get_models(
         'StaticSiteARMResource', 'StaticSiteBuildProperties', 'SkuDescription')
 
-    if existing_staticsite.build_properties is not None:
-        app_location = app_location or existing_staticsite.build_properties.app_location
-        api_location = api_location or existing_staticsite.build_properties.api_location
-        app_artifact_location = app_artifact_location or existing_staticsite.build_properties.app_artifact_location
-
-    build = StaticSiteBuildProperties(
-        app_location=app_location,
-        api_location=api_location,
-        app_artifact_location=app_artifact_location)
-
     sku_def = None
     if sku is not None:
         sku_def = SkuDescription(name=normalize_sku_for_staticapp(sku), tier=normalize_sku_for_staticapp(sku))
 
     staticsite_deployment_properties = StaticSiteARMResource(
-        location=location or existing_staticsite.location,
+        location=existing_staticsite.location,
         tags=tags or existing_staticsite.tags,
         repository_url=source or existing_staticsite.repository_url,
         branch=branch or existing_staticsite.branch,
         repository_token=token or existing_staticsite.repository_token,
-        build_properties=build,
+        build_properties=existing_staticsite.build_properties,
         sku=sku_def or existing_staticsite.sku)
 
     client = _get_staticsites_client_factory(cmd.cli_ctx)
+    resource_group_name = _get_resource_group_name_of_staticsite(client, name)
     return sdk_no_wait(no_wait, client.update_static_site,
                        resource_group_name=resource_group_name, name=name,
                        static_site_envelope=staticsite_deployment_properties)

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -191,7 +191,7 @@ def update_staticsite_users(cmd, name, roles, authentication_provider=None, user
 
 def create_staticsites(cmd, resource_group_name, name, location,
                        source, branch, token=None,
-                       app_location='.', api_location='.', app_artifact_location='.github/workflows',
+                       app_location='.', api_location='.', output_location='.github/workflows',
                        tags=None, no_wait=False, sku='Free'):
     if not token:
         _raise_missing_token_suggestion()
@@ -202,7 +202,7 @@ def create_staticsites(cmd, resource_group_name, name, location,
     build = StaticSiteBuildProperties(
         app_location=app_location,
         api_location=api_location,
-        app_artifact_location=app_artifact_location)
+        app_artifact_location=output_location)
 
     sku_def = SkuDescription(name=normalize_sku_for_staticapp(sku), tier=normalize_sku_for_staticapp(sku))
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -227,8 +227,7 @@ def update_staticsite(cmd, name, source=None, branch=None, token=None,
     if not existing_staticsite:
         raise CLIError("No static web app found with name {0}".format(name))
 
-    StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription = cmd.get_models(
-        'StaticSiteARMResource', 'StaticSiteBuildProperties', 'SkuDescription')
+    StaticSiteARMResource, SkuDescription = cmd.get_models('StaticSiteARMResource', 'SkuDescription')
 
     sku_def = None
     if sku is not None:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -10,7 +10,7 @@ from azure.cli.command_modules.appservice.static_sites import \
     reconnect_staticsite, list_staticsite_environments, show_staticsite_environment, list_staticsite_domains, \
     set_staticsite_domain, delete_staticsite_domain, list_staticsite_functions, list_staticsite_function_app_settings, \
     set_staticsite_function_app_settings, delete_staticsite_function_app_settings, list_staticsite_users, \
-    invite_staticsite_users, update_staticsite_users
+    invite_staticsite_users, update_staticsite_users, update_staticsite
 
 
 class TestStaticAppCommands(unittest.TestCase):
@@ -105,10 +105,22 @@ class TestStaticAppCommands(unittest.TestCase):
         self.assertEqual(self.source1, arg_list["static_site_envelope"].repository_url)
         self.assertEqual(self.branch1, arg_list["static_site_envelope"].branch)
         self.assertEqual(tags, arg_list["static_site_envelope"].tags)
-        self.assertEqual('Free', arg_list["static_site_envelope"].sku.name)
+        self.assertEqual('FREE', arg_list["static_site_envelope"].sku.name)
         self.assertEqual(app_location, arg_list["static_site_envelope"].build_properties.app_location)
         self.assertEqual(api_location, arg_list["static_site_envelope"].build_properties.api_location)
         self.assertEqual(app_artifact_location, arg_list["static_site_envelope"].build_properties.app_artifact_location)
+
+    def test_create_staticapp_with_standard_sku(self):
+        from azure.mgmt.web.models import StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+        self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+
+        create_staticsites(
+            self.mock_cmd, self.rg1, self.name1, self.location1,
+            self.source1, self.branch1, self.token1, sku='s1')
+
+        self.staticapp_client.create_or_update_static_site.assert_called_once()
+        arg_list = self.staticapp_client.create_or_update_static_site.call_args.kwargs
+        self.assertEqual('STANDARD', arg_list["static_site_envelope"].sku.name)
 
     def test_create_staticapp_missing_token(self):
         app_location = './src'
@@ -123,6 +135,61 @@ class TestStaticAppCommands(unittest.TestCase):
                 app_location=app_location, api_location=api_location, app_artifact_location=app_artifact_location,
                 tags=tags)
 
+    def test_update_staticapp(self):
+        from azure.mgmt.web.models import StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+        self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+        self.staticapp_client.get_static_site.return_value = self.app1
+        app_location = './src'
+        api_location = './api/'
+        app_artifact_location = '/.git/'
+        tags = {'key1': 'value1'}
+        sku = 's1'
+
+        update_staticsite(
+            self.mock_cmd, self.name1, self.rg2, self.location2,
+            self.source2, self.branch2, self.token2,
+            app_location=app_location, api_location=api_location, app_artifact_location=app_artifact_location,
+            tags=tags, sku=sku)
+
+        self.staticapp_client.update_static_site.assert_called_once()
+        arg_list = self.staticapp_client.update_static_site.call_args.kwargs
+        self.assertEqual(self.name1, arg_list["name"])
+        self.assertEqual(self.rg2, arg_list["resource_group_name"])
+        self.assertEqual(self.location2, arg_list["static_site_envelope"].location)
+        self.assertEqual(self.source2, arg_list["static_site_envelope"].repository_url)
+        self.assertEqual(self.branch2, arg_list["static_site_envelope"].branch)
+        self.assertEqual(tags, arg_list["static_site_envelope"].tags)
+        self.assertEqual('STANDARD', arg_list["static_site_envelope"].sku.name)
+        self.assertEqual(app_location, arg_list["static_site_envelope"].build_properties.app_location)
+        self.assertEqual(api_location, arg_list["static_site_envelope"].build_properties.api_location)
+        self.assertEqual(app_artifact_location, arg_list["static_site_envelope"].build_properties.app_artifact_location)
+
+    def test_update_staticapp_with_no_values_passed_in(self):
+        from azure.mgmt.web.models import StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+        self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+        self.staticapp_client.get_static_site.return_value = self.app1
+
+        update_staticsite(self.mock_cmd, self.name1, token=self.token1, resource_group_name=self.rg1)
+
+        self.staticapp_client.update_static_site.assert_called_once()
+        arg_list = self.staticapp_client.update_static_site.call_args.kwargs
+        self.assertEqual(self.name1, arg_list["name"])
+        self.assertEqual(self.rg1, arg_list["resource_group_name"])
+        self.assertEqual(self.location1, arg_list["static_site_envelope"].location)
+        self.assertEqual(self.source1, arg_list["static_site_envelope"].repository_url)
+        self.assertEqual(self.branch1, arg_list["static_site_envelope"].branch)
+        self.assertEqual(self.app1.tags, arg_list["static_site_envelope"].tags)
+        self.assertEqual('FREE', arg_list["static_site_envelope"].sku.name)
+
+    def test_update_staticapp_not_exist(self):
+        from azure.mgmt.web.models import StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+        self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+        self.staticapp_client.get_static_site.return_value = self.app1
+        self.staticapp_client.list.return_value = [self.app1, self.app2]
+        
+        with self.assertRaises(CLIError):
+            update_staticsite(self.mock_cmd, self.name1_not_exist)
+ 
     def test_disconnect_staticapp_with_resourcegroup(self):
         disconnect_staticsite(self.mock_cmd, self.name1, self.rg1)
 
@@ -487,8 +554,8 @@ def _set_up_fake_apps(self):
 
 
 def _contruct_static_site_object(rg, app_name, location, source, branch):
-    from azure.mgmt.web.models import StaticSiteARMResource
-    app = StaticSiteARMResource(location=location, repository_url=source, branch=branch)
+    from azure.mgmt.web.models import StaticSiteARMResource, SkuDescription
+    app = StaticSiteARMResource(location=location, repository_url=source, branch=branch, sku=SkuDescription(name='FREE', tier='FREE'))
     app.name = app_name
     app.id = \
         "/subscriptions/sub/resourceGroups/{}/providers/Microsoft.Web/staticSites/{}".format(rg, app_name)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -116,7 +116,7 @@ class TestStaticAppCommands(unittest.TestCase):
 
         create_staticsites(
             self.mock_cmd, self.rg1, self.name1, self.location1,
-            self.source1, self.branch1, self.token1, sku='s1')
+            self.source1, self.branch1, self.token1, sku='standard')
 
         self.staticapp_client.create_or_update_static_site.assert_called_once()
         arg_list = self.staticapp_client.create_or_update_static_site.call_args.kwargs
@@ -143,7 +143,7 @@ class TestStaticAppCommands(unittest.TestCase):
         api_location = './api/'
         app_artifact_location = '/.git/'
         tags = {'key1': 'value1'}
-        sku = 's1'
+        sku = 'standard'
 
         update_staticsite(
             self.mock_cmd, self.name1, self.rg2, self.location2,

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -88,13 +88,13 @@ class TestStaticAppCommands(unittest.TestCase):
         self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
         app_location = './src'
         api_location = './api/'
-        app_artifact_location = '/.git/'
+        output_location = '/.git/'
         tags = {'key1': 'value1'}
 
         create_staticsites(
             self.mock_cmd, self.rg1, self.name1, self.location1,
             self.source1, self.branch1, self.token1,
-            app_location=app_location, api_location=api_location, app_artifact_location=app_artifact_location,
+            app_location=app_location, api_location=api_location, output_location=output_location,
             tags=tags)
 
         self.staticapp_client.create_or_update_static_site.assert_called_once()
@@ -108,7 +108,7 @@ class TestStaticAppCommands(unittest.TestCase):
         self.assertEqual('Free', arg_list["static_site_envelope"].sku.name)
         self.assertEqual(app_location, arg_list["static_site_envelope"].build_properties.app_location)
         self.assertEqual(api_location, arg_list["static_site_envelope"].build_properties.api_location)
-        self.assertEqual(app_artifact_location, arg_list["static_site_envelope"].build_properties.app_artifact_location)
+        self.assertEqual(output_location, arg_list["static_site_envelope"].build_properties.app_artifact_location)
 
     def test_create_staticapp_with_standard_sku(self):
         from azure.mgmt.web.models import StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
@@ -125,14 +125,14 @@ class TestStaticAppCommands(unittest.TestCase):
     def test_create_staticapp_missing_token(self):
         app_location = './src'
         api_location = './api/'
-        app_artifact_location = '/.git/'
+        output_location = '/.git/'
         tags = {'key1': 'value1'}
 
         with self.assertRaises(CLIError):
             create_staticsites(
                 self.mock_cmd, self.rg1, self.name1, self.location1,
                 self.source1, self.branch1,
-                app_location=app_location, api_location=api_location, app_artifact_location=app_artifact_location,
+                app_location=app_location, api_location=api_location, output_location=output_location,
                 tags=tags)
 
     def test_update_staticapp(self):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -189,10 +189,10 @@ class TestStaticAppCommands(unittest.TestCase):
         self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
         self.staticapp_client.get_static_site.return_value = self.app1
         self.staticapp_client.list.return_value = [self.app1, self.app2]
-        
+
         with self.assertRaises(CLIError):
             update_staticsite(self.mock_cmd, self.name1_not_exist)
- 
+
     def test_disconnect_staticapp_with_resourcegroup(self):
         disconnect_staticsite(self.mock_cmd, self.name1, self.rg1)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -546,9 +546,9 @@ def _set_up_fake_apps(self):
 def _contruct_static_site_object(rg, app_name, location, source, branch, token):
     from azure.mgmt.web.models import StaticSiteARMResource, SkuDescription
     app = StaticSiteARMResource(
-        location=location, 
-        repository_url=source, 
-        branch=branch, 
+        location=location,
+        repository_url=source,
+        branch=branch,
         repository_token=token,
         sku=SkuDescription(name='Free', tier='Free'))
     app.name = app_name

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -136,8 +136,8 @@ class TestStaticAppCommands(unittest.TestCase):
                 tags=tags)
 
     def test_update_staticapp(self):
-        from azure.mgmt.web.models import StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
-        self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+        from azure.mgmt.web.models import StaticSiteARMResource, SkuDescription
+        self.mock_cmd.get_models.return_value = StaticSiteARMResource, SkuDescription
         self.staticapp_client.get_static_site.return_value = self.app1
         self.staticapp_client.list.return_value = [self.app1, self.app2]
         tags = {'key1': 'value1'}
@@ -155,8 +155,8 @@ class TestStaticAppCommands(unittest.TestCase):
         self.assertEqual(sku, arg_list["static_site_envelope"].sku.name)
 
     def test_update_staticapp_with_no_values_passed_in(self):
-        from azure.mgmt.web.models import StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
-        self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+        from azure.mgmt.web.models import StaticSiteARMResource, SkuDescription
+        self.mock_cmd.get_models.return_value = StaticSiteARMResource, SkuDescription
         self.staticapp_client.get_static_site.return_value = self.app1
         self.staticapp_client.list.return_value = [self.app1, self.app2]
 
@@ -172,8 +172,8 @@ class TestStaticAppCommands(unittest.TestCase):
         self.assertEqual('Free', arg_list["static_site_envelope"].sku.name)
 
     def test_update_staticapp_not_exist(self):
-        from azure.mgmt.web.models import StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
-        self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
+        from azure.mgmt.web.models import StaticSiteARMResource, SkuDescription
+        self.mock_cmd.get_models.return_value = StaticSiteARMResource, SkuDescription
         self.staticapp_client.get_static_site.return_value = self.app1
         self.staticapp_client.list.return_value = [self.app1, self.app2]
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -105,7 +105,7 @@ class TestStaticAppCommands(unittest.TestCase):
         self.assertEqual(self.source1, arg_list["static_site_envelope"].repository_url)
         self.assertEqual(self.branch1, arg_list["static_site_envelope"].branch)
         self.assertEqual(tags, arg_list["static_site_envelope"].tags)
-        self.assertEqual('FREE', arg_list["static_site_envelope"].sku.name)
+        self.assertEqual('Free', arg_list["static_site_envelope"].sku.name)
         self.assertEqual(app_location, arg_list["static_site_envelope"].build_properties.app_location)
         self.assertEqual(api_location, arg_list["static_site_envelope"].build_properties.api_location)
         self.assertEqual(app_artifact_location, arg_list["static_site_envelope"].build_properties.app_artifact_location)
@@ -120,7 +120,7 @@ class TestStaticAppCommands(unittest.TestCase):
 
         self.staticapp_client.create_or_update_static_site.assert_called_once()
         arg_list = self.staticapp_client.create_or_update_static_site.call_args.kwargs
-        self.assertEqual('STANDARD', arg_list["static_site_envelope"].sku.name)
+        self.assertEqual('Standard', arg_list["static_site_envelope"].sku.name)
 
     def test_create_staticapp_missing_token(self):
         app_location = './src'
@@ -159,7 +159,7 @@ class TestStaticAppCommands(unittest.TestCase):
         self.assertEqual(self.source2, arg_list["static_site_envelope"].repository_url)
         self.assertEqual(self.branch2, arg_list["static_site_envelope"].branch)
         self.assertEqual(tags, arg_list["static_site_envelope"].tags)
-        self.assertEqual('STANDARD', arg_list["static_site_envelope"].sku.name)
+        self.assertEqual('Standard', arg_list["static_site_envelope"].sku.name)
         self.assertEqual(app_location, arg_list["static_site_envelope"].build_properties.app_location)
         self.assertEqual(api_location, arg_list["static_site_envelope"].build_properties.api_location)
         self.assertEqual(app_artifact_location, arg_list["static_site_envelope"].build_properties.app_artifact_location)
@@ -169,7 +169,7 @@ class TestStaticAppCommands(unittest.TestCase):
         self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
         self.staticapp_client.get_static_site.return_value = self.app1
 
-        update_staticsite(self.mock_cmd, self.name1, token=self.token1, resource_group_name=self.rg1)
+        update_staticsite(self.mock_cmd, self.name1, resource_group_name=self.rg1)
 
         self.staticapp_client.update_static_site.assert_called_once()
         arg_list = self.staticapp_client.update_static_site.call_args.kwargs
@@ -179,7 +179,10 @@ class TestStaticAppCommands(unittest.TestCase):
         self.assertEqual(self.source1, arg_list["static_site_envelope"].repository_url)
         self.assertEqual(self.branch1, arg_list["static_site_envelope"].branch)
         self.assertEqual(self.app1.tags, arg_list["static_site_envelope"].tags)
-        self.assertEqual('FREE', arg_list["static_site_envelope"].sku.name)
+        self.assertEqual('Free', arg_list["static_site_envelope"].sku.name)
+        self.assertEqual(None, arg_list["static_site_envelope"].build_properties.app_location)
+        self.assertEqual(None, arg_list["static_site_envelope"].build_properties.api_location)
+        self.assertEqual(None, arg_list["static_site_envelope"].build_properties.app_artifact_location)
 
     def test_update_staticapp_not_exist(self):
         from azure.mgmt.web.models import StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
@@ -555,7 +558,7 @@ def _set_up_fake_apps(self):
 
 def _contruct_static_site_object(rg, app_name, location, source, branch):
     from azure.mgmt.web.models import StaticSiteARMResource, SkuDescription
-    app = StaticSiteARMResource(location=location, repository_url=source, branch=branch, sku=SkuDescription(name='FREE', tier='FREE'))
+    app = StaticSiteARMResource(location=location, repository_url=source, branch=branch, sku=SkuDescription(name='Free', tier='Free'))
     app.name = app_name
     app.id = \
         "/subscriptions/sub/resourceGroups/{}/providers/Microsoft.Web/staticSites/{}".format(rg, app_name)

--- a/src/azure-cli/azure/cli/command_modules/appservice/utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/utils.py
@@ -54,9 +54,9 @@ def get_sku_name(tier):  # pylint: disable=too-many-return-statements
 
 
 def normalize_sku_for_staticapp(sku):
-    if sku.lower() == 'free' or sku.lower() == 'f1':
+    if sku.lower() == 'free':
         return 'Free'
-    if sku.lower() == 'standard' or sku.lower() == 's1':
+    if sku.lower() == 'standard':
         return 'Standard'
     raise CLIError("Invalid sku(pricing tier), please refer to command help for valid values")
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/utils.py
@@ -53,6 +53,14 @@ def get_sku_name(tier):  # pylint: disable=too-many-return-statements
     raise CLIError("Invalid sku(pricing tier), please refer to command help for valid values")
 
 
+def normalize_sku_for_staticapp(sku):
+    if sku.lower() == 'free' or sku.lower() == 'f1':
+        return 'Free'
+    if sku.lower() == 'standard' or sku.lower() == 's1':
+        return 'Standard'
+    raise CLIError("Invalid sku(pricing tier), please refer to command help for valid values")
+
+
 def retryable_method(retries=3, interval_sec=5, excpt_type=Exception):
     def decorate(func):
         def call(*args, **kwargs):


### PR DESCRIPTION
**Description**
1. az staticwebapp browse -> az staticwebapp show
2. add option of sku for az staticwebapp create --sku
3. add command of az staticwebapp update

**Testing Guide**

Tested commands - working as expected:
     1. az staticwebapp show -n my-first-static-web-app
     2. az staticwebapp create -n my-second-static-web-app -g rg -s https://github.com/jiansong-msft/my-first-static-web-app -l CentralUS -b main --token github-token --sku Free
     3. az staticwebapp update -n my-second-static-web-app --tags "key=value"
     4. az staticwebapp update -n static-app-not-exists throws
     5. with invalid sku options passed in throws

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
