### PR TITLE
{Packaging} Be more strict on `requests`

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -57,7 +57,7 @@ DEPENDENCIES = [
     'pkginfo>=1.5.0.1',
     'PyJWT==1.7.1',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
-    'requests~=2.22',
+    'requests~=2.25.1',
     'six~=1.12',
     'urllib3[secure]>=1.26.5',
 ]


### PR DESCRIPTION
Close #18499

## Context

This command will go into almost endless [backtracking](https://pip.pypa.io/en/stable/user_guide/#dependency-resolution-backtracking):

```
pip requests~=2.24.0 azure-cli
```

The conflict comes from `requests~=2.24.0` 

https://github.com/psf/requests/blob/v2.24.0/setup.py#L47

```py
    'urllib3>=1.21.1,<1.26,!=1.25.0,!=1.25.1',
```

and `azure-cli-core`

https://github.com/Azure/azure-cli/blob/162be08eefaa1d64974a07b6179babe4c5b2830a/src/azure-cli-core/setup.py#L62

`azure-cli-core` requires the latest `urllib3` due to https://github.com/Azure/azure-cli/pull/18324.

## Change

By being more strict on `requests`, `pip` fails more quickly:

```
> pip install requests~=2.24.0 -e src/azure-cli-core

ERROR: Cannot install azure-cli-core==2.25.0 and requests~=2.24.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested requests~=2.24.0
    azure-cli-core 2.25.0 depends on requests~=2.25.1
```
