### PR TITLE
{Core} Change resource group preparer in testsdk

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -64,7 +64,10 @@ class ResourceGroupPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
         self.key = key
 
         self.dev_setting_name = os.environ.get(dev_setting_name, None)
-        self.dev_setting_location = os.environ.get(dev_setting_location, location)
+        # use environment variable to modify the default value of location
+        self.dev_setting_location = os.environ.get(dev_setting_location, None)
+        if self.dev_setting_location is not None and self.dev_setting_location != "":
+            self.location = self.dev_setting_location
 
     def create_resource(self, name, **kwargs):
         if self.dev_setting_name:

--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -66,7 +66,7 @@ class ResourceGroupPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
         self.dev_setting_name = os.environ.get(dev_setting_name, None)
         # use environment variable to modify the default value of location
         self.dev_setting_location = os.environ.get(dev_setting_location, None)
-        if self.dev_setting_location is not None and self.dev_setting_location != "":
+        if self.dev_setting_location:
             self.location = self.dev_setting_location
 
     def create_resource(self, name, **kwargs):


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Modify resource group preparer, replace the default value of location with the value of 
 'AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION', so that we can leverage the preparer of testsdk to automatically create and delete resource groups at the **specified location** (*rather than hardcoded default location*) when performing live tests.

Would like to know if there are other ways to change the default value of location in the preparer.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
