### PR TITLE
{CI} Unpin azdev

### DIFF
--- a/.azure-pipelines/templates/azdev_setup.yml
+++ b/.azure-pipelines/templates/azdev_setup.yml
@@ -13,7 +13,7 @@ steps:
       chmod +x env/bin/activate
       . env/bin/activate
       python -m pip install -U pip
-      pip install azdev==0.1.32
+      pip install azdev
       azdev --version
 
       if [ -z "$CLI_EXT_REPO_PATH" ]; then

--- a/src/azure-cli/azure/cli/command_modules/resource/_win_vt.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_win_vt.py
@@ -47,7 +47,7 @@ def _set_conout_mode(mode):
 def _update_conout_mode(mode):
     old_mode = _get_conout_mode()
     if old_mode & mode != mode:
-        mode = old_mode | mode
+        mode = old_mode | mode  # pylint: disable=unsupported-binary-operation
         _set_conout_mode(mode)
 
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
Unpin `azdev` so that the latest `azdev` ([0.1.33](https://github.com/Azure/azure-cli-dev-tools/releases/tag/v0.1.33)) can be automatically picked up by the CI.
