### PR TITLE
[KeyVault] Fix #11871: AKV10032: Invalid issuer error for operations in nondefault tenant/subscription

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -641,7 +641,6 @@ class AzCliCommandInvoker(CommandInvoker):
 
             if hasattr(expanded_arg, '_subscription'):
                 cmd_copy.cli_ctx.data['subscription_id'] = expanded_arg._subscription  # pylint: disable=protected-access
-                self.cli_ctx.data['subscription_id'] = expanded_arg._subscription  # pylint: disable=protected-access
 
             self._validation(expanded_arg)
             jobs.append((expanded_arg, cmd_copy))

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -641,6 +641,7 @@ class AzCliCommandInvoker(CommandInvoker):
 
             if hasattr(expanded_arg, '_subscription'):
                 cmd_copy.cli_ctx.data['subscription_id'] = expanded_arg._subscription  # pylint: disable=protected-access
+                self.cli_ctx.data['subscription_id'] = expanded_arg._subscription  # pylint: disable=protected-access
 
             self._validation(expanded_arg)
             jobs.append((expanded_arg, cmd_copy))

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -317,7 +317,7 @@ def __read_kv_from_config_store(azconfig_client,
 
     if cli_ctx:
         from azure.cli.command_modules.keyvault._client_factory import keyvault_data_plane_factory
-        keyvault_client = keyvault_data_plane_factory(cli_ctx, None)
+        keyvault_client = keyvault_data_plane_factory(cli_ctx)
     else:
         keyvault_client = None
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
@@ -171,7 +171,8 @@ def keyvault_private_data_plane_factory_v7_2_preview(cli_ctx, _):
     def get_token(server, resource, scope):  # pylint: disable=unused-argument
         import adal
         try:
-            return Profile(cli_ctx=cli_ctx).get_raw_token(resource)[0]
+            return Profile(cli_ctx=cli_ctx).get_raw_token(resource=resource,
+                                                          subscription=cli_ctx.data.get('subscription_id'))[0]
         except adal.AdalError as err:
             # pylint: disable=no-member
             if (hasattr(err, 'error_response') and

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
@@ -125,7 +125,7 @@ def keyvault_mgmt_client_factory(resource_type, client_name):
     return _keyvault_mgmt_client_factory
 
 
-def keyvault_data_plane_factory(cli_ctx, _):
+def keyvault_data_plane_factory(cli_ctx, *_):
     from azure.keyvault import KeyVaultAuthentication, KeyVaultClient
     from azure.cli.core.util import should_disable_connection_verify
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
@@ -134,7 +134,8 @@ def keyvault_data_plane_factory(cli_ctx, _):
     def get_token(server, resource, scope):  # pylint: disable=unused-argument
         import adal
         try:
-            return Profile(cli_ctx=cli_ctx).get_raw_token(resource)[0]
+            return Profile(cli_ctx=cli_ctx).get_raw_token(resource=resource,
+                                                          subscription=cli_ctx.data.get('subscription_id'))[0]
         except adal.AdalError as err:
             # pylint: disable=no-member
             if (hasattr(err, 'error_response') and

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_command_type.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_command_type.py
@@ -97,7 +97,7 @@ class KeyVaultCommandGroup(AzCommandGroup):
 
             client_arg_name = resolve_client_arg_name(operations_tmpl.format(method_name), kwargs)
             if client_arg_name in op_args:
-                client = client_factory(self.command_loader.cli_ctx, command_args)
+                client = client_factory(command_args['cmd'].cli_ctx, command_args)
                 command_args[client_arg_name] = client
             if 'cmd' not in op_args:
                 command_args.pop('cmd')

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -19,7 +19,7 @@ from msrestazure.azure_exceptions import CloudError
 from knack.log import get_logger
 from knack.util import CLIError, todict
 
-from azure.cli.core.profiles import ResourceType, get_api_version
+from azure.cli.core.profiles import ResourceType
 from azure.graphrbac.models import GraphErrorException
 
 from azure.cli.core.util import get_file_json, shell_safe_json_parse, is_guid

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1539,7 +1539,7 @@ def _get_signed_in_user_object_id(graph_client):
 
 def _get_keyvault_client(cli_ctx):
     from azure.cli.command_modules.keyvault._client_factory import keyvault_data_plane_factory
-    return keyvault_data_plane_factory(cli_ctx, None)
+    return keyvault_data_plane_factory(cli_ctx)
 
 
 def _create_self_signed_cert(start_date, end_date):  # pylint: disable=too-many-locals

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1538,14 +1538,8 @@ def _get_signed_in_user_object_id(graph_client):
 
 
 def _get_keyvault_client(cli_ctx):
-    from azure.cli.core._profile import Profile
-    from azure.keyvault import KeyVaultAuthentication, KeyVaultClient
-    version = str(get_api_version(cli_ctx, ResourceType.DATA_KEYVAULT))
-
-    def _get_token(server, resource, scope):  # pylint: disable=unused-argument
-        return Profile(cli_ctx=cli_ctx).get_raw_token(resource)[0]
-
-    return KeyVaultClient(KeyVaultAuthentication(_get_token), api_version=version)
+    from azure.cli.command_modules.keyvault._client_factory import keyvault_data_plane_factory
+    return keyvault_data_plane_factory(cli_ctx, None)
 
 
 def _create_self_signed_cert(start_date, end_date):  # pylint: disable=too-many-locals

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
@@ -1598,7 +1598,7 @@ def _create_self_signed_key_vault_certificate(cli_ctx, vault_base_url, certifica
 
 def _get_keyVault_not_arm_client(cli_ctx):
     from azure.cli.command_modules.keyvault._client_factory import keyvault_data_plane_factory
-    return keyvault_data_plane_factory(cli_ctx, None)
+    return keyvault_data_plane_factory(cli_ctx)
 
 
 def _create_keyvault(cmd,

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
@@ -20,8 +20,7 @@ from msrestazure.azure_exceptions import CloudError
 from azure.cli.core.util import CLIError, get_file_json, b64_to_hex, sdk_no_wait
 from azure.cli.core.commands import LongRunningOperation
 from azure.graphrbac import GraphRbacManagementClient
-from azure.cli.core.profiles import ResourceType, get_sdk, get_api_version
-from azure.keyvault import KeyVaultAuthentication, KeyVaultClient
+from azure.cli.core.profiles import ResourceType, get_sdk
 from azure.cli.command_modules.servicefabric._arm_deployment_utils import validate_and_deploy_arm_template
 from azure.cli.command_modules.servicefabric._sf_utils import _get_resource_group_by_name, _create_resource_group_name
 

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
@@ -1598,14 +1598,8 @@ def _create_self_signed_key_vault_certificate(cli_ctx, vault_base_url, certifica
 
 
 def _get_keyVault_not_arm_client(cli_ctx):
-    from azure.cli.core._profile import Profile
-    version = str(get_api_version(cli_ctx, ResourceType.DATA_KEYVAULT))
-
-    def get_token(server, resource, scope):  # pylint: disable=unused-argument
-        return Profile(cli_ctx=cli_ctx).get_raw_token(resource)[0]
-
-    client = KeyVaultClient(KeyVaultAuthentication(get_token), api_version=version)
-    return client
+    from azure.cli.command_modules.keyvault._client_factory import keyvault_data_plane_factory
+    return keyvault_data_plane_factory(cli_ctx, None)
 
 
 def _create_keyvault(cmd,

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -101,15 +101,8 @@ def check_existence(cli_ctx, value, resource_group, provider_namespace, resource
 
 
 def create_keyvault_data_plane_client(cli_ctx):
-    from azure.cli.core._profile import Profile
-    from azure.cli.core.profiles import get_api_version, ResourceType
-    version = str(get_api_version(cli_ctx, ResourceType.DATA_KEYVAULT))
-
-    def get_token(server, resource, scope):  # pylint: disable=unused-argument
-        return Profile(cli_ctx=cli_ctx).get_raw_token(resource)[0]
-
-    from azure.keyvault import KeyVaultAuthentication, KeyVaultClient
-    return KeyVaultClient(KeyVaultAuthentication(get_token), api_version=version)
+    from azure.cli.command_modules.keyvault._client_factory import keyvault_data_plane_factory
+    return keyvault_data_plane_factory(cli_ctx, None)
 
 
 def get_key_vault_base_url(cli_ctx, vault_name):

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -102,7 +102,7 @@ def check_existence(cli_ctx, value, resource_group, provider_namespace, resource
 
 def create_keyvault_data_plane_client(cli_ctx):
     from azure.cli.command_modules.keyvault._client_factory import keyvault_data_plane_factory
-    return keyvault_data_plane_factory(cli_ctx, None)
+    return keyvault_data_plane_factory(cli_ctx)
 
 
 def get_key_vault_base_url(cli_ctx, vault_name):


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #11871 
Previously, CX can't succeed to manage keyvault resources in nondefault tenant/subscription because KeyVault Data Plane Client Factory's `KeyvaultAuthentication` didn't honor `--subscription` parameter, it will always use the access token from the login subscription.

**Testing Guide**
<!--Example commands with explanations.-->
First of all, login to SUB_A:
```
> az login
> az account set -s SUB_A
```
Try to list keyvault secrets in SUB_B:
_Before_
```
> az keyvault secret list --vault-name ystestkv --subscription "1c638cf4-608f-4ee6-b680-c329e824c3a8"
AKV10032: Invalid issuer. Expected one of https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/, https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/, https://sts.windows.net/e2d54eb5-3869-4f70-8578-dee5fc7331f4/, https://sts.windows.net/33e01921-4d64-4f8c-a055-5bdaffd5e33d/, https://sts.windows.net/975f013f-7f24-47e8-a7d3-abc4752bf346/, found https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/.
```
_After_
```
> az keyvault secret list --vault-name ystestkv --subscription "1c638cf4-608f-4ee6-b680-c329e824c3a8"
[
  {
    "attributes": {
      "created": "2021-05-19T04:00:07+00:00",
      "enabled": true,
      "expires": null,
      "notBefore": null,
      "recoveryLevel": "Recoverable+Purgeable",
      "updated": "2021-05-19T04:00:07+00:00"
    },
    "contentType": null,
    "id": "https://ystestkv.vault.azure.net/secrets/testsecret",
    "managed": null,
    "name": "testsecret",
    "tags": null
  }
]
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
