### PR TITLE
[App Service] Fix #18500. Add service tag list check.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -219,6 +219,9 @@ def _validate_service_tag_format(cmd, namespace):
         name = namespace.name
         webapp = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get')
         service_tag_full_list = network_client.service_tags.list(webapp.location).values
+        if service_tag_full_list is None:
+            logger.warning('Not able to get full Service Tag list. Cannot validate Service Tag.')
+            return
         for tag in input_tags:
             valid_tag = False
             for tag_full_list in service_tag_full_list:


### PR DESCRIPTION

Fixes #18500 
**Description**<!--Mandatory-->
When caller does not have read permissions on subscription, an empty service tag list is returned, and validation fails. This will skip validation (ARM backend will do final validation)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AppService] az webapp config access-restrictions add: Skip validation if user does not have access to get service tag list. 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
