### PR TITLE
{Param Persist} Change term `local context` to `param persist` in customer-facing messages

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -168,14 +168,15 @@ class AzCli(CLI):
 
         # print warning if there are values saved to local context
         if local_context_args:
-            logger.warning('Local context is turned on. Its information is saved in working directory %s. You can '
-                           'run `az local-context off` to turn it off.',
+            logger.warning('Parameter persistence is turned on. Its information is saved in working directory %s. '
+                           'You can run `az config param-persist off` to turn it off.',
                            self.local_context.effective_working_directory())
             args_str = []
             for name, value in local_context_args:
                 args_str.append('{}: {}'.format(name, value))
-            logger.warning('Your preference of %s now saved to local context. To learn more, type in `az '
-                           'local-context --help`', ', '.join(args_str) + ' is' if len(args_str) == 1 else ' are')
+            logger.warning('Your preference of %s now saved to parameter persistence. To learn more, type in `az '
+                           'config param-persist --help`',
+                           ', '.join(args_str) + (' is' if len(args_str) == 1 else ' are'))
 
     def _configure_style(self):
         from azure.cli.core.util import in_cloud_console

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -174,7 +174,7 @@ class AzCli(CLI):
             args_str = []
             for name, value in local_context_args:
                 args_str.append('{}: {}'.format(name, value))
-            logger.warning('Your preference of %s now saved to parameter persistence. To learn more, type in `az '
+            logger.warning('Your preference of %s now saved as persistent parameter. To learn more, type in `az '
                            'config param-persist --help`',
                            ', '.join(args_str) + (' is' if len(args_str) == 1 else ' are'))
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -602,7 +602,7 @@ class AzCliCommandInvoker(CommandInvoker):
                 args_str = []
                 for name, value in local_context_args:
                     args_str.append('{}: {}'.format(name, value))
-                logger.warning('Command argument values from parameter persistence: %s', ', '.join(args_str))
+                logger.warning('Command argument values from persistent parameters: %s', ', '.join(args_str))
 
         # TODO: This fundamentally alters the way Knack.invocation works here. Cannot be customized
         # with an event. Would need to be customized via inheritance.

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -304,7 +304,7 @@ class AzCliCommand(CLICommand):
                 local_context = self.cli_ctx.local_context
                 value = local_context.get(self.name, lca.name)
                 if value:
-                    logger.debug("local context '%s' for arg %s", value, arg.name)
+                    logger.debug("parameter persistence '%s' for arg %s", value, arg.name)
                     overrides.settings['default'] = DefaultStr(value)
                     overrides.settings['required'] = False
                     overrides.settings['default_value_source'] = 'Local Context'
@@ -596,13 +596,13 @@ class AzCliCommandInvoker(CommandInvoker):
                     value = getattr(parsed_args, name)
                     local_context_args.append((options[0], value))
             if local_context_args:
-                logger.warning('Local context is turned on. Its information is saved in working directory %s. You can '
-                               'run `az local-context off` to turn it off.',
+                logger.warning('Parameter persistence is turned on. Its information is saved in working directory %s. '
+                               'You can run `az config param-persist off` to turn it off.',
                                self.cli_ctx.local_context.effective_working_directory())
                 args_str = []
                 for name, value in local_context_args:
                     args_str.append('{}: {}'.format(name, value))
-                logger.warning('Command argument values from local context: %s', ', '.join(args_str))
+                logger.warning('Command argument values from parameter persistence: %s', ', '.join(args_str))
 
         # TODO: This fundamentally alters the way Knack.invocation works here. Cannot be customized
         # with an event. Would need to be customized via inheritance.

--- a/src/azure-cli-core/azure/cli/core/local_context.py
+++ b/src/azure-cli-core/azure/cli/core/local_context.py
@@ -14,7 +14,7 @@ from knack.config import _ConfigFile
 ALL = 'all'   # effective level of local context, ALL means all commands can share this parameter value
 LOCAL_CONTEXT_FILE = '.local_context_{}'  # each user has a separate file, an example is .local_context_username
 LOCAL_CONTEXT_ON_OFF_CONFIG_SECTION = 'local_context'
-LOCAL_CONTEXT_NOTICE = '; This file is used to store local context data.\n'\
+LOCAL_CONTEXT_NOTICE = '; This file is used to store parameter persistence data.\n'\
                        '; DO NOT modify it manually unless you know it well.\n'
 logger = get_logger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/local_context.py
+++ b/src/azure-cli-core/azure/cli/core/local_context.py
@@ -14,7 +14,7 @@ from knack.config import _ConfigFile
 ALL = 'all'   # effective level of local context, ALL means all commands can share this parameter value
 LOCAL_CONTEXT_FILE = '.local_context_{}'  # each user has a separate file, an example is .local_context_username
 LOCAL_CONTEXT_ON_OFF_CONFIG_SECTION = 'local_context'
-LOCAL_CONTEXT_NOTICE = '; This file is used to store parameter persistence data.\n'\
+LOCAL_CONTEXT_NOTICE = '; This file is used to store persistent parameters.\n'\
                        '; DO NOT modify it manually unless you know it well.\n'
 logger = get_logger(__name__)
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -111,7 +111,7 @@ def database_delete_func(client, resource_group_name=None, server_name=None, dat
     if resource_group_name is None or server_name is None or database_name is None:
         raise CLIError("Incorrect Usage : Deleting a database needs resource-group, server-name and database-name."
                        "If your parameter persistence is turned ON, make sure these three parameters exist in "
-                       "parameter persistence using \'az config param-persist show\'. "
+                       "persistent parameters using \'az config param-persist show\'. "
                        "If your parameter persistence is turned OFF, consider passing them explicitly.")
     if not yes:
         confirm = user_confirmation(

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -110,9 +110,9 @@ def database_delete_func(client, resource_group_name=None, server_name=None, dat
     result = None
     if resource_group_name is None or server_name is None or database_name is None:
         raise CLIError("Incorrect Usage : Deleting a database needs resource-group, server-name and database-name."
-                       "If your local context is turned ON, make sure these three parameters exist in local context "
-                       "using \'az local-context show\' If your local context is turned ON, but they are missing or "
-                       "If your local context is turned OFF, consider passing them explicitly.")
+                       "If your parameter persistence is turned ON, make sure these three parameters exist in "
+                       "parameter persistence using \'az config param-persist show\'. "
+                       "If your parameter persistence is turned OFF, consider passing them explicitly.")
     if not yes:
         confirm = user_confirmation(
             "Are you sure you want to delete the server '{0}' in resource group '{1}'".format(server_name,


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Resolve #17920

**Testing Guide**
<!--Example commands with explanations.-->
Run the following commands and check the output messages:
```
az config param-persist on
az group create -n test-rg -l westsus
az storage account create -n mytestsa -g test-rg --sku standard_lrs
az config param-persist off
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
