### PR TITLE
{Pylint} Fix `use-a-generator`

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -32,7 +32,6 @@ disable=
     too-many-arguments,
     too-many-function-args,
     too-many-lines,
-    use-a-generator,
     using-constant-test,
     wrong-import-order,
 

--- a/pylintrc
+++ b/pylintrc
@@ -12,7 +12,6 @@ reports=no
 disable=
     arguments-out-of-order,
     bad-option-value,
-    consider-using-generator,
     consider-using-with,
     cyclic-import,
     duplicate-code,

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -107,7 +107,7 @@ def _expand_file_prefixed_files(args):
         except IndexError:
             return _maybe_load_file(arg_split[0])
 
-    return list([_expand_file_prefix(arg) for arg in args])
+    return [_expand_file_prefix(arg) for arg in args]
 
 
 def _pre_command_table_create(cli_ctx, args):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1099,7 +1099,7 @@ def url_validator(url):
 def _get_linux_multicontainer_decoded_config(cmd, resource_group_name, name, slot=None):
     from base64 import b64decode
     linux_fx_version = _get_fx_version(cmd, resource_group_name, name, slot)
-    if not any([linux_fx_version.startswith(s) for s in MULTI_CONTAINER_TYPES]):
+    if not any(linux_fx_version.startswith(s) for s in MULTI_CONTAINER_TYPES):
         raise CLIError("Cannot decode config that is not one of the"
                        " following types: {}".format(','.join(MULTI_CONTAINER_TYPES)))
     return b64decode(linux_fx_version.split('|')[1].encode('utf-8'))

--- a/src/azure-cli/azure/cli/command_modules/batch/_command_type.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_command_type.py
@@ -250,7 +250,7 @@ class BatchArgumentTree:
         required_args = []
         children = self._get_children(path)
         if not required:
-            if not any([getattr(namespace, n) for n in children]):
+            if not any(getattr(namespace, n) for n in children):
                 return []
         siblings = self._get_siblings(path)
         if not siblings:
@@ -377,7 +377,7 @@ class BatchArgumentTree:
             child_args = self._get_children(arg_group)
             if child_args:
                 ex_group_names.append(group_title(arg_group))
-                if any([getattr(namespace, arg) for arg in child_args]):
+                if any(getattr(namespace, arg) for arg in child_args):
                     ex_groups.append(ex_group_names[-1])
 
         message = None
@@ -613,7 +613,7 @@ class AzureBatchDataPlaneCommand:
                 model._validation.get(attr, {}).get('readonly'))  # pylint: disable=protected-access
             conditions.append(
                 model._validation.get(attr, {}).get('constant'))  # pylint: disable=protected-access
-            conditions.append(any([i for i in pformat.IGNORE_PARAMETERS if i in full_path]))
+            conditions.append(any(i for i in pformat.IGNORE_PARAMETERS if i in full_path))
             conditions.append(details['type'][0] in ['{'])
             if not any(conditions):
                 yield attr, details

--- a/src/azure-cli/azure/cli/command_modules/cdn/custom/custom_afdx.py
+++ b/src/azure-cli/azure/cli/command_modules/cdn/custom/custom_afdx.py
@@ -663,8 +663,8 @@ def create_afd_security_policy(client: SecurityPoliciesOperations,
                                domains: List[str],
                                waf_policy: str):
 
-    if any([("/afdendpoints/" not in domain.lower() and
-             "/customdomains/" not in domain.lower()) for domain in domains]):
+    if any(("/afdendpoints/" not in domain.lower() and
+            "/customdomains/" not in domain.lower()) for domain in domains):
         raise InvalidArgumentValueError('Domain should either be endpoint ID or custom domain ID.')
 
     if "/frontdoorwebapplicationfirewallpolicies/" not in waf_policy.lower():
@@ -690,8 +690,8 @@ def update_afd_security_policy(client: SecurityPoliciesOperations,
                                domains: List[str] = None,
                                waf_policy: str = None):
 
-    if domains is not None and any([("/afdendpoints/" not in domain.lower() and
-                                     "/customdomains/" not in domain.lower()) for domain in domains]):
+    if domains is not None and any(("/afdendpoints/" not in domain.lower() and
+                                    "/customdomains/" not in domain.lower()) for domain in domains):
         raise InvalidArgumentValueError('Domain should be either endpoint ID or custom domain ID.')
 
     if waf_policy is not None and "/frontdoorwebapplicationfirewallpolicies/" not in waf_policy:

--- a/src/azure-cli/azure/cli/command_modules/monitor/operations/activity_log_alerts.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/operations/activity_log_alerts.py
@@ -35,7 +35,7 @@ def process_condition_parameter(namespace):
 
     # Ensure all the string at even options are AND operator
     operators = [expression[i] for i in range(1, len(expression), 2)]
-    if any([op != 'and' for op in operators]):
+    if any(op != 'and' for op in operators):
         raise CLIError(error)
 
     # Pick the strings at odd position and convert them into condition leaf.

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -259,7 +259,7 @@ def validate_trusted_client_cert(namespace):
 
 def validate_ssl_cert(namespace):
     params = [namespace.cert_data, namespace.cert_password]
-    if all([not x for x in params]) and not namespace.key_vault_secret_id:
+    if all(not x for x in params) and not namespace.key_vault_secret_id:
         # no cert supplied -- use HTTP
         if not namespace.frontend_port:
             namespace.frontend_port = 80


### PR DESCRIPTION
**Description**<!--Mandatory-->

http://pylint.pycqa.org/en/latest/technical_reference/features.html

> use-a-generator (R1729)
> Use a generator instead '%s(%s)'. Comprehension inside of 'any' or 'all' is unnecessary. A generator would be sufficient and faster.

