### PR TITLE
{Packaging} Remove full Release History from project description

### DIFF
--- a/src/azure-cli-core/README.rst
+++ b/src/azure-cli-core/README.rst
@@ -1,2 +1,7 @@
 Microsoft Azure CLI Core Module
 ==================================
+
+Release History
+===============
+
+See `Release History on GitHub <https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/HISTORY.rst>`__.

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -72,14 +72,12 @@ TESTS_REQUIRE = [
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()
-with open('HISTORY.rst', 'r', encoding='utf-8') as f:
-    HISTORY = f.read()
 
 setup(
     name='azure-cli-core',
     version=VERSION,
     description='Microsoft Azure Command-Line Tools Core Module',
-    long_description=README + '\n\n' + HISTORY,
+    long_description=README,
     license='MIT',
     author='Microsoft Corporation',
     author_email='azpycli@microsoft.com',

--- a/src/azure-cli/README.rst
+++ b/src/azure-cli/README.rst
@@ -103,3 +103,8 @@ License
 =======
 
 `MIT <https://github.com/Azure/azure-cli/blob/master/LICENSE.txt>`__
+
+Release History
+===============
+
+See `Azure CLI release notes <https://docs.microsoft.com/cli/azure/release-notes-azure-cli>`__.

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -155,14 +155,12 @@ TESTS_REQUIRE = [
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()
-with open('HISTORY.rst', 'r', encoding='utf-8') as f:
-    HISTORY = f.read()
 
 setup(
     name='azure-cli',
     version=VERSION,
     description='Microsoft Azure Command-Line Tools',
-    long_description=README + '\n\n' + HISTORY,
+    long_description=README,
     license='MIT',
     author='Microsoft Corporation',
     author_email='azpycli@microsoft.com',


### PR DESCRIPTION
## Description

Fix #18383

Full **Release History** is included in the project description on PyPI: https://pypi.org/project/azure-cli/

With each release, the Release History will grow, making the Azure CLI project description grow.

Even though https://packaging.python.org/specifications/core-metadata/#description says:

> Software that deals with metadata should not assume any maximum size for this field

Azure DevOps has a limit on the package description size of 324608 bytes. The latest Azure CLI's project description already exceeds this limit so can't be installed on Azure DevOps.

## Changes

This PR removes full Release History from project description and uses a link to point to the full Release History instead.
