### PR TITLE
{ARM} Hotfix: Fix KeyError with template spec API version 2021-03-01-preview

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -893,7 +893,7 @@ def _prepare_deployment_properties_unmodified(cmd, deployment_scope, template_fi
         template_obj = _remove_comments_from_json(_urlretrieve(template_uri).decode('utf-8'), file_path=template_uri)
     elif template_spec:
         template_link = TemplateLink(id=template_spec, mode="Incremental")
-        template_obj = show_resource(cmd=cmd, resource_ids=[template_spec]).properties['template']
+        template_obj = show_resource(cmd=cmd, resource_ids=[template_spec]).properties['mainTemplate']
     else:
         template_content = (
             run_bicep_command(["build", "--stdout", template_file])


### PR DESCRIPTION
**Description**
Deploying template specs currently does not work. The API version `2021-03-01-preview` returns a template spec with `mainTemplate` as part of `properties` while the code in `src/azure-cli/azure/cli/command_modules/resource/custom.py` tries to access key `template` which has been the name of the key in API version `2019-06-01-preview`.

This PR fixes #17733

The code contains other places where dict key `template` is being referenced but I am unsure whether this plays a role for this particular case (deploy a template spec version).

**Testing Guide**
See #17733 for a detailed explanation, especially [this comment](https://github.com/Azure/azure-cli/issues/17733#issuecomment-826241039) by @tonystz.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
