### PR TITLE
{container} Bugfix #15856,#18251,#18275: az container exec - decode received bytes as utf-8 string

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/container/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/container/custom.py
@@ -681,7 +681,7 @@ def _cycle_exec_pipe(ws):
     r, _, _ = select.select([ws.sock, sys.stdin], [], [])
     if ws.sock in r:
         data = ws.recv()
-        if type(data) is bytes:
+        if isinstance(data, bytes):
             data = data.decode('utf-8')
         sys.stdout.write(data)
         sys.stdout.flush()

--- a/src/azure-cli/azure/cli/command_modules/container/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/container/custom.py
@@ -681,6 +681,8 @@ def _cycle_exec_pipe(ws):
     r, _, _ = select.select([ws.sock, sys.stdin], [], [])
     if ws.sock in r:
         data = ws.recv()
+        if type(data) is bytes:
+            data = data.decode('utf-8')
         sys.stdout.write(data)
         sys.stdout.flush()
     if sys.stdin in r:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The websocket response can be a string for text or bytes for an utf-8 string. utf-8 was not handled properly. This pr adds detection of bytes and decoding as utf-8 string before writing to the console.

Fixes: https://github.com/Azure/azure-cli/issues/15856
Fixes: https://github.com/Azure/azure-cli/issues/18251
Fixes: https://github.com/Azure/azure-cli/issues/18275

**Testing Guide**
<!--Example commands with explanations.-->
- start a container e.g. with `az container create` with a long living container
- try to execute a shell inside the container with `az container exec --exec-command "/bin/bash" ...`
- currently it just exits without an error or shell
- 
**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[container] az container exec: decode received bytes as utf-8 string

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
