### PR TITLE
[AppService] Fix #17850 - prevent duplicate rules for service endpoints

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/access_restrictions.py
@@ -58,7 +58,11 @@ def add_webapp_access_restriction(
         subnet_id = _validate_subnet(cmd.cli_ctx, subnet, vnet_name, vnet_rg)
         if not ignore_missing_vnet_service_endpoint:
             _ensure_subnet_service_endpoint(cmd.cli_ctx, subnet_id)
-
+        # check for duplicates
+        for rule in list(access_rules):
+            if rule.vnet_subnet_resource_id and rule.vnet_subnet_resource_id.lower() == subnet_id.lower():
+                raise ArgumentUsageError('Service endpoint rule for: ' + subnet_id + ' already exists. '
+                                         'Cannot add duplicate service endpoint rules.')
         rule_instance = IpSecurityRestriction(
             name=rule_name, vnet_subnet_resource_id=subnet_id,
             priority=priority, action=action, tag='Default', description=description)
@@ -113,7 +117,7 @@ def remove_webapp_access_restriction(cmd, resource_group_name, name, rule_name=N
                 break
         elif subnet:
             subnet_id = _validate_subnet(cmd.cli_ctx, subnet, vnet_name, resource_group_name)
-            if rule.vnet_subnet_resource_id == subnet_id and rule.action == action:
+            if rule.vnet_subnet_resource_id.lower() == subnet_id.lower() and rule.action == action:
                 if rule_name and (not rule.name or (rule.name and rule.name.lower() != rule_name.lower())):
                     continue
                 rule_instance = rule


### PR DESCRIPTION
Fixes #17850 
**Description**<!--Mandatory-->
Small change to ensure duplicate rules are not created for service endpoints (subnet/vnet) and make remove command case-insensitive.

**Testing Guide**
az webapp config access-restriction add -g <rg> -n <webapp> -p 2 --subnet <subnet-name> --vnet-name <vnet-name>
az webapp config access-restriction add -g <rg> -n <webapp> -p 2 --subnet <subnet-name> --vnet-name <vnet-name>

run twice should throw an exception - even if casing is different

az webapp config access-restriction remove -g <rg> -n <webapp> --subnet <subnet-name> --vnet-name <vnet-name>

rule should be removed - even if casing is different.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
[App Service] az webapp/functionapp config access-restriction add: Prevent duplicate rules using service endpoints.
[App Service] az webapp/functionapp config access-restriction remove: Remove service endpoints are case-insensitive
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
