### PR TITLE
[AppService] Fix#18033: az staticwebapp appsettings set of missing positional param app_settings

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -120,7 +120,7 @@ def set_staticsite_function_app_settings(cmd, name, setting_pairs, resource_grou
         setting_dict[key] = value
 
     return client.create_or_update_static_site_function_app_settings(
-        resource_group_name, name, kind=None, properties=setting_dict)
+        resource_group_name, name, app_settings=setting_dict)
 
 
 def delete_staticsite_function_app_settings(cmd, name, setting_names, resource_group_name=None):
@@ -137,7 +137,7 @@ def delete_staticsite_function_app_settings(cmd, name, setting_names, resource_g
             logger.warning("key '%s' not found in app settings", key)
 
     return client.create_or_update_static_site_function_app_settings(
-        resource_group_name, name, kind=None, properties=app_settings)
+        resource_group_name, name, app_settings=app_settings)
 
 
 def list_staticsite_users(cmd, name, resource_group_name=None, authentication_provider='all'):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -245,7 +245,7 @@ class TestStaticAppCommands(unittest.TestCase):
         set_staticsite_function_app_settings(self.mock_cmd, self.name1, app_settings1_input, self.rg1)
 
         self.staticapp_client.create_or_update_static_site_function_app_settings.assert_called_once_with(
-            self.rg1, self.name1, kind=None, properties=app_settings1_dict)
+            self.rg1, self.name1, app_settings=app_settings1_dict)
 
     def test_set_staticsite_function_app_settings_without_resourcegroup(self):
         app_settings1_input = ['key1=val1', 'key2=val2']
@@ -255,7 +255,7 @@ class TestStaticAppCommands(unittest.TestCase):
         set_staticsite_function_app_settings(self.mock_cmd, self.name1, app_settings1_input)
 
         self.staticapp_client.create_or_update_static_site_function_app_settings.assert_called_once_with(
-            self.rg1, self.name1, kind=None, properties=app_settings1_dict)
+            self.rg1, self.name1, app_settings=app_settings1_dict)
 
     def test_delete_staticsite_function_app_settings_with_resourcegroup(self):
         # setup
@@ -273,7 +273,7 @@ class TestStaticAppCommands(unittest.TestCase):
 
         # validate
         self.staticapp_client.create_or_update_static_site_function_app_settings.assert_called_once_with(
-            self.rg1, self.name1, kind=None, properties=updated_app_settings)
+            self.rg1, self.name1, app_settings=updated_app_settings)
 
     def test_delete_staticsite_function_app_settings_without_resourcegroup(self):
         # setup
@@ -292,7 +292,7 @@ class TestStaticAppCommands(unittest.TestCase):
 
         # validate
         self.staticapp_client.create_or_update_static_site_function_app_settings.assert_called_once_with(
-            self.rg1, self.name1, kind=None, properties=updated_app_settings)
+            self.rg1, self.name1, app_settings=updated_app_settings)
 
     def test_list_staticsite_users_with_resourcegroup(self):
         authentication_provider = 'GitHub'


### PR DESCRIPTION
**Description**<!--Mandatory-->
Fix#18033: az staticwebapp appsettings set of missing positional param app_settings

**Testing Guide**
az staticwebapp appsettings set -n staticwebappname --setting-names foo=bar

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
