### PR TITLE
[Storage] Fix #18393 - `az storage blob list` --delimiter parameter value is ignored

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -143,7 +143,8 @@ def list_blobs(client, delimiter=None, include=None, marker=None, num_results=No
     from ..track2_util import list_generator
 
     if delimiter:
-        generator = client.walk_blobs(name_starts_with=prefix, include=include, results_per_page=num_results, **kwargs)
+        generator = client.walk_blobs(
+            name_starts_with=prefix, include=include, results_per_page=num_results, delimiter=delimiter, **kwargs)
     else:
         generator = client.list_blobs(name_starts_with=prefix, include=include, results_per_page=num_results, **kwargs)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_blob_list_scenarios.yaml
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_blob_list_scenarios.yaml
@@ -15,12 +15,12 @@ interactions:
       ParameterSetName:
       - -n -g --query -o
       User-Agent:
-      - AZURECLI/2.23.0 azsdk-python-azure-mgmt-storage/17.1.0 Python/3.7.7 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.24.0 azsdk-python-azure-mgmt-storage/18.0.0 Python/3.8.6 (Windows-10-10.0.19041-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Storage/storageAccounts/storage000002/listKeys?api-version=2021-04-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2021-05-11T05:09:57.3119190Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2021-05-11T05:09:57.3119190Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2021-06-09T00:21:28.9910737Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2021-06-09T00:21:28.9910737Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -29,7 +29,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 11 May 2021 05:10:17 GMT
+      - Wed, 09 Jun 2021 00:21:47 GMT
       expires:
       - '-1'
       pragma:
@@ -57,9 +57,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.7.7; Windows 10) AZURECLI/2.23.0
+      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.8.6; Windows 10) AZURECLI/2.24.0
       x-ms-date:
-      - Tue, 11 May 2021 05:10:18 GMT
+      - Wed, 09 Jun 2021 00:21:48 GMT
       x-ms-version:
       - '2018-11-09'
     method: PUT
@@ -71,11 +71,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 11 May 2021 05:10:20 GMT
+      - Wed, 09 Jun 2021 00:21:48 GMT
       etag:
-      - '"0x8D9143B1372B8AA"'
+      - '"0x8D92ADC925E6177"'
       last-modified:
-      - Tue, 11 May 2021 05:10:21 GMT
+      - Wed, 09 Jun 2021 00:21:48 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -91,11 +91,11 @@ interactions:
       Content-Length:
       - '131072'
       User-Agent:
-      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.7.7; Windows 10) AZURECLI/2.23.0
+      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.8.6; Windows 10) AZURECLI/2.24.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Tue, 11 May 2021 05:10:21 GMT
+      - Wed, 09 Jun 2021 00:21:49 GMT
       x-ms-version:
       - '2018-11-09'
     method: PUT
@@ -109,11 +109,11 @@ interactions:
       content-md5:
       - DfvoqkwgtS4bi/PLbL3xkw==
       date:
-      - Tue, 11 May 2021 05:10:22 GMT
+      - Wed, 09 Jun 2021 00:21:48 GMT
       etag:
-      - '"0x8D9143B14C082E8"'
+      - '"0x8D92ADC92AAAF9B"'
       last-modified:
-      - Tue, 11 May 2021 05:10:23 GMT
+      - Wed, 09 Jun 2021 00:21:49 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
@@ -137,9 +137,9 @@ interactions:
       ParameterSetName:
       - -c --account-name --account-key
       User-Agent:
-      - AZURECLI/2.23.0 azsdk-python-storage-blob/12.7.1 Python/3.7.7 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Tue, 11 May 2021 05:10:23 GMT
+      - Wed, 09 Jun 2021 00:21:49 GMT
       x-ms-version:
       - '2020-04-08'
     method: GET
@@ -147,9 +147,9 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:23 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:23
-        GMT</Last-Modified><Etag>0x8D9143B14C082E8</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:49 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:49
+        GMT</Last-Modified><Etag>0x8D92ADC92AAAF9B</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -157,7 +157,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 11 May 2021 05:10:24 GMT
+      - Wed, 09 Jun 2021 00:21:49 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -175,9 +175,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.7.7; Windows 10) AZURECLI/2.23.0
+      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.8.6; Windows 10) AZURECLI/2.24.0
       x-ms-date:
-      - Tue, 11 May 2021 05:10:24 GMT
+      - Wed, 09 Jun 2021 00:21:50 GMT
       x-ms-version:
       - '2018-11-09'
     method: PUT
@@ -189,17 +189,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 11 May 2021 05:10:25 GMT
+      - Wed, 09 Jun 2021 00:21:49 GMT
       etag:
-      - '"0x8D9143B14C082E8"'
+      - '"0x8D92ADC92AAAF9B"'
       last-modified:
-      - Tue, 11 May 2021 05:10:23 GMT
+      - Wed, 09 Jun 2021 00:21:49 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'false'
       x-ms-snapshot:
-      - '2021-05-11T05:10:26.0030653Z'
+      - '2021-06-09T00:21:49.6941057Z'
       x-ms-version:
       - '2018-11-09'
     status:
@@ -219,9 +219,9 @@ interactions:
       ParameterSetName:
       - -c --include --account-name --account-key
       User-Agent:
-      - AZURECLI/2.23.0 azsdk-python-storage-blob/12.7.1 Python/3.7.7 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Tue, 11 May 2021 05:10:26 GMT
+      - Wed, 09 Jun 2021 00:21:50 GMT
       x-ms-version:
       - '2020-04-08'
     method: GET
@@ -229,14 +229,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Snapshot>2021-05-11T05:10:26.0030653Z</Snapshot><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:23 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:23
-        GMT</Last-Modified><Etag>0x8D9143B14C082E8</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Snapshot>2021-06-09T00:21:49.6941057Z</Snapshot><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:49 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:49
+        GMT</Last-Modified><Etag>0x8D92ADC92AAAF9B</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:23 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:23
-        GMT</Last-Modified><Etag>0x8D9143B14C082E8</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:49 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:49
+        GMT</Last-Modified><Etag>0x8D92ADC92AAAF9B</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -244,7 +244,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 11 May 2021 05:10:26 GMT
+      - Wed, 09 Jun 2021 00:21:49 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -262,9 +262,9 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.7.7; Windows 10) AZURECLI/2.23.0
+      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.8.6; Windows 10) AZURECLI/2.24.0
       x-ms-date:
-      - Tue, 11 May 2021 05:10:27 GMT
+      - Wed, 09 Jun 2021 00:21:50 GMT
       x-ms-meta-test:
       - '1'
       x-ms-version:
@@ -278,11 +278,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 11 May 2021 05:10:28 GMT
+      - Wed, 09 Jun 2021 00:21:50 GMT
       etag:
-      - '"0x8D9143B17E3F991"'
+      - '"0x8D92ADC93614FA1"'
       last-modified:
-      - Tue, 11 May 2021 05:10:28 GMT
+      - Wed, 09 Jun 2021 00:21:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
@@ -298,9 +298,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.7.7; Windows 10) AZURECLI/2.23.0
+      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.8.6; Windows 10) AZURECLI/2.24.0
       x-ms-date:
-      - Tue, 11 May 2021 05:10:28 GMT
+      - Wed, 09 Jun 2021 00:21:51 GMT
       x-ms-version:
       - '2018-11-09'
     method: GET
@@ -312,11 +312,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 11 May 2021 05:10:29 GMT
+      - Wed, 09 Jun 2021 00:21:50 GMT
       etag:
-      - '"0x8D9143B17E3F991"'
+      - '"0x8D92ADC93614FA1"'
       last-modified:
-      - Tue, 11 May 2021 05:10:28 GMT
+      - Wed, 09 Jun 2021 00:21:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-meta-test:
@@ -340,9 +340,9 @@ interactions:
       ParameterSetName:
       - -c --include --account-name --account-key
       User-Agent:
-      - AZURECLI/2.23.0 azsdk-python-storage-blob/12.7.1 Python/3.7.7 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Tue, 11 May 2021 05:10:30 GMT
+      - Wed, 09 Jun 2021 00:21:51 GMT
       x-ms-version:
       - '2020-04-08'
     method: GET
@@ -350,9 +350,9 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:23 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:28
-        GMT</Last-Modified><Etag>0x8D9143B17E3F991</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:49 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:50
+        GMT</Last-Modified><Etag>0x8D92ADC93614FA1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><test>1</test></Metadata><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -360,7 +360,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 11 May 2021 05:10:30 GMT
+      - Wed, 09 Jun 2021 00:21:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -378,11 +378,11 @@ interactions:
       Content-Length:
       - '131072'
       User-Agent:
-      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.7.7; Windows 10) AZURECLI/2.23.0
+      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.8.6; Windows 10) AZURECLI/2.24.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Tue, 11 May 2021 05:10:31 GMT
+      - Wed, 09 Jun 2021 00:21:51 GMT
       x-ms-version:
       - '2018-11-09'
     method: PUT
@@ -396,11 +396,11 @@ interactions:
       content-md5:
       - DfvoqkwgtS4bi/PLbL3xkw==
       date:
-      - Tue, 11 May 2021 05:10:33 GMT
+      - Wed, 09 Jun 2021 00:21:51 GMT
       etag:
-      - '"0x8D9143B1ACCA6F1"'
+      - '"0x8D92ADC93FDFA4D"'
       last-modified:
-      - Tue, 11 May 2021 05:10:33 GMT
+      - Wed, 09 Jun 2021 00:21:51 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
@@ -424,9 +424,9 @@ interactions:
       ParameterSetName:
       - -c --account-name --account-key
       User-Agent:
-      - AZURECLI/2.23.0 azsdk-python-storage-blob/12.7.1 Python/3.7.7 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Tue, 11 May 2021 05:10:33 GMT
+      - Wed, 09 Jun 2021 00:21:52 GMT
       x-ms-version:
       - '2020-04-08'
     method: GET
@@ -434,14 +434,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:33 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:33
-        GMT</Last-Modified><Etag>0x8D9143B1ACCA6F1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:49 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:50
+        GMT</Last-Modified><Etag>0x8D92ADC93614FA1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:23 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:28
-        GMT</Last-Modified><Etag>0x8D9143B17E3F991</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:51 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:51
+        GMT</Last-Modified><Etag>0x8D92ADC93FDFA4D</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -449,7 +449,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 11 May 2021 05:10:34 GMT
+      - Wed, 09 Jun 2021 00:21:51 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -473,9 +473,9 @@ interactions:
       ParameterSetName:
       - -c --num-results --account-name --account-key
       User-Agent:
-      - AZURECLI/2.23.0 azsdk-python-storage-blob/12.7.1 Python/3.7.7 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Tue, 11 May 2021 05:10:34 GMT
+      - Wed, 09 Jun 2021 00:21:52 GMT
       x-ms-version:
       - '2020-04-08'
     method: GET
@@ -483,17 +483,17 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>1</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:33 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:33
-        GMT</Last-Modified><Etag>0x8D9143B1ACCA6F1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>1</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:49 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:50
+        GMT</Last-Modified><Etag>0x8D92ADC93614FA1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob></Blobs><NextMarker>2!96!MDAwMDI4IWRpci9ibG9idm15eWJ4d2phNDNiaXB3Z3JuanchMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</NextMarker></EnumerationResults>"
+        /></Blob></Blobs><NextMarker>2!96!MDAwMDI4IWRpci9ibG9icmNqNmJvY3BkeXBybGw3a3FjcHYhMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</NextMarker></EnumerationResults>"
     headers:
       content-type:
       - application/xml
       date:
-      - Tue, 11 May 2021 05:10:35 GMT
+      - Wed, 09 Jun 2021 00:21:51 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -517,9 +517,9 @@ interactions:
       ParameterSetName:
       - -c --num-results --show-next-marker --account-name --account-key
       User-Agent:
-      - AZURECLI/2.23.0 azsdk-python-storage-blob/12.7.1 Python/3.7.7 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Tue, 11 May 2021 05:10:36 GMT
+      - Wed, 09 Jun 2021 00:21:52 GMT
       x-ms-version:
       - '2020-04-08'
     method: GET
@@ -527,17 +527,17 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>1</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:33 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:33
-        GMT</Last-Modified><Etag>0x8D9143B1ACCA6F1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>1</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:49 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:50
+        GMT</Last-Modified><Etag>0x8D92ADC93614FA1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob></Blobs><NextMarker>2!96!MDAwMDI4IWRpci9ibG9idm15eWJ4d2phNDNiaXB3Z3JuanchMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</NextMarker></EnumerationResults>"
+        /></Blob></Blobs><NextMarker>2!96!MDAwMDI4IWRpci9ibG9icmNqNmJvY3BkeXBybGw3a3FjcHYhMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</NextMarker></EnumerationResults>"
     headers:
       content-type:
       - application/xml
       date:
-      - Tue, 11 May 2021 05:10:36 GMT
+      - Wed, 09 Jun 2021 00:21:51 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -561,19 +561,19 @@ interactions:
       ParameterSetName:
       - -c --marker --account-name --account-key
       User-Agent:
-      - AZURECLI/2.23.0 azsdk-python-storage-blob/12.7.1 Python/3.7.7 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Tue, 11 May 2021 05:10:37 GMT
+      - Wed, 09 Jun 2021 00:21:52 GMT
       x-ms-version:
       - '2020-04-08'
     method: GET
-    uri: https://storage000002.blob.core.windows.net/con000003?restype=container&comp=list&marker=2%2196%21MDAwMDI4IWRpci9ibG9idm15eWJ4d2phNDNiaXB3Z3JuanchMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh&maxresults=5000
+    uri: https://storage000002.blob.core.windows.net/con000003?restype=container&comp=list&marker=2%2196%21MDAwMDI4IWRpci9ibG9icmNqNmJvY3BkeXBybGw3a3FjcHYhMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh&maxresults=5000
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><Marker>2!96!MDAwMDI4IWRpci9ibG9idm15eWJ4d2phNDNiaXB3Z3JuanchMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</Marker><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:23 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:28
-        GMT</Last-Modified><Etag>0x8D9143B17E3F991</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><Marker>2!96!MDAwMDI4IWRpci9ibG9icmNqNmJvY3BkeXBybGw3a3FjcHYhMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</Marker><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:51 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:51
+        GMT</Last-Modified><Etag>0x8D92ADC93FDFA4D</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -581,7 +581,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 11 May 2021 05:10:38 GMT
+      - Wed, 09 Jun 2021 00:21:51 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -605,9 +605,9 @@ interactions:
       ParameterSetName:
       - -c --prefix --account-name --account-key
       User-Agent:
-      - AZURECLI/2.23.0 azsdk-python-storage-blob/12.7.1 Python/3.7.7 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Tue, 11 May 2021 05:10:38 GMT
+      - Wed, 09 Jun 2021 00:21:53 GMT
       x-ms-version:
       - '2020-04-08'
     method: GET
@@ -615,14 +615,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><Prefix>dir/</Prefix><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:33 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:33
-        GMT</Last-Modified><Etag>0x8D9143B1ACCA6F1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><Prefix>dir/</Prefix><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:49 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:50
+        GMT</Last-Modified><Etag>0x8D92ADC93614FA1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:23 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:28
-        GMT</Last-Modified><Etag>0x8D9143B17E3F991</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:51 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:51
+        GMT</Last-Modified><Etag>0x8D92ADC93FDFA4D</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -630,7 +630,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 11 May 2021 05:10:39 GMT
+      - Wed, 09 Jun 2021 00:21:51 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -654,9 +654,9 @@ interactions:
       ParameterSetName:
       - -c --delimiter --account-name --account-key
       User-Agent:
-      - AZURECLI/2.23.0 azsdk-python-storage-blob/12.7.1 Python/3.7.7 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Tue, 11 May 2021 05:10:40 GMT
+      - Wed, 09 Jun 2021 00:21:53 GMT
       x-ms-version:
       - '2020-04-08'
     method: GET
@@ -670,7 +670,47 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 11 May 2021 05:10:41 GMT
+      - Wed, 09 Jun 2021 00:21:52 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2020-04-08'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -c --delimiter --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 09 Jun 2021 00:21:53 GMT
+      x-ms-version:
+      - '2020-04-08'
+    method: GET
+    uri: https://storage000002.blob.core.windows.net/con000003?restype=container&comp=list&delimiter=ir&maxresults=5000
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Delimiter>ir</Delimiter><Blobs><BlobPrefix><Name>dir</Name></BlobPrefix></Blobs><NextMarker
+        /></EnumerationResults>"
+    headers:
+      content-type:
+      - application/xml
+      date:
+      - Wed, 09 Jun 2021 00:21:52 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -694,9 +734,50 @@ interactions:
       ParameterSetName:
       - -c --account-name --account-key
       User-Agent:
-      - AZURECLI/2.23.0 azsdk-python-storage-blob/12.7.1 Python/3.7.7 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
       x-ms-date:
-      - Tue, 11 May 2021 05:10:41 GMT
+      - Wed, 09 Jun 2021 00:21:54 GMT
+      x-ms-version:
+      - '2020-04-08'
+    method: GET
+    uri: https://storage000002-secondary.blob.core.windows.net/con000003?restype=container&comp=list&maxresults=5000
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The
+        specified container does not exist.\nRequestId:e5aca6f4-e01e-008d-3cc5-5ce33f000000\nTime:2021-06-09T00:21:53.8633713Z</Message></Error>"
+    headers:
+      content-length:
+      - '225'
+      content-type:
+      - application/xml
+      date:
+      - Wed, 09 Jun 2021 00:21:53 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-error-code:
+      - ContainerNotFound
+      x-ms-version:
+      - '2020-04-08'
+    status:
+      code: 404
+      message: The specified container does not exist.
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -c --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.24.0 azsdk-python-storage-blob/12.7.1 Python/3.8.6 (Windows-10-10.0.19041-SP0)
+      x-ms-date:
+      - Wed, 09 Jun 2021 00:22:11 GMT
       x-ms-version:
       - '2020-04-08'
     method: GET
@@ -705,14 +786,14 @@ interactions:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
         ServiceEndpoint=\"https://storage000002-secondary.blob.core.windows.net/\"
-        ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:33 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:33
-        GMT</Last-Modified><Etag>0x8D9143B1ACCA6F1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:49 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:50
+        GMT</Last-Modified><Etag>0x8D92ADC93614FA1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Tue,
-        11 May 2021 05:10:23 GMT</Creation-Time><Last-Modified>Tue, 11 May 2021 05:10:28
-        GMT</Last-Modified><Etag>0x8D9143B17E3F991</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Wed,
+        09 Jun 2021 00:21:51 GMT</Creation-Time><Last-Modified>Wed, 09 Jun 2021 00:21:51
+        GMT</Last-Modified><Etag>0x8D92ADC93FDFA4D</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -720,7 +801,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Tue, 11 May 2021 05:10:43 GMT
+      - Wed, 09 Jun 2021 00:22:10 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_scenarios.py
@@ -665,6 +665,11 @@ class StorageBlobCommonTests(StorageScenarioMixin, ScenarioTest):
             .assert_with_checks(JMESPathCheck('length(@)', 1),
                                 JMESPathCheck('[0].name', 'dir/'))
 
+        # Test with custom delimiter
+        self.storage_cmd('storage blob list -c {} --delimiter "ir"', account_info, container) \
+            .assert_with_checks(JMESPathCheck('length(@)', 1),
+                                JMESPathCheck('[0].name', 'dir'))
+
         # Test secondary location
         account_name = account_info[0] + '-secondary'
         account_key = account_info[1]


### PR DESCRIPTION
**Description**
Fix issue #18393

`--delimiter` parameter value for `az storage blob list` is always ignored and defaults to `/`.

This is my first time contributing to this repository, I have not directly modified the `HISTORY.rst` as mentioned in the contribution guide because I was unsure of the version in which this would land. I can add it once the the Pull Request is reviewed and approved.

**Testing Guide**
Repro is in the linked issue. I have extended one of the storage blob scenarios test to include a custom delimiter.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] az storage blob list: --delimiter parameter value will now be honored

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
