### PR TITLE
[SQL] Split concatenated words in the help message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_params.py
@@ -1360,7 +1360,7 @@ def load_arguments(self, _):
 
         c.argument('assign_identity',
                    options_list=['--assign-identity', '-i'],
-                   help='Generate and assign an Azure Active Directory Identity for this server'
+                   help='Generate and assign an Azure Active Directory Identity for this server '
                    'for use with key management services like Azure KeyVault.')
 
     with self.argument_context('sql server update') as c:

--- a/src/azure-cli/azure/cli/command_modules/sql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_params.py
@@ -1325,7 +1325,7 @@ def load_arguments(self, _):
 
         c.argument('assign_identity',
                    options_list=['--assign_identity', '-i'],
-                   help='Generate and assign an Azure Active Directory Identity for this server'
+                   help='Generate and assign an Azure Active Directory Identity for this server '
                    'for use with key management services like Azure KeyVault.')
 
         c.argument('minimal_tls_version',


### PR DESCRIPTION
**Description**

I found some words are concatenated by mistake.

"serverfor" vs. "server for":

> ## az sql server create
> 
> ### Optional Parameters
> 
> `--assign-identity -i`  
> Generate and assign an Azure Active Directory Identity for this **serverfor** use with key management services like Azure KeyVault.

> ## az sql server update
> 
> ### Optional Parameters
> 
> `--assign_identity -i`  
> Generate and assign an Azure Active Directory Identity for this **serverfor** use with key management services like Azure KeyVault.

I fixed them.

**History Notes**

[SQL] az sql server create: Add a space to split the concatenated words in the help message of the argument --assign-identity.  
[SQL] az sql server update: Add a space to split the concatenated words in the help message of the argument --assign_identity.  

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
