### PR TITLE
{AppService} Add custom location sdk

### DIFF
--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -59,6 +59,7 @@ class ResourceType(Enum):  # pylint: disable=too-few-public-methods
     MGMT_IOTHUB = ('azure.mgmt.iothub', 'IotHubClient')
     MGMT_ARO = ('azure.mgmt.redhatopenshift', 'AzureRedHatOpenShiftClient')
     MGMT_DATABOXEDGE = ('azure.mgmt.databoxedge', 'DataBoxEdgeManagementClient')
+    MGMT_CUSTOMLOCATION = ('azure.mgmt.extendedlocation', 'CustomLocations')
     # the "None" below will stay till a command module fills in the type so "get_mgmt_service_client"
     # can be provided with "ResourceType.XXX" to initialize the client object. This usually happens
     # when related commands start to support Multi-API
@@ -210,7 +211,8 @@ AZURE_API_PROFILES = {
         ResourceType.MGMT_APPSERVICE: '2020-09-01',
         ResourceType.MGMT_IOTHUB: '2021-03-31',
         ResourceType.MGMT_ARO: '2020-04-30',
-        ResourceType.MGMT_DATABOXEDGE: '2019-08-01'
+        ResourceType.MGMT_DATABOXEDGE: '2019-08-01',
+        ResourceType.MGMT_CUSTOMLOCATION: '2021-03-15-preview'
     },
     '2020-09-01-hybrid': {
         ResourceType.MGMT_STORAGE: '2019-06-01',

--- a/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
@@ -47,6 +47,12 @@ def providers_client_factory(cli_ctx):
     return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES).providers
 
 
+def customlocation_client_factory(cli_ctx, api_version=None, **_):
+    from azure.cli.core.profiles import ResourceType
+    from azure.cli.core.commands.client_factory import get_mgmt_service_client
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_CUSTOMLOCATION, api_version=api_version)
+
+
 def cf_plans(cli_ctx, _):
     return web_client_factory(cli_ctx).app_service_plans
 

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -46,6 +46,7 @@ azure-mgmt-devtestlabs==4.0.0
 azure-mgmt-dns==8.0.0
 azure-mgmt-eventgrid==9.0.0
 azure-mgmt-eventhub==4.1.0
+azure-mgmt-extendedlocation==1.0.0b2
 azure-mgmt-hdinsight==7.0.0
 azure-mgmt-imagebuilder==0.4.0
 azure-mgmt-iotcentral==4.1.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -46,6 +46,7 @@ azure-mgmt-devtestlabs==4.0.0
 azure-mgmt-dns==8.0.0
 azure-mgmt-eventgrid==9.0.0
 azure-mgmt-eventhub==4.1.0
+azure-mgmt-extendedlocation==1.0.0b2
 azure-mgmt-hdinsight==7.0.0
 azure-mgmt-imagebuilder==0.4.0
 azure-mgmt-iotcentral==4.1.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -46,6 +46,7 @@ azure-mgmt-devtestlabs==4.0.0
 azure-mgmt-dns==8.0.0
 azure-mgmt-eventgrid==9.0.0
 azure-mgmt-eventhub==4.1.0
+azure-mgmt-extendedlocation==1.0.0b2
 azure-mgmt-hdinsight==7.0.0
 azure-mgmt-imagebuilder==0.4.0
 azure-mgmt-iotcentral==4.1.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -88,6 +88,7 @@ DEPENDENCIES = [
     'azure-mgmt-dns~=8.0.0',
     'azure-mgmt-eventgrid==9.0.0',
     'azure-mgmt-eventhub~=4.1.0',
+    'azure-mgmt-extendedlocation~=1.0.0b2',
     'azure-mgmt-hdinsight~=7.0.0',
     'azure-mgmt-imagebuilder~=0.4.0',
     'azure-mgmt-iotcentral~=4.1.0',


### PR DESCRIPTION
**Description**<!--Mandatory-->
Add custom location SDK which will be used in appservice-kube extension. The commands from the appservice-kube extension will eventually be moved to core

The ExtendedLocation model is included in appservice package, however I want to be able to use ExtendedLocation management commands (like get & list: https://docs.microsoft.com/en-us/python/api/azure-mgmt-extendedlocation/azure.mgmt.extendedlocation.v2021_03_15_preview.operations.customlocationsoperations?view=azure-python-preview) in order to verify the ExtendedLocation before using it in our AppService commands

**Testing Guide**
No changes to existing commands, just adding custom location SDK 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
