### PR TITLE
{Keyvault} `az keyvault update-hsm`: --secondary-location not supported

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -850,7 +850,7 @@ def update_hsm(cmd, instance,
 
     if secondary_locations is not None:
         # service not ready
-        raise InvalidArgumentValueError('--secondary-locations has not been supported yet for hsm')
+        raise InvalidArgumentValueError('--secondary-location has not been supported yet for hsm')
 
     if bypass or default_action and (hasattr(instance.properties, 'network_acls')):
         if instance.properties.network_acls is None:

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -850,7 +850,7 @@ def update_hsm(cmd, instance,
 
     if secondary_locations is not None:
         # service not ready
-        raise InvalidArgumentValueError('--secondary-location has not been supported yet for hsm')
+        raise InvalidArgumentValueError('--secondary-locations has not been supported yet for hsm')
 
     if bypass or default_action and (hasattr(instance.properties, 'network_acls')):
         if instance.properties.network_acls is None:

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -849,7 +849,8 @@ def update_hsm(cmd, instance,
         instance.properties.enable_purge_protection = enable_purge_protection
 
     if secondary_locations is not None:
-        instance.properties.secondary_locations = secondary_locations
+        # service not ready
+        raise InvalidArgumentValueError('--secondary-locations has not been supported yet for hsm')
 
     if bypass or default_action and (hasattr(instance.properties, 'network_acls')):
         if instance.properties.network_acls is None:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Service has not yet implemented multi-region HA for hsm yet. They asked us to disable `--secondary-locations` temporarily

**Testing Guide**
<!--Example commands with explanations.-->
`az keyvault update-hsm --hsm-name --secondary-locations`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
