### PR TITLE
[AKS] az aks check-acr: add the nodeslector linux to avoid the "canipull" pod to be scheduled on the windows node

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1544,6 +1544,7 @@ def aks_check_acr(cmd, client, resource_group_name, name, acr):
                 {"name": "azurejson", "hostPath": {"path": "/etc/kubernetes"}},
                 {"name": "sslcerts", "hostPath": {"path": "/etc/ssl/certs"}},
             ],
+            "nodeSelector": {"kubernetes.io/os": "linux"},
         }
     }
 


### PR DESCRIPTION


**Description**<!--Mandatory-->
referring to the issue #17930 , the command will timeout when the "canipull" pod is scheduled on the windows node. The windows node doesn't support host network mode hence the pod will get stuck in container creating 
https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#networking-limitations

**Testing Guide**
Example usage: az aks check-acr -g <RG name>-n <Cluster> --acr xx.azurecr.io
Example YAML of "canipull" pod:
![image](https://user-images.githubusercontent.com/6046716/116674376-25aba200-a9d7-11eb-924a-4c801fa82f88.png)


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
