### PR TITLE
{AppService} Fix linter error in `_github_oauth.py`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
@@ -17,7 +17,7 @@ https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow
 '''
 
 
-def get_github_access_token(cmd, scope_list=None):
+def get_github_access_token(cmd, scope_list=None):  # pylint:disable=unused-import
     if scope_list:
         for scope in scope_list:
             if scope not in GITHUB_OAUTH_SCOPES:
@@ -30,11 +30,9 @@ def get_github_access_token(cmd, scope_list=None):
         'client_id': GITHUB_OAUTH_CLIENT_ID
     }
 
-    import base64
-    import json
     import requests
     import time
-    from urllib.parse import urlparse, parse_qs
+    from urllib.parse import parse_qs
 
     try:
         response = requests.post(authorize_url, data=authorize_url_data)

--- a/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py
@@ -17,7 +17,7 @@ https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow
 '''
 
 
-def get_github_access_token(cmd, scope_list=None):  # pylint:disable=unused-import
+def get_github_access_token(cmd, scope_list=None):  # pylint: disable=unused-argument
     if scope_list:
         for scope in scope_list:
             if scope not in GITHUB_OAUTH_SCOPES:


### PR DESCRIPTION
**Description**<!--Mandatory-->

For unknown reason, Pylint 2.3.0 fails to find linter errors in `_github_oauth.py` added by https://github.com/Azure/azure-cli/pull/17826.

After bumping Pylint 2.8.0 (https://github.com/Azure/azure-cli/pull/17861), those errors are revealed.

https://dev.azure.com/azure-sdk/public/_build/results?buildId=880573&view=logs&j=36dd4138-4d53-5e46-00d9-e5cd9744be05&t=1cf3879c-0a42-5ccd-7693-7a4781d739d8&l=107

```
src/azure-cli/azure/cli/command_modules/appservice/_github_oauth.py:20:28: W0613: Unused argument 'cmd' (unused-argument)
```