### PR TITLE
{CI} Ignore `fzf` in CI job `TestExtensionsLoading`

### DIFF
--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -20,7 +20,7 @@ exit_code=0
 
 # azure-cli-ml: https://github.com/Azure/azure-cli-extensions/issues/826
 # azure-iot: https://github.com/Azure/azure-cli/pull/17456
-block_list='azure-cli-ml azure-iot'
+block_list='azure-cli-ml azure-iot fzf'
 
 for ext in $output; do
     echo

--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -20,13 +20,13 @@ exit_code=0
 
 # azure-cli-ml: https://github.com/Azure/azure-cli-extensions/issues/826
 # azure-iot: https://github.com/Azure/azure-cli/pull/17456
-block_list='azure-cli-ml azure-iot fzf'
+ignore_list='azure-cli-ml azure-iot fzf'
 
 for ext in $output; do
     echo
-    # Use regex to detect if $ext is in $block_list
-    if [[ $block_list =~ $ext ]]; then
-        echo "Skip extension: $ext"
+    # Use regex to detect if $ext is in $ignore_list
+    if [[ $ignore_list =~ $ext ]]; then
+        echo "Ignore extension: $ext"
         continue
     fi
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
CI is blocked by

https://dev.azure.com/azure-sdk/public/_build/results?buildId=876833&view=logs&j=cedb4d72-63c2-581b-2274-24a4ef43c946&t=1b7b5e8c-f0d3-504e-ebf4-a86923fb02b9&l=1068

```
Verifying extension: fzf
WARNING: This package of the Batch Extensions module supports Azure Batch up to version 7.1. The current version 10.0.0 has not been tested for compatibility.
WARNING: This package of the Batch Extensions module supports Azure Batch Management up to version 6.1. The current version 9.0.0 has not been tested for compatibility.
WARNING: This package of the Batch Extensions module supports Azure Batch Extensions up to version 6.1. The current version 8.0.0 has not been tested for compatibility.
ERROR: Request to https://pahealy.blob.core.windows.net/azext-fzf/fzf-1.0.2-py2.py3-none-any.whl failed with 403
```

This is because the custom extension installation source https://pahealy.blob.core.windows.net/azext-fzf/fzf-1.0.2-py2.py3-none-any.whl is no longer available. 

Block `fzf` from CI job `TestExtensionsLoading`.