### PR TITLE
{Core} `az extension`: Retry `shutil.rmtree`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -81,7 +81,7 @@ def _validate_whl_extension(ext_file):
     zip_ref.extractall(tmp_dir)
     zip_ref.close()
     azext_metadata = WheelExtension.get_azext_metadata(tmp_dir)
-    shutil.rmtree(tmp_dir)
+    rmtree_with_retry(tmp_dir)
     check_version_compatibility(azext_metadata)
 
 
@@ -169,7 +169,7 @@ def _add_whl_ext(cli_ctx, source, ext_sha256=None, pip_extra_index_urls=None, pi
         pip_status_code = _run_pip(pip_args, extension_path)
     if pip_status_code > 0:
         logger.debug('Pip failed so deleting anything we might have installed at %s', extension_path)
-        shutil.rmtree(extension_path, ignore_errors=True)
+        rmtree_with_retry(extension_path)
         raise CLIError('An error occurred. Pip failed with status code {}. '
                        'Use --debug for more information.'.format(pip_status_code))
     # Save the whl we used to install the extension in the extension dir.
@@ -351,10 +351,6 @@ def add_extension(cmd=None, source=None, extension_name=None, index_url=None, ye
 
 
 def remove_extension(extension_name):
-    def log_err(func, path, exc_info):
-        logger.warning("Error occurred attempting to delete item from the extension '%s'.", extension_name)
-        logger.warning("%s: %s - %s", func, path, exc_info)
-
     try:
         # Get the extension and it will raise an error if it doesn't exist
         ext = get_extension(extension_name)
@@ -364,7 +360,7 @@ def remove_extension(extension_name):
                 "`azdev extension remove {name}`".format(name=extension_name))
         # We call this just before we remove the extension so we can get the metadata before it is gone
         _augment_telemetry_with_ext_info(extension_name, ext)
-        shutil.rmtree(ext.path, onerror=log_err)
+        rmtree_with_retry(ext.path)
         CommandIndex().invalidate()
     except ExtensionNotInstalledException as e:
         raise CLIError(e)
@@ -408,13 +404,13 @@ def update_extension(cmd=None, extension_name=None, index_url=None, pip_extra_in
         logger.debug('Backing up the current extension: %s to %s', extension_path, backup_dir)
         shutil.copytree(extension_path, backup_dir)
         # Remove current version of the extension
-        shutil.rmtree(extension_path)
+        rmtree_with_retry(extension_path)
         # Install newer version
         try:
             _add_whl_ext(cli_ctx=cmd_cli_ctx, source=download_url, ext_sha256=ext_sha256,
                          pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy)
             logger.debug('Deleting backup of old extension at %s', backup_dir)
-            shutil.rmtree(backup_dir)
+            rmtree_with_retry(backup_dir)
         except Exception as err:
             logger.error('An error occurred whilst updating.')
             logger.error(err)
@@ -563,3 +559,22 @@ def check_distro_consistency():
                      "for your distribution or change the above file accordingly.")
         logger.debug("Linux distro check: %s has '%s', current distro is '%s'",
                      LIST_FILE_PATH, stored_linux_dist_name, current_linux_dist_name)
+
+
+def rmtree_with_retry(path):
+    # A workaround for https://bugs.python.org/issue33240
+    # Retry shutil.rmtree several times, but even if it fails after several retries, don't block the command execution.
+    retry_num = 3
+    import time
+    while True:
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError as err:
+            if retry_num > 0:
+                logger.warning("Failed to delete '%s': %s. Retrying ...", path, err)
+                retry_num -= 1
+                time.sleep(1)
+            else:
+                logger.warning("Failed to delete '%s': %s. You may try to delete it manually.", path, err)
+                break


### PR DESCRIPTION
## Description

Fix #17961

Due to https://bugs.python.org/issue33240, there is a very small chance that [`shutil.rmtree`](https://docs.python.org/3/library/shutil.html#shutil.rmtree) fails on Windows. 

(Personally, I have also observed it even when deleting a directory with `explorer.exe` - the contents of the directory is deleted but the directory remains.)

## Changes

- Add a retry logic to `shutil.rmtree`
- Even if `shutil.rmtree` fails after several retries, the failure doesn't block command execution
