### PR TITLE
{Misc.} Use neutral language for AI recommendations

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -91,7 +91,7 @@ class CLIPrintMixin(CLIHelp):
     def _print_az_find_message(command, enable_color):
         from colorama import Style
         indent = 0
-        message = 'For more specific examples, use: az find "az {}"'.format(command)
+        message = 'To search AI knowledge base for examples, use: az find "az {}"'.format(command)
         if enable_color:
             message = Style.BRIGHT + message + Style.RESET_ALL
         _print_indent(message + '\n', indent)

--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -76,7 +76,7 @@ class AzCLIError(CLIError):
                 print(recommendation, file=sys.stderr)
 
         if self.aladdin_recommendations:
-            print('\nTRY THIS:', file=sys.stderr)
+            print('\nExamples from AI knowledge base:', file=sys.stderr)
             for recommendation, description in self.aladdin_recommendations:
                 print_styled_text(recommendation, file=sys.stderr)
                 print_styled_text(description, file=sys.stderr)


### PR DESCRIPTION
**Description**<!--Mandatory-->

Using positive language like `more`, `try` can leads to user frustration if the recommendation is not helpful or even wrong: #17393, #17398, #17395, #17086, https://github.com/Azure/azure-cli-extensions/issues/2246#issuecomment-684016541

I would propose to use neutral language to indicate the example/recommendation system is AI-driven, not human-maintained, therefore the correctness/accuracy of the result is not guaranteed.

Email (with survey feedbacks): _Refine the instruction of Aladdin-based recommendations_