### PR TITLE
[App Service] az staticwebapp appsettings set issue #17792

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -265,8 +265,8 @@ def _parse_pair(pair, delimiter):
     if delimiter not in pair:
         CLIError("invalid format of pair {0}".format(pair))
 
-    pair_split = pair.split(delimiter)
-    return pair_split[0], pair_split[1]
+    index = pair.index(delimiter)
+    return pair[:index], pair[1 + index:]
 
 
 def _raise_missing_token_suggestion():

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -296,8 +296,8 @@ class TestStaticAppCommands(unittest.TestCase):
             self.rg1, self.name1)
 
     def test_set_staticsite_function_app_settings_with_resourcegroup(self):
-        app_settings1_input = ['key1=val1', 'key2=val2']
-        app_settings1_dict = {'key1': 'val1', 'key2': 'val2'}
+        app_settings1_input = ['key1=val1', 'key2=val2==', 'key3=val3=']
+        app_settings1_dict = {'key1': 'val1', 'key2': 'val2==', 'key3': 'val3='}
 
         set_staticsite_function_app_settings(self.mock_cmd, self.name1, app_settings1_input, self.rg1)
 
@@ -305,8 +305,8 @@ class TestStaticAppCommands(unittest.TestCase):
             self.rg1, self.name1, kind=None, properties=app_settings1_dict)
 
     def test_set_staticsite_function_app_settings_without_resourcegroup(self):
-        app_settings1_input = ['key1=val1', 'key2=val2']
-        app_settings1_dict = {'key1': 'val1', 'key2': 'val2'}
+        app_settings1_input = ['key1=val1', 'key2=val2==', 'key3=val3=']
+        app_settings1_dict = {'key1': 'val1', 'key2': 'val2==', 'key3': 'val3='}
         self.staticapp_client.list.return_value = [self.app1, self.app2]
 
         set_staticsite_function_app_settings(self.mock_cmd, self.name1, app_settings1_input)


### PR DESCRIPTION
**Description**<!--Mandatory-->
This is a fix for this [PR](https://github.com/Azure/azure-cli/issues/17792). You can't set static web app settings if the value contains an equal sign.

**Testing Guide**
`az staticwebapp appsettings set --app-settings foo=bar==` 
That should produce {"foo": "bar=="}

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
