### PR TITLE
[DevTestLabs] az labs create environment: Fix error creating an environment from an ARM template

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/lab/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/custom.py
@@ -90,7 +90,8 @@ def create_environment(client, resource_group_name, lab_name, name, arm_template
 
     from azure.mgmt.devtestlabs.models import EnvironmentDeploymentProperties, DtlEnvironment
 
-    environment_deployment_properties = EnvironmentDeploymentProperties(arm_template_id=arm_template, parameters=parameters)
+    environment_deployment_properties = EnvironmentDeploymentProperties(arm_template_id=arm_template,
+                                                                        parameters=parameters)
     dtl_environment = DtlEnvironment(tags=tags,
                                      deployment_properties=environment_deployment_properties)
 

--- a/src/azure-cli/azure/cli/command_modules/lab/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/lab/custom.py
@@ -90,7 +90,7 @@ def create_environment(client, resource_group_name, lab_name, name, arm_template
 
     from azure.mgmt.devtestlabs.models import EnvironmentDeploymentProperties, DtlEnvironment
 
-    environment_deployment_properties = EnvironmentDeploymentProperties(arm_template, parameters)
+    environment_deployment_properties = EnvironmentDeploymentProperties(arm_template_id=arm_template, parameters=parameters)
     dtl_environment = DtlEnvironment(tags=tags,
                                      deployment_properties=environment_deployment_properties)
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
Running ```az labs create environment ...``` to produce an environment from an ARM template produces an error on azure-cli 2.23.0 as below

```
cli.azure.cli.core.azclierror: The command failed with an unexpected error. Here is the traceback:
az_command_data_logger: The command failed with an unexpected error. Here is the traceback:
cli.azure.cli.core.azclierror: __init__() takes 1 positional argument but 3 were given
Traceback (most recent call last):
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\knack/cli.py", line 231, in invoke
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 657, in execute
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 720, in _run_jobs_serially
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 691, in _run_job
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 328, in __call__
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/__init__.py", line 807, in default_command_handler
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/lab/custom.py", line 93, in create_environment
TypeError: __init__() takes 1 positional argument but 3 were given
az_command_data_logger: __init__() takes 1 positional argument but 3 were given
Traceback (most recent call last):
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\knack/cli.py", line 231, in invoke
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 657, in execute
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 720, in _run_jobs_serially
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 691, in _run_job
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 328, in __call__
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/__init__.py", line 807, in default_command_handler
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/lab/custom.py", line 93, in create_environment
TypeError: __init__() takes 1 positional argument but 3 were given
```

The error is fixed by making the parameters for creating the type EnvironmentDeploymentProperties from positional parameters to named parameters

**Testing Guide**
I have made the change and run the command from a VSCode debug session. I can now successfully create an environment.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
