### PR TITLE
{Packaging} Bump PyJWT to 2.1.0

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -358,7 +358,7 @@ class Profile:
         token_entry = msi_creds.token
         token = token_entry['access_token']
         logger.info('MSI: token was retrieved. Now trying to initialize local accounts...')
-        decode = jwt.decode(token, verify=False, algorithms=['RS256'])
+        decode = jwt.decode(token, algorithms=['RS256'], options={"verify_signature": False})
         tenant = decode['tid']
 
         subscription_finder = SubscriptionFinder(self.cli_ctx, self.auth_ctx_factory, None)
@@ -382,7 +382,7 @@ class Profile:
 
         _, token, _ = self._get_token_from_cloud_shell(self.cli_ctx.cloud.endpoints.active_directory_resource_id)
         logger.info('MSI: token was retrieved. Now trying to initialize local accounts...')
-        decode = jwt.decode(token, verify=False, algorithms=['RS256'])
+        decode = jwt.decode(token, algorithms=['RS256'], options={"verify_signature": False})
         tenant = decode['tid']
 
         subscription_finder = SubscriptionFinder(self.cli_ctx, self.auth_ctx_factory, None)

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -55,6 +55,7 @@ DEPENDENCIES = [
     'msal>=1.10.0,<2.0.0',
     'paramiko>=2.0.8,<3.0.0',
     'pkginfo>=1.5.0.1',
+    'PyJWT>=2.1.0',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
     'requests~=2.22',
     'six~=1.12',

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -55,7 +55,6 @@ DEPENDENCIES = [
     'msal>=1.10.0,<2.0.0',
     'paramiko>=2.0.8,<3.0.0',
     'pkginfo>=1.5.0.1',
-    'PyJWT==1.7.1',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
     'requests~=2.22',
     'six~=1.12',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -120,7 +120,7 @@ portalocker==1.7.1
 psutil==5.8.0
 pycparser==2.19
 PyGithub==1.38
-PyJWT==1.7.1
+PyJWT==2.1.0
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -120,7 +120,7 @@ portalocker==1.7.1
 psutil==5.8.0
 pycparser==2.19
 PyGithub==1.38
-PyJWT==1.7.1
+PyJWT==2.1.0
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -119,7 +119,7 @@ portalocker==1.7.1
 psutil==5.8.0
 pycparser==2.19
 PyGithub==1.38
-PyJWT==1.7.1
+PyJWT==2.1.0
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 pyreadline==2.1


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix #17939

ADAL already supports PyJWT > 2.0 (https://github.com/AzureAD/azure-activedirectory-library-for-python/pull/246), it is safe for Azure CLI to use PyJWT 2.1.0.
