### PR TITLE
{Core} Always use UTF-8 for command metadata log file encoding

### DIFF
--- a/src/azure-cli-core/azure/cli/core/azlogging.py
+++ b/src/azure-cli-core/azure/cli/core/azlogging.py
@@ -30,7 +30,7 @@ import datetime
 from azure.cli.core.commands.events import EVENT_INVOKER_PRE_CMD_TBL_TRUNCATE
 
 from knack.events import EVENT_CLI_POST_EXECUTE
-from knack.log import CLILogging, get_logger
+from knack.log import CLILogging, get_logger, LOG_FILE_ENCODING
 from knack.util import ensure_dir
 
 
@@ -112,7 +112,7 @@ class AzCliLogging(CLILogging):
         log_file_path = os.path.join(self.command_log_dir, log_name)
         get_logger(__name__).debug("metadata file logging enabled - writing logs to '%s'.", log_file_path)
 
-        logfile_handler = logging.FileHandler(log_file_path)
+        logfile_handler = logging.FileHandler(log_file_path, encoding=LOG_FILE_ENCODING)
 
         lfmt = logging.Formatter(_CMD_LOG_LINE_PREFIX + ' %(process)d | %(asctime)s | %(levelname)s | %(name)s | %(message)s')  # pylint: disable=line-too-long
         logfile_handler.setFormatter(lfmt)

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -50,7 +50,7 @@ DEPENDENCIES = [
     'cryptography>=3.2,<3.4',
     'humanfriendly>=4.7,<10.0',
     'jmespath',
-    'knack~=0.8.1',
+    'knack~=0.8.2',
     'msal>=1.10.0,<2.0.0',
     # Dependencies of the vendored subscription SDK
     # https://github.com/Azure/azure-sdk-for-python/blob/ab12b048ddf676fe0ccec16b2167117f0609700d/sdk/resources/azure-mgmt-resource/setup.py#L82-L86

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -105,7 +105,7 @@ isodate==0.6.0
 Jinja2==2.11.3
 jmespath==0.9.5
 jsmin==2.2.2
-knack==0.8.1
+knack==0.8.2
 MarkupSafe==1.1.1
 mock==4.0.2
 msal==1.10.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -105,7 +105,7 @@ isodate==0.6.0
 Jinja2==2.11.3
 jmespath==0.9.5
 jsmin==2.2.2
-knack==0.8.1
+knack==0.8.2
 MarkupSafe==1.1.1
 mock==4.0.2
 msal==1.10.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -104,7 +104,7 @@ isodate==0.6.0
 Jinja2==2.11.3
 jmespath==0.9.5
 jsmin==2.2.2
-knack==0.8.1
+knack==0.8.2
 MarkupSafe==1.1.1
 mock==4.0.2
 msal==1.10.0


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/17994
Adopt https://github.com/microsoft/knack/pull/247

## Context

On Windows with English as the system language (without UTC-8 enabled), the system encoding by default is `cp1252` (Western Europe), and Python will use `cp1252` as the file encoding by default. 

Writing Unicode characters like `汉字` to log file results in error:

```
Traceback (most recent call last):
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python38\lib\logging\__init__.py", line 1084, in emit
    stream.write(msg + self.terminator)
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python38\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 87-88: character maps to <undefined>
```

## Change

This PR forces command metadata log files to use UTF-8 so that `az feedback` works on non-UTF-8 systems as well.