### PR TITLE
[ARO] add cidr values for pod/service to cli params

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_params.py
@@ -51,10 +51,10 @@ def load_arguments(self, _):
                    validator=validate_client_secret(isCreate=True))
 
         c.argument('pod_cidr',
-                   help='CIDR of pod network.',
+                   help='CIDR of pod network. Must be a minimum of /18 or larger.',
                    validator=validate_cidr('pod_cidr'))
         c.argument('service_cidr',
-                   help='CIDR of service network.',
+                   help='CIDR of service network. Must be a minimum of /18 or larger',
                    validator=validate_cidr('service_cidr'))
 
         c.argument('master_vm_size',


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Resolves [13531](https://github.com/Azure/azure-cli/issues/13531) by adding CIDR ranges for pod network and service network.

**Testing Guide**
<!--Example commands with explanations.-->
`az aro create --help` shows the cidr range that is applicable for the service (i.e /18)
output: 
```bash
 --pod-cidr                     : CIDR of pod network. Must be a minimum of /18 or larger.
 --pull-secret                  : Pull secret of cluster.
 --service-cidr                 : CIDR of service network. Must be a minimum of /18 or larger.
```


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
