### PR TITLE
[Compute] Fix a compatibility issue of old API version

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_template_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_template_builder.py
@@ -516,6 +516,10 @@ def build_vm_resource(  # pylint: disable=too-many-locals, too-many-statements
             'vTpmEnabled': enable_vtpm
         }
 
+    # Compatibility of various API versions
+    if vm_properties['securityProfile'] == {}:
+        del vm_properties['securityProfile']
+
     if platform_fault_domain is not None:
         vm_properties['platformFaultDomain'] = platform_fault_domain
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Resolve https://github.com/Azure/azure-cli/issues/17904

```
az cloud set -n AzureCloud --profile 2019-03-01-hybrid
az vm create -g fy -n vm --image win2016datacenter --admin-username clitester --admin-password PasswordPassword1!
```
returns
```
Could not find member 'securityProfile' on object of type 'Properties
```

The request body contains `"securityProfile": {}`. It appears that the old version of Compute does not accept this field even it is an empty dict.


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
