### PR TITLE
{Core} Use `from collections.abc import Iterable` to support Python 3.10

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -1124,8 +1124,8 @@ def _load_azure_exception_class():
 # pylint: disable=no-member
 def _is_paged(obj):
     # Since loading msrest is expensive, we avoid it until we have to
-    import collections
-    if isinstance(obj, collections.Iterable) \
+    from collections.abc import Iterable
+    if isinstance(obj, Iterable) \
             and not isinstance(obj, list) \
             and not isinstance(obj, dict):
         from msrest.paging import Paged


### PR DESCRIPTION
importing the ABCs from 'collections' instead of from 'collections.abc'
is deprecated since Python 3.3, and in 3.10 it will stop working.

**Description**<!--Mandatory-->
On Python 3.10  running any az commands show the following error:
```console
$ az account list
The command failed with an unexpected error. Here is the traceback:
module 'collections' has no attribute 'Iterable'
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/knack/cli.py", line 231, in invoke
    cmd_result = self.invocation.execute(args)
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 657, in execute
    raise ex
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 720, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 703, in _run_job
    elif _is_paged(result):
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 1119, in _is_paged
    if isinstance(obj, collections.Iterable) \
AttributeError: module 'collections' has no attribute 'Iterable'
To open an issue, please run: 'az feedback'
```

**Testing Guide**
Testing any az commands like: az account list or az account get-access-token

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
