### PR TITLE
{Pylint} Ignore `tests` folders

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,3 +20,4 @@ exclude =
     build_scripts
     */grammar/
     vendored_sdks
+    tests

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,6 @@
 [MASTER]
-ignore-patterns=test_*,azure_devops_build_*
+ignore=tests,vendored_sdks,privates
+ignore-patterns=test.*,azure_devops_build.*
 reports=no
 
 [MESSAGES CONTROL]

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-ignore=tests,vendored_sdks,privates
+ignore=tests,generated,vendored_sdks,privates
 ignore-patterns=test.*,azure_devops_build.*
 reports=no
 


### PR DESCRIPTION
**Description**<!--Mandatory-->

Require https://github.com/Azure/azure-cli-dev-tools/pull/301

Due to https://github.com/PyCQA/pylint/issues/2686, `test.*` directories are not ignored. This causes files like `src/azure-cli/azure/cli/command_modules/billing/tests/__init__.py` to be checked which is not desired.

However, `ignore=tests` works because `tests` directories in Azure CLI are actually modules (because they contain `__init__.py`), so `pylint` goes through a different code path of `modutils.get_module_files`:

https://github.com/PyCQA/pylint/blob/8f84dec53d53b8297ef753277fc1d820becd8428/pylint/lint/expand_modules.py#L114-L121

```py
        if has_init or is_namespace or is_directory:
            for subfilepath in modutils.get_module_files(
                os.path.dirname(filepath), ignore_list, list_all=is_namespace
            ):
                if filepath == subfilepath:
                    continue
                if _basename_in_ignore_list_re(
                    os.path.basename(subfilepath), ignore_list_re
```
