### PR TITLE
[Network] - 8532 : Delete resources with tag

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -5269,6 +5269,9 @@ short-summary: Delete a virtual network.
 examples:
   - name: Delete a virtual network.
     text: az network vnet delete -g MyResourceGroup -n myVNet
+
+  - name: Delete all virtual networks by tag.
+    text: az network vnet delete --tag MyEn=Test
 """
 
 helps['network vnet list'] = """

--- a/src/azure-cli/azure/cli/command_modules/network/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/commands.py
@@ -1296,7 +1296,7 @@ def load_command_table(self, _):
 
     # region VirtualNetworks
     with self.command_group('network vnet', network_vnet_sdk) as g:
-        g.command('delete', 'begin_delete')
+        g.custom_command('delete', 'delete_vnet')
         g.custom_command('list', 'list_vnet', table_transformer=transform_vnet_table_output)
         g.show_command('show', 'get')
         g.command('check-ip-address', 'check_ip_address_availability', min_api='2016-09-01')

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -122,6 +122,22 @@ def list_application_gateways(cmd, resource_group_name=None):
 def list_network_watchers(cmd, resource_group_name=None):
     return _generic_list(cmd.cli_ctx, 'network_watchers', resource_group_name)
 
+
+def delete_vnet(cmd, virtual_network_name=None, resource_group_name=None, tags=None):
+    from msrestazure.tools import parse_resource_id
+    vnet_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_NETWORK).virtual_networks
+    if tags is not None:
+        for vnet in list_vnet(cmd, None):
+            # TODO compliance vtw python3 and python2 ?
+            if len(tags) == len(set(tags.items()) & set(vnet.tags.items())):
+                resource = parse_resource_id(vnet.id)
+                vnet_client.begin_delete(resource.get('resource_group', None), resource.get('name', None))
+    else:
+        from msrest.exceptions import ValidationError
+        try:
+            vnet_client.begin_delete(resource_group_name, virtual_network_name)
+        except ValidationError:
+            raise ValidationError("required", "(--resource-group | --ids)", None)
 # endregion
 
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -1937,6 +1937,9 @@ examples:
   - name: Delete a virtual machine named 'MyVm' by using the latest api-version whether this version is a preview version.
     text: >
         az resource delete -g MyResourceGroup -n MyVm --resource-type "Microsoft.Compute/virtualMachines" --latest-include-preview
+  - name: Delete all resources tagged 'testing'
+    text: >
+        az resource delete -g MyResourceGroup -t testing
 """
 
 helps['resource invoke-action'] = """

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1671,7 +1671,6 @@ def delete_resource(cmd, resource_ids=None, resource_group_name=None,
         from msrestazure.tools import parse_resource_id
         # TODO : maybe add a check Resource class in order to access to id (isinstanceof(Resource)) ?
         resources = [parse_resource_id(resource.id) for resource in resources]
-        logger.info(f"resources {resources}")
         parsed_ids = [_create_parsed_id(cmd.cli_ctx,
                                         resource.get('resource_group', None),
                                         resource.get('namespace', None),

--- a/src/azure-cli/azure/cli/command_modules/vm/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_help.py
@@ -1133,6 +1133,9 @@ examples:
     text: >
         az vm delete --ids $(az vm list -g MyResourceGroup --query "[].id" -o tsv)
 
+  - name: Delete VMs in a resource group with a tag.
+    text: >
+        az vm delete --tag MyEnv=Test
 """
 
 helps['vm diagnostics'] = """

--- a/src/azure-cli/azure/cli/command_modules/vm/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/commands.py
@@ -269,7 +269,7 @@ def load_command_table(self, _):
         g.custom_command('create', 'create_vm', transform=transform_vm_create_output, supports_no_wait=True, table_transformer=deployment_validate_table_format, validator=process_vm_create_namespace, exception_handler=handle_template_based_exception)
         g.command('convert', 'begin_convert_to_managed_disks', min_api='2016-04-30-preview')
         g.command('deallocate', 'begin_deallocate', supports_no_wait=True)
-        g.command('delete', 'begin_delete', confirmation=True, supports_no_wait=True)
+        g.custom_command('delete', 'delete_vm', confirmation=True, supports_no_wait=True)
         g.command('generalize', 'generalize', supports_no_wait=True)
         g.custom_command('get-instance-view', 'get_instance_view', table_transformer='{Name:name, ResourceGroup:resourceGroup, Location:location, ProvisioningState:provisioningState, PowerState:instanceView.statuses[1].displayStatus}')
         g.custom_command('list', 'list_vm', table_transformer=transform_vm_list)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR implement the deletion by tag for the command `az resource delete`, `az vm delete` and `az network vnet delete` in the issue #8532

In order to achieve this objective, the `command` are replace by `custom_command` and some `help` are added

**Testing Guide**
<!--Example commands with explanations.-->
`az resource delete --tag # deletes all resources that have a specific tag`
`az vm delete --tag # deletes all VMs that have a specific tag`
`az network vnet delete --tag # deletes all vnets that have a specific tag`

**Questions**
* Could you explain me how to add and modify some tests, in order to test the different modifications ?
* Do you want a `Python2` retro-compatibility ?

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
