### PR TITLE
{Core} Small fix on patching versioned sdk path

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -887,6 +887,7 @@ class AzCommandsLoader(CLICommandsLoader):  # pylint: disable=too-many-instance-
                 operation = operation.replace(rt.import_prefix,
                                               get_versioned_sdk_path(self.cli_ctx.cloud.profile, rt,
                                                                      operation_group=operation_group))
+                break
 
         try:
             mod_to_import, attr_path = operation.split('#')

--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -576,7 +576,7 @@ def get_versioned_sdk_path(api_profile, resource_type, operation_group=None):
     """
     api_version = get_api_version(api_profile, resource_type)
     if api_version is None:
-        return resource_type
+        return resource_type.import_prefix
     if isinstance(api_version, _ApiVersions):
         if operation_group is None:
             raise ValueError("operation_group is required for resource type '{}'".format(resource_type))


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
There exists logic in core to patch versioned sdk path for command's operation. For example, it will replace `azure.mgmt.storage.operations.storage_accounts_operations` to `azure.mgmt.storage.operations.v2016_12_01.storage_accounts_operations`.

Here's some small fix on this feature. See my comments for details.

**Background**

Keyvault data plane track2 migration just hit these bugs.
- While getting operation handler, `operation` was replaced wrongly with previous code:
https://github.com/Azure/azure-cli/blob/efb2f359df9035a5b6b1989b763cbe94962bb171/src/azure-cli-core/azure/cli/core/__init__.py#L877-L890
a. `ResourceType.DATA_KEYVAULT`(track1) has `azure.keyvault` as its `import_prefix`
b. `ResourceType.DATA_KEYVAULT_KEYS`(track2) has `azure.keyvault.keys` as its `import_prefix`
c. When `operation` equals `azure.keyvault.keys._client#KeyClient...`, the `for...loop` will match twice with both `azure.keyvault` and `azure.keyvault.keys` which will cause confusion

- While getting sdk path, the return value is expected to be a `Str` but we got a `ResourceType` instead in L579:
https://github.com/Azure/azure-cli/blob/efb2f359df9035a5b6b1989b763cbe94962bb171/src/azure-cli-core/azure/cli/core/profiles/_shared.py#L570-L584
`get_api_version('latest', ResourceType.DATA_KEYVAULT_KEYS)` will return `None` in L577 as keyvault data plane track2 SDK is not multi-api. In this case, the origin `resource_type.import_prefix` should return, not the whole `resource_type`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
