### PR TITLE
[AppService] Add interactive way to get token for staticwebapp

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2307,7 +2307,10 @@ helps['staticwebapp create'] = """
     examples:
     - name: Create static app in a subscription.
       text: az staticwebapp create -n MyStaticAppName -g MyExistingRg
-       -s https://github.com/JohnDoe/my-first-static-web-app -l WestUs2 -b master
+       -s https://github.com/JohnDoe/my-first-static-web-app -l WestUs2 -b master -t MyAccessToken
+    - name: Create static app in a subscription, retrieving token interactively
+      text: az staticwebapp create -n MyStaticAppName -g MyExistingRg
+       -s https://github.com/JohnDoe/my-first-static-web-app -l WestUs2 -b master --login-with-github
 """
 
 helps['staticwebapp update'] = """
@@ -2332,6 +2335,8 @@ helps['staticwebapp reconnect'] = """
     examples:
     - name: Connect a repo and branch to static app.
       text: az staticwebapp reconnect -n MyStaticAppName --source MyGitHubRepo -b master --token MyAccessToken
+    - name: Connect a repo and branch to static app, retrieving token interactively
+      text: az staticwebapp reconnect -n MyStaticAppName --source MyGitHubRepo -b master --login-with-github
 """
 
 helps['staticwebapp delete'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -984,8 +984,9 @@ def load_arguments(self, _):
         c.argument('token', options_list=['--token', '-t'],
                    help="A user's github repository token. This is used to setup the Github Actions workflow file and "
                         "API secrets. If you need to create a Github Personal Access Token, "
-                        "please follow the steps found at the following link:\n"
+                        "please run with the '--login-with-github' flag or follow the steps found at the following link:\n"
                         "https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line")
+        c.argument('login_with_github', help="Interactively log in with Github to retrieve the Personal Access Token")
         c.argument('branch', options_list=['--branch', '-b'], help="The target branch in the repository.")
     with self.argument_context('staticwebapp environment') as c:
         c.argument('environment_name',

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -200,6 +200,8 @@ def create_staticsites(cmd, resource_group_name, name, location,
         from ._github_oauth import get_github_access_token
         scopes = ["admin:repo_hook", "repo", "workflow"]
         token = get_github_access_token(cmd, scopes)
+    elif token and login_with_github:
+        logger.warning("Both token and --login-with-github flag are provided. Will use provided token")
 
     StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription = cmd.get_models(
         'StaticSiteARMResource', 'StaticSiteBuildProperties', 'SkuDescription')

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -200,7 +200,7 @@ class TestStaticAppCommands(unittest.TestCase):
                              resource_group_name=self.rg1)
 
         create_staticsites_mock.assert_called_once_with(self.mock_cmd, self.rg1, self.name1, self.location1,
-                                                        self.source1, self.branch1, self.token1, no_wait=False)
+                                                        self.source1, self.branch1, self.token1, login_with_github=False, no_wait=False)
 
     @mock.patch('azure.cli.command_modules.appservice.static_sites.create_staticsites', autospec=True)
     def test_reconnect_staticapp_without_resourcegroup(self, create_staticsites_mock):
@@ -209,7 +209,7 @@ class TestStaticAppCommands(unittest.TestCase):
         reconnect_staticsite(self.mock_cmd, self.name1, self.source1, self.branch1, self.token1)
 
         create_staticsites_mock.assert_called_once_with(self.mock_cmd, self.rg1, self.name1, self.location1,
-                                                        self.source1, self.branch1, self.token1, no_wait=False)
+                                                        self.source1, self.branch1, self.token1, login_with_github=False, no_wait=False)
 
     def test_list_staticsite_environments_with_resourcegroup(self):
         list_staticsite_environments(self.mock_cmd, self.name1, self.rg1)


### PR DESCRIPTION
**Description**<!--Mandatory-->
Let users get github personal access token interactively using https://github.com/Azure/azure-cli/pull/17826

**Testing Guide**
`az staticwebapp create --login-with-github`
`az staticwebapp reconnect --login-with-github`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
