### PR TITLE
{Packaging} Bump `urllib3` and `requests`

### DIFF
--- a/scripts/release/debian/Dockerfile
+++ b/scripts/release/debian/Dockerfile
@@ -28,8 +28,7 @@ COPY . .
 RUN mkdir -p ./bin/pypi && \
     BUILD_STAGINGDIRECTORY=/azure-cli/bin/pypi ./scripts/release/pypi/build.sh && \
     if [ -d ./privates ]; then find ./privates -name '*.whl' | xargs pip install; fi && \
-    find ./bin/pypi -name '*.whl' | xargs pip install && \
-    pip install --force-reinstall urllib3==1.25.9
+    find ./bin/pypi -name '*.whl' | xargs pip install &&
 
 ARG cli_version=0.0.0-dev
 ARG cli_version_revision=1

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -53,16 +53,13 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.8.2',
     'msal>=1.10.0,<2.0.0',
-    # Dependencies of the vendored subscription SDK
-    # https://github.com/Azure/azure-sdk-for-python/blob/ab12b048ddf676fe0ccec16b2167117f0609700d/sdk/resources/azure-mgmt-resource/setup.py#L82-L86
-    'msrest>=0.5.0',
-    'msrestazure>=0.6.3',
     'paramiko>=2.0.8,<3.0.0',
     'pkginfo>=1.5.0.1',
     'PyJWT==1.7.1',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
     'requests~=2.22',
     'six~=1.12',
+    'urllib3[secure]>=1.26.4',
 ]
 
 # dependencies for specific OSes

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -125,13 +125,13 @@ pyOpenSSL==19.0.0
 python-dateutil==2.8.0
 pytz==2019.1
 requests-oauthlib==1.2.0
-requests==2.22.0
+requests==2.25.1
 scp==0.13.2
 semver==2.13.0
 six==1.14.0
 sshtunnel==0.1.5
 tabulate==0.8.3
-urllib3==1.25.9
+urllib3==1.26.4
 vsts-cd-manager==1.0.2
 vsts==0.1.25
 wcwidth==0.1.7

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -125,13 +125,13 @@ pyOpenSSL==19.0.0
 python-dateutil==2.8.0
 pytz==2019.1
 requests-oauthlib==1.2.0
-requests==2.22.0
+requests==2.25.1
 scp==0.13.2
 semver==2.13.0
 six==1.14.0
 sshtunnel==0.1.5
 tabulate==0.8.3
-urllib3==1.25.9
+urllib3==1.26.4
 vsts-cd-manager==1.0.2
 vsts==0.1.25
 wcwidth==0.1.7

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -126,13 +126,13 @@ python-dateutil==2.8.0
 pytz==2019.1
 pywin32==300
 requests-oauthlib==1.2.0
-requests==2.22.0
+requests==2.25.1
 scp==0.13.2
 semver==2.13.0
 six==1.14.0
 sshtunnel==0.1.5
 tabulate==0.8.3
-urllib3==1.25.9
+urllib3==1.26.4
 vsts-cd-manager==1.0.2
 vsts==0.1.25
 wcwidth==0.1.7

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -143,7 +143,6 @@ DEPENDENCIES = [
     'scp~=0.13.2',
     'semver==2.13.0',
     'sshtunnel~=0.1.4',
-    'urllib3[secure]>=1.25.9,<2.0.0',
     'vsts-cd-manager~=1.0.0,>=1.0.2',
     'websocket-client~=0.56.0',
     'xmltodict~=0.12'


### PR DESCRIPTION
**Description**<!--Mandatory-->

Since `setup.py` doesn't pin `urllib3`

https://github.com/Azure/azure-cli/blob/d1585e356d547fe5adcc4c6651096e8884dcb45e/src/azure-cli/setup.py#L146

[Component Governance alert](https://dev.azure.com/azure-sdk/internal/_componentGovernance/144540/alert/4535820?typeId=2389919) is triggered when `urllib3` 1.26.2 is installed.

The current `urllib3` is 1.26.4, so the alert is no longer valid. 

For security sake, we should force `urllib3` >= 2.26.4.
