### PR TITLE
{AppService} Make `appservice` tests serial

### DIFF
--- a/scripts/release/rpm/test_rpm_package.py
+++ b/scripts/release/rpm/test_rpm_package.py
@@ -14,7 +14,7 @@ pytest_base_cmd = 'PYTHONPATH=/usr/lib64/az/lib/python3.6/site-packages python3 
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
 
 for mod_name in mod_list:
-    if mod_name in ['botservice', 'network', 'cloud']:
+    if mod_name in ['botservice', 'network', 'cloud', 'appservice']:
         exit_code = subprocess.call(['{} --junit-xml /azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(pytest_base_cmd, mod_name, mod_name)], shell=True)
     else:
         exit_code = subprocess.call(['{} --junit-xml /azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(pytest_parallel_cmd, mod_name, mod_name)], shell=True)


### PR DESCRIPTION
## Context

**Test Yum Package** keeps failing with race condition:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=953187&view=logs&j=1e6fba43-bdcf-51f0-a062-3712c33fbb51&s=d654deb9-056d-50a2-1717-90c08683d50a&t=a1e787eb-ec67-5c3d-79ec-0c68f4f59d65&l=1717

```
==================================== ERRORS ====================================
____ ERROR collecting tests/latest/test_devops_build_commands_thru_mock.py _____
/usr/lib64/az/lib/python3.6/site-packages/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands_thru_mock.py:10: in <module>
    from azure.cli.command_modules.appservice.azure_devops_build_interactive import (
/usr/lib64/az/lib/python3.6/site-packages/azure/cli/command_modules/appservice/azure_devops_build_interactive.py:31: in <module>
    from .azure_devops_build_provider import AzureDevopsBuildProvider
/usr/lib64/az/lib/python3.6/site-packages/azure/cli/command_modules/appservice/azure_devops_build_provider.py:7: in <module>
    from azure_functions_devops_build.project.project_manager import ProjectManager
/usr/lib64/az/lib/python3.6/site-packages/azure_functions_devops_build/project/project_manager.py:14: in <module>
    from ..base.base_manager import BaseManager
/usr/lib64/az/lib/python3.6/site-packages/azure_functions_devops_build/base/base_manager.py:6: in <module>
    from vsts.vss_connection import VssConnection
/usr/lib64/az/lib/python3.6/site-packages/vsts/vss_connection.py:9: in <module>
    from ._file_cache import RESOURCE_CACHE as RESOURCE_FILE_CACHE
/usr/lib64/az/lib/python3.6/site-packages/vsts/_file_cache.py:122: in <module>
    DEFAULT_CACHE_DIR = get_cache_dir()
/usr/lib64/az/lib/python3.6/site-packages/vsts/_file_cache.py:117: in get_cache_dir
    os.makedirs(vsts_cache_dir)
/usr/lib64/python3.6/os.py:220: in makedirs
    mkdir(name, mode)
E   FileExistsError: [Errno 17] File exists: '/root/.vsts/python-sdk/cache'
```

By checking `/usr/lib64/az/lib/python3.6/site-packages/vsts/_file_cache.py:117`, it does check if the `vsts_cache_dir` exists first:

```py
def get_cache_dir():
    vsts_cache_dir = os.getenv('VSTS_CACHE_DIR', None) or os.path.expanduser(os.path.join('~', '.vsts', 'python-sdk',
                                                                                          'cache'))
    if not os.path.exists(vsts_cache_dir):
        os.makedirs(vsts_cache_dir)
    return vsts_cache_dir
```

But when multiple tests are run in parallel, `vsts_cache_dir` may be created by another test when `os.makedirs(vsts_cache_dir)` is executed.

## Change

This PR makes `appservice` tests serial to avoid race condition.

## Best solution

The best solution is to make `vsts` resilient to such race condition by simply using `os.makedirs(path, exist_ok=True)` or ignoring `makedirs`'s `FileExistsError`. See

- https://github.com/google/yapf/issues/731
- https://stackoverflow.com/questions/1586648/race-condition-creating-folder-in-python
- https://stackoverflow.com/questions/11360858/what-is-the-eafp-principle-in-python/56036903#56036903

