### PR TITLE
[AppService] Fix get resource management client properly

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
@@ -42,9 +42,9 @@ def dns_client_factory(cli_ctx, api_version=None, **_):
 
 
 def providers_client_factory(cli_ctx):
-    from azure.mgmt.resource import ResourceManagementClient
+    from azure.cli.core.profiles import ResourceType
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(cli_ctx, ResourceManagementClient).providers
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES).providers
 
 
 def cf_plans(cli_ctx, _):

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_list_locations_free_sku.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_webapp_list_locations_free_sku.yaml
@@ -13,10 +13,7 @@ interactions:
       ParameterSetName:
       - --sku
       User-Agent:
-      - python/3.8.2 (macOS-10.16-x86_64-i386-64bit) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-resource/12.0.0 Azure-SDK-For-Python AZURECLI/2.21.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.23.0 azsdk-python-azure-mgmt-resource/16.1.0 Python/3.6.7 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web?api-version=2020-10-01
   response:
@@ -93,16 +90,16 @@ interactions:
         East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
         US (Stage)","North Central US (Stage)","France Central","South Africa North","Australia
         Central","Switzerland North","Germany West Central","Norway East","UAE North","East
-        US 2 EUAP","Central US EUAP"],"apiVersions":["2020-10-01"],"capabilities":"None"},{"resourceType":"locations/webAppStacks","locations":["South
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01"],"capabilities":"None"},{"resourceType":"locations/webAppStacks","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-10-01"],"capabilities":"None"},{"resourceType":"functionAppStacks","locations":["Central
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01"],"capabilities":"None"},{"resourceType":"functionAppStacks","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -111,22 +108,28 @@ interactions:
         East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
         US (Stage)","North Central US (Stage)","France Central","South Africa North","Australia
         Central","Switzerland North","Germany West Central","Norway East","UAE North","East
-        US 2 EUAP","Central US EUAP"],"apiVersions":["2020-10-01"],"capabilities":"None"},{"resourceType":"locations/functionAppStacks","locations":["South
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01"],"capabilities":"None"},{"resourceType":"locations/functionAppStacks","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-10-01"],"capabilities":"None"},{"resourceType":"staticSites","locations":["West
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01"],"capabilities":"None"},{"resourceType":"staticSites","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
         US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"locations/previewStaticSiteWorkflowFile","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"listSitesAssignedToHostName","locations":["Central
+        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSites/builds","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"listSitesAssignedToHostName","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -164,40 +167,40 @@ interactions:
         US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/networkConfig","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/networkConfig","locations":["South
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/networkConfig","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/hostNameBindings","locations":["South
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/hostNameBindings","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/hostNameBindings","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["Central
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -209,95 +212,96 @@ interactions:
         US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"certificates","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","West US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossSubscriptionResourceMove,
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossSubscriptionResourceMove,
         SupportsTags, SupportsLocation"},{"resourceType":"serverFarms","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway East","UAE North","Switzerland
-        North","UK West","Australia Southeast","Korea South","Canada Central","West
-        Europe","South India","West Central US","East Asia (Stage)","North Central
-        US (Stage)","East Asia","Japan East","East US 2 EUAP","Central US EUAP","West
-        US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway East","UAE North","Switzerland North","North Central US","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","East Asia (Stage)","North Central US (Stage)","East
+        Asia","Japan East","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"sites","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway East","UAE North","Switzerland
-        North","UK West","Australia Southeast","Korea South","Canada Central","West
-        Europe","South India","West Central US","East Asia (Stage)","North Central
-        US (Stage)","East Asia","Japan East","East US 2 EUAP","Central US EUAP","West
-        US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway East","UAE North","Switzerland North","North Central US","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","East Asia (Stage)","North Central US (Stage)","East
+        Asia","Japan East","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"sites/slots","locations":["South Central
         US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway East","UAE North","Switzerland
-        North","UK West","Australia Southeast","Korea South","Canada Central","West
-        Europe","South India","West Central US","East Asia (Stage)","North Central
-        US (Stage)","East Asia","Japan East","East US 2 EUAP","Central US EUAP","West
-        US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway East","UAE North","Switzerland North","North Central US","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","East Asia (Stage)","North Central US (Stage)","East
+        Asia","Japan East","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"runtimes","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"recommendations","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"resourceHealthMetadata","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"georegions","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/premieraddons","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","West US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"hostingEnvironments","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Central US","South Africa North","West US 2","East US 2","East
         US","UK South","Southeast Asia","North Europe","Japan East","West Europe","East
-        Asia","Australia East","Brazil South","Japan West","Central India","Canada
-        East","Korea Central","France Central","West India","Australia Central","Germany
-        West Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","South India","West Central US","East
-        Asia (Stage)","North Central US (Stage)","West US","Central US","North Central
-        US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"zoneMappings":[{"location":"East
-        US 2","zones":["2","3","1"]},{"location":"Central US","zones":["2","3","1"]},{"location":"West
-        Europe","zones":["2","3","1"]},{"location":"East US 2 EUAP","zones":["2","3","1"]},{"location":"Central
-        US EUAP","zones":[]},{"location":"France Central","zones":["2","3","1"]},{"location":"Southeast
-        Asia","zones":["2","3","1"]},{"location":"West US 2","zones":["2","3","1"]},{"location":"North
-        Europe","zones":["2","3","1"]},{"location":"East US","zones":["2","3","1"]},{"location":"UK
-        South","zones":["2","3","1"]},{"location":"Japan East","zones":["2","3","1"]},{"location":"Australia
-        East","zones":["2","3","1"]},{"location":"South Africa North","zones":["2","3","1"]},{"location":"South
-        Central US","zones":["2","3","1"]},{"location":"Canada Central","zones":["2","3","1"]},{"location":"Germany
-        West Central","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Central
+        Asia","West US","Australia East","Brazil South","Central US","Japan West","Central
+        India","Canada East","Korea Central","France Central","West India","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","South
+        India","West Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"zoneMappings":[{"location":"East
+        US 2","zones":["2","1","3"]},{"location":"Central US","zones":["2","1","3"]},{"location":"West
+        Europe","zones":["2","1","3"]},{"location":"East US 2 EUAP","zones":["2","1","3"]},{"location":"Central
+        US EUAP","zones":[]},{"location":"France Central","zones":["2","1","3"]},{"location":"Southeast
+        Asia","zones":["2","1","3"]},{"location":"West US 2","zones":["2","1","3"]},{"location":"North
+        Europe","zones":["2","1","3"]},{"location":"East US","zones":["2","1","3"]},{"location":"UK
+        South","zones":["2","1","3"]},{"location":"Japan East","zones":["2","1","3"]},{"location":"Australia
+        East","zones":["2","1","3"]},{"location":"South Africa North","zones":["2","1","3"]},{"location":"South
+        Central US","zones":["2","1","3"]},{"location":"Canada Central","zones":["2","1","3"]},{"location":"Germany
+        West Central","zones":["2","1","3"]},{"location":"Brazil South","zones":["2","1","3"]},{"location":"Central
         India","zones":[]},{"location":"Korea Central","zones":[]},{"location":"Norway
-        East","zones":[]}],"capabilities":"SupportsTags, SupportsLocation"},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        East","zones":[]},{"location":"East Asia","zones":[]}],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"hostingEnvironments/workerPools","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"kubeEnvironments","locations":["North
-        Central US (Stage)","Central US EUAP"],"apiVersions":["2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"kubeEnvironments","locations":["North
+        Central US (Stage)","West Central US","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"deploymentLocations","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
@@ -309,31 +313,31 @@ interactions:
         North","Germany West Central","Norway East","UAE North"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"deletedSites","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deletedSites","locations":["South
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deletedSites","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["South
-        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway East","UAE North","Switzerland
-        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
         Europe","South India","West Central US","East Asia (Stage)","North Central
-        US (Stage)","East Asia","Japan East","East US 2 EUAP","Central US EUAP","West
-        US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-11-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"connections","locations":["North
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway East","UAE North","Switzerland North","North Central US","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","East Asia (Stage)","North Central US (Stage)","East
+        Asia","Japan East","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-11-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"connections","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
@@ -437,41 +441,44 @@ interactions:
         Central","Switzerland North","Germany West Central","Norway East","UAE North","East
         US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"serverFarms/eventGridFilters","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway West","Norway East","UAE
-        North","Switzerland North","UK West","Australia Southeast","Korea South","Canada
-        Central","West Europe","South India","West Central US","East Asia (Stage)","North
-        Central US (Stage)","East Asia","Japan East","South Africa West","East US
-        2 EUAP","Central US EUAP","West US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"sites/eventGridFilters","locations":["South
-        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway West","Norway East","UAE
-        North","Switzerland North","UK West","Australia Southeast","Korea South","Canada
-        Central","West Europe","South India","West Central US","East Asia (Stage)","North
-        Central US (Stage)","East Asia","Japan East","South Africa West","East US
-        2 EUAP","Central US EUAP","West US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"sites/slots/eventGridFilters","locations":["South
-        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway West","Norway East","Switzerland
-        North","UAE North","UK West","Australia Southeast","Korea South","Canada Central","West
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway West","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
         Europe","South India","West Central US","East Asia (Stage)","North Central
         US (Stage)","East Asia","Japan East","South Africa West","East US 2 EUAP","Central
-        US EUAP","West US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"hostingEnvironments/eventGridFilters","locations":["South
-        Central US","Brazil South","Canada East","UK West","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central US (Stage)","South
-        Africa North","West US 2","East US 2","East US","UK South","Southeast Asia","North
-        Europe","Japan East","West Europe","East Asia","Australia East","Japan West","Central
-        India","Korea Central","France Central","West India","Australia Central","Germany
-        West Central","Norway East","Switzerland North","UAE North","Australia Southeast","Korea
-        South","Canada Central","South India","West Central US","East Asia (Stage)","North
-        Central US (Stage)","West US","Central US","North Central US","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps","locations":["South
+        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"sites/eventGridFilters","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway West","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East Asia","Japan East","South Africa West","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"sites/slots/eventGridFilters","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway West","Norway East","Switzerland North","UAE North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East Asia","Japan East","South Africa West","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"hostingEnvironments/eventGridFilters","locations":["West
+        US","North Central US","South Central US","Brazil South","Canada East","UK
+        West","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US 2","East
+        US 2","East US","UK South","Southeast Asia","North Europe","Japan East","West
+        Europe","East Asia","Australia East","Central US","Japan West","Central India","Korea
+        Central","France Central","West India","Australia Central","Germany West Central","Norway
+        East","Switzerland North","UAE North","Australia Southeast","Korea South","Canada
+        Central","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
         East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
@@ -496,11 +503,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '65301'
+      - '66264'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Mar 2021 19:29:24 GMT
+      - Wed, 19 May 2021 16:00:28 GMT
       expires:
       - '-1'
       pragma:
@@ -528,7 +535,7 @@ interactions:
       ParameterSetName:
       - --sku
       User-Agent:
-      - AZURECLI/2.21.0 azsdk-python-azure-mgmt-web/2.0.0 Python/3.8.2 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.23.0 azsdk-python-azure-mgmt-web/2.0.0 Python/3.6.7 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions?sku=FREE&api-version=2020-09-01
   response:
@@ -605,7 +612,7 @@ interactions:
         Central","name":"Korea Central","type":"Microsoft.Web/geoRegions","properties":{"name":"Korea
         Central","description":null,"sortOrder":2147483647,"displayName":"Korea Central","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;DSERIES;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/France
         South","name":"France South","type":"Microsoft.Web/geoRegions","properties":{"name":"France
-        South","description":null,"sortOrder":2147483647,"displayName":"France South","orgDomain":"PUBLIC;DSERIES"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/France
+        South","description":null,"sortOrder":2147483647,"displayName":"France South","orgDomain":"PUBLIC;LINUX;LINUXDSERIES;DSERIES"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/France
         Central","name":"France Central","type":"Microsoft.Web/geoRegions","properties":{"name":"France
         Central","description":null,"sortOrder":2147483647,"displayName":"France Central","orgDomain":"PUBLIC;MSFTPUBLIC;DSERIES;DYNAMIC;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
         Central 2","name":"Australia Central 2","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
@@ -613,7 +620,7 @@ interactions:
         Central 2","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;ELASTICPREMIUM"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
         Central","name":"Australia Central","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
         Central","description":null,"sortOrder":2147483647,"displayName":"Australia
-        Central","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;ELASTICPREMIUM"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
+        Central","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;ELASTICPREMIUM;ELASTICLINUX"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
         Africa North","name":"South Africa North","type":"Microsoft.Web/geoRegions","properties":{"name":"South
         Africa North","description":null,"sortOrder":2147483647,"displayName":"South
         Africa North","orgDomain":"PUBLIC;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;LINUXDSERIES;DSERIES;ELASTICPREMIUM;ELASTICLINUX"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
@@ -646,11 +653,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '18501'
+      - '18533'
       content-type:
       - application/json
       date:
-      - Wed, 31 Mar 2021 19:29:24 GMT
+      - Wed, 19 May 2021 16:00:28 GMT
       expires:
       - '-1'
       pragma:
@@ -686,10 +693,7 @@ interactions:
       ParameterSetName:
       - --sku
       User-Agent:
-      - python/3.8.2 (macOS-10.16-x86_64-i386-64bit) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-resource/12.0.0 Azure-SDK-For-Python AZURECLI/2.21.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.23.0 azsdk-python-azure-mgmt-resource/16.1.0 Python/3.6.7 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web?api-version=2020-10-01
   response:
@@ -766,16 +770,16 @@ interactions:
         East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
         US (Stage)","North Central US (Stage)","France Central","South Africa North","Australia
         Central","Switzerland North","Germany West Central","Norway East","UAE North","East
-        US 2 EUAP","Central US EUAP"],"apiVersions":["2020-10-01"],"capabilities":"None"},{"resourceType":"locations/webAppStacks","locations":["South
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01"],"capabilities":"None"},{"resourceType":"locations/webAppStacks","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-10-01"],"capabilities":"None"},{"resourceType":"functionAppStacks","locations":["Central
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01"],"capabilities":"None"},{"resourceType":"functionAppStacks","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -784,22 +788,28 @@ interactions:
         East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
         US (Stage)","North Central US (Stage)","France Central","South Africa North","Australia
         Central","Switzerland North","Germany West Central","Norway East","UAE North","East
-        US 2 EUAP","Central US EUAP"],"apiVersions":["2020-10-01"],"capabilities":"None"},{"resourceType":"locations/functionAppStacks","locations":["South
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01"],"capabilities":"None"},{"resourceType":"locations/functionAppStacks","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-10-01"],"capabilities":"None"},{"resourceType":"staticSites","locations":["West
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01"],"capabilities":"None"},{"resourceType":"staticSites","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
         US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"locations/previewStaticSiteWorkflowFile","locations":["West
         US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"listSitesAssignedToHostName","locations":["Central
+        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"staticSites/builds","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01"],"defaultApiVersion":"2020-06-01","capabilities":"None"},{"resourceType":"staticSites/builds/userProvidedFunctionApps","locations":["West
+        US 2","Central US","East US 2","West Europe","East Asia","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2020-12-01"],"defaultApiVersion":"2020-12-01","capabilities":"None"},{"resourceType":"listSitesAssignedToHostName","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -837,40 +847,40 @@ interactions:
         US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-12-01-preview","2019-08-01","2019-01-01","2018-11-01","2018-02-01","2016-08-01"],"defaultApiVersion":"2019-01-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/networkConfig","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/networkConfig","locations":["South
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/networkConfig","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/hostNameBindings","locations":["South
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/hostNameBindings","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/slots/hostNameBindings","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["Central
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
         US","South Central US","Brazil South","Australia East","Australia Southeast","West
@@ -882,95 +892,96 @@ interactions:
         US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"certificates","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","West US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossSubscriptionResourceMove,
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossSubscriptionResourceMove,
         SupportsTags, SupportsLocation"},{"resourceType":"serverFarms","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway East","UAE North","Switzerland
-        North","UK West","Australia Southeast","Korea South","Canada Central","West
-        Europe","South India","West Central US","East Asia (Stage)","North Central
-        US (Stage)","East Asia","Japan East","East US 2 EUAP","Central US EUAP","West
-        US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway East","UAE North","Switzerland North","North Central US","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","East Asia (Stage)","North Central US (Stage)","East
+        Asia","Japan East","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"sites","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway East","UAE North","Switzerland
-        North","UK West","Australia Southeast","Korea South","Canada Central","West
-        Europe","South India","West Central US","East Asia (Stage)","North Central
-        US (Stage)","East Asia","Japan East","East US 2 EUAP","Central US EUAP","West
-        US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway East","UAE North","Switzerland North","North Central US","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","East Asia (Stage)","North Central US (Stage)","East
+        Asia","Japan East","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"sites/slots","locations":["South Central
         US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway East","UAE North","Switzerland
-        North","UK West","Australia Southeast","Korea South","Canada Central","West
-        Europe","South India","West Central US","East Asia (Stage)","North Central
-        US (Stage)","East Asia","Japan East","East US 2 EUAP","Central US EUAP","West
-        US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway East","UAE North","Switzerland North","North Central US","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","East Asia (Stage)","North Central US (Stage)","East
+        Asia","Japan East","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-08-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
         SupportsLocation"},{"resourceType":"runtimes","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"recommendations","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"resourceHealthMetadata","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"georegions","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"sites/premieraddons","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","East US 2 EUAP","Central
-        US EUAP","West US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2016-03-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"hostingEnvironments","locations":["MSFT
         West US","MSFT East US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central
         US (Stage)","South Central US","South Africa North","West US 2","East US 2","East
         US","UK South","Southeast Asia","North Europe","Japan East","West Europe","East
-        Asia","Australia East","Brazil South","Japan West","Central India","Canada
-        East","Korea Central","France Central","West India","Australia Central","Germany
-        West Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","South India","West Central US","East
-        Asia (Stage)","North Central US (Stage)","West US","Central US","North Central
-        US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"zoneMappings":[{"location":"East
-        US 2","zones":["2","3","1"]},{"location":"Central US","zones":["2","3","1"]},{"location":"West
-        Europe","zones":["2","3","1"]},{"location":"East US 2 EUAP","zones":["2","3","1"]},{"location":"Central
-        US EUAP","zones":[]},{"location":"France Central","zones":["2","3","1"]},{"location":"Southeast
-        Asia","zones":["2","3","1"]},{"location":"West US 2","zones":["2","3","1"]},{"location":"North
-        Europe","zones":["2","3","1"]},{"location":"East US","zones":["2","3","1"]},{"location":"UK
-        South","zones":["2","3","1"]},{"location":"Japan East","zones":["2","3","1"]},{"location":"Australia
-        East","zones":["2","3","1"]},{"location":"South Africa North","zones":["2","3","1"]},{"location":"South
-        Central US","zones":["2","3","1"]},{"location":"Canada Central","zones":["2","3","1"]},{"location":"Germany
-        West Central","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Central
+        Asia","West US","Australia East","Brazil South","Central US","Japan West","Central
+        India","Canada East","Korea Central","France Central","West India","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","South
+        India","West Central US","East Asia (Stage)","North Central US (Stage)","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"zoneMappings":[{"location":"East
+        US 2","zones":["2","1","3"]},{"location":"Central US","zones":["2","1","3"]},{"location":"West
+        Europe","zones":["2","1","3"]},{"location":"East US 2 EUAP","zones":["2","1","3"]},{"location":"Central
+        US EUAP","zones":[]},{"location":"France Central","zones":["2","1","3"]},{"location":"Southeast
+        Asia","zones":["2","1","3"]},{"location":"West US 2","zones":["2","1","3"]},{"location":"North
+        Europe","zones":["2","1","3"]},{"location":"East US","zones":["2","1","3"]},{"location":"UK
+        South","zones":["2","1","3"]},{"location":"Japan East","zones":["2","1","3"]},{"location":"Australia
+        East","zones":["2","1","3"]},{"location":"South Africa North","zones":["2","1","3"]},{"location":"South
+        Central US","zones":["2","1","3"]},{"location":"Canada Central","zones":["2","1","3"]},{"location":"Germany
+        West Central","zones":["2","1","3"]},{"location":"Brazil South","zones":["2","1","3"]},{"location":"Central
         India","zones":[]},{"location":"Korea Central","zones":[]},{"location":"Norway
-        East","zones":[]}],"capabilities":"SupportsTags, SupportsLocation"},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        East","zones":[]},{"location":"East Asia","zones":[]}],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"hostingEnvironments/workerPools","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"kubeEnvironments","locations":["North
-        Central US (Stage)","Central US EUAP"],"apiVersions":["2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2018-11-01","2018-08-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"kubeEnvironments","locations":["North
+        Central US (Stage)","West Central US","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-09-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-08-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"deploymentLocations","locations":["Central
         US","North Europe","West Europe","Southeast Asia","Korea Central","Korea South","West
         US","East US","Japan West","Japan East","East Asia","East US 2","North Central
@@ -982,31 +993,31 @@ interactions:
         North","Germany West Central","Norway East","UAE North"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"deletedSites","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deletedSites","locations":["South
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deletedSites","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","East Asia","Japan
-        East","Australia East","Brazil South","Southeast Asia","Japan West","Central
-        India","UK South","Canada East","Korea Central","France Central","North Europe","West
-        US 2","East US","West India","East US 2","Australia Central","Germany West
-        Central","Norway East","UAE North","Switzerland North","UK West","Australia
-        Southeast","Korea South","Canada Central","West Europe","South India","West
-        Central US","East Asia (Stage)","North Central US (Stage)","West US","Central
-        US","North Central US","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["South
-        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway East","UAE North","Switzerland
-        North","UK West","Australia Southeast","Korea South","Canada Central","West
+        East","West US","Australia East","Brazil South","Southeast Asia","Central
+        US","Japan West","Central India","UK South","Canada East","Korea Central","France
+        Central","North Europe","West US 2","East US","West India","East US 2","Australia
+        Central","Germany West Central","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
         Europe","South India","West Central US","East Asia (Stage)","North Central
-        US (Stage)","East Asia","Japan East","East US 2 EUAP","Central US EUAP","West
-        US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-11-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"connections","locations":["North
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway East","UAE North","Switzerland North","North Central US","UK
+        West","Australia Southeast","Korea South","Canada Central","West Europe","South
+        India","West Central US","East Asia (Stage)","North Central US (Stage)","East
+        Asia","Japan East","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-11-01","2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"defaultApiVersion":"2018-02-01","apiProfiles":[{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"connections","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Brazil Southeast","Australia Southeast","South
@@ -1110,41 +1121,44 @@ interactions:
         Central","Switzerland North","Germany West Central","Norway East","UAE North","East
         US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-01"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2016-03-01"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-02-01"},{"profileVersion":"2019-03-01-hybrid","apiVersion":"2018-02-01"}],"capabilities":"None"},{"resourceType":"serverFarms/eventGridFilters","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway West","Norway East","UAE
-        North","Switzerland North","UK West","Australia Southeast","Korea South","Canada
-        Central","West Europe","South India","West Central US","East Asia (Stage)","North
-        Central US (Stage)","East Asia","Japan East","South Africa West","East US
-        2 EUAP","Central US EUAP","West US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"sites/eventGridFilters","locations":["South
-        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway West","Norway East","UAE
-        North","Switzerland North","UK West","Australia Southeast","Korea South","Canada
-        Central","West Europe","South India","West Central US","East Asia (Stage)","North
-        Central US (Stage)","East Asia","Japan East","South Africa West","East US
-        2 EUAP","Central US EUAP","West US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"sites/slots/eventGridFilters","locations":["South
-        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
-        US 2 (Stage)","Central US (Stage)","South Africa North","Australia East","Brazil
-        South","Southeast Asia","Japan West","Central India","UK South","Canada East","Korea
-        Central","France Central","North Europe","West US 2","East US","West India","East
-        US 2","Australia Central","Germany West Central","Norway West","Norway East","Switzerland
-        North","UAE North","UK West","Australia Southeast","Korea South","Canada Central","West
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway West","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
         Europe","South India","West Central US","East Asia (Stage)","North Central
         US (Stage)","East Asia","Japan East","South Africa West","East US 2 EUAP","Central
-        US EUAP","West US","Central US","North Central US"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"hostingEnvironments/eventGridFilters","locations":["South
-        Central US","Brazil South","Canada East","UK West","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","Central US (Stage)","South
-        Africa North","West US 2","East US 2","East US","UK South","Southeast Asia","North
-        Europe","Japan East","West Europe","East Asia","Australia East","Japan West","Central
-        India","Korea Central","France Central","West India","Australia Central","Germany
-        West Central","Norway East","Switzerland North","UAE North","Australia Southeast","Korea
-        South","Canada Central","South India","West Central US","East Asia (Stage)","North
-        Central US (Stage)","West US","Central US","North Central US","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps","locations":["South
+        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"sites/eventGridFilters","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway West","Norway East","UAE North","Switzerland North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East Asia","Japan East","South Africa West","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"sites/slots/eventGridFilters","locations":["South
+        Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
+        East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
+        South","Canada East","Korea Central","France Central","North Europe","West
+        US 2","East US","West India","East US 2","Australia Central","Germany West
+        Central","Norway West","Norway East","Switzerland North","UAE North","North
+        Central US","UK West","Australia Southeast","Korea South","Canada Central","West
+        Europe","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East Asia","Japan East","South Africa West","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2018-11-01","2018-02-01","2017-08-01","2016-09-01","2016-08-01","2016-03-01","2015-11-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2015-01-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"],"capabilities":"None"},{"resourceType":"hostingEnvironments/eventGridFilters","locations":["West
+        US","North Central US","South Central US","Brazil South","Canada East","UK
+        West","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","Central US (Stage)","South Africa North","West US 2","East
+        US 2","East US","UK South","Southeast Asia","North Europe","Japan East","West
+        Europe","East Asia","Australia East","Central US","Japan West","Central India","Korea
+        Central","France Central","West India","Australia Central","Germany West Central","Norway
+        East","Switzerland North","UAE North","Australia Southeast","Korea South","Canada
+        Central","South India","West Central US","East Asia (Stage)","North Central
+        US (Stage)","East US 2 EUAP","Central US EUAP"],"apiVersions":["2020-12-01","2020-10-01","2020-09-01","2020-06-01","2019-08-01","2019-02-01","2019-01-01","2018-11-01","2018-08-01","2018-05-01-preview","2018-02-01","2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"],"capabilities":"None"},{"resourceType":"serverFarms/firstPartyApps","locations":["South
         Central US","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
         US 2 (Stage)","Central US (Stage)","South Africa North","West US","Australia
         East","Brazil South","Southeast Asia","Central US","Japan West","Central India","UK
@@ -1169,11 +1183,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '65301'
+      - '66264'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Mar 2021 19:29:25 GMT
+      - Wed, 19 May 2021 16:00:29 GMT
       expires:
       - '-1'
       pragma:
@@ -1201,7 +1215,7 @@ interactions:
       ParameterSetName:
       - --sku
       User-Agent:
-      - AZURECLI/2.21.0 azsdk-python-azure-mgmt-web/2.0.0 Python/3.8.2 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.23.0 azsdk-python-azure-mgmt-web/2.0.0 Python/3.6.7 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions?sku=FREE&api-version=2020-09-01
   response:
@@ -1278,7 +1292,7 @@ interactions:
         Central","name":"Korea Central","type":"Microsoft.Web/geoRegions","properties":{"name":"Korea
         Central","description":null,"sortOrder":2147483647,"displayName":"Korea Central","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;DSERIES;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/France
         South","name":"France South","type":"Microsoft.Web/geoRegions","properties":{"name":"France
-        South","description":null,"sortOrder":2147483647,"displayName":"France South","orgDomain":"PUBLIC;DSERIES"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/France
+        South","description":null,"sortOrder":2147483647,"displayName":"France South","orgDomain":"PUBLIC;LINUX;LINUXDSERIES;DSERIES"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/France
         Central","name":"France Central","type":"Microsoft.Web/geoRegions","properties":{"name":"France
         Central","description":null,"sortOrder":2147483647,"displayName":"France Central","orgDomain":"PUBLIC;MSFTPUBLIC;DSERIES;DYNAMIC;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
         Central 2","name":"Australia Central 2","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
@@ -1286,7 +1300,7 @@ interactions:
         Central 2","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;ELASTICPREMIUM"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
         Central","name":"Australia Central","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
         Central","description":null,"sortOrder":2147483647,"displayName":"Australia
-        Central","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;ELASTICPREMIUM"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
+        Central","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;ELASTICPREMIUM;ELASTICLINUX"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
         Africa North","name":"South Africa North","type":"Microsoft.Web/geoRegions","properties":{"name":"South
         Africa North","description":null,"sortOrder":2147483647,"displayName":"South
         Africa North","orgDomain":"PUBLIC;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;LINUXDSERIES;DSERIES;ELASTICPREMIUM;ELASTICLINUX"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
@@ -1319,11 +1333,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '18501'
+      - '18533'
       content-type:
       - application/json
       date:
-      - Wed, 31 Mar 2021 19:29:25 GMT
+      - Wed, 19 May 2021 16:00:29 GMT
       expires:
       - '-1'
       pragma:


### PR DESCRIPTION
**Description**<!--Mandatory-->
Importing `ResourceManagementClient` incorrectly causes it to use latest version of python SDK automatically, instead of the version specified by core CLI

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
