### PR TITLE
[ARO] Fail if resource doesn't exist on delete

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/custom.py
@@ -145,7 +145,11 @@ def aro_delete(cmd, client, resource_group_name, resource_name, no_wait=False):
 
     try:
         oc = client.get(resource_group_name, resource_name)
-    except (CloudError, HttpOperationError) as e:
+    except CloudError as e:
+        if e.status_code == 404:
+            raise ResourceNotFoundError(e.message) from e
+        logger.info(e.message)
+    except HttpOperationError as e:
         logger.info(e.message)
 
     aad = AADManager(cmd.cli_ctx)

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_create.yaml
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_create.yaml
@@ -13,15 +13,12 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_create000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001","name":"cli_test_aro_create000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:21:15Z","createdAt":"2021-04-30T12:21:16.6845323Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001","name":"cli_test_aro_create000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-17T17:07:15Z","createdAt":"2021-06-17T17:07:18.4444172Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:18 GMT
+      - Thu, 17 Jun 2021 17:07:19 GMT
       expires:
       - '-1'
       pragma:
@@ -63,16 +60,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"05a8aa88-f7a9-4245-9783-596ad46fa55a\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"fda452b4-ecb4-4aad-baa3-bf55db25ca4c\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"7766e07e-2b11-44d3-91ee-aab96daffb76\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"3eae10f6-fbe7-4702-ba5a-cc89558facb9\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -81,7 +78,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/f5fd3a14-18b0-4fd5-bcec-66410cfcd468?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/5960d503-e041-4c5a-9623-79497c43db70?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
@@ -89,7 +86,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:22 GMT
+      - Thu, 17 Jun 2021 17:07:20 GMT
       expires:
       - '-1'
       pragma:
@@ -102,7 +99,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 20556190-403a-437a-a06f-2bed7afef8da
+      - 3e14642e-fc76-4d11-abac-fce043abe247
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -122,9 +119,9 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/f5fd3a14-18b0-4fd5-bcec-66410cfcd468?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/5960d503-e041-4c5a-9623-79497c43db70?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -136,7 +133,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:26 GMT
+      - Thu, 17 Jun 2021 17:07:24 GMT
       expires:
       - '-1'
       pragma:
@@ -153,7 +150,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 38bf1230-eb3f-4a4c-8b69-0c66622d44be
+      - def14389-5355-4f8b-8189-40b5ffa151e2
     status:
       code: 200
       message: OK
@@ -171,16 +168,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"f704b8fe-d882-475f-82e8-91d8f0827a61\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"fdf64f75-ed88-45bf-ae8d-702ec73b4bde\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"7766e07e-2b11-44d3-91ee-aab96daffb76\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"3eae10f6-fbe7-4702-ba5a-cc89558facb9\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -193,9 +190,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:26 GMT
+      - Thu, 17 Jun 2021 17:07:24 GMT
       etag:
-      - W/"f704b8fe-d882-475f-82e8-91d8f0827a61"
+      - W/"fdf64f75-ed88-45bf-ae8d-702ec73b4bde"
       expires:
       - '-1'
       pragma:
@@ -212,7 +209,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 698c3a9d-b119-4e0e-8bf8-d72c70fdd3e2
+      - e296ac37-8508-4dd8-afba-026041f8406f
     status:
       code: 200
       message: OK
@@ -230,16 +227,16 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"f704b8fe-d882-475f-82e8-91d8f0827a61\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"fdf64f75-ed88-45bf-ae8d-702ec73b4bde\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"7766e07e-2b11-44d3-91ee-aab96daffb76\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"3eae10f6-fbe7-4702-ba5a-cc89558facb9\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -252,9 +249,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:26 GMT
+      - Thu, 17 Jun 2021 17:07:25 GMT
       etag:
-      - W/"f704b8fe-d882-475f-82e8-91d8f0827a61"
+      - W/"fdf64f75-ed88-45bf-ae8d-702ec73b4bde"
       expires:
       - '-1'
       pragma:
@@ -271,7 +268,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 375bcc4c-5829-4223-a86a-c597c59fe02f
+      - 9c49b5da-1d8e-48f2-82d5-ec25d2c2e178
     status:
       code: 200
       message: OK
@@ -279,9 +276,10 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"name": "dev_master000002",
-      "properties": {"addressPrefix": "10.112.154.0/24", "serviceEndpoints": [{"service":
-      "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings": [], "enableDdosProtection":
-      false}}'
+      "properties": {"addressPrefix": "10.13.53.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
+      [], "enableDdosProtection": false}}'
     headers:
       Accept:
       - application/json
@@ -292,29 +290,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '516'
+      - '607'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"2e975104-5d2e-4cd4-a449-faca9e95c255\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"fc9adbea-07c5-4d93-b135-17fade119210\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"7766e07e-2b11-44d3-91ee-aab96daffb76\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"3eae10f6-fbe7-4702-ba5a-cc89558facb9\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"2e975104-5d2e-4cd4-a449-faca9e95c255\\\"\",\r\n
+        \       \"etag\": \"W/\\\"fc9adbea-07c5-4d93-b135-17fade119210\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.112.154.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.13.53.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -325,15 +323,15 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/19b218c7-cff6-4040-bb47-7b00c238f0b7?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/d18d575a-4e46-44bb-b9ed-6983896dd442?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
-      - '1585'
+      - '1583'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:27 GMT
+      - Thu, 17 Jun 2021 17:07:26 GMT
       expires:
       - '-1'
       pragma:
@@ -350,7 +348,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - a6b5cd7d-3218-403d-bc14-15c9697f2064
+      - 538e217e-ac33-4add-990d-18f2bc84debc
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -370,9 +368,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/19b218c7-cff6-4040-bb47-7b00c238f0b7?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/d18d575a-4e46-44bb-b9ed-6983896dd442?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -384,7 +382,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:30 GMT
+      - Thu, 17 Jun 2021 17:07:29 GMT
       expires:
       - '-1'
       pragma:
@@ -401,7 +399,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - c627f950-b207-4cab-8f5f-461661337e50
+      - fd692691-c158-4569-ab88-3de35bd9472c
     status:
       code: 200
       message: OK
@@ -419,23 +417,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"2ac0819e-ecb8-4c0a-9ff5-0a1f6fbac123\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"dd7c7fe7-aa5f-4817-9f63-e9f20ffba361\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"7766e07e-2b11-44d3-91ee-aab96daffb76\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"3eae10f6-fbe7-4702-ba5a-cc89558facb9\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"2ac0819e-ecb8-4c0a-9ff5-0a1f6fbac123\\\"\",\r\n
+        \       \"etag\": \"W/\\\"dd7c7fe7-aa5f-4817-9f63-e9f20ffba361\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.112.154.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.13.53.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -448,13 +446,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1588'
+      - '1586'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:30 GMT
+      - Thu, 17 Jun 2021 17:07:29 GMT
       etag:
-      - W/"2ac0819e-ecb8-4c0a-9ff5-0a1f6fbac123"
+      - W/"dd7c7fe7-aa5f-4817-9f63-e9f20ffba361"
       expires:
       - '-1'
       pragma:
@@ -471,7 +469,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - a5ae647b-8b3a-4f11-b1be-44de06dcc9bf
+      - fe12f108-b9c0-414a-b27b-b95cdd62f77e
     status:
       code: 200
       message: OK
@@ -489,23 +487,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"2ac0819e-ecb8-4c0a-9ff5-0a1f6fbac123\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"dd7c7fe7-aa5f-4817-9f63-e9f20ffba361\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"7766e07e-2b11-44d3-91ee-aab96daffb76\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"3eae10f6-fbe7-4702-ba5a-cc89558facb9\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"2ac0819e-ecb8-4c0a-9ff5-0a1f6fbac123\\\"\",\r\n
+        \       \"etag\": \"W/\\\"dd7c7fe7-aa5f-4817-9f63-e9f20ffba361\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.112.154.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.13.53.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -518,13 +516,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1588'
+      - '1586'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:31 GMT
+      - Thu, 17 Jun 2021 17:07:29 GMT
       etag:
-      - W/"2ac0819e-ecb8-4c0a-9ff5-0a1f6fbac123"
+      - W/"dd7c7fe7-aa5f-4817-9f63-e9f20ffba361"
       expires:
       - '-1'
       pragma:
@@ -541,7 +539,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 42e7e9bd-5c73-43cd-bdf2-1c4642e1d9c7
+      - 2b51678c-7564-4dcc-a45e-a438b23ca8a3
     status:
       code: 200
       message: OK
@@ -549,11 +547,13 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.112.154.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Enabled"}}, {"name": "dev_worker000003", "properties": {"addressPrefix": "10.68.87.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings":
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.13.53.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Enabled"}}, {"name": "dev_worker000003",
+      "properties": {"addressPrefix": "10.80.201.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
       [], "enableDdosProtection": false}}'
     headers:
       Accept:
@@ -565,29 +565,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '973'
+      - '1118'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"e597aaf0-da89-4ca9-a268-5d967a0a952d\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"87c562a0-0e82-4079-a573-8456629afab6\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"7766e07e-2b11-44d3-91ee-aab96daffb76\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"3eae10f6-fbe7-4702-ba5a-cc89558facb9\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"e597aaf0-da89-4ca9-a268-5d967a0a952d\\\"\",\r\n
+        \       \"etag\": \"W/\\\"87c562a0-0e82-4079-a573-8456629afab6\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.112.154.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.13.53.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -596,9 +596,9 @@ interactions:
         \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
         \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"e597aaf0-da89-4ca9-a268-5d967a0a952d\\\"\",\r\n
+        \       \"etag\": \"W/\\\"87c562a0-0e82-4079-a573-8456629afab6\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.68.87.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.80.201.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -609,15 +609,15 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/d970d437-fa1e-4445-a359-a383e9e1c2f7?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/0600ffbd-cc63-482a-98df-2be7cc83db06?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
-      - '2474'
+      - '2473'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:32 GMT
+      - Thu, 17 Jun 2021 17:07:30 GMT
       expires:
       - '-1'
       pragma:
@@ -634,9 +634,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 7e50b4e8-d608-4fe3-9576-6d65a7d0dc6b
+      - 9e145c2c-baf0-4a3a-adad-9cde7ff65550
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 200
       message: OK
@@ -654,9 +654,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/d970d437-fa1e-4445-a359-a383e9e1c2f7?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/0600ffbd-cc63-482a-98df-2be7cc83db06?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -668,7 +668,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:35 GMT
+      - Thu, 17 Jun 2021 17:07:33 GMT
       expires:
       - '-1'
       pragma:
@@ -685,7 +685,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - dca65ade-4b67-4aed-ba9c-263c317f7ae4
+      - 57728dab-fcee-4985-8b0f-3301d291ac57
     status:
       code: 200
       message: OK
@@ -703,23 +703,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"dd946426-2457-4dca-8f72-47e59a894e3c\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"400ac762-dd46-4980-8ca2-3b3e2f59e963\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"7766e07e-2b11-44d3-91ee-aab96daffb76\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"3eae10f6-fbe7-4702-ba5a-cc89558facb9\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"dd946426-2457-4dca-8f72-47e59a894e3c\\\"\",\r\n
+        \       \"etag\": \"W/\\\"400ac762-dd46-4980-8ca2-3b3e2f59e963\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.112.154.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.13.53.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -728,9 +728,9 @@ interactions:
         \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
         \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"dd946426-2457-4dca-8f72-47e59a894e3c\\\"\",\r\n
+        \       \"etag\": \"W/\\\"400ac762-dd46-4980-8ca2-3b3e2f59e963\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.68.87.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.80.201.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -743,13 +743,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2478'
+      - '2477'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:36 GMT
+      - Thu, 17 Jun 2021 17:07:34 GMT
       etag:
-      - W/"dd946426-2457-4dca-8f72-47e59a894e3c"
+      - W/"400ac762-dd46-4980-8ca2-3b3e2f59e963"
       expires:
       - '-1'
       pragma:
@@ -766,7 +766,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 6c86df42-9d65-4c85-ada5-ebef2ff4f5da
+      - d6f03b7a-b34a-4f4c-ad7b-f246885c5dca
     status:
       code: 200
       message: OK
@@ -784,305 +784,14 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"dd946426-2457-4dca-8f72-47e59a894e3c\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.112.154.0/24\",\r\n
-        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
-        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
-        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
-        \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:36 GMT
-      etag:
-      - W/"dd946426-2457-4dca-8f72-47e59a894e3c"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 5664190e-41a9-489e-b3b8-3b4dfd22b9bc
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.112.154.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Disabled"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet update
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '458'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g --vnet-name -n --disable-private-link-service-network-policies
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"40e17c8a-e79b-43b5-ad50-98fc9151604a\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.112.154.0/24\",\r\n
-        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
-        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
-        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
-        \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/1fc9e037-c18e-4570-aa13-0891ecb11906?api-version=2021-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 062f002d-8869-421b-bbd1-b563e5196b29
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --disable-private-link-service-network-policies
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/1fc9e037-c18e-4570-aa13-0891ecb11906?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '29'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - d2f18434-f6d1-46c5-b45a-c04871161f89
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --disable-private-link-service-network-policies
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"93734d3a-bf76-4f23-86fd-c620be3a7005\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.112.154.0/24\",\r\n
-        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
-        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
-        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
-        \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '758'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:40 GMT
-      etag:
-      - W/"93734d3a-bf76-4f23-86fd-c620be3a7005"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 21116b84-d231-4438-9296-156ab023314c
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"93734d3a-bf76-4f23-86fd-c620be3a7005\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.112.154.0/24\",\r\n
-        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
-        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
-        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
-        \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '758'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:41 GMT
-      etag:
-      - W/"93734d3a-bf76-4f23-86fd-c620be3a7005"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 0047c18f-138c-440d-9165-4e6b48afa359
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"93734d3a-bf76-4f23-86fd-c620be3a7005\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.68.87.0/24\",\r\n
+        \ \"etag\": \"W/\\\"400ac762-dd46-4980-8ca2-3b3e2f59e963\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.13.53.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1096,9 +805,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:41 GMT
+      - Thu, 17 Jun 2021 17:07:34 GMT
       etag:
-      - W/"93734d3a-bf76-4f23-86fd-c620be3a7005"
+      - W/"400ac762-dd46-4980-8ca2-3b3e2f59e963"
       expires:
       - '-1'
       pragma:
@@ -1115,7 +824,182 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 3072d407-87db-4414-b5ea-2994b390dff2
+      - 1f04f60c-c5cc-48d1-97b0-e9481075f794
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.13.53.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '509'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --vnet-name -n --disable-private-link-service-network-policies
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \ \"etag\": \"W/\\\"8827191e-b257-42b7-adfb-99711cb04580\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.13.53.0/24\",\r\n
+        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
+        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
+        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
+        \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/f9dd85ef-9850-4f4e-abc8-73430669974c?api-version=2021-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '755'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 17:07:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 4b579292-f2a7-475c-90de-7581a0ca27fa
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --disable-private-link-service-network-policies
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/f9dd85ef-9850-4f4e-abc8-73430669974c?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '29'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 17:07:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 43145518-62d1-4ecb-800a-44946e64939d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --disable-private-link-service-network-policies
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \ \"etag\": \"W/\\\"2e70653e-aea7-4f7f-9655-cd762fd579e7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.13.53.0/24\",\r\n
+        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
+        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
+        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
+        \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '756'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 17:07:38 GMT
+      etag:
+      - W/"2e70653e-aea7-4f7f-9655-cd762fd579e7"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - a6cfdc95-9e89-423b-be67-442cc562a2e4
     status:
       code: 200
       message: OK
@@ -1133,15 +1017,128 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \ \"etag\": \"W/\\\"2e70653e-aea7-4f7f-9655-cd762fd579e7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.13.53.0/24\",\r\n
+        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
+        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
+        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
+        \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '756'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 17:07:39 GMT
+      etag:
+      - W/"2e70653e-aea7-4f7f-9655-cd762fd579e7"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 5e7855cb-8216-4aba-b507-bec8864a853f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \ \"etag\": \"W/\\\"2e70653e-aea7-4f7f-9655-cd762fd579e7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.80.201.0/24\",\r\n
+        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
+        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
+        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
+        \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '756'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 17:07:39 GMT
+      etag:
+      - W/"2e70653e-aea7-4f7f-9655-cd762fd579e7"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - a97eb46f-2d09-4b2f-ae6a-540f52421b16
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_create000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001","name":"cli_test_aro_create000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:21:15Z","createdAt":"2021-04-30T12:21:16.6845323Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001","name":"cli_test_aro_create000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-17T17:07:15Z","createdAt":"2021-06-17T17:07:18.4444172Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1150,7 +1147,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:41 GMT
+      - Thu, 17 Jun 2021 17:07:41 GMT
       expires:
       - '-1'
       pragma:
@@ -1178,10 +1175,7 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift?api-version=2020-10-01
   response:
@@ -1214,7 +1208,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:42 GMT
+      - Thu, 17 Jun 2021 17:07:41 GMT
       expires:
       - '-1'
       pragma:
@@ -1229,10 +1223,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"passwordCredentials": [{"startDate": "2021-04-30T12:21:42.78871Z", "endDate":
+    body: '{"passwordCredentials": [{"startDate": "2021-06-17T17:07:41.744213Z", "endDate":
       "2299-12-31T00:00:00.000Z", "value": "ReplacedSPPassword123*", "customKeyIdentifier":
-      "MjAyMS0wNC0zMCAxMjoyMTo0Mi43ODg3MTA="}], "displayName": "aro-np9862i9", "identifierUris":
-      ["https://az.aro.azure.com/9d016c07-be7d-4331-9d90-bf1da701c875"]}'
+      "MjAyMS0wNi0xNyAxNzowNzo0MS43NDQyMTM="}], "displayName": "aro-b0cbwn82", "identifierUris":
+      ["https://az.aro.azure.com/72a84a7d-7f5d-45a9-9fff-673083f61cc2"]}'
     headers:
       Accept:
       - application/json
@@ -1243,14 +1237,14 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '337'
+      - '338'
       Content-Type:
       - application/json; charset=utf-8
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
@@ -1259,29 +1253,29 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "27550ca7-b6dd-41ec-97fd-e81944eb9a98", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "5475d059-071b-44ee-8306-01ae7ca016c6",
+        "objectId": "2df5bd3a-b16d-42ec-823a-65fd9488feea", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "56d7ae44-a5f1-49e5-944f-254034af38f1",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
-        false, "displayName": "aro-np9862i9", "errorUrl": null, "groupMembershipClaims":
-        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/9d016c07-be7d-4331-9d90-bf1da701c875"],
+        false, "displayName": "aro-b0cbwn82", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/72a84a7d-7f5d-45a9-9fff-673083f61cc2"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/27550ca7-b6dd-41ec-97fd-e81944eb9a98/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/2df5bd3a-b16d-42ec-823a-65fd9488feea/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/27550ca7-b6dd-41ec-97fd-e81944eb9a98/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/2df5bd3a-b16d-42ec-823a-65fd9488feea/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
-        "Allow the application to access aro-np9862i9 on behalf of the signed-in user.",
-        "adminConsentDisplayName": "Access aro-np9862i9", "id": "3f640e4b-535b-4d04-8426-6649af1500a0",
+        "Allow the application to access aro-b0cbwn82 on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Access aro-b0cbwn82", "id": "ff86d446-f8a4-45bd-8c52-6e77099ca298",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
-        to access aro-np9862i9 on your behalf.", "userConsentDisplayName": "Access
-        aro-np9862i9", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        to access aro-b0cbwn82 on your behalf.", "userConsentDisplayName": "Access
+        aro-b0cbwn82", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
-        [{"customKeyIdentifier": "MjAyMS0wNC0zMCAxMjoyMTo0Mi43ODg3MTA=", "endDate":
-        "2299-12-31T00:00:00Z", "keyId": "b01b2a32-4eed-42b1-a025-2452403d1d1d", "startDate":
-        "2021-04-30T12:21:42.78871Z", "value": "ReplacedSPPassword123*"}], "publicClient":
+        [{"customKeyIdentifier": "MjAyMS0wNi0xNyAxNzowNzo0MS43NDQyMTM=", "endDate":
+        "2299-12-31T00:00:00Z", "keyId": "084fb824-2066-4917-9da0-90fc1011aa6e", "startDate":
+        "2021-06-17T17:07:41.744213Z", "value": "ReplacedSPPassword123*"}], "publicClient":
         null, "publisherDomain": "rhcuppettgmail.onmicrosoft.com", "recordConsentConditions":
         null, "replyUrls": [], "requiredResourceAccess": [], "samlMetadataUrl": null,
         "signInAudience": "AzureADMyOrg", "tokenEncryptionKeyId": null}'
@@ -1291,27 +1285,27 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2299'
+      - '2300'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:43 GMT
+      - Thu, 17 Jun 2021 17:07:42 GMT
       duration:
-      - '6827011'
+      - '4051503'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/27550ca7-b6dd-41ec-97fd-e81944eb9a98/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/2df5bd3a-b16d-42ec-823a-65fd9488feea/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - qlPIvEic8eVh5MU7VUueS29XEFKfR/2IrpRdoo+09Qg=
+      - tMfina+PAnmF4G7OK+HPYdXmxD5C3ZCJapEv1cZ2m4Y=
       ocp-aad-session-key:
-      - 8boZ1kjfeP0g2JiPyGUrMsfo6jVqcx9IqAjX9GehNKl4qUBQFVHlgIZOXlQ5u7ueaWmpEAhlLYbD-Fm6sYNe_tQ4WAkcNbztnmkh0ZilUdGRATx2oAGvr8CrnavRVBWnhWIwEToFCQQrTUttHsqFCTMgP0NOHS75P3p4Lid3_VCHphHfI0uOPWrpY16aca6j8whSoAgAwR7kmVIxV9k5Mw.jDzd8ZXaSBehsxRCXyypWexNcQahc1y8tGRo4PBAOBc
+      - sW32fodtIsglJnWwFsyeqXZ8EYkkYpe9m6_NEUnYw0SirYGTLuMtht-BtR7M1YYge-CNCGRP87c1iIR-3Zf2A7YsYRvVf2iFBKpK-JPzIE7hEVZsFlVi1rQtLPRhQoBfPKc-I76Dk6xEW-hCHv9j-3BKjUK6u_KiJa9gAK71kZY.XPAh9CkpKhgRe0L9LXAPiJBPZABaXq1Uxv35FV-6EFQ
       pragma:
       - no-cache
       request-id:
-      - 747dd672-559c-427a-bce1-b33626c826bb
+      - c056cb0f-de87-49d9-83f3-fa176e3d68a4
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1339,12 +1333,12 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%275475d059-071b-44ee-8306-01ae7ca016c6%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%2756d7ae44-a5f1-49e5-944f-254034af38f1%27&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -1360,19 +1354,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:44 GMT
+      - Thu, 17 Jun 2021 17:07:42 GMT
       duration:
-      - '1281875'
+      - '319275'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - yTY39zp7iEfP/qnZmy9n1PlH6JMTulgXEFQ39IH4B00=
+      - 4r4CGxE3SB7rsozXQ40lb8uQsc17A9nHKII0AUH5QT0=
       ocp-aad-session-key:
-      - dfk7h9hFF1TAONK_4YqZIQPm9dytNTQX7DIvizKBl94BOfYFTgsWcvhXYBHBjGO9GIwMbIvS3ik-oBI02vwu4sCYStBX8GnKGh7ADCdK71z0ZCLBT4bwsLEbsPYmbB6okcZibCsmFrDZkgJwGd26p68jNRiikwp39QYkBoq5zSUM5VQFP0XDVu9Rf7S5WNQBwc3Tqtb1qZKXTHopatQ1Qg.72v4bT1i2C0y8tobHiKzSDR5U_986Ri-uXJwZePOmnw
+      - 5ozc7hIwaOJvw1pgA8eIc9uVLwfUkdMZiAfEvSiRg2WCm0FMfbxj0eObQSPrkb34IUm5wwzOSkZv8hNKuRLMlFq-gAohy-jyMAZL4UIU0cyMlNTvzTAOZgoSaohMLy2vOpfbdW2O_Yep3ig9EjT1fwy6m8QX_u6uyM4-l9m1azQ.f3t6JdtZjaugEA72ZD_i-XOQHi-4cMhQIWncYEtQJ38
       pragma:
       - no-cache
       request-id:
-      - 97fd5b99-446b-4ff5-8c94-fb2382279161
+      - 4d254feb-3acb-4dbe-a40a-8b348787d113
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1387,7 +1381,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"appId": "5475d059-071b-44ee-8306-01ae7ca016c6"}'
+    body: '{"appId": "56d7ae44-a5f1-49e5-944f-254034af38f1"}'
     headers:
       Accept:
       - application/json
@@ -1404,20 +1398,20 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"4af7002e-7407-4d39-8daf-a4f2fa0998df","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-np9862i9","appId":"5475d059-071b-44ee-8306-01ae7ca016c6","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-np9862i9","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access aro-np9862i9 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        aro-np9862i9","id":"3f640e4b-535b-4d04-8426-6649af1500a0","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access aro-np9862i9 on your behalf.","userConsentDisplayName":"Access
-        aro-np9862i9","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
-        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["5475d059-071b-44ee-8306-01ae7ca016c6","https://az.aro.azure.com/9d016c07-be7d-4331-9d90-bf1da701c875"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"7be1e7c1-8e3c-4fe2-9826-1b12641e00ee","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-b0cbwn82","appId":"56d7ae44-a5f1-49e5-944f-254034af38f1","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-b0cbwn82","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access aro-b0cbwn82 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        aro-b0cbwn82","id":"ff86d446-f8a4-45bd-8c52-6e77099ca298","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access aro-b0cbwn82 on your behalf.","userConsentDisplayName":"Access
+        aro-b0cbwn82","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
+        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["56d7ae44-a5f1-49e5-944f-254034af38f1","https://az.aro.azure.com/72a84a7d-7f5d-45a9-9fff-673083f61cc2"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1430,21 +1424,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:44 GMT
+      - Thu, 17 Jun 2021 17:07:43 GMT
       duration:
-      - '3455145'
+      - '1814454'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/4af7002e-7407-4d39-8daf-a4f2fa0998df/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/7be1e7c1-8e3c-4fe2-9826-1b12641e00ee/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - 0BLyYGCHtdpm1Y2lqNwjW4fbpNMJ9zWOOrRn0mvmdrM=
+      - gU7iZhmHbwQMSh/A7T+Sru6UvnYFPTArRltksauaJJo=
       ocp-aad-session-key:
-      - lRJ1cWlFAdkn3iCE7Ad7z-n8bBdwlJkyZcnVAlFQJwOaeKzc7oyOeAJDbY07emoqhKEQISrUo4Y_1_2Yq6xX_eFviw3NioSDM-ZBuf5rplNWmMt00dGxprvWMHYIz44hSTd1aFtRtiDNFa68H9YH-_iyy3sMVEa4mITrT9hojzCcyGjVgpD6ZtaNBdb3LRcMU2y2SdSekATlawPYdfIycw.hNUSRtYn2RW7hMQAwFY2FyZ98N9zHREngfQrcWZF65k
+      - _HjZTt1u7kZv-BUh60WUuBCIos6rAHGsTyLxJD1xhlCuGJ79Qp07LtJi2iCd2wR2Z9OkcTonO6kT2j8FVRoFIud8lHgesFxRk2BsDtFfjWjRIxUf75xoKbjcGaXnEjlf_7MXfkhw-MD1nahc7rFNG1OQGMkIds--fvKRNvv2Tb4.pspDlJu8iC6_E_iecxMMaoHqKkioW-sB9nvLT4OA_Z4
       pragma:
       - no-cache
       request-id:
-      - 26477f72-ba90-4f22-b41d-e6bca3868278
+      - 2b54eecf-ef23-4a10-a430-1ca1e8e8a4b3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1472,8 +1466,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -1496,19 +1490,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
+      - Thu, 17 Jun 2021 17:07:43 GMT
       duration:
-      - '1271094'
+      - '343853'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - b803NvrbzSh7lw3GLvpOfDb0K+A3CBaxjzNCQXuw2VY=
+      - z2tIVyEH+3hRlIstXMovRuvSZPmIls6MTAfEpIJ0xmE=
       ocp-aad-session-key:
-      - XWMz2SQesoyn3C4HTN4lnuIzLs8Rx1bIK5UHGpcW406i4A8v_Hjc67yoAYMsCidVw82ELC2-9pSzg9OaLpDcZjTIAvEIDQ1Xh-i1HXLst7pY0aBANYK97goHnKz60CdagPsdjcxhgVddmohHiv7qUigAJwi6Vh-8Bm7dyJjODgijlKGlAbXMKFtAcMc89933z7fOYZSy6jNReR8Jtj3FEQ.Yw0Zt78sGTc0guYXa22LjNy90G7Lqw8evz-vXXvZeLA
+      - 6lScjDNNpBLpp8t7IolDv0l9qmdFiRuXGx7bgHPrVw4NtiVvKn76oNyHYTs91c4tXPcixkbSlyrm01y5yYJFKj1Fl8uaYgGrLnovZ0wdHCsm8EzyPLxXMRBrdoUiNPpQp8VAWzj11uZJ9ZFBLK3T4lPPsBhZL61t80KTzOddQfQ.o47YZlc3lznnlh6VXEUYIjSkq7HhvNLmcw0nafX0Kdg
       pragma:
       - no-cache
       request-id:
-      - 401e24c1-3605-4686-84b7-afea2e0f89f6
+      - 18d5a792-0936-4601-92a3-6210de596473
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1536,14 +1530,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"93734d3a-bf76-4f23-86fd-c620be3a7005\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.68.87.0/24\",\r\n
+        \ \"etag\": \"W/\\\"2e70653e-aea7-4f7f-9655-cd762fd579e7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.80.201.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1553,13 +1547,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '755'
+      - '756'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
+      - Thu, 17 Jun 2021 17:07:43 GMT
       etag:
-      - W/"93734d3a-bf76-4f23-86fd-c620be3a7005"
+      - W/"2e70653e-aea7-4f7f-9655-cd762fd579e7"
       expires:
       - '-1'
       pragma:
@@ -1576,7 +1570,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - bc80f870-f078-4832-bad0-26434af5d58b
+      - 8a67def9-b719-414d-88f4-3b30b251255e
     status:
       code: 200
       message: OK
@@ -1594,14 +1588,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"93734d3a-bf76-4f23-86fd-c620be3a7005\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.112.154.0/24\",\r\n
+        \ \"etag\": \"W/\\\"2e70653e-aea7-4f7f-9655-cd762fd579e7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.13.53.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1611,13 +1605,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '758'
+      - '756'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
+      - Thu, 17 Jun 2021 17:07:43 GMT
       etag:
-      - W/"93734d3a-bf76-4f23-86fd-c620be3a7005"
+      - W/"2e70653e-aea7-4f7f-9655-cd762fd579e7"
       expires:
       - '-1'
       pragma:
@@ -1634,7 +1628,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 5a4518f4-e6bb-46df-be4c-5ecfce033e3a
+      - ea34841b-3e04-4710-bcfd-727ea112174b
     status:
       code: 200
       message: OK
@@ -1652,24 +1646,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '23097'
+      - '24837'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
+      - Thu, 17 Jun 2021 17:07:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1689,7 +1683,7 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
-      "principalId": "4af7002e-7407-4d39-8daf-a4f2fa0998df", "principalType": "ServicePrincipal"}}'
+      "principalId": "7be1e7c1-8e3c-4fe2-9826-1b12641e00ee", "principalType": "ServicePrincipal"}}'
     headers:
       Accept:
       - application/json
@@ -1706,15 +1700,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"4af7002e-7407-4d39-8daf-a4f2fa0998df","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:46.7444643Z","updatedOn":"2021-04-30T12:21:47.3044670Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"7be1e7c1-8e3c-4fe2-9826-1b12641e00ee","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T17:07:45.5353384Z","updatedOn":"2021-06-17T17:07:45.8503372Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
     headers:
       cache-control:
       - no-cache
@@ -1723,7 +1717,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:49 GMT
+      - Thu, 17 Jun 2021 17:07:46 GMT
       expires:
       - '-1'
       pragma:
@@ -1753,24 +1747,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"4af7002e-7407-4d39-8daf-a4f2fa0998df","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:47.5345007Z","updatedOn":"2021-04-30T12:21:47.5345007Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"7be1e7c1-8e3c-4fe2-9826-1b12641e00ee","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T17:07:45.9703682Z","updatedOn":"2021-06-17T17:07:45.9703682Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '24149'
+      - '25889'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:49 GMT
+      - Thu, 17 Jun 2021 17:07:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1807,15 +1801,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:50.7888381Z","updatedOn":"2021-04-30T12:21:51.4988097Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T17:07:48.2255161Z","updatedOn":"2021-06-17T17:07:48.6354681Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
     headers:
       cache-control:
       - no-cache
@@ -1824,7 +1818,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:53 GMT
+      - Thu, 17 Jun 2021 17:07:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1842,9 +1836,9 @@ interactions:
       message: Created
 - request:
     body: '{"tags": {"test": "create"}, "location": "eastus", "properties": {"clusterProfile":
-      {"pullSecret": "", "domain": "np9862i9", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-np9862i9"},
-      "servicePrincipalProfile": {"clientId": "5475d059-071b-44ee-8306-01ae7ca016c6",
-      "clientSecret": "93519760-e886-4ee8-bda7-a334151f76ee"}, "networkProfile": {"podCidr":
+      {"pullSecret": "", "domain": "b0cbwn82", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-b0cbwn82"},
+      "servicePrincipalProfile": {"clientId": "56d7ae44-a5f1-49e5-944f-254034af38f1",
+      "clientSecret": "9da86c89-7f79-4811-a1f0-822c0a55fa11"}, "networkProfile": {"podCidr":
       "10.128.0.0/14", "serviceCidr": "172.30.0.0/16"}, "masterProfile": {"vmSize":
       "Standard_D8s_v3", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002"},
       "workerProfiles": [{"name": "worker", "vmSize": "Standard_D4s_v3", "diskSizeGB":
@@ -1867,8 +1861,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
@@ -1879,10 +1873,10 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"create\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Creating\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"np9862i9\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-np9862i9\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"b0cbwn82\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-b0cbwn82\"\n
         \       },\n        \"consoleProfile\": {},\n        \"servicePrincipalProfile\":
-        {\n            \"clientId\": \"5475d059-071b-44ee-8306-01ae7ca016c6\"\n        },\n
+        {\n            \"clientId\": \"56d7ae44-a5f1-49e5-944f-254034af38f1\"\n        },\n
         \       \"networkProfile\": {\n            \"podCidr\": \"10.128.0.0/14\",\n
         \           \"serviceCidr\": \"172.30.0.0/16\"\n        },\n        \"masterProfile\":
         {\n            \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\":
@@ -1896,7 +1890,7 @@ interactions:
         \"Public\"\n            }\n        ]\n    }\n}\n"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -1904,7 +1898,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:21:58 GMT
+      - Thu, 17 Jun 2021 17:07:51 GMT
       expires:
       - '-1'
       pragma:
@@ -1932,24 +1926,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:22:28 GMT
+      - Thu, 17 Jun 2021 17:08:21 GMT
       expires:
       - '-1'
       pragma:
@@ -1979,24 +1973,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:22:59 GMT
+      - Thu, 17 Jun 2021 17:08:51 GMT
       expires:
       - '-1'
       pragma:
@@ -2026,24 +2020,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:23:29 GMT
+      - Thu, 17 Jun 2021 17:09:22 GMT
       expires:
       - '-1'
       pragma:
@@ -2073,24 +2067,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:23:59 GMT
+      - Thu, 17 Jun 2021 17:09:52 GMT
       expires:
       - '-1'
       pragma:
@@ -2120,24 +2114,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:24:29 GMT
+      - Thu, 17 Jun 2021 17:10:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2167,24 +2161,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:25:00 GMT
+      - Thu, 17 Jun 2021 17:10:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2214,24 +2208,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:25:30 GMT
+      - Thu, 17 Jun 2021 17:11:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2261,24 +2255,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:26:00 GMT
+      - Thu, 17 Jun 2021 17:11:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2308,24 +2302,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:26:30 GMT
+      - Thu, 17 Jun 2021 17:12:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2355,24 +2349,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:27:01 GMT
+      - Thu, 17 Jun 2021 17:12:54 GMT
       expires:
       - '-1'
       pragma:
@@ -2402,24 +2396,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:27:31 GMT
+      - Thu, 17 Jun 2021 17:13:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2449,24 +2443,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:28:01 GMT
+      - Thu, 17 Jun 2021 17:13:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2496,24 +2490,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:28:31 GMT
+      - Thu, 17 Jun 2021 17:14:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2543,24 +2537,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:29:02 GMT
+      - Thu, 17 Jun 2021 17:14:54 GMT
       expires:
       - '-1'
       pragma:
@@ -2590,24 +2584,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:29:32 GMT
+      - Thu, 17 Jun 2021 17:15:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2637,24 +2631,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:30:02 GMT
+      - Thu, 17 Jun 2021 17:15:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2684,24 +2678,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:30:33 GMT
+      - Thu, 17 Jun 2021 17:16:25 GMT
       expires:
       - '-1'
       pragma:
@@ -2731,24 +2725,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:31:03 GMT
+      - Thu, 17 Jun 2021 17:16:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2778,24 +2772,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:31:33 GMT
+      - Thu, 17 Jun 2021 17:17:25 GMT
       expires:
       - '-1'
       pragma:
@@ -2825,24 +2819,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:32:04 GMT
+      - Thu, 17 Jun 2021 17:17:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2872,24 +2866,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:32:34 GMT
+      - Thu, 17 Jun 2021 17:18:26 GMT
       expires:
       - '-1'
       pragma:
@@ -2919,24 +2913,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:33:04 GMT
+      - Thu, 17 Jun 2021 17:18:56 GMT
       expires:
       - '-1'
       pragma:
@@ -2966,24 +2960,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:33:34 GMT
+      - Thu, 17 Jun 2021 17:19:26 GMT
       expires:
       - '-1'
       pragma:
@@ -3013,24 +3007,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:34:05 GMT
+      - Thu, 17 Jun 2021 17:19:56 GMT
       expires:
       - '-1'
       pragma:
@@ -3060,24 +3054,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:34:35 GMT
+      - Thu, 17 Jun 2021 17:20:26 GMT
       expires:
       - '-1'
       pragma:
@@ -3107,24 +3101,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:35:05 GMT
+      - Thu, 17 Jun 2021 17:20:57 GMT
       expires:
       - '-1'
       pragma:
@@ -3154,24 +3148,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:35:36 GMT
+      - Thu, 17 Jun 2021 17:21:27 GMT
       expires:
       - '-1'
       pragma:
@@ -3201,24 +3195,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:36:06 GMT
+      - Thu, 17 Jun 2021 17:21:57 GMT
       expires:
       - '-1'
       pragma:
@@ -3248,24 +3242,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:36:36 GMT
+      - Thu, 17 Jun 2021 17:22:27 GMT
       expires:
       - '-1'
       pragma:
@@ -3295,24 +3289,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:37:06 GMT
+      - Thu, 17 Jun 2021 17:22:56 GMT
       expires:
       - '-1'
       pragma:
@@ -3342,24 +3336,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:37:37 GMT
+      - Thu, 17 Jun 2021 17:23:28 GMT
       expires:
       - '-1'
       pragma:
@@ -3389,24 +3383,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:38:07 GMT
+      - Thu, 17 Jun 2021 17:23:58 GMT
       expires:
       - '-1'
       pragma:
@@ -3436,24 +3430,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:38:37 GMT
+      - Thu, 17 Jun 2021 17:24:28 GMT
       expires:
       - '-1'
       pragma:
@@ -3483,24 +3477,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:39:07 GMT
+      - Thu, 17 Jun 2021 17:24:58 GMT
       expires:
       - '-1'
       pragma:
@@ -3530,24 +3524,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:39:37 GMT
+      - Thu, 17 Jun 2021 17:25:28 GMT
       expires:
       - '-1'
       pragma:
@@ -3577,24 +3571,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:40:07 GMT
+      - Thu, 17 Jun 2021 17:25:59 GMT
       expires:
       - '-1'
       pragma:
@@ -3624,24 +3618,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:40:38 GMT
+      - Thu, 17 Jun 2021 17:26:29 GMT
       expires:
       - '-1'
       pragma:
@@ -3671,24 +3665,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:41:08 GMT
+      - Thu, 17 Jun 2021 17:26:59 GMT
       expires:
       - '-1'
       pragma:
@@ -3718,24 +3712,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:41:38 GMT
+      - Thu, 17 Jun 2021 17:27:29 GMT
       expires:
       - '-1'
       pragma:
@@ -3765,24 +3759,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:42:08 GMT
+      - Thu, 17 Jun 2021 17:27:59 GMT
       expires:
       - '-1'
       pragma:
@@ -3812,24 +3806,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:42:39 GMT
+      - Thu, 17 Jun 2021 17:28:30 GMT
       expires:
       - '-1'
       pragma:
@@ -3859,24 +3853,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:43:10 GMT
+      - Thu, 17 Jun 2021 17:29:00 GMT
       expires:
       - '-1'
       pragma:
@@ -3906,24 +3900,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:43:40 GMT
+      - Thu, 17 Jun 2021 17:29:30 GMT
       expires:
       - '-1'
       pragma:
@@ -3953,24 +3947,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:44:10 GMT
+      - Thu, 17 Jun 2021 17:30:00 GMT
       expires:
       - '-1'
       pragma:
@@ -4000,24 +3994,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:44:40 GMT
+      - Thu, 17 Jun 2021 17:30:31 GMT
       expires:
       - '-1'
       pragma:
@@ -4047,24 +4041,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:45:11 GMT
+      - Thu, 17 Jun 2021 17:31:01 GMT
       expires:
       - '-1'
       pragma:
@@ -4094,24 +4088,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:45:41 GMT
+      - Thu, 17 Jun 2021 17:31:31 GMT
       expires:
       - '-1'
       pragma:
@@ -4141,24 +4135,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:46:11 GMT
+      - Thu, 17 Jun 2021 17:32:01 GMT
       expires:
       - '-1'
       pragma:
@@ -4188,24 +4182,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:46:41 GMT
+      - Thu, 17 Jun 2021 17:32:31 GMT
       expires:
       - '-1'
       pragma:
@@ -4235,24 +4229,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:47:12 GMT
+      - Thu, 17 Jun 2021 17:33:02 GMT
       expires:
       - '-1'
       pragma:
@@ -4282,24 +4276,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:47:42 GMT
+      - Thu, 17 Jun 2021 17:33:32 GMT
       expires:
       - '-1'
       pragma:
@@ -4329,24 +4323,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:48:12 GMT
+      - Thu, 17 Jun 2021 17:34:02 GMT
       expires:
       - '-1'
       pragma:
@@ -4376,24 +4370,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:48:42 GMT
+      - Thu, 17 Jun 2021 17:34:32 GMT
       expires:
       - '-1'
       pragma:
@@ -4423,24 +4417,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:49:13 GMT
+      - Thu, 17 Jun 2021 17:35:02 GMT
       expires:
       - '-1'
       pragma:
@@ -4470,24 +4464,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:49:43 GMT
+      - Thu, 17 Jun 2021 17:35:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4517,24 +4511,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:50:13 GMT
+      - Thu, 17 Jun 2021 17:36:03 GMT
       expires:
       - '-1'
       pragma:
@@ -4564,24 +4558,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:50:43 GMT
+      - Thu, 17 Jun 2021 17:36:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4611,24 +4605,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:51:14 GMT
+      - Thu, 17 Jun 2021 17:37:03 GMT
       expires:
       - '-1'
       pragma:
@@ -4658,24 +4652,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:51:44 GMT
+      - Thu, 17 Jun 2021 17:37:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4705,24 +4699,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:52:14 GMT
+      - Thu, 17 Jun 2021 17:38:03 GMT
       expires:
       - '-1'
       pragma:
@@ -4752,24 +4746,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:52:44 GMT
+      - Thu, 17 Jun 2021 17:38:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4799,24 +4793,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n
-        \   \"name\": \"04f5f7ba-2857-4d8c-ad72-4c70498ff21f\",\n    \"status\": \"Succeeded\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.726216624Z\",\n    \"endTime\": \"2021-04-30T12:52:47.581900653Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n
+        \   \"name\": \"9b79580a-5710-48d6-842d-fa01a3e5ffa3\",\n    \"status\": \"Succeeded\",\n
+        \   \"startTime\": \"2021-06-17T17:07:51.15964756Z\",\n    \"endTime\": \"2021-06-17T17:38:41.499182441Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '354'
+      - '353'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:53:14 GMT
+      - Thu, 17 Jun 2021 17:39:04 GMT
       expires:
       - '-1'
       pragma:
@@ -4846,8 +4840,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
   response:
@@ -4856,28 +4850,28 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"create\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"np9862i9\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-np9862i9\"\n
-        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.np9862i9.eastus.aroapp.io/\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"b0cbwn82\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-b0cbwn82\"\n
+        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.b0cbwn82.eastus.aroapp.io/\"\n
         \       },\n        \"servicePrincipalProfile\": {\n            \"clientId\":
-        \"5475d059-071b-44ee-8306-01ae7ca016c6\"\n        },\n        \"networkProfile\":
+        \"56d7ae44-a5f1-49e5-944f-254034af38f1\"\n        },\n        \"networkProfile\":
         {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\":
         \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n            \"vmSize\":
         \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \       },\n        \"workerProfiles\": [\n            {\n                \"name\":
-        \"aro000004-5dd5v-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-hm9xv-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-5dd5v-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-hm9xv-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-5dd5v-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-hm9xv-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_create000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            }\n        ],\n        \"apiserverProfile\":
-        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.np9862i9.eastus.aroapp.io:6443/\",\n
-        \           \"ip\": \"20.75.157.90\"\n        },\n        \"ingressProfiles\":
+        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.b0cbwn82.eastus.aroapp.io:6443/\",\n
+        \           \"ip\": \"20.62.209.6\"\n        },\n        \"ingressProfiles\":
         [\n            {\n                \"name\": \"default\",\n                \"visibility\":
-        \"Public\",\n                \"ip\": \"20.75.158.31\"\n            }\n        ]\n
+        \"Public\",\n                \"ip\": \"20.62.213.178\"\n            }\n        ]\n
         \   }\n}\n"
     headers:
       cache-control:
@@ -4887,7 +4881,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:53:15 GMT
+      - Thu, 17 Jun 2021 17:39:04 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_delete.yaml
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_delete.yaml
@@ -13,15 +13,12 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_delete000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001","name":"cli_test_aro_delete000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:21:15Z","createdAt":"2021-04-30T12:21:17.0377074Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001","name":"cli_test_aro_delete000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-17T14:25:50Z","createdAt":"2021-06-17T14:25:52.2375394Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:18 GMT
+      - Thu, 17 Jun 2021 14:25:53 GMT
       expires:
       - '-1'
       pragma:
@@ -63,16 +60,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"fd9b316e-cf23-435a-bfcf-9423dd987f15\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"10329b32-9611-40c1-907b-74ac6389bda4\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"11504dfc-89ff-461c-93dd-7143ea15fe43\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"77f76122-04b4-40fe-98a2-61ddddd74667\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -81,7 +78,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/399a3bec-a4ab-4ec8-96cf-106d83660f69?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/00c4b232-b954-4807-9645-80a4609a9681?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
@@ -89,7 +86,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:22 GMT
+      - Thu, 17 Jun 2021 14:25:54 GMT
       expires:
       - '-1'
       pragma:
@@ -102,7 +99,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - dd5c8ec7-e9ca-451e-9b34-c98a6905347f
+      - 1e6c1994-5747-4cbc-8477-a0ad1e5fecae
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -122,9 +119,9 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/399a3bec-a4ab-4ec8-96cf-106d83660f69?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/00c4b232-b954-4807-9645-80a4609a9681?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -136,7 +133,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:26 GMT
+      - Thu, 17 Jun 2021 14:25:57 GMT
       expires:
       - '-1'
       pragma:
@@ -153,7 +150,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e3abfe52-2237-4682-939e-4729192a6dba
+      - 3585896e-4527-45d1-960f-edc8f7fe3e13
     status:
       code: 200
       message: OK
@@ -171,16 +168,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"c7012cf6-66d5-4013-ac63-2526c703b235\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"b9d68ee4-eeae-4048-a515-435e88a8c0d8\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"11504dfc-89ff-461c-93dd-7143ea15fe43\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"77f76122-04b4-40fe-98a2-61ddddd74667\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -193,9 +190,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:26 GMT
+      - Thu, 17 Jun 2021 14:25:57 GMT
       etag:
-      - W/"c7012cf6-66d5-4013-ac63-2526c703b235"
+      - W/"b9d68ee4-eeae-4048-a515-435e88a8c0d8"
       expires:
       - '-1'
       pragma:
@@ -212,7 +209,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 1b3ac6a3-ac9d-4efc-af7e-bbcc3a41862d
+      - 10ecd915-b7fb-4d6b-847b-e7d5b257d922
     status:
       code: 200
       message: OK
@@ -230,16 +227,16 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"c7012cf6-66d5-4013-ac63-2526c703b235\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"b9d68ee4-eeae-4048-a515-435e88a8c0d8\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"11504dfc-89ff-461c-93dd-7143ea15fe43\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"77f76122-04b4-40fe-98a2-61ddddd74667\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -252,9 +249,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:27 GMT
+      - Thu, 17 Jun 2021 14:25:58 GMT
       etag:
-      - W/"c7012cf6-66d5-4013-ac63-2526c703b235"
+      - W/"b9d68ee4-eeae-4048-a515-435e88a8c0d8"
       expires:
       - '-1'
       pragma:
@@ -271,7 +268,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 20947d28-2be3-4a7c-832c-229405e28b21
+      - f1744740-c75b-4e69-959c-f3f1e82bd6b4
     status:
       code: 200
       message: OK
@@ -279,281 +276,9 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"name": "dev_master000002",
-      "properties": {"addressPrefix": "10.60.54.0/24", "serviceEndpoints": [{"service":
-      "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings": [], "enableDdosProtection":
-      false}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '514'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"0c0053b1-f943-4e25-ac11-442fa4dc35ec\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"11504dfc-89ff-461c-93dd-7143ea15fe43\",\r\n    \"addressSpace\":
-        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
-        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
-        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"0c0053b1-f943-4e25-ac11-442fa4dc35ec\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.60.54.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
-        false\r\n  }\r\n}"
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/683024a8-eab3-4992-9b8c-fe3ccc81fc7a?api-version=2021-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '1583'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:28 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 1677a26f-9cf0-4c67-b1c2-ddca5901db0c
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/683024a8-eab3-4992-9b8c-fe3ccc81fc7a?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '29'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 79ee501f-4181-4549-978d-d00267ec44ed
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"22f1b294-e46b-461d-8c05-d3319111e405\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"11504dfc-89ff-461c-93dd-7143ea15fe43\",\r\n    \"addressSpace\":
-        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
-        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
-        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"22f1b294-e46b-461d-8c05-d3319111e405\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.60.54.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
-        false\r\n  }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1586'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:31 GMT
-      etag:
-      - W/"22f1b294-e46b-461d-8c05-d3319111e405"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 65f1ed2a-9573-46d1-98ee-5d8b8a335050
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"22f1b294-e46b-461d-8c05-d3319111e405\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"11504dfc-89ff-461c-93dd-7143ea15fe43\",\r\n    \"addressSpace\":
-        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
-        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
-        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"22f1b294-e46b-461d-8c05-d3319111e405\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.60.54.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
-        false\r\n  }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1586'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:31 GMT
-      etag:
-      - W/"22f1b294-e46b-461d-8c05-d3319111e405"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - b579157d-3740-4ba8-9979-7ee57ca0d8ae
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
-      "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
-      ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.60.54.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Enabled"}}, {"name": "dev_worker000003", "properties": {"addressPrefix": "10.75.249.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings":
+      "properties": {"addressPrefix": "10.32.140.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
       [], "enableDdosProtection": false}}'
     headers:
       Accept:
@@ -565,40 +290,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '972'
+      - '608'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"8b02cfee-a977-447f-88e6-0a560ee79e73\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"08410acd-93bf-4a04-be2f-7dc8d4c838f6\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"11504dfc-89ff-461c-93dd-7143ea15fe43\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"77f76122-04b4-40fe-98a2-61ddddd74667\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"8b02cfee-a977-447f-88e6-0a560ee79e73\\\"\",\r\n
+        \       \"etag\": \"W/\\\"08410acd-93bf-4a04-be2f-7dc8d4c838f6\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.60.54.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"8b02cfee-a977-447f-88e6-0a560ee79e73\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.75.249.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.32.140.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -609,15 +323,15 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/cba36b43-3cd0-4537-bdf5-ce195426938b?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/08d50be5-d450-4cbf-a2f1-c89553d4890f?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
-      - '2473'
+      - '1584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:32 GMT
+      - Thu, 17 Jun 2021 14:25:59 GMT
       expires:
       - '-1'
       pragma:
@@ -634,9 +348,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 1bbfc398-65a2-4a84-bae0-0e9f9e725aaa
+      - 581ddb91-52c4-4389-95a6-8fd9f52b7661
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 200
       message: OK
@@ -654,9 +368,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/cba36b43-3cd0-4537-bdf5-ce195426938b?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/08d50be5-d450-4cbf-a2f1-c89553d4890f?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -668,7 +382,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:36 GMT
+      - Thu, 17 Jun 2021 14:26:02 GMT
       expires:
       - '-1'
       pragma:
@@ -685,7 +399,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - fc685658-584d-400a-8b3e-c07b8eea97fe
+      - aab0e399-3bc4-436d-9914-f4ca925806ee
     status:
       code: 200
       message: OK
@@ -703,34 +417,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"14a08d61-66ae-44b4-a99c-b775fb9dc3c8\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"59383132-ef77-4c47-b1b6-1f813aa689bc\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"11504dfc-89ff-461c-93dd-7143ea15fe43\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"77f76122-04b4-40fe-98a2-61ddddd74667\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"14a08d61-66ae-44b4-a99c-b775fb9dc3c8\\\"\",\r\n
+        \       \"etag\": \"W/\\\"59383132-ef77-4c47-b1b6-1f813aa689bc\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.60.54.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"14a08d61-66ae-44b4-a99c-b775fb9dc3c8\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.75.249.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.32.140.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -743,13 +446,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2477'
+      - '1587'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:36 GMT
+      - Thu, 17 Jun 2021 14:26:02 GMT
       etag:
-      - W/"14a08d61-66ae-44b4-a99c-b775fb9dc3c8"
+      - W/"59383132-ef77-4c47-b1b6-1f813aa689bc"
       expires:
       - '-1'
       pragma:
@@ -766,7 +469,304 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 4207be15-5e64-44c4-b5e2-6af8c09de536
+      - 3c5c3ed1-c58d-46cb-9512-ce0444f27ff1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
+        \ \"etag\": \"W/\\\"59383132-ef77-4c47-b1b6-1f813aa689bc\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"77f76122-04b4-40fe-98a2-61ddddd74667\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \       \"etag\": \"W/\\\"59383132-ef77-4c47-b1b6-1f813aa689bc\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.32.140.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1587'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 14:26:04 GMT
+      etag:
+      - W/"59383132-ef77-4c47-b1b6-1f813aa689bc"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - a286e789-0ffd-4c78-870b-e97b40146525
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
+      "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.32.140.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Enabled"}}, {"name": "dev_worker000003",
+      "properties": {"addressPrefix": "10.117.241.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
+      [], "enableDdosProtection": false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1120'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
+        \ \"etag\": \"W/\\\"f0d7436f-dfc5-486c-9452-770fdc3e6d9a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"77f76122-04b4-40fe-98a2-61ddddd74667\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \       \"etag\": \"W/\\\"f0d7436f-dfc5-486c-9452-770fdc3e6d9a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"addressPrefix\": \"10.32.140.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \       \"etag\": \"W/\\\"f0d7436f-dfc5-486c-9452-770fdc3e6d9a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"addressPrefix\": \"10.117.241.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/8378c2c3-56c3-4a33-b321-ae041f6b19ee?api-version=2021-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2475'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 14:26:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 40080891-8357-4fa2-b14f-be013400049e
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/8378c2c3-56c3-4a33-b321-ae041f6b19ee?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '29'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 14:26:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - f118c6c8-4763-4d14-a653-1bfabddae373
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
+        \ \"etag\": \"W/\\\"621030e8-e430-48a7-a261-9854f87197c4\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"77f76122-04b4-40fe-98a2-61ddddd74667\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \       \"etag\": \"W/\\\"621030e8-e430-48a7-a261-9854f87197c4\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.32.140.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \       \"etag\": \"W/\\\"621030e8-e430-48a7-a261-9854f87197c4\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.117.241.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2479'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 14:26:08 GMT
+      etag:
+      - W/"621030e8-e430-48a7-a261-9854f87197c4"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 1608ecd1-c262-40aa-ab12-c36cc4206e8c
     status:
       code: 200
       message: OK
@@ -784,14 +784,14 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"14a08d61-66ae-44b4-a99c-b775fb9dc3c8\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.60.54.0/24\",\r\n
+        \ \"etag\": \"W/\\\"621030e8-e430-48a7-a261-9854f87197c4\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.32.140.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -801,13 +801,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '755'
+      - '756'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:37 GMT
+      - Thu, 17 Jun 2021 14:26:08 GMT
       etag:
-      - W/"14a08d61-66ae-44b4-a99c-b775fb9dc3c8"
+      - W/"621030e8-e430-48a7-a261-9854f87197c4"
       expires:
       - '-1'
       pragma:
@@ -824,16 +824,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 3fc22109-0909-4b34-80ed-52ce34cd5f68
+      - b99d0fb9-57dc-43ad-87f5-1526b8f8de83
     status:
       code: 200
       message: OK
 - request:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.60.54.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Disabled"}}'
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.32.140.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Disabled"}}'
     headers:
       Accept:
       - application/json
@@ -844,20 +844,20 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '456'
+      - '510'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"f2e9c556-3cf9-4e9b-b360-168c663d831c\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.60.54.0/24\",\r\n
+        \ \"etag\": \"W/\\\"c782637a-23a5-431e-a4df-7d43541eebf5\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.32.140.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -865,15 +865,15 @@ interactions:
         \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/581100e7-91c7-42f9-a340-bd774bdb35e1?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/7697fefc-c74a-4060-96e0-1f06e2b0407c?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
-      - '755'
+      - '756'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:37 GMT
+      - Thu, 17 Jun 2021 14:26:08 GMT
       expires:
       - '-1'
       pragma:
@@ -890,7 +890,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - cfbc11dd-4605-41e9-a250-bd3e70ca6f6e
+      - 985473ae-d23a-4bd9-a9b3-7fca232cabe8
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -910,9 +910,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/581100e7-91c7-42f9-a340-bd774bdb35e1?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/7697fefc-c74a-4060-96e0-1f06e2b0407c?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -924,7 +924,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:40 GMT
+      - Thu, 17 Jun 2021 14:26:11 GMT
       expires:
       - '-1'
       pragma:
@@ -941,7 +941,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 50941ef9-5c4a-44ce-93e3-c571c50b0b4c
+      - ea28a019-7eff-4d7b-94db-51f21a10376c
     status:
       code: 200
       message: OK
@@ -959,14 +959,14 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"6c1a4944-2a79-4d76-8b74-ba219aca6e5f\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.60.54.0/24\",\r\n
+        \ \"etag\": \"W/\\\"2abbd1ea-4850-4c3e-9880-661d6ab1b753\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.32.140.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -976,13 +976,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '757'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:40 GMT
+      - Thu, 17 Jun 2021 14:26:11 GMT
       etag:
-      - W/"6c1a4944-2a79-4d76-8b74-ba219aca6e5f"
+      - W/"2abbd1ea-4850-4c3e-9880-661d6ab1b753"
       expires:
       - '-1'
       pragma:
@@ -999,7 +999,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 57e7b0ef-db63-4578-82fd-2cf238a12253
+      - ba49de1b-e089-4235-9750-f08bdb28828b
     status:
       code: 200
       message: OK
@@ -1017,14 +1017,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"6c1a4944-2a79-4d76-8b74-ba219aca6e5f\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.60.54.0/24\",\r\n
+        \ \"etag\": \"W/\\\"2abbd1ea-4850-4c3e-9880-661d6ab1b753\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.32.140.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1034,13 +1034,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '757'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:41 GMT
+      - Thu, 17 Jun 2021 14:26:12 GMT
       etag:
-      - W/"6c1a4944-2a79-4d76-8b74-ba219aca6e5f"
+      - W/"2abbd1ea-4850-4c3e-9880-661d6ab1b753"
       expires:
       - '-1'
       pragma:
@@ -1057,7 +1057,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 4c81fba2-b863-4f75-bd40-e1661a6e2333
+      - b6326344-df0b-4643-aef0-17795c30a8db
     status:
       code: 200
       message: OK
@@ -1075,14 +1075,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"6c1a4944-2a79-4d76-8b74-ba219aca6e5f\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.75.249.0/24\",\r\n
+        \ \"etag\": \"W/\\\"2abbd1ea-4850-4c3e-9880-661d6ab1b753\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.117.241.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1092,13 +1092,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '757'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:41 GMT
+      - Thu, 17 Jun 2021 14:26:13 GMT
       etag:
-      - W/"6c1a4944-2a79-4d76-8b74-ba219aca6e5f"
+      - W/"2abbd1ea-4850-4c3e-9880-661d6ab1b753"
       expires:
       - '-1'
       pragma:
@@ -1115,7 +1115,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 44f35992-9519-41c9-9de6-d44f253cc11c
+      - b23425a5-bf62-4b00-a122-5fa9e912461d
     status:
       code: 200
       message: OK
@@ -1133,15 +1133,12 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_delete000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001","name":"cli_test_aro_delete000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:21:15Z","createdAt":"2021-04-30T12:21:17.0377074Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001","name":"cli_test_aro_delete000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-17T14:25:50Z","createdAt":"2021-06-17T14:25:52.2375394Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1150,7 +1147,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:42 GMT
+      - Thu, 17 Jun 2021 14:26:12 GMT
       expires:
       - '-1'
       pragma:
@@ -1178,10 +1175,7 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift?api-version=2020-10-01
   response:
@@ -1214,7 +1208,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:42 GMT
+      - Thu, 17 Jun 2021 14:26:13 GMT
       expires:
       - '-1'
       pragma:
@@ -1229,10 +1223,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"passwordCredentials": [{"startDate": "2021-04-30T12:21:43.365126Z", "endDate":
+    body: '{"passwordCredentials": [{"startDate": "2021-06-17T14:26:14.052129Z", "endDate":
       "2299-12-31T00:00:00.000Z", "value": "ReplacedSPPassword123*", "customKeyIdentifier":
-      "MjAyMS0wNC0zMCAxMjoyMTo0My4zNjUxMjY="}], "displayName": "aro-p5cy3hol", "identifierUris":
-      ["https://az.aro.azure.com/eed7a36a-1d83-4489-9350-83ec122bed71"]}'
+      "MjAyMS0wNi0xNyAxNDoyNjoxNC4wNTIxMjk="}], "displayName": "aro-y6thnz4z", "identifierUris":
+      ["https://az.aro.azure.com/25d5db8f-d1b8-4287-846e-69b805f84d60"]}'
     headers:
       Accept:
       - application/json
@@ -1249,8 +1243,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
@@ -1259,29 +1253,29 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "0f2b512b-82b4-4bf3-9915-99165f6f7609", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "e9567204-abb3-4618-bb30-19dec1985316",
+        "objectId": "e6fe0ca1-5918-4484-8688-7ab7c0509013", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "7fae9de1-2441-4b54-96f5-2810c3de14af",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
-        false, "displayName": "aro-p5cy3hol", "errorUrl": null, "groupMembershipClaims":
-        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/eed7a36a-1d83-4489-9350-83ec122bed71"],
+        false, "displayName": "aro-y6thnz4z", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/25d5db8f-d1b8-4287-846e-69b805f84d60"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/0f2b512b-82b4-4bf3-9915-99165f6f7609/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/e6fe0ca1-5918-4484-8688-7ab7c0509013/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/0f2b512b-82b4-4bf3-9915-99165f6f7609/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/e6fe0ca1-5918-4484-8688-7ab7c0509013/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
-        "Allow the application to access aro-p5cy3hol on behalf of the signed-in user.",
-        "adminConsentDisplayName": "Access aro-p5cy3hol", "id": "dba17cca-f0ad-48f3-85cd-082081c4da48",
+        "Allow the application to access aro-y6thnz4z on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Access aro-y6thnz4z", "id": "83969a53-48bc-43fa-9cbd-4848168e86f1",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
-        to access aro-p5cy3hol on your behalf.", "userConsentDisplayName": "Access
-        aro-p5cy3hol", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        to access aro-y6thnz4z on your behalf.", "userConsentDisplayName": "Access
+        aro-y6thnz4z", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
-        [{"customKeyIdentifier": "MjAyMS0wNC0zMCAxMjoyMTo0My4zNjUxMjY=", "endDate":
-        "2299-12-31T00:00:00Z", "keyId": "de3c9d3a-b6ce-47d6-bf87-67c98a2527cf", "startDate":
-        "2021-04-30T12:21:43.365126Z", "value": "ReplacedSPPassword123*"}], "publicClient":
+        [{"customKeyIdentifier": "MjAyMS0wNi0xNyAxNDoyNjoxNC4wNTIxMjk=", "endDate":
+        "2299-12-31T00:00:00Z", "keyId": "3a22524d-3d56-4146-a8fb-9b0aa149423b", "startDate":
+        "2021-06-17T14:26:14.052129Z", "value": "ReplacedSPPassword123*"}], "publicClient":
         null, "publisherDomain": "rhcuppettgmail.onmicrosoft.com", "recordConsentConditions":
         null, "replyUrls": [], "requiredResourceAccess": [], "samlMetadataUrl": null,
         "signInAudience": "AzureADMyOrg", "tokenEncryptionKeyId": null}'
@@ -1297,21 +1291,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:44 GMT
+      - Thu, 17 Jun 2021 14:26:14 GMT
       duration:
-      - '8373030'
+      - '3227254'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/0f2b512b-82b4-4bf3-9915-99165f6f7609/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/e6fe0ca1-5918-4484-8688-7ab7c0509013/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - R7/MRuVJplbKVYLGE2uBxvsciEiuHvEDyU5P3ZjwIMg=
+      - 3qc6r1AzMjd+shP3RdPGeI7JE3uu4Oi6NWZWQDhCbzk=
       ocp-aad-session-key:
-      - inAEjTs2JJb0DMGIhiHq35Lidj7caS1S45RU1Eo2SnTBt2npVuXYmA8ihooVUM2Bqs26J8QUb5RH5Pr9gVgC3HQmcKsTLMoNiYJm1p1JGYIvK5QaV4rOCVIDV_Iv3mQJTjeTK0eUB8bfoDGSs_nLTi3TpN5rS0Ue_o91fZjetktIxvlOpDGZmMQNYQsNw8C3Aw9inDTxJfyr_S5xyoIZrQ.M8f3h6bow5a1O4J1PMLPKoeHndYE_n0t2NUf_jYBBGc
+      - GBFT7jvw0nVfnAYUWd7sKK8phNIIon9CEAw7RGUGHOu32Ke3WGxk1TFzqkHGcqbjlc_JphXSLkQyh0nbu10oXstuDKlZpa--zxEKnWPu8R9sWq0PvGu9qkCwDKwYC6qr5ds9IhTQljg4qIEWTXlCklBESWRwYxIR3imNZrC6zSs.STP1XZT19gK0m6CaEIUQ2posQgKe588196xlyVuTAFY
       pragma:
       - no-cache
       request-id:
-      - 9d5f3dc2-d593-4dd4-960a-e9e1352c5f75
+      - eabf8580-c1a3-437d-b5bb-f08709bdeac2
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1339,12 +1333,12 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27e9567204-abb3-4618-bb30-19dec1985316%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%277fae9de1-2441-4b54-96f5-2810c3de14af%27&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -1360,19 +1354,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:44 GMT
+      - Thu, 17 Jun 2021 14:26:14 GMT
       duration:
-      - '1193156'
+      - '268315'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - V1z+/V6xpBR8gRuscCZlS6SNSiKL6sbq+HEsVuH3xS0=
+      - yuCMRIwRsnxJdzpH3HIbGdW1PmNg6rGopL7kgKUeDpI=
       ocp-aad-session-key:
-      - RqSknns2IfgPJ4Lb8jaTSSatlSihHRxB2yRMIopFl23BV_vsWkBs0gnvWpF04-4yWvCqEP3vKdfYcEzIG-rsM_mnH02zHHNh-q6FRbG24S_Ll31Cb6QLdSs_vISqWS6YbWldiNMxDAtmj-PbRc0P8A5SynBTTwK1VbXj466a-c-h_7_8cjoFcSlCBP0IPvnj06MRTcNYVQAX7JbwsjWKRg.4xX9CMm_sG5-sKTKEdAGl8DDX2ws0WRuCgpmDV-oFtA
+      - IszdHVapd_PXNNH483npre2me2RHwZQmar6dH1WFAP-bwuBCMtsLychgfE16hFlQH9NJj4uUeZqbsYiO1XkuAkni_5JhqNTSzHZDZ0XPBhLZ8Q7gpFAIhjGSF1ifdS8LWzz52M3oe9ZYPDeAexDn8DX2Wb_Vc1dwmAvgwbgldBk.9GuPp1_LmvCfq1TejJy4e6Z4Q8O0vEScMBW0fbbqjtY
       pragma:
       - no-cache
       request-id:
-      - af8c8cfb-e892-444f-8c34-f0016f4ef1b1
+      - 77c80433-f696-46e5-8bc4-cd4f7b8e0c9f
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1387,7 +1381,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"appId": "e9567204-abb3-4618-bb30-19dec1985316"}'
+    body: '{"appId": "7fae9de1-2441-4b54-96f5-2810c3de14af"}'
     headers:
       Accept:
       - application/json
@@ -1404,20 +1398,20 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"ef060b73-22bb-41ee-818b-c94e4c545270","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-p5cy3hol","appId":"e9567204-abb3-4618-bb30-19dec1985316","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-p5cy3hol","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access aro-p5cy3hol on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        aro-p5cy3hol","id":"dba17cca-f0ad-48f3-85cd-082081c4da48","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access aro-p5cy3hol on your behalf.","userConsentDisplayName":"Access
-        aro-p5cy3hol","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
-        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["e9567204-abb3-4618-bb30-19dec1985316","https://az.aro.azure.com/eed7a36a-1d83-4489-9350-83ec122bed71"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"2ff9a1a4-96fb-4f80-8ef0-d28d92245bd2","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-y6thnz4z","appId":"7fae9de1-2441-4b54-96f5-2810c3de14af","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-y6thnz4z","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access aro-y6thnz4z on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        aro-y6thnz4z","id":"83969a53-48bc-43fa-9cbd-4848168e86f1","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access aro-y6thnz4z on your behalf.","userConsentDisplayName":"Access
+        aro-y6thnz4z","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
+        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["7fae9de1-2441-4b54-96f5-2810c3de14af","https://az.aro.azure.com/25d5db8f-d1b8-4287-846e-69b805f84d60"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1430,21 +1424,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
+      - Thu, 17 Jun 2021 14:26:15 GMT
       duration:
-      - '3600594'
+      - '1712142'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/ef060b73-22bb-41ee-818b-c94e4c545270/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/2ff9a1a4-96fb-4f80-8ef0-d28d92245bd2/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - thZE3KtNyqyQzwgsnESRMWdBy1qLVbSpY6Z02Ec00oo=
+      - crPvdX/LotgY0rjL26is8Tq67+mLsDFajqVZLoZ1ZcU=
       ocp-aad-session-key:
-      - -LpNLI8uJagv5haqUpIDMPe3aapOwgNxzRW7u6hZMk8Nx1gxIlE7Kyir_vgfjs-GBCm9Wp6O_SD8uVBr2FEhdSzhkNIJiFP_olTNKaFjVYAMrRDZzefv_L4reTuMHt6DzzFp_-oM_KZRA3dvY7acMetGXWvVPQuREDHA2Xxqzf9EtXlxs3LLM-jjC0biMIaR7zivhF1uc5TmTqhHtBCgbQ.X20OAdeqeUEOJLLVC0LSJoHz2r6rYt4yf8SlMe41q7o
+      - _u7CCkZTFqmUClKxtl5vRkHupAyWbWujRmhZH1ffRyKsia0KlItA3AJsjL3_IBpeHVg2WMhnwit_fzRXB-i9bVFj7eKluFE9bVRQQs49h3Jbr1bMe7dXBSEOqzhVNPjaclrkyw1Feqy3c06GhABGqCgnRMH6ZpxkyyJ_ti6eM3o.1moqnKOYEsf5RunjHwGqUDEMb1zy545DzdurJjE84bw
       pragma:
       - no-cache
       request-id:
-      - cea998cb-9c2a-4f6a-b8b4-75963d5d2bae
+      - 53dc98bc-75dc-4259-b7e1-348cd6be0437
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1472,8 +1466,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -1496,19 +1490,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
+      - Thu, 17 Jun 2021 14:26:15 GMT
       duration:
-      - '1318435'
+      - '367233'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 9tI6RqdFeCGeZQFU83Fe0OIJVehgM7nvHsd30MjaJf0=
+      - z5RlIeSIU79B+CNc0oWq8hkCq9Wx7Li/mAlWYP+IMbU=
       ocp-aad-session-key:
-      - RH3GdOwuIBRjUMaKcbxH6bdr_30Le44iBnQV6dqHyeTn4LjpKcjZvcnTntZTvH83EanIU5d4wkQossXzpkd8w-1U2lzdSaMrMAHvIbG3aPAB9j6BQ30cErQVpIIpH_nWogW3ETxEW9ot5dqIV566zQ03Bl9ch9YblSNeAWdo9qTXazRAT0R4i2LIa_FAYXUcrj31j9gw3VlECfEYpdDAGA.0mIk8wkXKiHi9IBLAS0VnGZUVXl2HwqjEBaliB4sifQ
+      - K-mbSGqOnEDsuaOZXzzj9kzbeB8BWOghaXgN3MDYwZ3ji0cIhCKEJ99gwl7aRgm23F2LxxQlmWBkpV15wYy2guf5dL8a8-502FYujHhl3j1lJFDtfViSKfvjuR6ww-eUZwLtcBeLEHEMRnbtgQqREcjoMlkzbq1Bp7ijupU-pYs.UrkzmezkCW_g9lF6tYOFW6W-BvDMtor64k2NbErdE-4
       pragma:
       - no-cache
       request-id:
-      - 137e4b36-8203-496d-8b9b-78abe3e80994
+      - daddfa33-6f82-40d4-9e7c-80f650fabff3
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1536,72 +1530,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"6c1a4944-2a79-4d76-8b74-ba219aca6e5f\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.75.249.0/24\",\r\n
-        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
-        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
-        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
-        \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '756'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:46 GMT
-      etag:
-      - W/"6c1a4944-2a79-4d76-8b74-ba219aca6e5f"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 0d516cc2-8f28-427e-8840-ff37c6440ec4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"6c1a4944-2a79-4d76-8b74-ba219aca6e5f\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.60.54.0/24\",\r\n
+        \ \"etag\": \"W/\\\"2abbd1ea-4850-4c3e-9880-661d6ab1b753\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.32.140.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1611,13 +1547,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '757'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:46 GMT
+      - Thu, 17 Jun 2021 14:26:16 GMT
       etag:
-      - W/"6c1a4944-2a79-4d76-8b74-ba219aca6e5f"
+      - W/"2abbd1ea-4850-4c3e-9880-661d6ab1b753"
       expires:
       - '-1'
       pragma:
@@ -1634,7 +1570,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 599ee5c6-d2fd-44f8-99ff-6604604947aa
+      - a1554166-3b35-469b-b7fe-ef949a1ce535
     status:
       code: 200
       message: OK
@@ -1652,24 +1588,82 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \ \"etag\": \"W/\\\"2abbd1ea-4850-4c3e-9880-661d6ab1b753\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.117.241.0/24\",\r\n
+        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
+        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
+        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
+        \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '757'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 14:26:16 GMT
+      etag:
+      - W/"2abbd1ea-4850-4c3e-9880-661d6ab1b753"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 671d7515-bebc-4466-b092-c95befbe12c0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '23097'
+      - '24837'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
+      - Thu, 17 Jun 2021 14:26:16 GMT
       expires:
       - '-1'
       pragma:
@@ -1689,7 +1683,7 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
-      "principalId": "ef060b73-22bb-41ee-818b-c94e4c545270", "principalType": "ServicePrincipal"}}'
+      "principalId": "2ff9a1a4-96fb-4f80-8ef0-d28d92245bd2", "principalType": "ServicePrincipal"}}'
     headers:
       Accept:
       - application/json
@@ -1706,15 +1700,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"ef060b73-22bb-41ee-818b-c94e4c545270","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:47.2374739Z","updatedOn":"2021-04-30T12:21:48.0574770Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"2ff9a1a4-96fb-4f80-8ef0-d28d92245bd2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T14:26:17.5299891Z","updatedOn":"2021-06-17T14:26:17.8199390Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
     headers:
       cache-control:
       - no-cache
@@ -1723,7 +1717,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:49 GMT
+      - Thu, 17 Jun 2021 14:26:18 GMT
       expires:
       - '-1'
       pragma:
@@ -1753,24 +1747,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"ef060b73-22bb-41ee-818b-c94e4c545270","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:48.2924764Z","updatedOn":"2021-04-30T12:21:48.2924764Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"2ff9a1a4-96fb-4f80-8ef0-d28d92245bd2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T14:26:17.9449883Z","updatedOn":"2021-06-17T14:26:17.9449883Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '24149'
+      - '25889'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:49 GMT
+      - Thu, 17 Jun 2021 14:26:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1807,15 +1801,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:51.0846993Z","updatedOn":"2021-04-30T12:21:51.3396522Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T14:26:20.0180502Z","updatedOn":"2021-06-17T14:26:20.3380896Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
     headers:
       cache-control:
       - no-cache
@@ -1824,7 +1818,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:53 GMT
+      - Thu, 17 Jun 2021 14:26:20 GMT
       expires:
       - '-1'
       pragma:
@@ -1836,15 +1830,15 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
 - request:
     body: '{"tags": {"test": "delete"}, "location": "eastus", "properties": {"clusterProfile":
-      {"pullSecret": "", "domain": "p5cy3hol", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol"},
-      "servicePrincipalProfile": {"clientId": "e9567204-abb3-4618-bb30-19dec1985316",
-      "clientSecret": "40328b75-3206-4380-a644-91161f8f9d4f"}, "networkProfile": {"podCidr":
+      {"pullSecret": "", "domain": "y6thnz4z", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z"},
+      "servicePrincipalProfile": {"clientId": "7fae9de1-2441-4b54-96f5-2810c3de14af",
+      "clientSecret": "443a210a-892d-430a-8bfa-228e86986c1b"}, "networkProfile": {"podCidr":
       "10.128.0.0/14", "serviceCidr": "172.30.0.0/16"}, "masterProfile": {"vmSize":
       "Standard_D8s_v3", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002"},
       "workerProfiles": [{"name": "worker", "vmSize": "Standard_D4s_v3", "diskSizeGB":
@@ -1867,8 +1861,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
@@ -1879,10 +1873,10 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"delete\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Creating\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"p5cy3hol\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-p5cy3hol\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"y6thnz4z\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-y6thnz4z\"\n
         \       },\n        \"consoleProfile\": {},\n        \"servicePrincipalProfile\":
-        {\n            \"clientId\": \"e9567204-abb3-4618-bb30-19dec1985316\"\n        },\n
+        {\n            \"clientId\": \"7fae9de1-2441-4b54-96f5-2810c3de14af\"\n        },\n
         \       \"networkProfile\": {\n            \"podCidr\": \"10.128.0.0/14\",\n
         \           \"serviceCidr\": \"172.30.0.0/16\"\n        },\n        \"masterProfile\":
         {\n            \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\":
@@ -1896,7 +1890,7 @@ interactions:
         \"Public\"\n            }\n        ]\n    }\n}\n"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -1904,7 +1898,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:21:57 GMT
+      - Thu, 17 Jun 2021 14:26:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1932,15 +1926,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -1949,7 +1943,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:22:27 GMT
+      - Thu, 17 Jun 2021 14:26:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1979,15 +1973,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -1996,7 +1990,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:22:58 GMT
+      - Thu, 17 Jun 2021 14:27:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2026,15 +2020,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2043,7 +2037,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:23:28 GMT
+      - Thu, 17 Jun 2021 14:27:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2073,15 +2067,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2090,7 +2084,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:23:58 GMT
+      - Thu, 17 Jun 2021 14:28:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2120,15 +2114,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2137,7 +2131,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:24:29 GMT
+      - Thu, 17 Jun 2021 14:28:54 GMT
       expires:
       - '-1'
       pragma:
@@ -2167,15 +2161,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2184,7 +2178,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:24:59 GMT
+      - Thu, 17 Jun 2021 14:29:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2214,15 +2208,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2231,7 +2225,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:25:29 GMT
+      - Thu, 17 Jun 2021 14:29:54 GMT
       expires:
       - '-1'
       pragma:
@@ -2261,15 +2255,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2278,7 +2272,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:25:58 GMT
+      - Thu, 17 Jun 2021 14:30:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2308,15 +2302,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2325,7 +2319,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:26:29 GMT
+      - Thu, 17 Jun 2021 14:30:54 GMT
       expires:
       - '-1'
       pragma:
@@ -2355,15 +2349,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2372,7 +2366,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:26:59 GMT
+      - Thu, 17 Jun 2021 14:31:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2402,15 +2396,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2419,7 +2413,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:27:29 GMT
+      - Thu, 17 Jun 2021 14:31:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2449,15 +2443,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2466,7 +2460,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:28:00 GMT
+      - Thu, 17 Jun 2021 14:32:25 GMT
       expires:
       - '-1'
       pragma:
@@ -2496,15 +2490,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2513,7 +2507,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:28:31 GMT
+      - Thu, 17 Jun 2021 14:32:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2543,15 +2537,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2560,7 +2554,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:29:01 GMT
+      - Thu, 17 Jun 2021 14:33:25 GMT
       expires:
       - '-1'
       pragma:
@@ -2590,15 +2584,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2607,7 +2601,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:29:31 GMT
+      - Thu, 17 Jun 2021 14:33:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2637,15 +2631,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2654,7 +2648,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:30:01 GMT
+      - Thu, 17 Jun 2021 14:34:26 GMT
       expires:
       - '-1'
       pragma:
@@ -2684,15 +2678,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2701,7 +2695,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:30:32 GMT
+      - Thu, 17 Jun 2021 14:34:56 GMT
       expires:
       - '-1'
       pragma:
@@ -2731,15 +2725,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2748,7 +2742,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:31:01 GMT
+      - Thu, 17 Jun 2021 14:35:26 GMT
       expires:
       - '-1'
       pragma:
@@ -2778,15 +2772,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2795,7 +2789,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:31:31 GMT
+      - Thu, 17 Jun 2021 14:35:56 GMT
       expires:
       - '-1'
       pragma:
@@ -2825,15 +2819,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2842,7 +2836,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:32:02 GMT
+      - Thu, 17 Jun 2021 14:36:26 GMT
       expires:
       - '-1'
       pragma:
@@ -2872,15 +2866,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2889,7 +2883,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:32:32 GMT
+      - Thu, 17 Jun 2021 14:36:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2919,15 +2913,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2936,7 +2930,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:33:02 GMT
+      - Thu, 17 Jun 2021 14:37:28 GMT
       expires:
       - '-1'
       pragma:
@@ -2966,15 +2960,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2983,7 +2977,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:33:33 GMT
+      - Thu, 17 Jun 2021 14:37:57 GMT
       expires:
       - '-1'
       pragma:
@@ -3013,15 +3007,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3030,7 +3024,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:34:03 GMT
+      - Thu, 17 Jun 2021 14:38:27 GMT
       expires:
       - '-1'
       pragma:
@@ -3060,15 +3054,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3077,7 +3071,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:34:33 GMT
+      - Thu, 17 Jun 2021 14:38:58 GMT
       expires:
       - '-1'
       pragma:
@@ -3107,15 +3101,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3124,7 +3118,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:35:03 GMT
+      - Thu, 17 Jun 2021 14:39:29 GMT
       expires:
       - '-1'
       pragma:
@@ -3154,15 +3148,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3171,7 +3165,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:35:34 GMT
+      - Thu, 17 Jun 2021 14:39:59 GMT
       expires:
       - '-1'
       pragma:
@@ -3201,15 +3195,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3218,7 +3212,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:36:04 GMT
+      - Thu, 17 Jun 2021 14:40:29 GMT
       expires:
       - '-1'
       pragma:
@@ -3248,15 +3242,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3265,7 +3259,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:36:34 GMT
+      - Thu, 17 Jun 2021 14:40:59 GMT
       expires:
       - '-1'
       pragma:
@@ -3295,15 +3289,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3312,7 +3306,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:37:05 GMT
+      - Thu, 17 Jun 2021 14:41:29 GMT
       expires:
       - '-1'
       pragma:
@@ -3342,15 +3336,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3359,7 +3353,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:37:35 GMT
+      - Thu, 17 Jun 2021 14:41:59 GMT
       expires:
       - '-1'
       pragma:
@@ -3389,15 +3383,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3406,7 +3400,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:38:05 GMT
+      - Thu, 17 Jun 2021 14:42:30 GMT
       expires:
       - '-1'
       pragma:
@@ -3436,15 +3430,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3453,7 +3447,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:38:36 GMT
+      - Thu, 17 Jun 2021 14:43:00 GMT
       expires:
       - '-1'
       pragma:
@@ -3483,15 +3477,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3500,7 +3494,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:39:06 GMT
+      - Thu, 17 Jun 2021 14:43:30 GMT
       expires:
       - '-1'
       pragma:
@@ -3530,15 +3524,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3547,7 +3541,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:39:36 GMT
+      - Thu, 17 Jun 2021 14:44:00 GMT
       expires:
       - '-1'
       pragma:
@@ -3577,15 +3571,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3594,7 +3588,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:40:06 GMT
+      - Thu, 17 Jun 2021 14:44:30 GMT
       expires:
       - '-1'
       pragma:
@@ -3624,15 +3618,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3641,7 +3635,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:40:37 GMT
+      - Thu, 17 Jun 2021 14:45:00 GMT
       expires:
       - '-1'
       pragma:
@@ -3671,15 +3665,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3688,7 +3682,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:41:07 GMT
+      - Thu, 17 Jun 2021 14:45:31 GMT
       expires:
       - '-1'
       pragma:
@@ -3718,15 +3712,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3735,7 +3729,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:41:37 GMT
+      - Thu, 17 Jun 2021 14:46:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3765,15 +3759,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3782,7 +3776,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:42:08 GMT
+      - Thu, 17 Jun 2021 14:46:31 GMT
       expires:
       - '-1'
       pragma:
@@ -3812,15 +3806,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3829,7 +3823,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:42:38 GMT
+      - Thu, 17 Jun 2021 14:47:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3859,15 +3853,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3876,7 +3870,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:43:08 GMT
+      - Thu, 17 Jun 2021 14:47:31 GMT
       expires:
       - '-1'
       pragma:
@@ -3906,15 +3900,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3923,7 +3917,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:43:37 GMT
+      - Thu, 17 Jun 2021 14:48:02 GMT
       expires:
       - '-1'
       pragma:
@@ -3953,15 +3947,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3970,7 +3964,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:44:09 GMT
+      - Thu, 17 Jun 2021 14:48:32 GMT
       expires:
       - '-1'
       pragma:
@@ -4000,15 +3994,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4017,7 +4011,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:44:39 GMT
+      - Thu, 17 Jun 2021 14:49:02 GMT
       expires:
       - '-1'
       pragma:
@@ -4047,15 +4041,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4064,7 +4058,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:45:09 GMT
+      - Thu, 17 Jun 2021 14:49:32 GMT
       expires:
       - '-1'
       pragma:
@@ -4094,15 +4088,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4111,7 +4105,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:45:39 GMT
+      - Thu, 17 Jun 2021 14:50:02 GMT
       expires:
       - '-1'
       pragma:
@@ -4141,15 +4135,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4158,7 +4152,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:46:10 GMT
+      - Thu, 17 Jun 2021 14:50:32 GMT
       expires:
       - '-1'
       pragma:
@@ -4188,15 +4182,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4205,7 +4199,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:46:40 GMT
+      - Thu, 17 Jun 2021 14:51:03 GMT
       expires:
       - '-1'
       pragma:
@@ -4235,15 +4229,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4252,7 +4246,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:47:09 GMT
+      - Thu, 17 Jun 2021 14:51:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4282,15 +4276,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4299,7 +4293,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:47:39 GMT
+      - Thu, 17 Jun 2021 14:52:03 GMT
       expires:
       - '-1'
       pragma:
@@ -4329,15 +4323,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4346,7 +4340,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:48:10 GMT
+      - Thu, 17 Jun 2021 14:52:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4376,15 +4370,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4393,7 +4387,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:48:40 GMT
+      - Thu, 17 Jun 2021 14:53:03 GMT
       expires:
       - '-1'
       pragma:
@@ -4423,15 +4417,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4440,7 +4434,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:49:10 GMT
+      - Thu, 17 Jun 2021 14:53:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4470,15 +4464,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4487,7 +4481,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:49:41 GMT
+      - Thu, 17 Jun 2021 14:54:04 GMT
       expires:
       - '-1'
       pragma:
@@ -4517,15 +4511,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4534,7 +4528,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:50:11 GMT
+      - Thu, 17 Jun 2021 14:54:34 GMT
       expires:
       - '-1'
       pragma:
@@ -4564,15 +4558,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4581,7 +4575,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:50:41 GMT
+      - Thu, 17 Jun 2021 14:55:04 GMT
       expires:
       - '-1'
       pragma:
@@ -4611,15 +4605,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4628,7 +4622,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:51:11 GMT
+      - Thu, 17 Jun 2021 14:55:34 GMT
       expires:
       - '-1'
       pragma:
@@ -4658,109 +4652,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:51:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:52:12 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/6156f764-89f6-4b8f-a605-c27d82a0598e\",\n
-        \   \"name\": \"6156f764-89f6-4b8f-a605-c27d82a0598e\",\n    \"status\": \"Succeeded\",\n
-        \   \"startTime\": \"2021-04-30T12:21:56.570674013Z\",\n    \"endTime\": \"2021-04-30T12:52:24.148892396Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/78d09563-fa71-467b-9609-455600f9acde\",\n
+        \   \"name\": \"78d09563-fa71-467b-9609-455600f9acde\",\n    \"status\": \"Succeeded\",\n
+        \   \"startTime\": \"2021-06-17T14:26:22.960388543Z\",\n    \"endTime\": \"2021-06-17T14:55:59.019537735Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4769,7 +4669,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:52:42 GMT
+      - Thu, 17 Jun 2021 14:56:05 GMT
       expires:
       - '-1'
       pragma:
@@ -4799,8 +4699,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
   response:
@@ -4809,28 +4709,28 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"delete\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"p5cy3hol\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-p5cy3hol\"\n
-        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.p5cy3hol.eastus.aroapp.io/\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"y6thnz4z\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-y6thnz4z\"\n
+        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.y6thnz4z.eastus.aroapp.io/\"\n
         \       },\n        \"servicePrincipalProfile\": {\n            \"clientId\":
-        \"e9567204-abb3-4618-bb30-19dec1985316\"\n        },\n        \"networkProfile\":
+        \"7fae9de1-2441-4b54-96f5-2810c3de14af\"\n        },\n        \"networkProfile\":
         {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\":
         \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n            \"vmSize\":
         \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \       },\n        \"workerProfiles\": [\n            {\n                \"name\":
-        \"aro000004-fcbbq-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-5crwm-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-fcbbq-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-5crwm-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-fcbbq-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-5crwm-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            }\n        ],\n        \"apiserverProfile\":
-        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.p5cy3hol.eastus.aroapp.io:6443/\",\n
-        \           \"ip\": \"20.75.158.48\"\n        },\n        \"ingressProfiles\":
+        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.y6thnz4z.eastus.aroapp.io:6443/\",\n
+        \           \"ip\": \"52.224.79.215\"\n        },\n        \"ingressProfiles\":
         [\n            {\n                \"name\": \"default\",\n                \"visibility\":
-        \"Public\",\n                \"ip\": \"20.75.158.60\"\n            }\n        ]\n
+        \"Public\",\n                \"ip\": \"52.226.48.3\"\n            }\n        ]\n
         \   }\n}\n"
     headers:
       cache-control:
@@ -4840,7 +4740,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:52:42 GMT
+      - Thu, 17 Jun 2021 14:56:06 GMT
       expires:
       - '-1'
       pragma:
@@ -4870,8 +4770,8 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -4882,28 +4782,28 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"delete\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"p5cy3hol\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-p5cy3hol\"\n
-        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.p5cy3hol.eastus.aroapp.io/\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"y6thnz4z\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-y6thnz4z\"\n
+        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.y6thnz4z.eastus.aroapp.io/\"\n
         \       },\n        \"servicePrincipalProfile\": {\n            \"clientId\":
-        \"e9567204-abb3-4618-bb30-19dec1985316\"\n        },\n        \"networkProfile\":
+        \"7fae9de1-2441-4b54-96f5-2810c3de14af\"\n        },\n        \"networkProfile\":
         {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\":
         \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n            \"vmSize\":
         \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \       },\n        \"workerProfiles\": [\n            {\n                \"name\":
-        \"aro000004-fcbbq-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-5crwm-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-fcbbq-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-5crwm-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-fcbbq-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-5crwm-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            }\n        ],\n        \"apiserverProfile\":
-        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.p5cy3hol.eastus.aroapp.io:6443/\",\n
-        \           \"ip\": \"20.75.158.48\"\n        },\n        \"ingressProfiles\":
+        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.y6thnz4z.eastus.aroapp.io:6443/\",\n
+        \           \"ip\": \"52.224.79.215\"\n        },\n        \"ingressProfiles\":
         [\n            {\n                \"name\": \"default\",\n                \"visibility\":
-        \"Public\",\n                \"ip\": \"20.75.158.60\"\n            }\n        ]\n
+        \"Public\",\n                \"ip\": \"52.226.48.3\"\n            }\n        ]\n
         \   }\n}\n"
     headers:
       cache-control:
@@ -4913,7 +4813,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:52:43 GMT
+      - Thu, 17 Jun 2021 14:56:06 GMT
       expires:
       - '-1'
       pragma:
@@ -4943,8 +4843,8 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -4967,19 +4867,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:52:44 GMT
+      - Thu, 17 Jun 2021 14:56:08 GMT
       duration:
-      - '1414139'
+      - '475625'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 4dKzoEmvpjwLs9qzDilNgRsLw1AydmyS346/JeDJZAQ=
+      - yuCMRIwRsnxJdzpH3HIbGdW1PmNg6rGopL7kgKUeDpI=
       ocp-aad-session-key:
-      - LXk8gCfF1C7sizBzDUQ0mgCCm8eR5h3Gcsl1UyRkwnjydRWQYWzH2PMbLre6gGHlOCYJkT52DaM7bAzCLhnapQkJ8VK3fnkYpPv8dtlv5j0RNie4ch41FAGl8PUI3VkqtJqkAckJUfoy15QxSr-JXwbKdG6kGV6u3gxmkE706HAkkYdFu4ziTHycsCOw3SnGsj9kFY6K8BY_idPPPpbgFw._r8u2U9AXxkF_UPrVDuwyM61HfFtbNUh9dKSNzIFjyo
+      - oOZxldiDWs3wP5WF8VLpROUkR2a-EXFthwOo2LDY9sWtQBMh5N9qfR3I-fsg6eNueuUXYakGC7qGYEgSp2f5Z1Af6Dhc6U15n4LR1rvCgYBnqC_N-Wn6qm0mTxeubRSOM0d_mOQ98ZtXC4p8P7jebKhx0M_xTxrFBeSGtBwnclY.jCYs4cQrZqIM9AI-XDp7XomE5pC-PwGC4XsTagMyqsU
       pragma:
       - no-cache
       request-id:
-      - bd8341be-4080-4d5e-9920-efd4a7c9f7cc
+      - 047d5189-90a0-45ee-afd8-98364d37f09f
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -5007,84 +4907,21 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"44c1675e-c975-4b28-8297-64eedb0a9f4b\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.75.249.0/24\",\r\n
-        \   \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol/providers/Microsoft.Network/networkSecurityGroups/aro000004-fcbbq-nsg\"\r\n
-        \   },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol/providers/Microsoft.Network/networkInterfaces/aro000004-fcbbq-worker-eastus1-wk7cd-nic/ipConfigurations/pipConfig\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol/providers/Microsoft.Network/networkInterfaces/aro000004-fcbbq-worker-eastus2-z5f9h-nic/ipConfigurations/pipConfig\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol/providers/Microsoft.Network/networkInterfaces/aro000004-fcbbq-worker-eastus3-hzc7r-nic/ipConfigurations/pipConfig\"\r\n
-        \     }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\":
-        \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\",\r\n
-        \       \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n
-        \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
-        \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
-        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1704'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:52:44 GMT
-      etag:
-      - W/"44c1675e-c975-4b28-8297-64eedb0a9f4b"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 826db817-ffd7-4a83-b5a0-ea5352ecaeac
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -y -g -n --subscription
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"44c1675e-c975-4b28-8297-64eedb0a9f4b\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.60.54.0/24\",\r\n
-        \   \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol/providers/Microsoft.Network/networkSecurityGroups/aro000004-fcbbq-nsg\"\r\n
-        \   },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol/providers/Microsoft.Network/loadBalancers/aro000004-fcbbq-internal/frontendIPConfigurations/internal-lb-ip-v4\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol/providers/Microsoft.Network/networkInterfaces/aro000004-fcbbq-pls.nic.2ea587ef-e5bb-4f6e-a840-849732bc73bf/ipConfigurations/aro000004-fcbbq-pls-nic\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol/providers/Microsoft.Network/privateLinkServices/aro000004-fcbbq-pls/ipConfigurations/aro000004-fcbbq-pls-nic\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol/providers/Microsoft.Network/networkInterfaces/aro000004-fcbbq-master0-nic/ipConfigurations/pipConfig\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol/providers/Microsoft.Network/networkInterfaces/aro000004-fcbbq-master2-nic/ipConfigurations/pipConfig\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-p5cy3hol/providers/Microsoft.Network/networkInterfaces/aro000004-fcbbq-master1-nic/ipConfigurations/pipConfig\"\r\n
+        \ \"etag\": \"W/\\\"1e028e1d-b2a0-4082-bab1-a893bf742421\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.32.140.0/24\",\r\n
+        \   \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z/providers/Microsoft.Network/networkSecurityGroups/aro000004-5crwm-nsg\"\r\n
+        \   },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z/providers/Microsoft.Network/loadBalancers/aro000004-5crwm-internal/frontendIPConfigurations/internal-lb-ip-v4\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z/providers/Microsoft.Network/networkInterfaces/aro000004-5crwm-pls.nic.62710c3b-20dc-48d4-8706-bea0ba6911f3/ipConfigurations/aro000004-5crwm-pls-nic\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z/providers/Microsoft.Network/privateLinkServices/aro000004-5crwm-pls/ipConfigurations/aro000004-5crwm-pls-nic\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z/providers/Microsoft.Network/networkInterfaces/aro000004-5crwm-master2-nic/ipConfigurations/pipConfig\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z/providers/Microsoft.Network/networkInterfaces/aro000004-5crwm-master1-nic/ipConfigurations/pipConfig\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z/providers/Microsoft.Network/networkInterfaces/aro000004-5crwm-master0-nic/ipConfigurations/pipConfig\"\r\n
         \     }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\":
         \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\",\r\n
         \       \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n
@@ -5095,13 +4932,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2405'
+      - '2406'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:52:44 GMT
+      - Thu, 17 Jun 2021 14:56:09 GMT
       etag:
-      - W/"44c1675e-c975-4b28-8297-64eedb0a9f4b"
+      - W/"1e028e1d-b2a0-4082-bab1-a893bf742421"
       expires:
       - '-1'
       pragma:
@@ -5118,7 +4955,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 90edf7a2-4e45-4a13-8507-5fa13d732072
+      - 22360aa4-ee61-41f1-bc97-7906d2e6f363
     status:
       code: 200
       message: OK
@@ -5136,24 +4973,87 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \ \"etag\": \"W/\\\"1e028e1d-b2a0-4082-bab1-a893bf742421\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.117.241.0/24\",\r\n
+        \   \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z/providers/Microsoft.Network/networkSecurityGroups/aro000004-5crwm-nsg\"\r\n
+        \   },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z/providers/Microsoft.Network/networkInterfaces/aro000004-5crwm-worker-eastus1-md9xh-nic/ipConfigurations/pipConfig\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z/providers/Microsoft.Network/networkInterfaces/aro000004-5crwm-worker-eastus2-twjqt-nic/ipConfigurations/pipConfig\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-y6thnz4z/providers/Microsoft.Network/networkInterfaces/aro000004-5crwm-worker-eastus3-8wrbt-nic/ipConfigurations/pipConfig\"\r\n
+        \     }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\":
+        \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\",\r\n
+        \       \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n
+        \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
+        \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1705'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 14:56:09 GMT
+      etag:
+      - W/"1e028e1d-b2a0-4082-bab1-a893bf742421"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - ced02be5-e2fd-4e28-8015-9a50a60e6f34
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -y -g -n --subscription
+      User-Agent:
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"ef060b73-22bb-41ee-818b-c94e4c545270","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:48.2924764Z","updatedOn":"2021-04-30T12:21:48.2924764Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:51.5696903Z","updatedOn":"2021-04-30T12:21:51.5696903Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"2ff9a1a4-96fb-4f80-8ef0-d28d92245bd2","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T14:26:17.9449883Z","updatedOn":"2021-06-17T14:26:17.9449883Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T14:26:20.4680765Z","updatedOn":"2021-06-17T14:26:20.4680765Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_delete000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '25201'
+      - '26941'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:52:45 GMT
+      - Thu, 17 Jun 2021 14:56:09 GMT
       expires:
       - '-1'
       pragma:
@@ -5187,8 +5087,8 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: DELETE
@@ -5198,7 +5098,7 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -5206,11 +5106,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:52:46 GMT
+      - Thu, 17 Jun 2021 14:56:09 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationresults/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationresults/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
       pragma:
       - no-cache
       strict-transport-security:
@@ -5236,15 +5136,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5253,7 +5153,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:53:17 GMT
+      - Thu, 17 Jun 2021 14:56:40 GMT
       expires:
       - '-1'
       pragma:
@@ -5283,15 +5183,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5300,7 +5200,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:53:47 GMT
+      - Thu, 17 Jun 2021 14:57:10 GMT
       expires:
       - '-1'
       pragma:
@@ -5330,15 +5230,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5347,7 +5247,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:54:17 GMT
+      - Thu, 17 Jun 2021 14:57:40 GMT
       expires:
       - '-1'
       pragma:
@@ -5377,15 +5277,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5394,7 +5294,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:54:48 GMT
+      - Thu, 17 Jun 2021 14:58:11 GMT
       expires:
       - '-1'
       pragma:
@@ -5424,15 +5324,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5441,7 +5341,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:55:18 GMT
+      - Thu, 17 Jun 2021 14:58:41 GMT
       expires:
       - '-1'
       pragma:
@@ -5471,15 +5371,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5488,7 +5388,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:55:48 GMT
+      - Thu, 17 Jun 2021 14:59:11 GMT
       expires:
       - '-1'
       pragma:
@@ -5518,15 +5418,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5535,7 +5435,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:56:19 GMT
+      - Thu, 17 Jun 2021 14:59:41 GMT
       expires:
       - '-1'
       pragma:
@@ -5565,15 +5465,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5582,7 +5482,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:56:49 GMT
+      - Thu, 17 Jun 2021 15:00:11 GMT
       expires:
       - '-1'
       pragma:
@@ -5612,15 +5512,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5629,7 +5529,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:57:19 GMT
+      - Thu, 17 Jun 2021 15:00:42 GMT
       expires:
       - '-1'
       pragma:
@@ -5659,15 +5559,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5676,7 +5576,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:57:49 GMT
+      - Thu, 17 Jun 2021 15:01:12 GMT
       expires:
       - '-1'
       pragma:
@@ -5706,15 +5606,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5723,7 +5623,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:58:19 GMT
+      - Thu, 17 Jun 2021 15:01:42 GMT
       expires:
       - '-1'
       pragma:
@@ -5753,15 +5653,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5770,7 +5670,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:58:50 GMT
+      - Thu, 17 Jun 2021 15:02:12 GMT
       expires:
       - '-1'
       pragma:
@@ -5800,15 +5700,15 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Deleting\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Deleting\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5817,7 +5717,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:59:19 GMT
+      - Thu, 17 Jun 2021 15:02:42 GMT
       expires:
       - '-1'
       pragma:
@@ -5847,24 +5747,24 @@ interactions:
       ParameterSetName:
       - -y -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n
-        \   \"name\": \"ddbde8eb-acf6-4d7f-b847-71f42f940f58\",\n    \"status\": \"Succeeded\",\n
-        \   \"startTime\": \"2021-04-30T12:52:47.100193467Z\",\n    \"endTime\": \"2021-04-30T12:59:47.09245106Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n
+        \   \"name\": \"2302f966-f296-4ca3-ab18-6e1f1da3d732\",\n    \"status\": \"Succeeded\",\n
+        \   \"startTime\": \"2021-06-17T14:56:10.430833622Z\",\n    \"endTime\": \"2021-06-17T15:03:08.424760964Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '353'
+      - '354'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:59:50 GMT
+      - Thu, 17 Jun 2021 15:03:12 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_list.yaml
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_list.yaml
@@ -13,15 +13,12 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_list000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001","name":"cli_test_aro_list000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:21:15Z","createdAt":"2021-04-30T12:21:16.6990119Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001","name":"cli_test_aro_list000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-23T14:08:03Z","createdAt":"2021-06-23T14:08:06.1535484Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:18 GMT
+      - Wed, 23 Jun 2021 14:08:07 GMT
       expires:
       - '-1'
       pragma:
@@ -63,16 +60,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"1c9933c1-9f46-4958-92c4-87eabcfc9df8\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"aa3b0ed0-d5af-40dd-a49a-94e4357f00bb\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"e29c180b-cf5d-4c3c-838d-bcffc835e45d\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"ea767b1f-0c1b-4610-95bb-f2a1a238f752\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -81,7 +78,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e26f9854-5d78-4637-a5c6-9551e6493459?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e9628308-b011-4820-a225-7aa177fb8d00?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
@@ -89,7 +86,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:23 GMT
+      - Wed, 23 Jun 2021 14:08:08 GMT
       expires:
       - '-1'
       pragma:
@@ -102,7 +99,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 189f6ece-b4d8-4b3a-9472-0f0ae54d59fa
+      - e9844643-3693-4e20-9a65-d1e41e007ce0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -122,9 +119,9 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e26f9854-5d78-4637-a5c6-9551e6493459?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e9628308-b011-4820-a225-7aa177fb8d00?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -136,7 +133,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:27 GMT
+      - Wed, 23 Jun 2021 14:08:11 GMT
       expires:
       - '-1'
       pragma:
@@ -153,7 +150,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 21b8312d-79e9-4c5e-836a-d7f03c3ce27e
+      - d4fda95c-cefd-4f2e-a3c0-03d4457de054
     status:
       code: 200
       message: OK
@@ -171,16 +168,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"fa5bf88e-8014-40d0-be5e-582511944cb8\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"eb53648d-e6d4-4316-9db9-0221ee7f5553\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"e29c180b-cf5d-4c3c-838d-bcffc835e45d\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"ea767b1f-0c1b-4610-95bb-f2a1a238f752\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -193,9 +190,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:27 GMT
+      - Wed, 23 Jun 2021 14:08:11 GMT
       etag:
-      - W/"fa5bf88e-8014-40d0-be5e-582511944cb8"
+      - W/"eb53648d-e6d4-4316-9db9-0221ee7f5553"
       expires:
       - '-1'
       pragma:
@@ -212,7 +209,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 45ca5587-1b48-4fe1-aa06-289162c12c87
+      - d371fb14-cb06-4d31-9aae-1a11c3e51b18
     status:
       code: 200
       message: OK
@@ -230,16 +227,16 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"fa5bf88e-8014-40d0-be5e-582511944cb8\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"eb53648d-e6d4-4316-9db9-0221ee7f5553\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"e29c180b-cf5d-4c3c-838d-bcffc835e45d\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"ea767b1f-0c1b-4610-95bb-f2a1a238f752\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -252,9 +249,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:27 GMT
+      - Wed, 23 Jun 2021 14:08:11 GMT
       etag:
-      - W/"fa5bf88e-8014-40d0-be5e-582511944cb8"
+      - W/"eb53648d-e6d4-4316-9db9-0221ee7f5553"
       expires:
       - '-1'
       pragma:
@@ -271,7 +268,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 1490297c-2f38-450d-95ff-f00a7db4e787
+      - 4479a066-15ea-4c14-858a-d0716f14990a
     status:
       code: 200
       message: OK
@@ -279,9 +276,10 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"name": "dev_master000002",
-      "properties": {"addressPrefix": "10.73.109.0/24", "serviceEndpoints": [{"service":
-      "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings": [], "enableDdosProtection":
-      false}}'
+      "properties": {"addressPrefix": "10.62.108.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
+      [], "enableDdosProtection": false}}'
     headers:
       Accept:
       - application/json
@@ -292,29 +290,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '515'
+      - '608'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"b1445eff-ce74-431c-9576-cbf181015a32\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"a9c0ffee-601c-4dba-94ec-30d181ce08c1\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"e29c180b-cf5d-4c3c-838d-bcffc835e45d\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"ea767b1f-0c1b-4610-95bb-f2a1a238f752\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"b1445eff-ce74-431c-9576-cbf181015a32\\\"\",\r\n
+        \       \"etag\": \"W/\\\"a9c0ffee-601c-4dba-94ec-30d181ce08c1\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.73.109.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.62.108.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -325,7 +323,7 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/db398ec7-930a-4174-bb5a-79c8321a30b8?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/32aa4c9a-0e95-44ef-808f-767164fad3b5?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
@@ -333,7 +331,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:28 GMT
+      - Wed, 23 Jun 2021 14:08:12 GMT
       expires:
       - '-1'
       pragma:
@@ -350,7 +348,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 94020473-2e61-494c-9d46-0a52e21376b4
+      - b64f4ecb-5532-4346-8875-a9531f5275bb
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -370,9 +368,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/db398ec7-930a-4174-bb5a-79c8321a30b8?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/32aa4c9a-0e95-44ef-808f-767164fad3b5?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -384,7 +382,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:32 GMT
+      - Wed, 23 Jun 2021 14:08:16 GMT
       expires:
       - '-1'
       pragma:
@@ -401,7 +399,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 2f977eee-15a4-4d06-ad85-333b44564d26
+      - 416896d0-0261-456f-8472-79d36059d8df
     status:
       code: 200
       message: OK
@@ -419,23 +417,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"09fac1bc-b31c-4f74-9626-ef32719e49df\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"e8454183-bccc-4629-a21e-149d7a4861cd\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"e29c180b-cf5d-4c3c-838d-bcffc835e45d\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"ea767b1f-0c1b-4610-95bb-f2a1a238f752\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"09fac1bc-b31c-4f74-9626-ef32719e49df\\\"\",\r\n
+        \       \"etag\": \"W/\\\"e8454183-bccc-4629-a21e-149d7a4861cd\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.73.109.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.62.108.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -452,9 +450,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:33 GMT
+      - Wed, 23 Jun 2021 14:08:16 GMT
       etag:
-      - W/"09fac1bc-b31c-4f74-9626-ef32719e49df"
+      - W/"e8454183-bccc-4629-a21e-149d7a4861cd"
       expires:
       - '-1'
       pragma:
@@ -471,7 +469,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - f958c6aa-25c3-4fca-b98f-f39685ce19e2
+      - cd378002-ae19-424e-a0bf-d58449606b57
     status:
       code: 200
       message: OK
@@ -489,23 +487,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"09fac1bc-b31c-4f74-9626-ef32719e49df\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"e8454183-bccc-4629-a21e-149d7a4861cd\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"e29c180b-cf5d-4c3c-838d-bcffc835e45d\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"ea767b1f-0c1b-4610-95bb-f2a1a238f752\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"09fac1bc-b31c-4f74-9626-ef32719e49df\\\"\",\r\n
+        \       \"etag\": \"W/\\\"e8454183-bccc-4629-a21e-149d7a4861cd\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.73.109.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.62.108.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -522,9 +520,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:32 GMT
+      - Wed, 23 Jun 2021 14:08:17 GMT
       etag:
-      - W/"09fac1bc-b31c-4f74-9626-ef32719e49df"
+      - W/"e8454183-bccc-4629-a21e-149d7a4861cd"
       expires:
       - '-1'
       pragma:
@@ -541,7 +539,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 89dbe5ee-5e17-43cd-98e7-8e364a4bfea7
+      - 9b0e64ac-23cf-45de-a09d-352d70a88946
     status:
       code: 200
       message: OK
@@ -549,11 +547,13 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.73.109.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Enabled"}}, {"name": "dev_worker000003", "properties": {"addressPrefix": "10.4.117.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings":
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.62.108.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Enabled"}}, {"name": "dev_worker000003",
+      "properties": {"addressPrefix": "10.118.2.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
       [], "enableDdosProtection": false}}'
     headers:
       Accept:
@@ -565,29 +565,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '972'
+      - '1118'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"88f50c32-9f20-4eec-b4a6-f6acfe0a656d\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"420e5491-fc83-43a7-8319-853808b386f2\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"e29c180b-cf5d-4c3c-838d-bcffc835e45d\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"ea767b1f-0c1b-4610-95bb-f2a1a238f752\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"88f50c32-9f20-4eec-b4a6-f6acfe0a656d\\\"\",\r\n
+        \       \"etag\": \"W/\\\"420e5491-fc83-43a7-8319-853808b386f2\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.73.109.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.62.108.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -596,9 +596,9 @@ interactions:
         \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
         \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"88f50c32-9f20-4eec-b4a6-f6acfe0a656d\\\"\",\r\n
+        \       \"etag\": \"W/\\\"420e5491-fc83-43a7-8319-853808b386f2\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.4.117.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.118.2.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -609,7 +609,7 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/7f50760a-8054-417b-af61-75a48d41ac92?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/b8f20530-7529-49f1-8851-6b5466f0ffed?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
@@ -617,7 +617,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:33 GMT
+      - Wed, 23 Jun 2021 14:08:18 GMT
       expires:
       - '-1'
       pragma:
@@ -634,9 +634,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - b25ea0ba-7bea-49f2-9bcb-5f0b2deafa54
+      - 997aacfe-8f5e-412a-aa62-602f1a853ac8
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 200
       message: OK
@@ -654,9 +654,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/7f50760a-8054-417b-af61-75a48d41ac92?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/b8f20530-7529-49f1-8851-6b5466f0ffed?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -668,7 +668,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:37 GMT
+      - Wed, 23 Jun 2021 14:08:21 GMT
       expires:
       - '-1'
       pragma:
@@ -685,7 +685,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 04df9143-a369-475f-beaf-8a6ed9d38bd1
+      - 4e134a53-8b73-4bec-8d1a-1eab3cf14bb7
     status:
       code: 200
       message: OK
@@ -703,23 +703,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"59fc7907-4756-4d21-b065-85c8846bb5b6\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"c77e53db-ca26-4490-b73f-b4ae2de2a826\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"e29c180b-cf5d-4c3c-838d-bcffc835e45d\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"ea767b1f-0c1b-4610-95bb-f2a1a238f752\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"59fc7907-4756-4d21-b065-85c8846bb5b6\\\"\",\r\n
+        \       \"etag\": \"W/\\\"c77e53db-ca26-4490-b73f-b4ae2de2a826\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.73.109.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.62.108.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -728,9 +728,9 @@ interactions:
         \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
         \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"59fc7907-4756-4d21-b065-85c8846bb5b6\\\"\",\r\n
+        \       \"etag\": \"W/\\\"c77e53db-ca26-4490-b73f-b4ae2de2a826\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.4.117.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.118.2.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -747,9 +747,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:37 GMT
+      - Wed, 23 Jun 2021 14:08:21 GMT
       etag:
-      - W/"59fc7907-4756-4d21-b065-85c8846bb5b6"
+      - W/"c77e53db-ca26-4490-b73f-b4ae2de2a826"
       expires:
       - '-1'
       pragma:
@@ -766,7 +766,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 29bb1822-46e5-4914-a75d-69647faa75d6
+      - 5c6b7d81-82c1-445b-b725-a22ec960f6ac
     status:
       code: 200
       message: OK
@@ -784,14 +784,14 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"59fc7907-4756-4d21-b065-85c8846bb5b6\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.73.109.0/24\",\r\n
+        \ \"etag\": \"W/\\\"c77e53db-ca26-4490-b73f-b4ae2de2a826\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.62.108.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -805,9 +805,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:38 GMT
+      - Wed, 23 Jun 2021 14:08:21 GMT
       etag:
-      - W/"59fc7907-4756-4d21-b065-85c8846bb5b6"
+      - W/"c77e53db-ca26-4490-b73f-b4ae2de2a826"
       expires:
       - '-1'
       pragma:
@@ -824,16 +824,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 4c3304a8-4d32-42d0-9fb1-46775bd99dfc
+      - ac762ecf-e48f-44a1-838a-41516281f6bd
     status:
       code: 200
       message: OK
 - request:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.73.109.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Disabled"}}'
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.62.108.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Disabled"}}'
     headers:
       Accept:
       - application/json
@@ -844,20 +844,20 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '457'
+      - '510'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"233df704-4833-488c-85a6-1cea528c4920\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.73.109.0/24\",\r\n
+        \ \"etag\": \"W/\\\"1fd65b13-6501-4f20-a66a-61216bc7f61b\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.62.108.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -865,7 +865,7 @@ interactions:
         \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/54bab3bf-aa78-429e-9647-ce950e0c6bbb?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/2db01cd2-dae4-4769-85c6-46141df9d9c9?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
@@ -873,7 +873,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:39 GMT
+      - Wed, 23 Jun 2021 14:08:21 GMT
       expires:
       - '-1'
       pragma:
@@ -890,7 +890,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 5fef53bb-c188-438f-ba11-63b2f6c6ebef
+      - bd13da47-94df-4e73-8021-d023fe32f8e4
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -910,9 +910,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/54bab3bf-aa78-429e-9647-ce950e0c6bbb?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/2db01cd2-dae4-4769-85c6-46141df9d9c9?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -924,7 +924,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:42 GMT
+      - Wed, 23 Jun 2021 14:08:24 GMT
       expires:
       - '-1'
       pragma:
@@ -941,7 +941,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 5815faa3-eb56-403b-bc05-43f8a6074dfb
+      - 8e74524c-ff6d-4448-ad7f-9b7d9aba079a
     status:
       code: 200
       message: OK
@@ -959,14 +959,14 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"38435f29-d14b-4559-8481-2b89dcf551e4\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.73.109.0/24\",\r\n
+        \ \"etag\": \"W/\\\"cdbb8512-3460-4214-a64a-59aa457603fe\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.62.108.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -980,9 +980,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:42 GMT
+      - Wed, 23 Jun 2021 14:08:24 GMT
       etag:
-      - W/"38435f29-d14b-4559-8481-2b89dcf551e4"
+      - W/"cdbb8512-3460-4214-a64a-59aa457603fe"
       expires:
       - '-1'
       pragma:
@@ -999,7 +999,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - fd8a6a3b-9bb8-44b3-8f47-19b443ac408d
+      - 67f7dd33-145a-45b4-b38e-77e98264044d
     status:
       code: 200
       message: OK
@@ -1017,14 +1017,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"38435f29-d14b-4559-8481-2b89dcf551e4\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.73.109.0/24\",\r\n
+        \ \"etag\": \"W/\\\"cdbb8512-3460-4214-a64a-59aa457603fe\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.62.108.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1038,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:42 GMT
+      - Wed, 23 Jun 2021 14:08:25 GMT
       etag:
-      - W/"38435f29-d14b-4559-8481-2b89dcf551e4"
+      - W/"cdbb8512-3460-4214-a64a-59aa457603fe"
       expires:
       - '-1'
       pragma:
@@ -1057,7 +1057,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 24288725-f567-4ac2-8619-83ee0c02e992
+      - 820688eb-0c87-42d2-bf11-43d5e5f00695
     status:
       code: 200
       message: OK
@@ -1075,14 +1075,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"38435f29-d14b-4559-8481-2b89dcf551e4\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.4.117.0/24\",\r\n
+        \ \"etag\": \"W/\\\"cdbb8512-3460-4214-a64a-59aa457603fe\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.118.2.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1096,9 +1096,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:43 GMT
+      - Wed, 23 Jun 2021 14:08:26 GMT
       etag:
-      - W/"38435f29-d14b-4559-8481-2b89dcf551e4"
+      - W/"cdbb8512-3460-4214-a64a-59aa457603fe"
       expires:
       - '-1'
       pragma:
@@ -1115,7 +1115,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 01f72976-63d1-410c-bbdc-abe220d21bc1
+      - 779370cd-a1db-4579-a46f-b3c30d61fa92
     status:
       code: 200
       message: OK
@@ -1133,15 +1133,12 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_list000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001","name":"cli_test_aro_list000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:21:15Z","createdAt":"2021-04-30T12:21:16.6990119Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001","name":"cli_test_aro_list000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-23T14:08:03Z","createdAt":"2021-06-23T14:08:06.1535484Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1150,7 +1147,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:43 GMT
+      - Wed, 23 Jun 2021 14:08:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1178,10 +1175,7 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift?api-version=2020-10-01
   response:
@@ -1214,7 +1208,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:44 GMT
+      - Wed, 23 Jun 2021 14:08:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1229,10 +1223,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"passwordCredentials": [{"startDate": "2021-04-30T12:21:44.290374Z", "endDate":
+    body: '{"passwordCredentials": [{"startDate": "2021-06-23T14:08:26.938296Z", "endDate":
       "2299-12-31T00:00:00.000Z", "value": "ReplacedSPPassword123*", "customKeyIdentifier":
-      "MjAyMS0wNC0zMCAxMjoyMTo0NC4yOTAzNzQ="}], "displayName": "aro-h6j9oso6", "identifierUris":
-      ["https://az.aro.azure.com/7f1dc679-3dca-4214-8dc2-47db71a478ae"]}'
+      "MjAyMS0wNi0yMyAxNDowODoyNi45MzgyOTY="}], "displayName": "aro-qryo9mgo", "identifierUris":
+      ["https://az.aro.azure.com/73d789b1-4b55-4f35-bb87-124445fe1dcb"]}'
     headers:
       Accept:
       - application/json
@@ -1249,8 +1243,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
@@ -1259,29 +1253,29 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "e71150c6-4a2a-40a6-b39b-94e3708ab19d", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "91366eb3-2b0c-4028-8b33-adc55a5fe580",
+        "objectId": "57a924c4-5d13-4153-8164-e53bfd30979b", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "aa05aa8f-38cd-4572-befe-fa92474f65e6",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
-        false, "displayName": "aro-h6j9oso6", "errorUrl": null, "groupMembershipClaims":
-        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/7f1dc679-3dca-4214-8dc2-47db71a478ae"],
+        false, "displayName": "aro-qryo9mgo", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/73d789b1-4b55-4f35-bb87-124445fe1dcb"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/e71150c6-4a2a-40a6-b39b-94e3708ab19d/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/57a924c4-5d13-4153-8164-e53bfd30979b/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/e71150c6-4a2a-40a6-b39b-94e3708ab19d/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/57a924c4-5d13-4153-8164-e53bfd30979b/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
-        "Allow the application to access aro-h6j9oso6 on behalf of the signed-in user.",
-        "adminConsentDisplayName": "Access aro-h6j9oso6", "id": "a2ba414f-f492-4007-a265-967abd65fc43",
+        "Allow the application to access aro-qryo9mgo on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Access aro-qryo9mgo", "id": "0c6fc2ad-7369-4580-90ed-ce07fe164ca4",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
-        to access aro-h6j9oso6 on your behalf.", "userConsentDisplayName": "Access
-        aro-h6j9oso6", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        to access aro-qryo9mgo on your behalf.", "userConsentDisplayName": "Access
+        aro-qryo9mgo", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
-        [{"customKeyIdentifier": "MjAyMS0wNC0zMCAxMjoyMTo0NC4yOTAzNzQ=", "endDate":
-        "2299-12-31T00:00:00Z", "keyId": "a1735524-819f-405c-9848-1b25e83c8dc9", "startDate":
-        "2021-04-30T12:21:44.290374Z", "value": "ReplacedSPPassword123*"}], "publicClient":
+        [{"customKeyIdentifier": "MjAyMS0wNi0yMyAxNDowODoyNi45MzgyOTY=", "endDate":
+        "2299-12-31T00:00:00Z", "keyId": "30c79936-c873-40ab-884e-eaafe8c2fdb4", "startDate":
+        "2021-06-23T14:08:26.938296Z", "value": "ReplacedSPPassword123*"}], "publicClient":
         null, "publisherDomain": "rhcuppettgmail.onmicrosoft.com", "recordConsentConditions":
         null, "replyUrls": [], "requiredResourceAccess": [], "samlMetadataUrl": null,
         "signInAudience": "AzureADMyOrg", "tokenEncryptionKeyId": null}'
@@ -1297,21 +1291,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:44 GMT
+      - Wed, 23 Jun 2021 14:08:28 GMT
       duration:
-      - '4705147'
+      - '5116888'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/e71150c6-4a2a-40a6-b39b-94e3708ab19d/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/57a924c4-5d13-4153-8164-e53bfd30979b/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - qlPIvEic8eVh5MU7VUueS29XEFKfR/2IrpRdoo+09Qg=
+      - t4KnkvKGgVi8bOs5qW9XPthk9CvOocz1gaShp5XbmOs=
       ocp-aad-session-key:
-      - a9BRnkPcdREyIO3vs5j-FesutWLn0czCogyWsxLY4sHsm2f8A-iUq9cOH8Fzzb33ElVahlTvt9G4i3cHIfy0y7ns-SG1OyAdwnegdFR1_iQ7Tz4bS7oyT_27iWFTuMsGjM7LWcBIvzjoWxsxrU1w8OwYPpBIFYSqbbkn6rnpv2Jtju4BKfL5iMuJmECLek3uXvbIN5ulpCegGWAcCLm9ng.V4d9Pmcg-RebMgiSN5pnZ-O3if_nOx1dfulYyJKs9ck
+      - VmvcY23mgkTVxqqBlBL0YbYCBO7UsDpakhcNgHxmbK3fyy3QfXUCAMznBW7CRhzsaCXZzLoF5UW_VTVRf6t523mI7B6Z4xjDLdw1VL9YbOJVa-ZT5K3FlbITSQBS-4P9ykYX0-ZVX6wfxR6pBjkOZsOobU0m4348ikVqXleDeSY.XpwVcSlp-I6rMXCDYs60EHfM_KRQTrxW7-zZ1A_OlNg
       pragma:
       - no-cache
       request-id:
-      - a9b7725c-4175-4dfe-b1f6-6691901f4dae
+      - 7b9e3222-7717-477d-97e2-2f250c5b87b6
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1339,12 +1333,12 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%2791366eb3-2b0c-4028-8b33-adc55a5fe580%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27aa05aa8f-38cd-4572-befe-fa92474f65e6%27&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -1360,19 +1354,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:44 GMT
+      - Wed, 23 Jun 2021 14:08:28 GMT
       duration:
-      - '1036176'
+      - '274012'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - XMxGLoG0FafLLkPmOF+A6rjqP9TTTO53alK8SiiySzs=
+      - n+g1//FsjYUkIuAR/QpWrvENv4Z1Sf2c1PwFoypQPQw=
       ocp-aad-session-key:
-      - TeVzu7XunW3-OPxbhnNN52M9d0sh3wPbir3lmWJ4kcUWoL5E7lLEBZ2XdANKiRb71ZmQ9Cri_DVXX7ykt6ZZUG3qpNX7rVCJnjcYAH3y9SBU8qUlNMAkS7TQDr1Fix_QJ__V39HDStvM3HJiCv8nLzyKWJmFOBQpF-f5_IpfV0OtogzLtx-9G6iPDSth2kxzHU6zTT0i5GaTuT1ptse59w.n5Siq4gTtgbfkdOhSepEH-H5e67oyUrEANyLM4cVxK8
+      - VjjNhod_rzjlc_dway23FiL5_eLVZFhgxmKm7ZfxoXZtPGqrln4PVFVfN7Mv_Azod2oXxKoijBPH7bUsCfuofy5hzLiDi1lBd4nRe6R5rcQl0babjmrvBYZJLrb5nSQDLTUUK0zdVBPWzg82JHf7wzjyKkIragRYyZhgTXTSSfQ.QApq3JIQ9znM8H2d6eYHb-GJ5Le7qMNFw_IMiU3EWSQ
       pragma:
       - no-cache
       request-id:
-      - 159709fb-0948-4131-8f04-5a5232830500
+      - fc722826-ec36-45ff-8b59-f81a1ad92f95
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1387,7 +1381,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"appId": "91366eb3-2b0c-4028-8b33-adc55a5fe580"}'
+    body: '{"appId": "aa05aa8f-38cd-4572-befe-fa92474f65e6"}'
     headers:
       Accept:
       - application/json
@@ -1404,20 +1398,20 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"bf097ed3-2cae-4792-9bc6-c50870a902c0","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-h6j9oso6","appId":"91366eb3-2b0c-4028-8b33-adc55a5fe580","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-h6j9oso6","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access aro-h6j9oso6 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        aro-h6j9oso6","id":"a2ba414f-f492-4007-a265-967abd65fc43","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access aro-h6j9oso6 on your behalf.","userConsentDisplayName":"Access
-        aro-h6j9oso6","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
-        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["91366eb3-2b0c-4028-8b33-adc55a5fe580","https://az.aro.azure.com/7f1dc679-3dca-4214-8dc2-47db71a478ae"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"3d7a195b-09ac-422b-86b9-46d2b156384a","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-qryo9mgo","appId":"aa05aa8f-38cd-4572-befe-fa92474f65e6","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-qryo9mgo","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access aro-qryo9mgo on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        aro-qryo9mgo","id":"0c6fc2ad-7369-4580-90ed-ce07fe164ca4","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access aro-qryo9mgo on your behalf.","userConsentDisplayName":"Access
+        aro-qryo9mgo","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
+        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["aa05aa8f-38cd-4572-befe-fa92474f65e6","https://az.aro.azure.com/73d789b1-4b55-4f35-bb87-124445fe1dcb"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1430,21 +1424,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
+      - Wed, 23 Jun 2021 14:08:28 GMT
       duration:
-      - '3719613'
+      - '3210615'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/bf097ed3-2cae-4792-9bc6-c50870a902c0/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/3d7a195b-09ac-422b-86b9-46d2b156384a/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - p7oHeYfsInkxbbgu43F1bFwlMEoYiFSlAN45we0GlQo=
+      - VnCfkqXx+TobvJXE8t/DuqlaLSejP242Awlleh9K8pE=
       ocp-aad-session-key:
-      - L-mZq039qhnBpU5Cq_6DDYlJ1CGVUf5ZfXZS7imZz9AptiiRawGikEVc8kBzYgmCP1Hxrx0piGi3k7sP2c4uBth5B_PeLfGwfkZu8Y2_kk-3q-izz5dP0Ec3E7T-9RtizkEUgiAEYXEki5s356lEBVHVtwt8R-pshVnoGS4qbIVLfNoIyEdVu2wPhnJFOBkLwRxuWkHrtpvrFrNFYNTRuA.cLMAJnwCvyZqWJZE2unpJVi-82PrYr3Wnayxj8MGkEg
+      - TuL_v4HybkGAR2Q1zVmwKpY4TIDMWIvhjxWW2FMolDfturVsk_Yks38097767-m9VR8Rn7LU3noplklzOMQ85l9oIR9r6_xwEXWlTGBWX5jImXzhLXfMvnUVunjVLgD4VF4Yzj6ghaPKlgyUrdP4ThAM35Vmv-O-XT_0btEKA7s.ew-P4Z0udLS3hGMnJbSSeuw_H-hH1k3rfcY-sVjUOus
       pragma:
       - no-cache
       request-id:
-      - 5f34f072-544c-49f7-939e-72e1e29aaeca
+      - 6af004a7-7b61-41e8-b3d8-fcf830a7e838
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1472,8 +1466,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -1496,19 +1490,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:46 GMT
+      - Wed, 23 Jun 2021 14:08:29 GMT
       duration:
-      - '1223360'
+      - '527855'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - HJaMBrScO9IwWtkMly6DxYdFf7NhwRWYoXV8q6I9XcI=
+      - oLcaBIUH+K4WvpItfJa9I9DMrshLwWPE1AGqdd/FWqc=
       ocp-aad-session-key:
-      - BJe5jnvXPmVh1S3dfzNG08n_6d44FRPzyIk53k-YZganfd9J1zdb7P5Hw7NYWx7kpkHFH6wWaEQeWiuBV_Rculk5kngiqsUplT7nJXwsncwgESmKynkoqVzEcKU6ebTa4wAz7KPuyQK-xaqDtdOGj2ETer0hJLh4PXNI9-oxf8R3vFJnTlApGbwyyvfb_SIG4czOT_bmzJT-hVd0_61PTw.8Tm9-eugFxlcracJ_DAED2ks5PoRLaWx4sCfEUT3uOc
+      - yO7iZfuQRjGafMOaQI-bk2EcICyjyWCjvaVLrrYeWXF7L5P8DtILfO_zKCGfrJcAuLtzTR56oirQI_o18-HZU6o1yizE_bJzzMrj4raGZv7AwUst32luDxsetl3bYxBIdcgjLc47t6EjaZw2kyyPBkY_8IniW_ygOmIXOHcSYsk.hf_xBpWgFu1yyD7UhFjqYddD3kJC717QbrqaS_BBxiw
       pragma:
       - no-cache
       request-id:
-      - 59b67767-0cb5-42ad-8ede-774423510b16
+      - 14f31c24-e340-4176-a70a-77c959aa85ac
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1536,72 +1530,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"38435f29-d14b-4559-8481-2b89dcf551e4\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.73.109.0/24\",\r\n
-        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
-        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
-        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
-        \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:46 GMT
-      etag:
-      - W/"38435f29-d14b-4559-8481-2b89dcf551e4"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - aa814cf9-6c12-4520-aae8-775b4d2d9c05
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"38435f29-d14b-4559-8481-2b89dcf551e4\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.4.117.0/24\",\r\n
+        \ \"etag\": \"W/\\\"cdbb8512-3460-4214-a64a-59aa457603fe\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.118.2.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1615,9 +1551,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:46 GMT
+      - Wed, 23 Jun 2021 14:08:30 GMT
       etag:
-      - W/"38435f29-d14b-4559-8481-2b89dcf551e4"
+      - W/"cdbb8512-3460-4214-a64a-59aa457603fe"
       expires:
       - '-1'
       pragma:
@@ -1634,7 +1570,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 57c8b249-6978-467a-bef9-b92fa6b898e9
+      - 2b2eb512-15f8-4790-a1c2-2eed5f5b1301
     status:
       code: 200
       message: OK
@@ -1652,24 +1588,82 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \ \"etag\": \"W/\\\"cdbb8512-3460-4214-a64a-59aa457603fe\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.62.108.0/24\",\r\n
+        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
+        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
+        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
+        \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '757'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 23 Jun 2021 14:08:30 GMT
+      etag:
+      - W/"cdbb8512-3460-4214-a64a-59aa457603fe"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 97c56059-9e16-4285-9644-b981ecdde52c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '23097'
+      - '24837'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:46 GMT
+      - Wed, 23 Jun 2021 14:08:30 GMT
       expires:
       - '-1'
       pragma:
@@ -1689,7 +1683,7 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
-      "principalId": "bf097ed3-2cae-4792-9bc6-c50870a902c0", "principalType": "ServicePrincipal"}}'
+      "principalId": "3d7a195b-09ac-422b-86b9-46d2b156384a", "principalType": "ServicePrincipal"}}'
     headers:
       Accept:
       - application/json
@@ -1706,15 +1700,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"bf097ed3-2cae-4792-9bc6-c50870a902c0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:47.9943632Z","updatedOn":"2021-04-30T12:21:48.4644058Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"3d7a195b-09ac-422b-86b9-46d2b156384a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-23T14:08:31.1950214Z","updatedOn":"2021-06-23T14:08:31.5998785Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
     headers:
       cache-control:
       - no-cache
@@ -1723,7 +1717,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:50 GMT
+      - Wed, 23 Jun 2021 14:08:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1735,7 +1729,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -1753,24 +1747,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"bf097ed3-2cae-4792-9bc6-c50870a902c0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:48.6944163Z","updatedOn":"2021-04-30T12:21:48.6944163Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"3d7a195b-09ac-422b-86b9-46d2b156384a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-23T14:08:31.7099032Z","updatedOn":"2021-06-23T14:08:31.7099032Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '24149'
+      - '25889'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:50 GMT
+      - Wed, 23 Jun 2021 14:08:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1807,15 +1801,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:51.8411091Z","updatedOn":"2021-04-30T12:21:52.1061097Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-23T14:08:33.7502231Z","updatedOn":"2021-06-23T14:08:34.0252310Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
     headers:
       cache-control:
       - no-cache
@@ -1824,7 +1818,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:52 GMT
+      - Wed, 23 Jun 2021 14:08:34 GMT
       expires:
       - '-1'
       pragma:
@@ -1836,15 +1830,15 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
 - request:
     body: '{"tags": {"test": "list"}, "location": "eastus", "properties": {"clusterProfile":
-      {"pullSecret": "", "domain": "h6j9oso6", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-h6j9oso6"},
-      "servicePrincipalProfile": {"clientId": "91366eb3-2b0c-4028-8b33-adc55a5fe580",
-      "clientSecret": "8b7d48f6-0ea6-4c4a-ae2a-d15aea4861d1"}, "networkProfile": {"podCidr":
+      {"pullSecret": "", "domain": "qryo9mgo", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-qryo9mgo"},
+      "servicePrincipalProfile": {"clientId": "aa05aa8f-38cd-4572-befe-fa92474f65e6",
+      "clientSecret": "d807746b-0968-4b04-bd6a-b59660e0744e"}, "networkProfile": {"podCidr":
       "10.128.0.0/14", "serviceCidr": "172.30.0.0/16"}, "masterProfile": {"vmSize":
       "Standard_D8s_v3", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002"},
       "workerProfiles": [{"name": "worker", "vmSize": "Standard_D4s_v3", "diskSizeGB":
@@ -1867,8 +1861,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
@@ -1879,10 +1873,10 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"list\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Creating\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"h6j9oso6\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-h6j9oso6\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"qryo9mgo\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-qryo9mgo\"\n
         \       },\n        \"consoleProfile\": {},\n        \"servicePrincipalProfile\":
-        {\n            \"clientId\": \"91366eb3-2b0c-4028-8b33-adc55a5fe580\"\n        },\n
+        {\n            \"clientId\": \"aa05aa8f-38cd-4572-befe-fa92474f65e6\"\n        },\n
         \       \"networkProfile\": {\n            \"podCidr\": \"10.128.0.0/14\",\n
         \           \"serviceCidr\": \"172.30.0.0/16\"\n        },\n        \"masterProfile\":
         {\n            \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\":
@@ -1896,7 +1890,7 @@ interactions:
         \"Public\"\n            }\n        ]\n    }\n}\n"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -1904,7 +1898,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:21:58 GMT
+      - Wed, 23 Jun 2021 14:08:36 GMT
       expires:
       - '-1'
       pragma:
@@ -1932,15 +1926,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -1949,7 +1943,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:22:29 GMT
+      - Wed, 23 Jun 2021 14:09:07 GMT
       expires:
       - '-1'
       pragma:
@@ -1979,15 +1973,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -1996,7 +1990,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:22:59 GMT
+      - Wed, 23 Jun 2021 14:09:37 GMT
       expires:
       - '-1'
       pragma:
@@ -2026,15 +2020,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2043,7 +2037,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:23:28 GMT
+      - Wed, 23 Jun 2021 14:10:07 GMT
       expires:
       - '-1'
       pragma:
@@ -2073,15 +2067,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2090,7 +2084,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:23:59 GMT
+      - Wed, 23 Jun 2021 14:10:37 GMT
       expires:
       - '-1'
       pragma:
@@ -2120,15 +2114,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2137,7 +2131,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:24:29 GMT
+      - Wed, 23 Jun 2021 14:11:07 GMT
       expires:
       - '-1'
       pragma:
@@ -2167,15 +2161,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2184,7 +2178,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:24:59 GMT
+      - Wed, 23 Jun 2021 14:11:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2214,15 +2208,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2231,7 +2225,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:25:29 GMT
+      - Wed, 23 Jun 2021 14:12:08 GMT
       expires:
       - '-1'
       pragma:
@@ -2261,15 +2255,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2278,7 +2272,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:26:00 GMT
+      - Wed, 23 Jun 2021 14:12:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2308,15 +2302,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2325,7 +2319,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:26:30 GMT
+      - Wed, 23 Jun 2021 14:13:08 GMT
       expires:
       - '-1'
       pragma:
@@ -2355,15 +2349,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2372,7 +2366,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:27:00 GMT
+      - Wed, 23 Jun 2021 14:13:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2402,15 +2396,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2419,7 +2413,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:27:30 GMT
+      - Wed, 23 Jun 2021 14:14:09 GMT
       expires:
       - '-1'
       pragma:
@@ -2449,15 +2443,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2466,7 +2460,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:28:01 GMT
+      - Wed, 23 Jun 2021 14:14:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2496,15 +2490,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2513,7 +2507,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:28:31 GMT
+      - Wed, 23 Jun 2021 14:15:09 GMT
       expires:
       - '-1'
       pragma:
@@ -2543,15 +2537,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2560,7 +2554,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:29:01 GMT
+      - Wed, 23 Jun 2021 14:15:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2590,15 +2584,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2607,7 +2601,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:29:31 GMT
+      - Wed, 23 Jun 2021 14:16:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2637,15 +2631,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2654,7 +2648,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:30:02 GMT
+      - Wed, 23 Jun 2021 14:16:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2684,15 +2678,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2701,7 +2695,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:30:32 GMT
+      - Wed, 23 Jun 2021 14:17:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2731,15 +2725,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2748,7 +2742,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:31:02 GMT
+      - Wed, 23 Jun 2021 14:17:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2778,15 +2772,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2795,7 +2789,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:31:33 GMT
+      - Wed, 23 Jun 2021 14:18:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2825,15 +2819,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2842,7 +2836,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:32:02 GMT
+      - Wed, 23 Jun 2021 14:18:41 GMT
       expires:
       - '-1'
       pragma:
@@ -2872,15 +2866,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2889,7 +2883,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:32:33 GMT
+      - Wed, 23 Jun 2021 14:19:11 GMT
       expires:
       - '-1'
       pragma:
@@ -2919,15 +2913,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2936,7 +2930,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:33:03 GMT
+      - Wed, 23 Jun 2021 14:19:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2966,15 +2960,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2983,7 +2977,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:33:33 GMT
+      - Wed, 23 Jun 2021 14:20:10 GMT
       expires:
       - '-1'
       pragma:
@@ -3013,15 +3007,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3030,7 +3024,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:34:03 GMT
+      - Wed, 23 Jun 2021 14:20:40 GMT
       expires:
       - '-1'
       pragma:
@@ -3060,15 +3054,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3077,7 +3071,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:34:34 GMT
+      - Wed, 23 Jun 2021 14:21:10 GMT
       expires:
       - '-1'
       pragma:
@@ -3107,15 +3101,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3124,7 +3118,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:35:04 GMT
+      - Wed, 23 Jun 2021 14:21:41 GMT
       expires:
       - '-1'
       pragma:
@@ -3154,15 +3148,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3171,7 +3165,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:35:34 GMT
+      - Wed, 23 Jun 2021 14:22:11 GMT
       expires:
       - '-1'
       pragma:
@@ -3201,15 +3195,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3218,7 +3212,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:36:05 GMT
+      - Wed, 23 Jun 2021 14:22:41 GMT
       expires:
       - '-1'
       pragma:
@@ -3248,15 +3242,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3265,7 +3259,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:36:35 GMT
+      - Wed, 23 Jun 2021 14:23:11 GMT
       expires:
       - '-1'
       pragma:
@@ -3295,15 +3289,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3312,7 +3306,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:37:06 GMT
+      - Wed, 23 Jun 2021 14:23:41 GMT
       expires:
       - '-1'
       pragma:
@@ -3342,15 +3336,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3359,7 +3353,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:37:36 GMT
+      - Wed, 23 Jun 2021 14:24:12 GMT
       expires:
       - '-1'
       pragma:
@@ -3389,15 +3383,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3406,7 +3400,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:38:06 GMT
+      - Wed, 23 Jun 2021 14:24:42 GMT
       expires:
       - '-1'
       pragma:
@@ -3436,15 +3430,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3453,7 +3447,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:38:37 GMT
+      - Wed, 23 Jun 2021 14:25:12 GMT
       expires:
       - '-1'
       pragma:
@@ -3483,15 +3477,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3500,7 +3494,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:39:06 GMT
+      - Wed, 23 Jun 2021 14:25:42 GMT
       expires:
       - '-1'
       pragma:
@@ -3530,15 +3524,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3547,7 +3541,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:39:37 GMT
+      - Wed, 23 Jun 2021 14:26:12 GMT
       expires:
       - '-1'
       pragma:
@@ -3577,15 +3571,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3594,7 +3588,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:40:08 GMT
+      - Wed, 23 Jun 2021 14:26:42 GMT
       expires:
       - '-1'
       pragma:
@@ -3624,15 +3618,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3641,7 +3635,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:40:38 GMT
+      - Wed, 23 Jun 2021 14:27:13 GMT
       expires:
       - '-1'
       pragma:
@@ -3671,15 +3665,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3688,7 +3682,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:41:08 GMT
+      - Wed, 23 Jun 2021 14:27:43 GMT
       expires:
       - '-1'
       pragma:
@@ -3718,15 +3712,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3735,7 +3729,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:41:37 GMT
+      - Wed, 23 Jun 2021 14:28:13 GMT
       expires:
       - '-1'
       pragma:
@@ -3765,15 +3759,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3782,7 +3776,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:42:08 GMT
+      - Wed, 23 Jun 2021 14:28:43 GMT
       expires:
       - '-1'
       pragma:
@@ -3812,15 +3806,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3829,7 +3823,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:42:38 GMT
+      - Wed, 23 Jun 2021 14:29:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3859,15 +3853,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3876,7 +3870,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:43:08 GMT
+      - Wed, 23 Jun 2021 14:29:44 GMT
       expires:
       - '-1'
       pragma:
@@ -3906,15 +3900,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3923,7 +3917,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:43:38 GMT
+      - Wed, 23 Jun 2021 14:30:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3953,15 +3947,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3970,7 +3964,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:44:09 GMT
+      - Wed, 23 Jun 2021 14:30:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4000,15 +3994,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4017,7 +4011,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:44:40 GMT
+      - Wed, 23 Jun 2021 14:31:15 GMT
       expires:
       - '-1'
       pragma:
@@ -4047,15 +4041,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4064,7 +4058,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:45:10 GMT
+      - Wed, 23 Jun 2021 14:31:45 GMT
       expires:
       - '-1'
       pragma:
@@ -4094,15 +4088,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4111,7 +4105,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:45:40 GMT
+      - Wed, 23 Jun 2021 14:32:15 GMT
       expires:
       - '-1'
       pragma:
@@ -4141,15 +4135,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4158,7 +4152,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:46:11 GMT
+      - Wed, 23 Jun 2021 14:32:45 GMT
       expires:
       - '-1'
       pragma:
@@ -4188,15 +4182,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4205,7 +4199,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:46:41 GMT
+      - Wed, 23 Jun 2021 14:33:15 GMT
       expires:
       - '-1'
       pragma:
@@ -4235,15 +4229,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4252,7 +4246,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:47:11 GMT
+      - Wed, 23 Jun 2021 14:33:45 GMT
       expires:
       - '-1'
       pragma:
@@ -4282,15 +4276,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4299,7 +4293,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:47:41 GMT
+      - Wed, 23 Jun 2021 14:34:16 GMT
       expires:
       - '-1'
       pragma:
@@ -4329,15 +4323,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4346,7 +4340,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:48:11 GMT
+      - Wed, 23 Jun 2021 14:34:46 GMT
       expires:
       - '-1'
       pragma:
@@ -4376,15 +4370,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4393,7 +4387,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:48:42 GMT
+      - Wed, 23 Jun 2021 14:35:16 GMT
       expires:
       - '-1'
       pragma:
@@ -4423,15 +4417,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4440,7 +4434,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:49:12 GMT
+      - Wed, 23 Jun 2021 14:35:46 GMT
       expires:
       - '-1'
       pragma:
@@ -4470,15 +4464,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4487,7 +4481,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:49:42 GMT
+      - Wed, 23 Jun 2021 14:36:16 GMT
       expires:
       - '-1'
       pragma:
@@ -4517,15 +4511,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4534,7 +4528,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:50:12 GMT
+      - Wed, 23 Jun 2021 14:36:47 GMT
       expires:
       - '-1'
       pragma:
@@ -4564,579 +4558,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:50:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:51:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:51:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:52:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:52:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:53:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:53:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:54:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:54:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:55:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:55:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 12:56:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n
-        \   \"name\": \"8b2b5bc8-cbd0-4613-ba0f-c96c564c552f\",\n    \"status\": \"Succeeded\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.764935248Z\",\n    \"endTime\": \"2021-04-30T12:56:44.687908871Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n
+        \   \"name\": \"dee10e2f-5a2e-4e2a-98f4-f8997cb9bd33\",\n    \"status\": \"Succeeded\",\n
+        \   \"startTime\": \"2021-06-23T14:08:36.700638917Z\",\n    \"endTime\": \"2021-06-23T14:37:01.255522741Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5145,7 +4575,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:56:46 GMT
+      - Wed, 23 Jun 2021 14:37:17 GMT
       expires:
       - '-1'
       pragma:
@@ -5175,8 +4605,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
   response:
@@ -5185,38 +4615,38 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"list\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"h6j9oso6\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-h6j9oso6\"\n
-        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.h6j9oso6.eastus.aroapp.io/\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"qryo9mgo\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-qryo9mgo\"\n
+        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.qryo9mgo.eastus.aroapp.io/\"\n
         \       },\n        \"servicePrincipalProfile\": {\n            \"clientId\":
-        \"91366eb3-2b0c-4028-8b33-adc55a5fe580\"\n        },\n        \"networkProfile\":
+        \"aa05aa8f-38cd-4572-befe-fa92474f65e6\"\n        },\n        \"networkProfile\":
         {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\":
         \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n            \"vmSize\":
         \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \       },\n        \"workerProfiles\": [\n            {\n                \"name\":
-        \"aro000004-72v4d-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-tvj42-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-72v4d-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-tvj42-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-72v4d-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-tvj42-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            }\n        ],\n        \"apiserverProfile\":
-        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.h6j9oso6.eastus.aroapp.io:6443/\",\n
-        \           \"ip\": \"20.75.158.64\"\n        },\n        \"ingressProfiles\":
+        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.qryo9mgo.eastus.aroapp.io:6443/\",\n
+        \           \"ip\": \"20.81.35.173\"\n        },\n        \"ingressProfiles\":
         [\n            {\n                \"name\": \"default\",\n                \"visibility\":
-        \"Public\",\n                \"ip\": \"20.75.158.71\"\n            }\n        ]\n
+        \"Public\",\n                \"ip\": \"20.81.36.1\"\n            }\n        ]\n
         \   }\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2863'
+      - '2861'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:56:46 GMT
+      - Wed, 23 Jun 2021 14:37:17 GMT
       expires:
       - '-1'
       pragma:
@@ -5246,8 +4676,8 @@ interactions:
       ParameterSetName:
       - -g --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -5259,45 +4689,45 @@ interactions:
         \           \"location\": \"eastus\",\n            \"tags\": {\n                \"test\":
         \"list\"\n            },\n            \"properties\": {\n                \"provisioningState\":
         \"Succeeded\",\n                \"clusterProfile\": {\n                    \"domain\":
-        \"h6j9oso6\",\n                    \"version\": \"4.6.21\",\n                    \"resourceGroupId\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-h6j9oso6\"\n
+        \"qryo9mgo\",\n                    \"version\": \"4.6.26\",\n                    \"resourceGroupId\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-qryo9mgo\"\n
         \               },\n                \"consoleProfile\": {\n                    \"url\":
-        \"https://console-openshift-console.apps.h6j9oso6.eastus.aroapp.io/\"\n                },\n
+        \"https://console-openshift-console.apps.qryo9mgo.eastus.aroapp.io/\"\n                },\n
         \               \"servicePrincipalProfile\": {\n                    \"clientId\":
-        \"91366eb3-2b0c-4028-8b33-adc55a5fe580\"\n                },\n                \"networkProfile\":
+        \"aa05aa8f-38cd-4572-befe-fa92474f65e6\"\n                },\n                \"networkProfile\":
         {\n                    \"podCidr\": \"10.128.0.0/14\",\n                    \"serviceCidr\":
         \"172.30.0.0/16\"\n                },\n                \"masterProfile\":
         {\n                    \"vmSize\": \"Standard_D8s_v3\",\n                    \"subnetId\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \               },\n                \"workerProfiles\": [\n                    {\n
-        \                       \"name\": \"aro000004-72v4d-worker-eastus1\",\n                        \"vmSize\":
+        \                       \"name\": \"aro000004-tvj42-worker-eastus1\",\n                        \"vmSize\":
         \"Standard_D4s_v3\",\n                        \"diskSizeGB\": 128,\n                        \"subnetId\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \                       \"count\": 1\n                    },\n                    {\n
-        \                       \"name\": \"aro000004-72v4d-worker-eastus2\",\n                        \"vmSize\":
+        \                       \"name\": \"aro000004-tvj42-worker-eastus2\",\n                        \"vmSize\":
         \"Standard_D4s_v3\",\n                        \"diskSizeGB\": 128,\n                        \"subnetId\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \                       \"count\": 1\n                    },\n                    {\n
-        \                       \"name\": \"aro000004-72v4d-worker-eastus3\",\n                        \"vmSize\":
+        \                       \"name\": \"aro000004-tvj42-worker-eastus3\",\n                        \"vmSize\":
         \"Standard_D4s_v3\",\n                        \"diskSizeGB\": 128,\n                        \"subnetId\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \                       \"count\": 1\n                    }\n                ],\n
         \               \"apiserverProfile\": {\n                    \"visibility\":
-        \"Public\",\n                    \"url\": \"https://api.h6j9oso6.eastus.aroapp.io:6443/\",\n
-        \                   \"ip\": \"20.75.158.64\"\n                },\n                \"ingressProfiles\":
+        \"Public\",\n                    \"url\": \"https://api.qryo9mgo.eastus.aroapp.io:6443/\",\n
+        \                   \"ip\": \"20.81.35.173\"\n                },\n                \"ingressProfiles\":
         [\n                    {\n                        \"name\": \"default\",\n
         \                       \"visibility\": \"Public\",\n                        \"ip\":
-        \"20.75.158.71\"\n                    }\n                ]\n            }\n
+        \"20.81.36.1\"\n                    }\n                ]\n            }\n
         \       }\n    ]\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3416'
+      - '3414'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:56:47 GMT
+      - Wed, 23 Jun 2021 14:37:18 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_list_credentials.yaml
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_list_credentials.yaml
@@ -13,15 +13,12 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_list_cred000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001","name":"cli_test_aro_list_cred000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:21:15Z","createdAt":"2021-04-30T12:21:16.6369905Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001","name":"cli_test_aro_list_cred000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-23T13:31:38Z","createdAt":"2021-06-23T13:31:39.6679014Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:19 GMT
+      - Wed, 23 Jun 2021 13:31:40 GMT
       expires:
       - '-1'
       pragma:
@@ -63,16 +60,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"ed18c090-ed68-4dd5-9713-aafca4368f2b\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"c5d672b3-942d-42b1-bcc6-9cfb288ffbe7\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"54ab703c-a3c2-43c4-b184-025432fbe60a\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"dcf496bb-3494-4c57-9364-c3b7902a892e\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -81,7 +78,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/96200bc4-f89f-4601-8559-24e2eda5fe70?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6252ecd4-aeda-4c5c-98db-d1287bd02db0?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
@@ -89,7 +86,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:23 GMT
+      - Wed, 23 Jun 2021 13:31:41 GMT
       expires:
       - '-1'
       pragma:
@@ -102,9 +99,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 66326be8-66e3-4ad6-b5f8-22200fde896b
+      - a79bc1a2-1697-4ece-93a0-41e175e0610f
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -122,9 +119,9 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/96200bc4-f89f-4601-8559-24e2eda5fe70?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6252ecd4-aeda-4c5c-98db-d1287bd02db0?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -136,7 +133,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:26 GMT
+      - Wed, 23 Jun 2021 13:31:44 GMT
       expires:
       - '-1'
       pragma:
@@ -153,7 +150,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 7cc0eed9-d96d-44a1-ae33-f810262161ad
+      - 11b0f3ef-0cc8-4cf8-a9a8-2f5554ed4bb6
     status:
       code: 200
       message: OK
@@ -171,16 +168,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"64613231-af4b-4526-95f2-956d63a00b40\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"c7a43fcc-4103-483c-97ec-cf0d1e25de47\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"54ab703c-a3c2-43c4-b184-025432fbe60a\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"dcf496bb-3494-4c57-9364-c3b7902a892e\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -193,9 +190,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:26 GMT
+      - Wed, 23 Jun 2021 13:31:44 GMT
       etag:
-      - W/"64613231-af4b-4526-95f2-956d63a00b40"
+      - W/"c7a43fcc-4103-483c-97ec-cf0d1e25de47"
       expires:
       - '-1'
       pragma:
@@ -212,7 +209,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - d0aef678-973a-4bc5-b123-a765a9448e0a
+      - f3cbdd9f-fe09-4de6-8b25-054126d7e3e8
     status:
       code: 200
       message: OK
@@ -230,16 +227,16 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"64613231-af4b-4526-95f2-956d63a00b40\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"c7a43fcc-4103-483c-97ec-cf0d1e25de47\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"54ab703c-a3c2-43c4-b184-025432fbe60a\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"dcf496bb-3494-4c57-9364-c3b7902a892e\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -252,9 +249,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:26 GMT
+      - Wed, 23 Jun 2021 13:31:45 GMT
       etag:
-      - W/"64613231-af4b-4526-95f2-956d63a00b40"
+      - W/"c7a43fcc-4103-483c-97ec-cf0d1e25de47"
       expires:
       - '-1'
       pragma:
@@ -271,7 +268,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e20a1ced-9da3-4b44-90ce-a29ba077211d
+      - ead66ce2-130e-4b35-bbeb-971fc4e758d6
     status:
       code: 200
       message: OK
@@ -279,9 +276,10 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"name": "dev_master000002",
-      "properties": {"addressPrefix": "10.70.226.0/24", "serviceEndpoints": [{"service":
-      "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings": [], "enableDdosProtection":
-      false}}'
+      "properties": {"addressPrefix": "10.91.6.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
+      [], "enableDdosProtection": false}}'
     headers:
       Accept:
       - application/json
@@ -292,29 +290,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '515'
+      - '606'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"52690f04-cfbb-4b49-b0ff-98fb9559fcc1\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"669417ed-9b94-411f-ba43-953f799f1d39\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"54ab703c-a3c2-43c4-b184-025432fbe60a\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"dcf496bb-3494-4c57-9364-c3b7902a892e\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"52690f04-cfbb-4b49-b0ff-98fb9559fcc1\\\"\",\r\n
+        \       \"etag\": \"W/\\\"669417ed-9b94-411f-ba43-953f799f1d39\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.70.226.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.91.6.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -325,15 +323,15 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/5dd26516-43f4-4a4a-9812-00a6d726aaee?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6c68c6af-e639-4b7d-b3b6-f74a522d5fe1?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
-      - '1584'
+      - '1582'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:27 GMT
+      - Wed, 23 Jun 2021 13:31:46 GMT
       expires:
       - '-1'
       pragma:
@@ -350,7 +348,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 7b50732b-027d-46b9-8f25-4195dc63a170
+      - 9cf62b14-3bed-4b10-9238-79ab0040cdcd
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -370,9 +368,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/5dd26516-43f4-4a4a-9812-00a6d726aaee?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6c68c6af-e639-4b7d-b3b6-f74a522d5fe1?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -384,7 +382,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:31 GMT
+      - Wed, 23 Jun 2021 13:31:49 GMT
       expires:
       - '-1'
       pragma:
@@ -401,7 +399,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - f2092752-9c57-4916-a518-deadf4d1384e
+      - c072ecf9-2f2d-445b-b7d5-09b2eadabd22
     status:
       code: 200
       message: OK
@@ -419,23 +417,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"50fc21da-eee3-42f7-a6e2-c8c2df181c8f\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"ef32d7d4-18eb-4848-a43b-30168453e0dc\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"54ab703c-a3c2-43c4-b184-025432fbe60a\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"dcf496bb-3494-4c57-9364-c3b7902a892e\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"50fc21da-eee3-42f7-a6e2-c8c2df181c8f\\\"\",\r\n
+        \       \"etag\": \"W/\\\"ef32d7d4-18eb-4848-a43b-30168453e0dc\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.70.226.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.91.6.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -448,13 +446,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1587'
+      - '1585'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:31 GMT
+      - Wed, 23 Jun 2021 13:31:49 GMT
       etag:
-      - W/"50fc21da-eee3-42f7-a6e2-c8c2df181c8f"
+      - W/"ef32d7d4-18eb-4848-a43b-30168453e0dc"
       expires:
       - '-1'
       pragma:
@@ -471,7 +469,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 8b651afc-0d94-4503-9cfc-0599b5ce552d
+      - 211f1cf1-110d-4af8-9791-1f5cd2abd7cc
     status:
       code: 200
       message: OK
@@ -489,23 +487,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"50fc21da-eee3-42f7-a6e2-c8c2df181c8f\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"ef32d7d4-18eb-4848-a43b-30168453e0dc\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"54ab703c-a3c2-43c4-b184-025432fbe60a\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"dcf496bb-3494-4c57-9364-c3b7902a892e\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"50fc21da-eee3-42f7-a6e2-c8c2df181c8f\\\"\",\r\n
+        \       \"etag\": \"W/\\\"ef32d7d4-18eb-4848-a43b-30168453e0dc\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.70.226.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.91.6.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -518,13 +516,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1587'
+      - '1585'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:31 GMT
+      - Wed, 23 Jun 2021 13:31:49 GMT
       etag:
-      - W/"50fc21da-eee3-42f7-a6e2-c8c2df181c8f"
+      - W/"ef32d7d4-18eb-4848-a43b-30168453e0dc"
       expires:
       - '-1'
       pragma:
@@ -541,7 +539,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - da3c7c5a-39c3-4f5a-85b4-cb2e9e896ed0
+      - 9823e780-08c7-4eac-8e67-3c73a203d988
     status:
       code: 200
       message: OK
@@ -549,11 +547,13 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.70.226.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Enabled"}}, {"name": "dev_worker000003", "properties": {"addressPrefix": "10.118.234.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings":
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.91.6.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Enabled"}}, {"name": "dev_worker000003",
+      "properties": {"addressPrefix": "10.74.145.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
       [], "enableDdosProtection": false}}'
     headers:
       Accept:
@@ -565,29 +565,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '974'
+      - '1117'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"d9887091-b70f-44a2-b04a-5d10f3e6d0d7\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"ebd39012-cf3c-46d1-bd35-c49e4fbc79a0\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"54ab703c-a3c2-43c4-b184-025432fbe60a\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"dcf496bb-3494-4c57-9364-c3b7902a892e\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"d9887091-b70f-44a2-b04a-5d10f3e6d0d7\\\"\",\r\n
+        \       \"etag\": \"W/\\\"ebd39012-cf3c-46d1-bd35-c49e4fbc79a0\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.70.226.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.91.6.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -596,9 +596,9 @@ interactions:
         \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
         \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"d9887091-b70f-44a2-b04a-5d10f3e6d0d7\\\"\",\r\n
+        \       \"etag\": \"W/\\\"ebd39012-cf3c-46d1-bd35-c49e4fbc79a0\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.118.234.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.74.145.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -609,15 +609,15 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/9192a468-f732-4a23-b8dc-a58c3c33756a?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/89046216-5396-4bca-807e-52da83da4e6b?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
-      - '2475'
+      - '2472'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:32 GMT
+      - Wed, 23 Jun 2021 13:31:50 GMT
       expires:
       - '-1'
       pragma:
@@ -634,7 +634,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - afe29f52-f8dc-4433-88b1-b859d4ee98b5
+      - 9b60b1ba-bc3d-4106-92d8-6a3384e5fcbc
       x-ms-ratelimit-remaining-subscription-writes:
       - '1198'
     status:
@@ -654,9 +654,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/9192a468-f732-4a23-b8dc-a58c3c33756a?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/89046216-5396-4bca-807e-52da83da4e6b?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -668,7 +668,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:36 GMT
+      - Wed, 23 Jun 2021 13:31:53 GMT
       expires:
       - '-1'
       pragma:
@@ -685,7 +685,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - ea192a39-92cb-486b-a567-f05dfd043faf
+      - d64a7fba-b905-41e9-9618-cc0541bdc29b
     status:
       code: 200
       message: OK
@@ -703,23 +703,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"3a7451b6-a6b6-4d1f-9b64-738df18a3493\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"43c7d3f9-f7bb-422a-84ee-e2ad320902b7\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"54ab703c-a3c2-43c4-b184-025432fbe60a\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"dcf496bb-3494-4c57-9364-c3b7902a892e\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"3a7451b6-a6b6-4d1f-9b64-738df18a3493\\\"\",\r\n
+        \       \"etag\": \"W/\\\"43c7d3f9-f7bb-422a-84ee-e2ad320902b7\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.70.226.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.91.6.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -728,9 +728,9 @@ interactions:
         \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
         \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"3a7451b6-a6b6-4d1f-9b64-738df18a3493\\\"\",\r\n
+        \       \"etag\": \"W/\\\"43c7d3f9-f7bb-422a-84ee-e2ad320902b7\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.118.234.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.74.145.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -743,13 +743,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2479'
+      - '2476'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:36 GMT
+      - Wed, 23 Jun 2021 13:31:53 GMT
       etag:
-      - W/"3a7451b6-a6b6-4d1f-9b64-738df18a3493"
+      - W/"43c7d3f9-f7bb-422a-84ee-e2ad320902b7"
       expires:
       - '-1'
       pragma:
@@ -766,7 +766,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 0e6fa445-d4fa-4fe0-bc2d-33c402983727
+      - 2c2bfe4d-bcad-4af7-8968-ea08d3ebe0ef
     status:
       code: 200
       message: OK
@@ -784,14 +784,14 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"3a7451b6-a6b6-4d1f-9b64-738df18a3493\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.70.226.0/24\",\r\n
+        \ \"etag\": \"W/\\\"43c7d3f9-f7bb-422a-84ee-e2ad320902b7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.91.6.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -801,13 +801,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '754'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:37 GMT
+      - Wed, 23 Jun 2021 13:31:53 GMT
       etag:
-      - W/"3a7451b6-a6b6-4d1f-9b64-738df18a3493"
+      - W/"43c7d3f9-f7bb-422a-84ee-e2ad320902b7"
       expires:
       - '-1'
       pragma:
@@ -824,16 +824,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - ba6c3798-a88f-4d04-9366-bebb1c820853
+      - 41e74898-101c-4a68-b5de-7e8fc4cc46ed
     status:
       code: 200
       message: OK
 - request:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.70.226.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Disabled"}}'
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.91.6.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Disabled"}}'
     headers:
       Accept:
       - application/json
@@ -844,20 +844,20 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '457'
+      - '508'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"a2566c6e-3fe1-49b5-a05d-4dad15b7ce2e\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.70.226.0/24\",\r\n
+        \ \"etag\": \"W/\\\"163f26d4-2fd2-45fa-8886-b2b52ae6bdb4\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.91.6.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -865,15 +865,15 @@ interactions:
         \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/a0a3ff5e-7001-42e1-8112-e1f544e26820?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/cde61dfa-793e-4f7c-9cee-701ce07e13b3?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '754'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:38 GMT
+      - Wed, 23 Jun 2021 13:31:55 GMT
       expires:
       - '-1'
       pragma:
@@ -890,7 +890,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 253fad67-a5ae-47b6-8ccc-ef17c80738cb
+      - 9f2857d7-6267-4a4a-9218-2474606b7c4a
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -910,9 +910,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/a0a3ff5e-7001-42e1-8112-e1f544e26820?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/cde61dfa-793e-4f7c-9cee-701ce07e13b3?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -924,7 +924,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:41 GMT
+      - Wed, 23 Jun 2021 13:31:58 GMT
       expires:
       - '-1'
       pragma:
@@ -941,7 +941,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 54e5d471-d2ed-4ea9-a6a3-e36d478f9f88
+      - 2526e971-3ab4-4ec4-b26e-792876f8ccb9
     status:
       code: 200
       message: OK
@@ -959,14 +959,14 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"5fa37197-4950-4676-a6c7-7273c1a0af75\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.70.226.0/24\",\r\n
+        \ \"etag\": \"W/\\\"69141712-1b6d-4024-bd0e-3fd859ae54a7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.91.6.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -976,13 +976,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '757'
+      - '755'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:41 GMT
+      - Wed, 23 Jun 2021 13:31:58 GMT
       etag:
-      - W/"5fa37197-4950-4676-a6c7-7273c1a0af75"
+      - W/"69141712-1b6d-4024-bd0e-3fd859ae54a7"
       expires:
       - '-1'
       pragma:
@@ -999,7 +999,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - e2d5de8c-603e-45d1-beb0-069e4f9fa13c
+      - 7e2b6184-4fca-4d2b-89ef-5d6ce85aef8f
     status:
       code: 200
       message: OK
@@ -1017,14 +1017,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"5fa37197-4950-4676-a6c7-7273c1a0af75\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.70.226.0/24\",\r\n
+        \ \"etag\": \"W/\\\"69141712-1b6d-4024-bd0e-3fd859ae54a7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.91.6.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1034,13 +1034,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '757'
+      - '755'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:42 GMT
+      - Wed, 23 Jun 2021 13:31:58 GMT
       etag:
-      - W/"5fa37197-4950-4676-a6c7-7273c1a0af75"
+      - W/"69141712-1b6d-4024-bd0e-3fd859ae54a7"
       expires:
       - '-1'
       pragma:
@@ -1057,7 +1057,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 63b3afa0-b8b3-413e-8bb8-fcfbfcb5cb7b
+      - 5ac598de-c546-4237-88d9-23dcb8072a26
     status:
       code: 200
       message: OK
@@ -1075,14 +1075,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"5fa37197-4950-4676-a6c7-7273c1a0af75\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.118.234.0/24\",\r\n
+        \ \"etag\": \"W/\\\"69141712-1b6d-4024-bd0e-3fd859ae54a7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.74.145.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1092,13 +1092,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '757'
+      - '756'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:42 GMT
+      - Wed, 23 Jun 2021 13:31:58 GMT
       etag:
-      - W/"5fa37197-4950-4676-a6c7-7273c1a0af75"
+      - W/"69141712-1b6d-4024-bd0e-3fd859ae54a7"
       expires:
       - '-1'
       pragma:
@@ -1115,7 +1115,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - d01835e3-832b-4bf0-95e2-5817c4067b94
+      - e6df7cb1-f42b-425f-9c68-eb5810bfd762
     status:
       code: 200
       message: OK
@@ -1133,15 +1133,12 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_list_cred000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001","name":"cli_test_aro_list_cred000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:21:15Z","createdAt":"2021-04-30T12:21:16.6369905Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001","name":"cli_test_aro_list_cred000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-23T13:31:38Z","createdAt":"2021-06-23T13:31:39.6679014Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1150,7 +1147,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:42 GMT
+      - Wed, 23 Jun 2021 13:31:58 GMT
       expires:
       - '-1'
       pragma:
@@ -1178,10 +1175,7 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift?api-version=2020-10-01
   response:
@@ -1214,7 +1208,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:42 GMT
+      - Wed, 23 Jun 2021 13:31:58 GMT
       expires:
       - '-1'
       pragma:
@@ -1229,10 +1223,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"passwordCredentials": [{"startDate": "2021-04-30T12:21:43.710542Z", "endDate":
+    body: '{"passwordCredentials": [{"startDate": "2021-06-23T13:31:59.711398Z", "endDate":
       "2299-12-31T00:00:00.000Z", "value": "ReplacedSPPassword123*", "customKeyIdentifier":
-      "MjAyMS0wNC0zMCAxMjoyMTo0My43MTA1NDI="}], "displayName": "aro-a4shzxf7", "identifierUris":
-      ["https://az.aro.azure.com/5b39836a-2d49-4962-b155-8c41a6117623"]}'
+      "MjAyMS0wNi0yMyAxMzozMTo1OS43MTEzOTg="}], "displayName": "aro-vji2sux3", "identifierUris":
+      ["https://az.aro.azure.com/b0627fd5-16e5-4e27-89ee-c0c9b73724c4"]}'
     headers:
       Accept:
       - application/json
@@ -1249,8 +1243,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
@@ -1259,29 +1253,29 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "3073d25a-81df-40e2-a8ff-8a58b9b6026d", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "5e6380ca-1a14-4bbf-9242-01c06de0a414",
+        "objectId": "a8ad7a0f-580c-4295-82ab-05769b42ff11", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "3e618e3d-5bbe-4781-a591-83040c835f9e",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
-        false, "displayName": "aro-a4shzxf7", "errorUrl": null, "groupMembershipClaims":
-        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/5b39836a-2d49-4962-b155-8c41a6117623"],
+        false, "displayName": "aro-vji2sux3", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/b0627fd5-16e5-4e27-89ee-c0c9b73724c4"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/3073d25a-81df-40e2-a8ff-8a58b9b6026d/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/a8ad7a0f-580c-4295-82ab-05769b42ff11/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/3073d25a-81df-40e2-a8ff-8a58b9b6026d/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/a8ad7a0f-580c-4295-82ab-05769b42ff11/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
-        "Allow the application to access aro-a4shzxf7 on behalf of the signed-in user.",
-        "adminConsentDisplayName": "Access aro-a4shzxf7", "id": "496f4cea-95f0-4932-816e-851189f08597",
+        "Allow the application to access aro-vji2sux3 on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Access aro-vji2sux3", "id": "aa18ae54-b877-42f1-89b2-ce25be8c5eb9",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
-        to access aro-a4shzxf7 on your behalf.", "userConsentDisplayName": "Access
-        aro-a4shzxf7", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        to access aro-vji2sux3 on your behalf.", "userConsentDisplayName": "Access
+        aro-vji2sux3", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
-        [{"customKeyIdentifier": "MjAyMS0wNC0zMCAxMjoyMTo0My43MTA1NDI=", "endDate":
-        "2299-12-31T00:00:00Z", "keyId": "3b3eb81d-8800-4f9d-bfaf-7a1282f98613", "startDate":
-        "2021-04-30T12:21:43.710542Z", "value": "ReplacedSPPassword123*"}], "publicClient":
+        [{"customKeyIdentifier": "MjAyMS0wNi0yMyAxMzozMTo1OS43MTEzOTg=", "endDate":
+        "2299-12-31T00:00:00Z", "keyId": "b102aaee-d079-479e-8e12-b855337dc327", "startDate":
+        "2021-06-23T13:31:59.711398Z", "value": "ReplacedSPPassword123*"}], "publicClient":
         null, "publisherDomain": "rhcuppettgmail.onmicrosoft.com", "recordConsentConditions":
         null, "replyUrls": [], "requiredResourceAccess": [], "samlMetadataUrl": null,
         "signInAudience": "AzureADMyOrg", "tokenEncryptionKeyId": null}'
@@ -1297,21 +1291,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:43 GMT
+      - Wed, 23 Jun 2021 13:32:00 GMT
       duration:
-      - '3859957'
+      - '4911512'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/3073d25a-81df-40e2-a8ff-8a58b9b6026d/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/a8ad7a0f-580c-4295-82ab-05769b42ff11/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - 1/M4aVL34x09UL12+fF1npaIagyWqbNb1txldK92zkw=
+      - 4h52fHtVwDDrpATQN4fZY26Dv4Q6N48yj9idx5tHdD4=
       ocp-aad-session-key:
-      - 13aaNocf8MDrLnmgQwNZB3VBEn3fkJV2BPty_ZeGnHHrM6ANBiE4mdVyzMDXslzQcztMA4jcSZkOJmeLTxm4C4l2A26ayZlcMJgWOsbH2Oy8f-bOvstOPNrsJURbGPgt6gXSOOL4SH1atC6PWbMuJihb994NXzHvkmu5p9bETiO_0CgTdAsasiYyaznHyaqZ6qdvrzTQuOmGe9L3LUXYHQ.PRwesIAZZ6TUyAc0ncHtfn94DDMWzw5y1U-6DaRqNoU
+      - GV5Hfi7f-VlrWdZr66ovJgUYJOcgqja9Q5Uf2Ir_LZbx0gd1xpHqW06X67SUCgSnSSoL2q_yn-Izfah5KIS4W_QAFWwTYkQ2tlCOhqep18IRSaGpRxWaLhkwijknXAE4IviD082IyCutpKAsM7ctGhn5Of0Np_wNiDceybZj8RU.5ECx7H6LAPKalJFux7M_42XPVXim-dpH_EAn1uQFKeI
       pragma:
       - no-cache
       request-id:
-      - 4ccc4b09-ef06-48ff-88e8-538bc2d5bff8
+      - 840eadb8-aca4-4983-ba72-1a895d315db1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1339,12 +1333,12 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%275e6380ca-1a14-4bbf-9242-01c06de0a414%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%273e618e3d-5bbe-4781-a591-83040c835f9e%27&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -1360,19 +1354,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:44 GMT
+      - Wed, 23 Jun 2021 13:32:00 GMT
       duration:
-      - '1262719'
+      - '389723'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - p7oHeYfsInkxbbgu43F1bFwlMEoYiFSlAN45we0GlQo=
+      - vob8Gpkogk3dr81QiChIq78HK0XoqyDf2HJAoeoAesQ=
       ocp-aad-session-key:
-      - acdQ25VHwSwRArKaKi0A0hUnFiWE5qc2OvlqOk2VWjWEFwjxr_uxO4Gbq21k1rQbiHnVHyqGFG6YIXkCx_NnFgkwvPrXvEAObU2VXhz-vx7NNNJ5JZkrRJrG8sYUgJ4ihVZWichgdiolJN2C9xtQq6gBc22Mv063IL76DHu2BW3gn3BQBqL8xMUxDA6XGdUgLcPEpkHh4JIPy3VkgeJtrw.7zv8Q3yw5UU7alT8mJQGFZyYNIDOGtJ-AunTw1Vgyu0
+      - 5cGiorqz2_N8NbrD2A-bylMf21xev4sAX9wJZZ2DwMQqqZ0rvchLtfRq_KnJDMdTp88f88yZmf7-wmTq6kILQXIJNM6sDcoKds1-h3xrypP3nCNuSbz93r_wYnPKpy0y3mug8oX46Ci39kBTmi-g2Vhnt1paLhmebcqAAuND26c.BESY-4RErppgtIVd1428-sAzyTPUbRekAerc-Pr-XCI
       pragma:
       - no-cache
       request-id:
-      - d2903f1e-8d35-4247-b581-8a9a6cbbb0a9
+      - ca4f6b1c-a03b-48f6-9b6d-cd552d1f9bf5
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1387,7 +1381,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"appId": "5e6380ca-1a14-4bbf-9242-01c06de0a414"}'
+    body: '{"appId": "3e618e3d-5bbe-4781-a591-83040c835f9e"}'
     headers:
       Accept:
       - application/json
@@ -1404,20 +1398,20 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"51b93607-4203-4776-851e-fd9473e110f0","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-a4shzxf7","appId":"5e6380ca-1a14-4bbf-9242-01c06de0a414","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-a4shzxf7","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access aro-a4shzxf7 on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        aro-a4shzxf7","id":"496f4cea-95f0-4932-816e-851189f08597","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access aro-a4shzxf7 on your behalf.","userConsentDisplayName":"Access
-        aro-a4shzxf7","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
-        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["5e6380ca-1a14-4bbf-9242-01c06de0a414","https://az.aro.azure.com/5b39836a-2d49-4962-b155-8c41a6117623"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"dcf6bf5e-8955-4adb-9775-e04d3cbf61ee","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-vji2sux3","appId":"3e618e3d-5bbe-4781-a591-83040c835f9e","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-vji2sux3","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access aro-vji2sux3 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        aro-vji2sux3","id":"aa18ae54-b877-42f1-89b2-ce25be8c5eb9","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access aro-vji2sux3 on your behalf.","userConsentDisplayName":"Access
+        aro-vji2sux3","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
+        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["3e618e3d-5bbe-4781-a591-83040c835f9e","https://az.aro.azure.com/b0627fd5-16e5-4e27-89ee-c0c9b73724c4"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1430,21 +1424,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
+      - Wed, 23 Jun 2021 13:32:01 GMT
       duration:
-      - '3515368'
+      - '3158322'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/51b93607-4203-4776-851e-fd9473e110f0/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/dcf6bf5e-8955-4adb-9775-e04d3cbf61ee/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - ZbeSBxhYFJEUwZ1Xtq9pKMBxu1DLoHZzcHo7oyuiHSc=
+      - v/1NZIszlSYpNtHNitbC/GH+0aO5ZPYKtGyRrBEtMZU=
       ocp-aad-session-key:
-      - kqx0iSjErYpclXoAFbOMqCWunsedIuHrr01jp4-pa2QnFz0FsBNGfT3tOEitbLI07HKYKE3-z61x7SHB6oc32IOhv4P1L6b84k4jXGHyA06H242EV9d_k4U07EKnG4xgSKY2eU4N9JAM3IKrp2Glzk-F0ri4d3NKc3PO4zThuU_UO2RjCVHkzJ9uPwVj75MmcImBbh7nz4k7LfU1qX8lIg.xMQgQJ-V3PsbciE2t82rusvq8lJvozqdmp54Dhmafec
+      - bwwOxD24l6Uf_MDUCBp-cFyLEGelmNbgbdKTiSOvxj-oSZqsCzYUpZ87QEAURZTcTUBimmPomBktLCebEshLIoslgkllXNZftBzscOgLdDRlwUgutcOgquBoHdr9ZNVLiSyDCuM9XzySlqAuz17c3ohGW0K3w7tDHjOWOd97JL8.MtVZybK_X1qSX08zRbG4-y-QjRX4A1R1Rubuwy7fIkY
       pragma:
       - no-cache
       request-id:
-      - 4a798281-c4d2-4b04-adb6-858ec879bed6
+      - 7105ce15-fb16-46be-b788-088481e06495
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1472,8 +1466,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -1496,19 +1490,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
+      - Wed, 23 Jun 2021 13:32:02 GMT
       duration:
-      - '1135332'
+      - '422729'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - aTitz9BQjmvjQo+9Yz/F314xUH2AdabyMNpJAuBeJME=
+      - v/1NZIszlSYpNtHNitbC/GH+0aO5ZPYKtGyRrBEtMZU=
       ocp-aad-session-key:
-      - AqFPR8qZYXnxd3S1taVSXmHUVT9KSh8cAD_5Vm4NXGF15d1yq9bO__EVoK5cH9LH8nzkidSZiBwN5U1gyEuTYdg0RFLPbKAScYMu3Y2smg5LqDKkZdDfOFsK9P5XjVqOS2Su1xHVBWews7oco071G9beHAWRoUle_pbtCZWPz__-T80L88w5Z0XItRiAayD3CDZFMEem4gey63DcDyiS4g.pyqDyUmK6N1rJRBoZ0IKb1u8060w5wToiUU6sm7XsOo
+      - wiUNVysbba04abRuk8uF9noR9N6oqEPa1RQktUAy99SGm6kgA2niIqt4Qx-zDbKvXx06xUNzsiG5dkRl_yeKIQnBZV8qBznC1O3SEKrgvSCwmJgyz9pYuTGGGmJP3wvUNuSnCzKSGB90BxeFzLJlgUZPGqCYqusqm_9icrTAP0Q.Lo8Ade9cnZZkm14ObQbDkZW-5RCOZ_bMVu2UoNfd-Mg
       pragma:
       - no-cache
       request-id:
-      - fd89fddd-915f-470a-a812-ab88f4949958
+      - 6da5171b-36db-4f97-a8b9-d4023f98ce80
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1536,72 +1530,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"5fa37197-4950-4676-a6c7-7273c1a0af75\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.118.234.0/24\",\r\n
-        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
-        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
-        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
-        \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '757'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
-      etag:
-      - W/"5fa37197-4950-4676-a6c7-7273c1a0af75"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 6dc5d968-19fb-4ddb-b9bf-9caa7eaa731d
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"5fa37197-4950-4676-a6c7-7273c1a0af75\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.70.226.0/24\",\r\n
+        \ \"etag\": \"W/\\\"69141712-1b6d-4024-bd0e-3fd859ae54a7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.91.6.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1611,13 +1547,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '757'
+      - '755'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:45 GMT
+      - Wed, 23 Jun 2021 13:32:01 GMT
       etag:
-      - W/"5fa37197-4950-4676-a6c7-7273c1a0af75"
+      - W/"69141712-1b6d-4024-bd0e-3fd859ae54a7"
       expires:
       - '-1'
       pragma:
@@ -1634,7 +1570,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 5586acd9-d9f6-4399-a8ba-648718ce711a
+      - e106203f-3031-4206-baa2-9cabca9f7a79
     status:
       code: 200
       message: OK
@@ -1652,24 +1588,82 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \ \"etag\": \"W/\\\"69141712-1b6d-4024-bd0e-3fd859ae54a7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.74.145.0/24\",\r\n
+        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
+        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
+        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
+        \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '756'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 23 Jun 2021 13:32:01 GMT
+      etag:
+      - W/"69141712-1b6d-4024-bd0e-3fd859ae54a7"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 1ddbdc44-fcc6-49ab-b76a-aa6f8bae1ba6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '23097'
+      - '24837'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:46 GMT
+      - Wed, 23 Jun 2021 13:32:02 GMT
       expires:
       - '-1'
       pragma:
@@ -1689,7 +1683,7 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
-      "principalId": "51b93607-4203-4776-851e-fd9473e110f0", "principalType": "ServicePrincipal"}}'
+      "principalId": "dcf6bf5e-8955-4adb-9775-e04d3cbf61ee", "principalType": "ServicePrincipal"}}'
     headers:
       Accept:
       - application/json
@@ -1706,15 +1700,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"51b93607-4203-4776-851e-fd9473e110f0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:47.1660421Z","updatedOn":"2021-04-30T12:21:47.8310455Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"dcf6bf5e-8955-4adb-9775-e04d3cbf61ee","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-23T13:32:03.4547292Z","updatedOn":"2021-06-23T13:32:03.8446700Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
     headers:
       cache-control:
       - no-cache
@@ -1723,7 +1717,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:49 GMT
+      - Wed, 23 Jun 2021 13:32:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1753,24 +1747,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"51b93607-4203-4776-851e-fd9473e110f0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:48.0560990Z","updatedOn":"2021-04-30T12:21:48.0560990Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"dcf6bf5e-8955-4adb-9775-e04d3cbf61ee","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-23T13:32:03.9546695Z","updatedOn":"2021-06-23T13:32:03.9546695Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '24149'
+      - '25889'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:49 GMT
+      - Wed, 23 Jun 2021 13:32:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1807,15 +1801,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:21:50.9114462Z","updatedOn":"2021-04-30T12:21:51.3714301Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-23T13:32:05.8086916Z","updatedOn":"2021-06-23T13:32:06.1087362Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
     headers:
       cache-control:
       - no-cache
@@ -1824,7 +1818,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:21:53 GMT
+      - Wed, 23 Jun 2021 13:32:06 GMT
       expires:
       - '-1'
       pragma:
@@ -1836,15 +1830,15 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
 - request:
     body: '{"tags": {"test": "list-cred"}, "location": "eastus", "properties": {"clusterProfile":
-      {"pullSecret": "", "domain": "a4shzxf7", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-a4shzxf7"},
-      "servicePrincipalProfile": {"clientId": "5e6380ca-1a14-4bbf-9242-01c06de0a414",
-      "clientSecret": "6a66ed4d-b4e2-4054-b11e-3a39e27be618"}, "networkProfile": {"podCidr":
+      {"pullSecret": "", "domain": "vji2sux3", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-vji2sux3"},
+      "servicePrincipalProfile": {"clientId": "3e618e3d-5bbe-4781-a591-83040c835f9e",
+      "clientSecret": "fa4acdb8-0c66-422d-8180-b49540c8d6e6"}, "networkProfile": {"podCidr":
       "10.128.0.0/14", "serviceCidr": "172.30.0.0/16"}, "masterProfile": {"vmSize":
       "Standard_D8s_v3", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002"},
       "workerProfiles": [{"name": "worker", "vmSize": "Standard_D4s_v3", "diskSizeGB":
@@ -1867,8 +1861,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
@@ -1879,10 +1873,10 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"list-cred\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Creating\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"a4shzxf7\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-a4shzxf7\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"vji2sux3\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-vji2sux3\"\n
         \       },\n        \"consoleProfile\": {},\n        \"servicePrincipalProfile\":
-        {\n            \"clientId\": \"5e6380ca-1a14-4bbf-9242-01c06de0a414\"\n        },\n
+        {\n            \"clientId\": \"3e618e3d-5bbe-4781-a591-83040c835f9e\"\n        },\n
         \       \"networkProfile\": {\n            \"podCidr\": \"10.128.0.0/14\",\n
         \           \"serviceCidr\": \"172.30.0.0/16\"\n        },\n        \"masterProfile\":
         {\n            \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\":
@@ -1896,7 +1890,7 @@ interactions:
         \"Public\"\n            }\n        ]\n    }\n}\n"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -1904,7 +1898,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:21:58 GMT
+      - Wed, 23 Jun 2021 13:32:08 GMT
       expires:
       - '-1'
       pragma:
@@ -1932,15 +1926,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -1949,7 +1943,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:22:28 GMT
+      - Wed, 23 Jun 2021 13:32:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1979,15 +1973,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -1996,7 +1990,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:22:59 GMT
+      - Wed, 23 Jun 2021 13:33:09 GMT
       expires:
       - '-1'
       pragma:
@@ -2026,15 +2020,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2043,7 +2037,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:23:29 GMT
+      - Wed, 23 Jun 2021 13:33:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2073,15 +2067,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2090,7 +2084,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:23:59 GMT
+      - Wed, 23 Jun 2021 13:34:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2120,15 +2114,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2137,7 +2131,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:24:29 GMT
+      - Wed, 23 Jun 2021 13:34:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2167,15 +2161,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2184,7 +2178,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:25:00 GMT
+      - Wed, 23 Jun 2021 13:35:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2214,15 +2208,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2231,7 +2225,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:25:29 GMT
+      - Wed, 23 Jun 2021 13:35:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2261,15 +2255,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2278,7 +2272,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:25:59 GMT
+      - Wed, 23 Jun 2021 13:36:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2308,15 +2302,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2325,7 +2319,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:26:29 GMT
+      - Wed, 23 Jun 2021 13:36:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2355,15 +2349,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2372,7 +2366,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:27:00 GMT
+      - Wed, 23 Jun 2021 13:37:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2402,15 +2396,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2419,7 +2413,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:27:31 GMT
+      - Wed, 23 Jun 2021 13:37:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2449,15 +2443,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2466,7 +2460,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:28:01 GMT
+      - Wed, 23 Jun 2021 13:38:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2496,15 +2490,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2513,7 +2507,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:28:31 GMT
+      - Wed, 23 Jun 2021 13:38:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2543,15 +2537,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2560,7 +2554,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:29:01 GMT
+      - Wed, 23 Jun 2021 13:39:11 GMT
       expires:
       - '-1'
       pragma:
@@ -2590,15 +2584,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2607,7 +2601,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:29:31 GMT
+      - Wed, 23 Jun 2021 13:39:41 GMT
       expires:
       - '-1'
       pragma:
@@ -2637,15 +2631,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2654,7 +2648,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:30:01 GMT
+      - Wed, 23 Jun 2021 13:40:11 GMT
       expires:
       - '-1'
       pragma:
@@ -2684,15 +2678,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2701,7 +2695,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:30:32 GMT
+      - Wed, 23 Jun 2021 13:40:41 GMT
       expires:
       - '-1'
       pragma:
@@ -2731,15 +2725,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2748,7 +2742,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:31:02 GMT
+      - Wed, 23 Jun 2021 13:41:11 GMT
       expires:
       - '-1'
       pragma:
@@ -2778,15 +2772,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2795,7 +2789,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:31:32 GMT
+      - Wed, 23 Jun 2021 13:41:42 GMT
       expires:
       - '-1'
       pragma:
@@ -2825,15 +2819,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2842,7 +2836,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:32:02 GMT
+      - Wed, 23 Jun 2021 13:42:12 GMT
       expires:
       - '-1'
       pragma:
@@ -2872,15 +2866,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2889,7 +2883,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:32:33 GMT
+      - Wed, 23 Jun 2021 13:42:42 GMT
       expires:
       - '-1'
       pragma:
@@ -2919,15 +2913,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2936,7 +2930,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:33:03 GMT
+      - Wed, 23 Jun 2021 13:43:12 GMT
       expires:
       - '-1'
       pragma:
@@ -2966,15 +2960,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2983,7 +2977,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:33:33 GMT
+      - Wed, 23 Jun 2021 13:43:42 GMT
       expires:
       - '-1'
       pragma:
@@ -3013,15 +3007,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3030,7 +3024,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:34:04 GMT
+      - Wed, 23 Jun 2021 13:44:12 GMT
       expires:
       - '-1'
       pragma:
@@ -3060,15 +3054,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3077,7 +3071,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:34:34 GMT
+      - Wed, 23 Jun 2021 13:44:43 GMT
       expires:
       - '-1'
       pragma:
@@ -3107,15 +3101,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3124,7 +3118,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:35:04 GMT
+      - Wed, 23 Jun 2021 13:45:13 GMT
       expires:
       - '-1'
       pragma:
@@ -3154,15 +3148,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3171,7 +3165,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:35:34 GMT
+      - Wed, 23 Jun 2021 13:45:43 GMT
       expires:
       - '-1'
       pragma:
@@ -3201,15 +3195,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3218,7 +3212,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:36:05 GMT
+      - Wed, 23 Jun 2021 13:46:13 GMT
       expires:
       - '-1'
       pragma:
@@ -3248,15 +3242,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3265,7 +3259,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:36:35 GMT
+      - Wed, 23 Jun 2021 13:46:44 GMT
       expires:
       - '-1'
       pragma:
@@ -3295,15 +3289,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3312,7 +3306,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:37:05 GMT
+      - Wed, 23 Jun 2021 13:47:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3342,15 +3336,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3359,7 +3353,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:37:36 GMT
+      - Wed, 23 Jun 2021 13:47:44 GMT
       expires:
       - '-1'
       pragma:
@@ -3389,15 +3383,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3406,7 +3400,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:38:06 GMT
+      - Wed, 23 Jun 2021 13:48:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3436,15 +3430,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3453,7 +3447,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:38:36 GMT
+      - Wed, 23 Jun 2021 13:48:44 GMT
       expires:
       - '-1'
       pragma:
@@ -3483,15 +3477,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3500,7 +3494,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:39:05 GMT
+      - Wed, 23 Jun 2021 13:49:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3530,15 +3524,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3547,7 +3541,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:39:36 GMT
+      - Wed, 23 Jun 2021 13:49:45 GMT
       expires:
       - '-1'
       pragma:
@@ -3577,15 +3571,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3594,7 +3588,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:40:06 GMT
+      - Wed, 23 Jun 2021 13:50:15 GMT
       expires:
       - '-1'
       pragma:
@@ -3624,15 +3618,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3641,7 +3635,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:40:37 GMT
+      - Wed, 23 Jun 2021 13:50:45 GMT
       expires:
       - '-1'
       pragma:
@@ -3671,15 +3665,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3688,7 +3682,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:41:07 GMT
+      - Wed, 23 Jun 2021 13:51:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3718,15 +3712,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3735,7 +3729,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:41:38 GMT
+      - Wed, 23 Jun 2021 13:51:45 GMT
       expires:
       - '-1'
       pragma:
@@ -3765,15 +3759,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3782,7 +3776,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:42:08 GMT
+      - Wed, 23 Jun 2021 13:52:15 GMT
       expires:
       - '-1'
       pragma:
@@ -3812,15 +3806,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3829,7 +3823,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:42:37 GMT
+      - Wed, 23 Jun 2021 13:52:45 GMT
       expires:
       - '-1'
       pragma:
@@ -3859,15 +3853,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3876,7 +3870,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:43:08 GMT
+      - Wed, 23 Jun 2021 13:53:15 GMT
       expires:
       - '-1'
       pragma:
@@ -3906,15 +3900,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3923,7 +3917,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:43:38 GMT
+      - Wed, 23 Jun 2021 13:53:46 GMT
       expires:
       - '-1'
       pragma:
@@ -3953,15 +3947,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3970,7 +3964,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:44:08 GMT
+      - Wed, 23 Jun 2021 13:54:16 GMT
       expires:
       - '-1'
       pragma:
@@ -4000,15 +3994,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4017,7 +4011,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:44:39 GMT
+      - Wed, 23 Jun 2021 13:54:46 GMT
       expires:
       - '-1'
       pragma:
@@ -4047,15 +4041,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4064,7 +4058,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:45:09 GMT
+      - Wed, 23 Jun 2021 13:55:16 GMT
       expires:
       - '-1'
       pragma:
@@ -4094,15 +4088,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4111,7 +4105,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:45:39 GMT
+      - Wed, 23 Jun 2021 13:55:46 GMT
       expires:
       - '-1'
       pragma:
@@ -4141,15 +4135,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4158,7 +4152,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:46:09 GMT
+      - Wed, 23 Jun 2021 13:56:17 GMT
       expires:
       - '-1'
       pragma:
@@ -4188,15 +4182,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4205,7 +4199,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:46:40 GMT
+      - Wed, 23 Jun 2021 13:56:47 GMT
       expires:
       - '-1'
       pragma:
@@ -4235,15 +4229,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4252,7 +4246,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:47:10 GMT
+      - Wed, 23 Jun 2021 13:57:17 GMT
       expires:
       - '-1'
       pragma:
@@ -4282,15 +4276,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4299,7 +4293,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:47:40 GMT
+      - Wed, 23 Jun 2021 13:57:47 GMT
       expires:
       - '-1'
       pragma:
@@ -4329,15 +4323,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4346,7 +4340,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:48:11 GMT
+      - Wed, 23 Jun 2021 13:58:17 GMT
       expires:
       - '-1'
       pragma:
@@ -4376,15 +4370,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4393,7 +4387,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:48:40 GMT
+      - Wed, 23 Jun 2021 13:58:48 GMT
       expires:
       - '-1'
       pragma:
@@ -4423,15 +4417,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4440,7 +4434,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:49:11 GMT
+      - Wed, 23 Jun 2021 13:59:18 GMT
       expires:
       - '-1'
       pragma:
@@ -4470,15 +4464,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4487,7 +4481,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:49:42 GMT
+      - Wed, 23 Jun 2021 13:59:48 GMT
       expires:
       - '-1'
       pragma:
@@ -4517,15 +4511,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4534,7 +4528,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:50:12 GMT
+      - Wed, 23 Jun 2021 14:00:18 GMT
       expires:
       - '-1'
       pragma:
@@ -4564,15 +4558,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4581,7 +4575,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:50:42 GMT
+      - Wed, 23 Jun 2021 14:00:48 GMT
       expires:
       - '-1'
       pragma:
@@ -4611,15 +4605,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4628,7 +4622,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:51:12 GMT
+      - Wed, 23 Jun 2021 14:01:19 GMT
       expires:
       - '-1'
       pragma:
@@ -4658,15 +4652,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4675,7 +4669,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:51:42 GMT
+      - Wed, 23 Jun 2021 14:01:49 GMT
       expires:
       - '-1'
       pragma:
@@ -4705,15 +4699,62 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/01c8286c-3612-47e3-8fd9-6a96f9882016\",\n
-        \   \"name\": \"01c8286c-3612-47e3-8fd9-6a96f9882016\",\n    \"status\": \"Succeeded\",\n
-        \   \"startTime\": \"2021-04-30T12:21:57.508028911Z\",\n    \"endTime\": \"2021-04-30T12:52:08.035101171Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Wed, 23 Jun 2021 14:02:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n
+        \   \"name\": \"94bfaa8f-e808-4334-ae4d-7aa0c53e257f\",\n    \"status\": \"Succeeded\",\n
+        \   \"startTime\": \"2021-06-23T13:32:08.611719955Z\",\n    \"endTime\": \"2021-06-23T14:02:38.939853032Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4722,7 +4763,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:52:12 GMT
+      - Wed, 23 Jun 2021 14:02:49 GMT
       expires:
       - '-1'
       pragma:
@@ -4752,8 +4793,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
   response:
@@ -4762,38 +4803,38 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"list-cred\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"a4shzxf7\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-a4shzxf7\"\n
-        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.a4shzxf7.eastus.aroapp.io/\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"vji2sux3\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-vji2sux3\"\n
+        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.vji2sux3.eastus.aroapp.io/\"\n
         \       },\n        \"servicePrincipalProfile\": {\n            \"clientId\":
-        \"5e6380ca-1a14-4bbf-9242-01c06de0a414\"\n        },\n        \"networkProfile\":
+        \"3e618e3d-5bbe-4781-a591-83040c835f9e\"\n        },\n        \"networkProfile\":
         {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\":
         \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n            \"vmSize\":
         \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \       },\n        \"workerProfiles\": [\n            {\n                \"name\":
-        \"aro000004-wxmxc-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-sgvbp-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-wxmxc-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-sgvbp-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-wxmxc-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-sgvbp-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_list_cred000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            }\n        ],\n        \"apiserverProfile\":
-        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.a4shzxf7.eastus.aroapp.io:6443/\",\n
-        \           \"ip\": \"20.75.158.74\"\n        },\n        \"ingressProfiles\":
+        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.vji2sux3.eastus.aroapp.io:6443/\",\n
+        \           \"ip\": \"20.81.10.109\"\n        },\n        \"ingressProfiles\":
         [\n            {\n                \"name\": \"default\",\n                \"visibility\":
-        \"Public\",\n                \"ip\": \"20.75.158.100\"\n            }\n        ]\n
+        \"Public\",\n                \"ip\": \"20.81.10.123\"\n            }\n        ]\n
         \   }\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2869'
+      - '2868'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:52:13 GMT
+      - Wed, 23 Jun 2021 14:02:49 GMT
       expires:
       - '-1'
       pragma:
@@ -4825,8 +4866,8 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
@@ -4834,7 +4875,7 @@ interactions:
   response:
     body:
       string: "{\n    \"kubeadminUsername\": \"kubeadmin\",\n    \"kubeadminPassword\":
-        \"pRv5U-nuUAj-NevB8-5uhtW\"\n}\n"
+        \"WZ88Z-tifKT-dgmHd-vL858\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4843,7 +4884,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:52:14 GMT
+      - Wed, 23 Jun 2021 14:02:50 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_show.yaml
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_show.yaml
@@ -13,15 +13,12 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_show000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001","name":"cli_test_aro_show000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:53:18Z","createdAt":"2021-04-30T12:53:19.7460181Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001","name":"cli_test_aro_show000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-23T13:00:02Z","createdAt":"2021-06-23T13:00:05.0615672Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:21 GMT
+      - Wed, 23 Jun 2021 13:00:06 GMT
       expires:
       - '-1'
       pragma:
@@ -63,16 +60,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"eb22544a-3301-4b0e-a8c2-dbbeac43607d\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"a431a4be-af71-4586-baf3-eb78f63fe42b\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"6b6a0d2b-e413-4081-9ba4-cd8b4a2523d3\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"10aa173d-db85-4918-9544-a9017dcf7fbe\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -81,7 +78,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e89f72ce-ffb6-482e-a501-0bec4e107008?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/96a511be-b325-4dd2-a5a9-4bce240601c0?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
@@ -89,7 +86,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:24 GMT
+      - Wed, 23 Jun 2021 13:00:07 GMT
       expires:
       - '-1'
       pragma:
@@ -102,9 +99,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - f3a169be-3667-4ab1-af53-6e94215ba39c
+      - 1de9e7c2-2fa1-4fee-94b8-3d8c10eed0cf
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -122,9 +119,9 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e89f72ce-ffb6-482e-a501-0bec4e107008?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/96a511be-b325-4dd2-a5a9-4bce240601c0?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -136,7 +133,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:27 GMT
+      - Wed, 23 Jun 2021 13:00:10 GMT
       expires:
       - '-1'
       pragma:
@@ -153,7 +150,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - b0c7857b-b3be-4b02-bac2-29bf051290c7
+      - c8efcde3-1b73-42b2-9c6c-e8c3c6a1682d
     status:
       code: 200
       message: OK
@@ -171,16 +168,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"b3f7948b-eee9-4dd2-b286-8e3db7ecd16c\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"ae0160ab-d005-4872-99be-31aa78b1dd5d\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"6b6a0d2b-e413-4081-9ba4-cd8b4a2523d3\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"10aa173d-db85-4918-9544-a9017dcf7fbe\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -193,9 +190,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:28 GMT
+      - Wed, 23 Jun 2021 13:00:10 GMT
       etag:
-      - W/"b3f7948b-eee9-4dd2-b286-8e3db7ecd16c"
+      - W/"ae0160ab-d005-4872-99be-31aa78b1dd5d"
       expires:
       - '-1'
       pragma:
@@ -212,7 +209,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - c797d4f1-e8d5-4a94-8d79-d954cecb135f
+      - d01d4af3-0872-4d7f-b17d-54d9e8abf27b
     status:
       code: 200
       message: OK
@@ -230,16 +227,16 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"b3f7948b-eee9-4dd2-b286-8e3db7ecd16c\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"ae0160ab-d005-4872-99be-31aa78b1dd5d\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"6b6a0d2b-e413-4081-9ba4-cd8b4a2523d3\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"10aa173d-db85-4918-9544-a9017dcf7fbe\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -252,9 +249,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:28 GMT
+      - Wed, 23 Jun 2021 13:00:10 GMT
       etag:
-      - W/"b3f7948b-eee9-4dd2-b286-8e3db7ecd16c"
+      - W/"ae0160ab-d005-4872-99be-31aa78b1dd5d"
       expires:
       - '-1'
       pragma:
@@ -271,7 +268,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - efee8d95-d4f7-47a8-90a5-1cc3287a3522
+      - 681e70b2-1c3d-4232-a10f-225a1e80426f
     status:
       code: 200
       message: OK
@@ -279,281 +276,9 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"name": "dev_master000002",
-      "properties": {"addressPrefix": "10.118.53.0/24", "serviceEndpoints": [{"service":
-      "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings": [], "enableDdosProtection":
-      false}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '515'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"0be3e249-c568-4cd5-bb4b-4a0d91c2057a\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"6b6a0d2b-e413-4081-9ba4-cd8b4a2523d3\",\r\n    \"addressSpace\":
-        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
-        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
-        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"0be3e249-c568-4cd5-bb4b-4a0d91c2057a\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.118.53.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
-        false\r\n  }\r\n}"
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e8bf2662-92bd-447f-bd33-0a22630a1076?api-version=2021-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '1584'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:53:29 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 4a91fa0e-2fab-41e2-b251-4d54bb1a40e2
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e8bf2662-92bd-447f-bd33-0a22630a1076?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '29'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:53:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 4e3df8eb-e4ba-4fc1-845b-e15798bca99c
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"45b2dfca-94b0-4017-87ca-d2c2706bacca\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"6b6a0d2b-e413-4081-9ba4-cd8b4a2523d3\",\r\n    \"addressSpace\":
-        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
-        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
-        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"45b2dfca-94b0-4017-87ca-d2c2706bacca\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.118.53.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
-        false\r\n  }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1587'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:53:33 GMT
-      etag:
-      - W/"45b2dfca-94b0-4017-87ca-d2c2706bacca"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 477c57cf-0017-455a-89ab-cbadd7f7f127
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"45b2dfca-94b0-4017-87ca-d2c2706bacca\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"6b6a0d2b-e413-4081-9ba4-cd8b4a2523d3\",\r\n    \"addressSpace\":
-        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
-        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
-        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"45b2dfca-94b0-4017-87ca-d2c2706bacca\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.118.53.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
-        false\r\n  }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1587'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 12:53:34 GMT
-      etag:
-      - W/"45b2dfca-94b0-4017-87ca-d2c2706bacca"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - e64adf92-7149-4322-b50f-6b16669d67dd
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
-      "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
-      ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.118.53.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Enabled"}}, {"name": "dev_worker000003", "properties": {"addressPrefix": "10.52.174.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings":
+      "properties": {"addressPrefix": "10.34.206.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
       [], "enableDdosProtection": false}}'
     headers:
       Accept:
@@ -565,40 +290,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '973'
+      - '608'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"6e62a7a8-94cc-4301-a3fb-af3d5d820162\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"794a696b-dfb6-4bac-9a60-9996284ab1a8\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"6b6a0d2b-e413-4081-9ba4-cd8b4a2523d3\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"10aa173d-db85-4918-9544-a9017dcf7fbe\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"6e62a7a8-94cc-4301-a3fb-af3d5d820162\\\"\",\r\n
+        \       \"etag\": \"W/\\\"794a696b-dfb6-4bac-9a60-9996284ab1a8\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.118.53.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"6e62a7a8-94cc-4301-a3fb-af3d5d820162\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.52.174.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.34.206.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -609,15 +323,15 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/f204e5ca-e835-4fb9-a1ed-8772d420cc65?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/637b9359-85bb-42c6-8829-1ed3604282ef?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
-      - '2474'
+      - '1584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:35 GMT
+      - Wed, 23 Jun 2021 13:00:11 GMT
       expires:
       - '-1'
       pragma:
@@ -634,9 +348,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 4488abde-58cf-48c2-8cb0-4248de3f0dd3
+      - 6987b9df-3e88-4d30-8ddc-4387e695bbbe
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 200
       message: OK
@@ -654,9 +368,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/f204e5ca-e835-4fb9-a1ed-8772d420cc65?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/637b9359-85bb-42c6-8829-1ed3604282ef?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -668,7 +382,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:38 GMT
+      - Wed, 23 Jun 2021 13:00:14 GMT
       expires:
       - '-1'
       pragma:
@@ -685,7 +399,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 1ad3ecaa-ec2c-49a6-92bd-19d48d8ac0bc
+      - ce571a5f-1c0e-4ef4-99c5-3cb8d7f320cf
     status:
       code: 200
       message: OK
@@ -703,34 +417,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"5508e552-67fd-4a62-829b-ae8637c310aa\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"e9eba9f5-c01e-4675-84f4-0366879b14e4\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"6b6a0d2b-e413-4081-9ba4-cd8b4a2523d3\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"10aa173d-db85-4918-9544-a9017dcf7fbe\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"5508e552-67fd-4a62-829b-ae8637c310aa\\\"\",\r\n
+        \       \"etag\": \"W/\\\"e9eba9f5-c01e-4675-84f4-0366879b14e4\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.118.53.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"5508e552-67fd-4a62-829b-ae8637c310aa\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.52.174.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.34.206.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -743,13 +446,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2478'
+      - '1587'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:38 GMT
+      - Wed, 23 Jun 2021 13:00:14 GMT
       etag:
-      - W/"5508e552-67fd-4a62-829b-ae8637c310aa"
+      - W/"e9eba9f5-c01e-4675-84f4-0366879b14e4"
       expires:
       - '-1'
       pragma:
@@ -766,7 +469,304 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 00bcdcac-d175-4a8d-9f81-230e28a17896
+      - 67084506-6f76-470e-b075-6c40025ff03a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
+        \ \"etag\": \"W/\\\"e9eba9f5-c01e-4675-84f4-0366879b14e4\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"10aa173d-db85-4918-9544-a9017dcf7fbe\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \       \"etag\": \"W/\\\"e9eba9f5-c01e-4675-84f4-0366879b14e4\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.34.206.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1587'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 23 Jun 2021 13:00:15 GMT
+      etag:
+      - W/"e9eba9f5-c01e-4675-84f4-0366879b14e4"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 0c2e7a4b-8e8f-40f2-84b7-1ec40e7577c5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
+      "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.34.206.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Enabled"}}, {"name": "dev_worker000003",
+      "properties": {"addressPrefix": "10.66.87.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
+      [], "enableDdosProtection": false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1118'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
+        \ \"etag\": \"W/\\\"1bf15275-25c2-4ea2-afb6-e9f42517e630\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"10aa173d-db85-4918-9544-a9017dcf7fbe\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \       \"etag\": \"W/\\\"1bf15275-25c2-4ea2-afb6-e9f42517e630\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"addressPrefix\": \"10.34.206.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \       \"etag\": \"W/\\\"1bf15275-25c2-4ea2-afb6-e9f42517e630\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"addressPrefix\": \"10.66.87.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/bdab13fe-5957-458a-9ebd-1c06f84b9d0b?api-version=2021-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2473'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 23 Jun 2021 13:00:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - fb57233f-e1cb-4eac-a0e6-69a7f7715031
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/bdab13fe-5957-458a-9ebd-1c06f84b9d0b?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '29'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 23 Jun 2021 13:00:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 89519708-4ac6-409c-93b8-e06127e2fb90
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
+        \ \"etag\": \"W/\\\"12dcda2a-9437-4a8a-9a8a-0befe2d012b6\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"10aa173d-db85-4918-9544-a9017dcf7fbe\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \       \"etag\": \"W/\\\"12dcda2a-9437-4a8a-9a8a-0befe2d012b6\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.34.206.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \       \"etag\": \"W/\\\"12dcda2a-9437-4a8a-9a8a-0befe2d012b6\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.66.87.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2477'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 23 Jun 2021 13:00:19 GMT
+      etag:
+      - W/"12dcda2a-9437-4a8a-9a8a-0befe2d012b6"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - be9bcb99-4e56-4520-adfd-11c91b596821
     status:
       code: 200
       message: OK
@@ -784,14 +784,14 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"5508e552-67fd-4a62-829b-ae8637c310aa\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.118.53.0/24\",\r\n
+        \ \"etag\": \"W/\\\"12dcda2a-9437-4a8a-9a8a-0befe2d012b6\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.34.206.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -805,9 +805,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:39 GMT
+      - Wed, 23 Jun 2021 13:00:19 GMT
       etag:
-      - W/"5508e552-67fd-4a62-829b-ae8637c310aa"
+      - W/"12dcda2a-9437-4a8a-9a8a-0befe2d012b6"
       expires:
       - '-1'
       pragma:
@@ -824,16 +824,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 1bb23914-50ea-48b0-8589-7aacb5e68046
+      - 14dea263-03cc-428a-af4f-18cb6bfb2845
     status:
       code: 200
       message: OK
 - request:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.118.53.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Disabled"}}'
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.34.206.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Disabled"}}'
     headers:
       Accept:
       - application/json
@@ -844,20 +844,20 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '457'
+      - '510'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"7965ec91-6bb2-4c4f-959f-c3766eb294d8\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.118.53.0/24\",\r\n
+        \ \"etag\": \"W/\\\"69aab6c7-5506-4e4b-b000-cfae4c53cdb6\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.34.206.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -865,7 +865,7 @@ interactions:
         \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/a735569a-f904-4d67-8c2f-16412547c5a1?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6ccb82d1-d2dd-4c4c-a268-68e83e5e1f6f?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
@@ -873,7 +873,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:40 GMT
+      - Wed, 23 Jun 2021 13:00:20 GMT
       expires:
       - '-1'
       pragma:
@@ -890,7 +890,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - ff0a8983-30a5-473b-998f-6fadaaf6f3a0
+      - 8cd2ee23-f82b-4923-bb5d-c50bae933ff5
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -910,9 +910,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/a735569a-f904-4d67-8c2f-16412547c5a1?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/6ccb82d1-d2dd-4c4c-a268-68e83e5e1f6f?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -924,7 +924,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:43 GMT
+      - Wed, 23 Jun 2021 13:00:24 GMT
       expires:
       - '-1'
       pragma:
@@ -941,7 +941,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 96784176-389a-4769-8d07-83956b0f93b7
+      - c0cce4c9-eaf9-41a0-8b47-09ac545f11f9
     status:
       code: 200
       message: OK
@@ -959,14 +959,14 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"cb08f8b1-c9c2-434b-a5cc-e3d449610c1c\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.118.53.0/24\",\r\n
+        \ \"etag\": \"W/\\\"25b7194a-d525-4f8f-b038-a0a616d2a6e7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.34.206.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -980,9 +980,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:43 GMT
+      - Wed, 23 Jun 2021 13:00:24 GMT
       etag:
-      - W/"cb08f8b1-c9c2-434b-a5cc-e3d449610c1c"
+      - W/"25b7194a-d525-4f8f-b038-a0a616d2a6e7"
       expires:
       - '-1'
       pragma:
@@ -999,7 +999,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 644f7bcd-054c-44f8-83b5-1ba14e1e2343
+      - 06516a94-47a9-4841-8297-3ff65b9945e3
     status:
       code: 200
       message: OK
@@ -1017,14 +1017,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"cb08f8b1-c9c2-434b-a5cc-e3d449610c1c\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.118.53.0/24\",\r\n
+        \ \"etag\": \"W/\\\"25b7194a-d525-4f8f-b038-a0a616d2a6e7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.34.206.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1038,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:44 GMT
+      - Wed, 23 Jun 2021 13:00:25 GMT
       etag:
-      - W/"cb08f8b1-c9c2-434b-a5cc-e3d449610c1c"
+      - W/"25b7194a-d525-4f8f-b038-a0a616d2a6e7"
       expires:
       - '-1'
       pragma:
@@ -1057,7 +1057,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 611b53de-9169-4cba-b9cc-f3533beeb0d4
+      - 34ab2159-d92f-487f-82af-84dd222e0bdc
     status:
       code: 200
       message: OK
@@ -1075,14 +1075,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"cb08f8b1-c9c2-434b-a5cc-e3d449610c1c\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.52.174.0/24\",\r\n
+        \ \"etag\": \"W/\\\"25b7194a-d525-4f8f-b038-a0a616d2a6e7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.66.87.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1092,13 +1092,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '755'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:44 GMT
+      - Wed, 23 Jun 2021 13:00:25 GMT
       etag:
-      - W/"cb08f8b1-c9c2-434b-a5cc-e3d449610c1c"
+      - W/"25b7194a-d525-4f8f-b038-a0a616d2a6e7"
       expires:
       - '-1'
       pragma:
@@ -1115,7 +1115,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 9bd401e0-66aa-4540-b41c-0ef18736aadf
+      - c116e37c-4368-42f6-ab2b-ffa5dcdb953e
     status:
       code: 200
       message: OK
@@ -1133,15 +1133,12 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_show000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001","name":"cli_test_aro_show000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:53:18Z","createdAt":"2021-04-30T12:53:19.7460181Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001","name":"cli_test_aro_show000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-23T13:00:02Z","createdAt":"2021-06-23T13:00:05.0615672Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1150,7 +1147,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:45 GMT
+      - Wed, 23 Jun 2021 13:00:25 GMT
       expires:
       - '-1'
       pragma:
@@ -1178,10 +1175,7 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift?api-version=2020-10-01
   response:
@@ -1214,7 +1208,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:44 GMT
+      - Wed, 23 Jun 2021 13:00:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1229,10 +1223,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"passwordCredentials": [{"startDate": "2021-04-30T12:53:45.574077Z", "endDate":
+    body: '{"passwordCredentials": [{"startDate": "2021-06-23T13:00:26.371365Z", "endDate":
       "2299-12-31T00:00:00.000Z", "value": "ReplacedSPPassword123*", "customKeyIdentifier":
-      "MjAyMS0wNC0zMCAxMjo1Mzo0NS41NzQwNzc="}], "displayName": "aro-r7tl89jw", "identifierUris":
-      ["https://az.aro.azure.com/ffdc4d8d-b3c4-40e4-8b40-f19fb2f12616"]}'
+      "MjAyMS0wNi0yMyAxMzowMDoyNi4zNzEzNjU="}], "displayName": "aro-cvaolo9h", "identifierUris":
+      ["https://az.aro.azure.com/dbaaf5c7-97d3-4fab-9fed-d6dccba522f9"]}'
     headers:
       Accept:
       - application/json
@@ -1249,8 +1243,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
@@ -1259,29 +1253,29 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "b934072c-6026-4e3e-a675-0d4770224087", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "59abcac5-b298-4b99-b7cd-289a86b19785",
+        "objectId": "f17a966b-b429-42ab-b1d6-7ec306ca272f", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "af30ca4c-e204-4dec-9a98-d5be98e90dd5",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
-        false, "displayName": "aro-r7tl89jw", "errorUrl": null, "groupMembershipClaims":
-        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/ffdc4d8d-b3c4-40e4-8b40-f19fb2f12616"],
+        false, "displayName": "aro-cvaolo9h", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/dbaaf5c7-97d3-4fab-9fed-d6dccba522f9"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/b934072c-6026-4e3e-a675-0d4770224087/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/f17a966b-b429-42ab-b1d6-7ec306ca272f/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/b934072c-6026-4e3e-a675-0d4770224087/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/f17a966b-b429-42ab-b1d6-7ec306ca272f/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
-        "Allow the application to access aro-r7tl89jw on behalf of the signed-in user.",
-        "adminConsentDisplayName": "Access aro-r7tl89jw", "id": "9716183e-70a1-4928-bfd2-4206a2f2a38f",
+        "Allow the application to access aro-cvaolo9h on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Access aro-cvaolo9h", "id": "20950b19-4f3e-4d73-bf43-cf8918efe7cd",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
-        to access aro-r7tl89jw on your behalf.", "userConsentDisplayName": "Access
-        aro-r7tl89jw", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        to access aro-cvaolo9h on your behalf.", "userConsentDisplayName": "Access
+        aro-cvaolo9h", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
-        [{"customKeyIdentifier": "MjAyMS0wNC0zMCAxMjo1Mzo0NS41NzQwNzc=", "endDate":
-        "2299-12-31T00:00:00Z", "keyId": "4475c557-9ae6-4c33-a221-3ed9f94717da", "startDate":
-        "2021-04-30T12:53:45.574077Z", "value": "ReplacedSPPassword123*"}], "publicClient":
+        [{"customKeyIdentifier": "MjAyMS0wNi0yMyAxMzowMDoyNi4zNzEzNjU=", "endDate":
+        "2299-12-31T00:00:00Z", "keyId": "5ee63ea2-712a-4cd8-9d96-325591d9fe1c", "startDate":
+        "2021-06-23T13:00:26.371365Z", "value": "ReplacedSPPassword123*"}], "publicClient":
         null, "publisherDomain": "rhcuppettgmail.onmicrosoft.com", "recordConsentConditions":
         null, "replyUrls": [], "requiredResourceAccess": [], "samlMetadataUrl": null,
         "signInAudience": "AzureADMyOrg", "tokenEncryptionKeyId": null}'
@@ -1297,21 +1291,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:53:46 GMT
+      - Wed, 23 Jun 2021 13:00:27 GMT
       duration:
-      - '4226819'
+      - '7656947'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/b934072c-6026-4e3e-a675-0d4770224087/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/f17a966b-b429-42ab-b1d6-7ec306ca272f/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - JzyUK3YQ60iMuxUGFXPWsonf5yp1gOr2g1qPnaHIguU=
+      - 2dD34o/lcZB/slOxvNaZCRaC0CN0ta6NRrqsgTWXJhc=
       ocp-aad-session-key:
-      - 18_qHAF8xJFVkEnfEn8aF_H2ksY9qGDHQlehkpBnegDHlC0F-P13Lag7qXSTIZ4tlUolgk-uiFxnoSTNYwwE0P8UaZVwO1nf2_Hl4GrZO3a1M8WU2YJny_hM97RVIUg1Ky421tHogz6-E7U8DK1yXGwZSAmt5LkvHVwOUuPdDWoqIbA7DRxC7VkLMzp-wWHjmvfq71iLv3p6Mxm-QkIAwg.mQIcC728PRStO5x55zMmKp6CLEOG_D66kTeD7tovSRg
+      - sCbJcqah3OqGMeygOATi3lJufs6K1n3ZDT0E_P2nX3lUvPIEXHxyAjVZHkvrM8q0q4Y-inaqN5e9Ldl2itX2epys09FC1I3cIRPZ0MQiskq2acNPeMcjbCGkuWTUsCRketdWvApTBAk2pNbx3x-O3foD8eRThF8ozPoMTQGf_as.hteRZjSOyfsQ9G2r819TC87WQ1tBLTBzBRe1L9M0vk8
       pragma:
       - no-cache
       request-id:
-      - fc73f031-ea31-4320-a5d1-92fee68c8748
+      - ac0fbabd-8e2d-4947-816b-dd4c04be5176
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1339,12 +1333,12 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%2759abcac5-b298-4b99-b7cd-289a86b19785%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27af30ca4c-e204-4dec-9a98-d5be98e90dd5%27&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -1360,19 +1354,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:53:47 GMT
+      - Wed, 23 Jun 2021 13:00:27 GMT
       duration:
-      - '1189439'
+      - '272335'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - fdvI57hVanuZlwGLHkx8EkhMcmBQiJvbUWedkA9tLNs=
+      - tS5OU3hj8trKJL13+mUrjKrcLFoxfRrbXcIl/KD0xRI=
       ocp-aad-session-key:
-      - f3pL1N1_1kH8YE7KBoAzbGNo9i2opZkAksyPV2xW2nDAcfGtOuCBmCdHO5im9qEubgB8mUk892EeL6zKLVdKvWDKrCtBuM75gd-Du4isYIHzHGYR8K0CHDomJ-jh_zuHtzvWc731K5UbwU89QtA7PpeIb8vY8Q5tYLQOvgJjuemOA7Um9Q6NLi-nUwb_P8pH47qccCfzD9YmOqfN67DKZQ.zfOgGmNYtUuXLqd1COddlyB5CNedXcCsCT1kdHuyEqc
+      - vnicQJNTDzRCQN7KGXUvyck_b_HNlQ-FLruWM5E51RJ55Xbd_JCItzB2SLcxufJbSH-o4zUjFjrCqXoKGCBkGGGq8qAlWJRT0vjgLaSpopaNWtBpDSaAT30INGDoJpPESZMOSkkGgwsdjf48m6voCltZ3rRqXMCiPZZfgiX1kHo.hoKrjyf_eUgO_1vClFHivASAO2UIcMxnKXwZVIoRrP8
       pragma:
       - no-cache
       request-id:
-      - 786d78ec-a119-4e5d-888a-84e9925722d8
+      - 830d2aee-297d-4972-84e7-0a02d610fd77
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1387,7 +1381,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"appId": "59abcac5-b298-4b99-b7cd-289a86b19785"}'
+    body: '{"appId": "af30ca4c-e204-4dec-9a98-d5be98e90dd5"}'
     headers:
       Accept:
       - application/json
@@ -1404,20 +1398,20 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"cca528a7-3a83-4dca-8589-bab6b3cbd09c","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-r7tl89jw","appId":"59abcac5-b298-4b99-b7cd-289a86b19785","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-r7tl89jw","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access aro-r7tl89jw on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        aro-r7tl89jw","id":"9716183e-70a1-4928-bfd2-4206a2f2a38f","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access aro-r7tl89jw on your behalf.","userConsentDisplayName":"Access
-        aro-r7tl89jw","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
-        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["59abcac5-b298-4b99-b7cd-289a86b19785","https://az.aro.azure.com/ffdc4d8d-b3c4-40e4-8b40-f19fb2f12616"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"663fd818-bc06-44c5-a35d-e06480969fda","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-cvaolo9h","appId":"af30ca4c-e204-4dec-9a98-d5be98e90dd5","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-cvaolo9h","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access aro-cvaolo9h on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        aro-cvaolo9h","id":"20950b19-4f3e-4d73-bf43-cf8918efe7cd","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access aro-cvaolo9h on your behalf.","userConsentDisplayName":"Access
+        aro-cvaolo9h","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
+        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["af30ca4c-e204-4dec-9a98-d5be98e90dd5","https://az.aro.azure.com/dbaaf5c7-97d3-4fab-9fed-d6dccba522f9"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1430,21 +1424,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:53:47 GMT
+      - Wed, 23 Jun 2021 13:00:27 GMT
       duration:
-      - '3744527'
+      - '3261613'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/cca528a7-3a83-4dca-8589-bab6b3cbd09c/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/663fd818-bc06-44c5-a35d-e06480969fda/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - sDQMUkXn9LVw3PqqzhMMIkv9mq+Kag3KwUOuEYgU9Cg=
+      - 36EL5MKLNJy2NoDnN5O5t1u7ckXBeEwrGYLS1rXvgx8=
       ocp-aad-session-key:
-      - 05A6jmwvt4jpmIbpkauYc7Lnl5pdwPWkTLSWwhIhs6cs2x8GTaI5c1DP480wDvEvRD0wdQWWEbpeGapgdY-1ipXAKIh0Y1ghdXAFaiooaWyZZc7CbwkGBCpmtSOQrPUJjNDrA7AST91vR9TB7he7R7ZZ6lhQvYWUkeBMZHjhmO6E5X3M1wrMvHmA5TIEvjgcPVxFi_d3aXRCAujtU_TG2A.T5XMjvjPRpWgp-nbZ0Z15GCXk3BQZcyM1MaL19KqXOg
+      - 0mFFxu3Lok50PeBzhr4Ziqq4WDqS6RdgLsCWDV2Q7sEK7tC-YIdULmtH8I2Y5t1RuKYPMuNP_lfIXHUgyiK0GMX8TdN1igb4c5euN1OiNE7tjya3t41G5dSJBQ_fwHiOshlnrUSCIOU29VCcw_4dXFuo8UksguTGlgErA3X244Y.xcp44QHqXt3VRjyhEfR9qSxsSEF5tjgggCbu-GC-fA4
       pragma:
       - no-cache
       request-id:
-      - 5518333d-0327-40de-8601-8240cd838c56
+      - 3b052caf-eb24-4e24-a7f6-5b24374c81f2
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1472,8 +1466,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -1496,19 +1490,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 12:53:47 GMT
+      - Wed, 23 Jun 2021 13:00:27 GMT
       duration:
-      - '1349188'
+      - '359273'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - HbBnQA+LUNm7hl96Mw1On+Bo6NbLNhkO7ncu/xx/QP4=
+      - GFn+G/7tRH+6EJv6AsueV7RLt1kn4OuFxpUOfDEge/E=
       ocp-aad-session-key:
-      - 6vepKmALkYgSXpI9reFM73Fwr7cSO__zgw5ErYdw8k_lwubbm8o8ZMpFrz3pY_w8nhaXxLoQkuNEqluQMIXJzDQzeOUqUuNADFmOywGhoZMrPELV-nvkJiR47DFO1g9qPKc0NbvgMPTFZrFJqj3xjJomhoa8NxbDdaMqExq5Q6dFmWtm7dties09tzRFgJGyyXVwCbeUySQ8l4gp6R1gZw.piyCsF9LrgoAyKARWSQmyPcgrcK6bar536yaQ8dyU3c
+      - 51aToJ4oZBrB03jnl6tXYZLG87939AXi6z3MnbOaNvJet8cvcQy5MJIe_emPRon2gciyz5pWDKpQyPmeXsOBtfU_9pncaRHXyz3CNWvXjt2aIO2vM0EtIIopz57exmTcGMWGIkV1eHiXfBtrVDsWP7Gy_GI04YwMJ7VeceNdAzw.oVXH6hmPtHPfrtT6uGyy5iq9LpbPEpgTcM5xC2P36S8
       pragma:
       - no-cache
       request-id:
-      - d09d248b-d34d-4dd6-956f-1a5eaecdb00c
+      - 1acbc6c6-86ed-4de1-a7bd-459cf5906744
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1536,14 +1530,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"cb08f8b1-c9c2-434b-a5cc-e3d449610c1c\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.118.53.0/24\",\r\n
+        \ \"etag\": \"W/\\\"25b7194a-d525-4f8f-b038-a0a616d2a6e7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.34.206.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1557,9 +1551,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:48 GMT
+      - Wed, 23 Jun 2021 13:00:28 GMT
       etag:
-      - W/"cb08f8b1-c9c2-434b-a5cc-e3d449610c1c"
+      - W/"25b7194a-d525-4f8f-b038-a0a616d2a6e7"
       expires:
       - '-1'
       pragma:
@@ -1576,7 +1570,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 16240089-3996-4f93-9a95-3e2ec81dbb1d
+      - d4f80951-e586-4cf2-82dd-12b566bcadcc
     status:
       code: 200
       message: OK
@@ -1594,14 +1588,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"cb08f8b1-c9c2-434b-a5cc-e3d449610c1c\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.52.174.0/24\",\r\n
+        \ \"etag\": \"W/\\\"25b7194a-d525-4f8f-b038-a0a616d2a6e7\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.66.87.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1611,13 +1605,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '755'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:48 GMT
+      - Wed, 23 Jun 2021 13:00:28 GMT
       etag:
-      - W/"cb08f8b1-c9c2-434b-a5cc-e3d449610c1c"
+      - W/"25b7194a-d525-4f8f-b038-a0a616d2a6e7"
       expires:
       - '-1'
       pragma:
@@ -1634,7 +1628,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - dea63b5d-2994-4aa9-8ccf-9dae1afd4418
+      - 2f0dd105-6230-49df-9caa-864a60f2c6f2
     status:
       code: 200
       message: OK
@@ -1652,24 +1646,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '23097'
+      - '24837'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:49 GMT
+      - Wed, 23 Jun 2021 13:00:28 GMT
       expires:
       - '-1'
       pragma:
@@ -1689,7 +1683,7 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
-      "principalId": "cca528a7-3a83-4dca-8589-bab6b3cbd09c", "principalType": "ServicePrincipal"}}'
+      "principalId": "663fd818-bc06-44c5-a35d-e06480969fda", "principalType": "ServicePrincipal"}}'
     headers:
       Accept:
       - application/json
@@ -1706,15 +1700,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"cca528a7-3a83-4dca-8589-bab6b3cbd09c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:53:50.0417607Z","updatedOn":"2021-04-30T12:53:50.8510209Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"663fd818-bc06-44c5-a35d-e06480969fda","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-23T13:00:29.9004422Z","updatedOn":"2021-06-23T13:00:30.3053686Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
     headers:
       cache-control:
       - no-cache
@@ -1723,7 +1717,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:52 GMT
+      - Wed, 23 Jun 2021 13:00:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1735,7 +1729,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -1753,24 +1747,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"cca528a7-3a83-4dca-8589-bab6b3cbd09c","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:53:51.0809863Z","updatedOn":"2021-04-30T12:53:51.0809863Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"663fd818-bc06-44c5-a35d-e06480969fda","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-23T13:00:30.4154096Z","updatedOn":"2021-06-23T13:00:30.4154096Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '24149'
+      - '25889'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:52 GMT
+      - Wed, 23 Jun 2021 13:00:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1807,15 +1801,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T12:53:54.1260787Z","updatedOn":"2021-04-30T12:53:54.6161361Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-23T13:00:32.6703862Z","updatedOn":"2021-06-23T13:00:32.9803777Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
     headers:
       cache-control:
       - no-cache
@@ -1824,7 +1818,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:53:56 GMT
+      - Wed, 23 Jun 2021 13:00:33 GMT
       expires:
       - '-1'
       pragma:
@@ -1842,9 +1836,9 @@ interactions:
       message: Created
 - request:
     body: '{"tags": {"test": "show"}, "location": "eastus", "properties": {"clusterProfile":
-      {"pullSecret": "", "domain": "r7tl89jw", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-r7tl89jw"},
-      "servicePrincipalProfile": {"clientId": "59abcac5-b298-4b99-b7cd-289a86b19785",
-      "clientSecret": "4da4da23-cdf4-4f24-993e-7de66703b066"}, "networkProfile": {"podCidr":
+      {"pullSecret": "", "domain": "cvaolo9h", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-cvaolo9h"},
+      "servicePrincipalProfile": {"clientId": "af30ca4c-e204-4dec-9a98-d5be98e90dd5",
+      "clientSecret": "bd044ea4-03c3-4e6e-a15d-f1d8a677c5e2"}, "networkProfile": {"podCidr":
       "10.128.0.0/14", "serviceCidr": "172.30.0.0/16"}, "masterProfile": {"vmSize":
       "Standard_D8s_v3", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002"},
       "workerProfiles": [{"name": "worker", "vmSize": "Standard_D4s_v3", "diskSizeGB":
@@ -1867,8 +1861,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
@@ -1879,10 +1873,10 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"show\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Creating\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"r7tl89jw\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-r7tl89jw\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"cvaolo9h\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-cvaolo9h\"\n
         \       },\n        \"consoleProfile\": {},\n        \"servicePrincipalProfile\":
-        {\n            \"clientId\": \"59abcac5-b298-4b99-b7cd-289a86b19785\"\n        },\n
+        {\n            \"clientId\": \"af30ca4c-e204-4dec-9a98-d5be98e90dd5\"\n        },\n
         \       \"networkProfile\": {\n            \"podCidr\": \"10.128.0.0/14\",\n
         \           \"serviceCidr\": \"172.30.0.0/16\"\n        },\n        \"masterProfile\":
         {\n            \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\":
@@ -1896,7 +1890,7 @@ interactions:
         \"Public\"\n            }\n        ]\n    }\n}\n"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -1904,7 +1898,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:54:00 GMT
+      - Wed, 23 Jun 2021 13:00:35 GMT
       expires:
       - '-1'
       pragma:
@@ -1914,7 +1908,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -1932,15 +1926,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -1949,7 +1943,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:54:31 GMT
+      - Wed, 23 Jun 2021 13:01:06 GMT
       expires:
       - '-1'
       pragma:
@@ -1979,15 +1973,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -1996,7 +1990,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:55:01 GMT
+      - Wed, 23 Jun 2021 13:01:36 GMT
       expires:
       - '-1'
       pragma:
@@ -2026,15 +2020,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2043,7 +2037,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:55:31 GMT
+      - Wed, 23 Jun 2021 13:02:06 GMT
       expires:
       - '-1'
       pragma:
@@ -2073,15 +2067,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2090,7 +2084,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:56:01 GMT
+      - Wed, 23 Jun 2021 13:02:36 GMT
       expires:
       - '-1'
       pragma:
@@ -2120,15 +2114,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2137,7 +2131,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:56:32 GMT
+      - Wed, 23 Jun 2021 13:03:07 GMT
       expires:
       - '-1'
       pragma:
@@ -2167,15 +2161,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2184,7 +2178,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:57:02 GMT
+      - Wed, 23 Jun 2021 13:03:37 GMT
       expires:
       - '-1'
       pragma:
@@ -2214,15 +2208,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2231,7 +2225,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:57:32 GMT
+      - Wed, 23 Jun 2021 13:04:07 GMT
       expires:
       - '-1'
       pragma:
@@ -2261,15 +2255,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2278,7 +2272,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:58:02 GMT
+      - Wed, 23 Jun 2021 13:04:37 GMT
       expires:
       - '-1'
       pragma:
@@ -2308,15 +2302,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2325,7 +2319,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:58:33 GMT
+      - Wed, 23 Jun 2021 13:05:07 GMT
       expires:
       - '-1'
       pragma:
@@ -2355,15 +2349,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2372,7 +2366,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:59:03 GMT
+      - Wed, 23 Jun 2021 13:05:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2402,15 +2396,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2419,7 +2413,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 12:59:33 GMT
+      - Wed, 23 Jun 2021 13:06:08 GMT
       expires:
       - '-1'
       pragma:
@@ -2449,15 +2443,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2466,7 +2460,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:00:03 GMT
+      - Wed, 23 Jun 2021 13:06:37 GMT
       expires:
       - '-1'
       pragma:
@@ -2496,15 +2490,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2513,7 +2507,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:00:33 GMT
+      - Wed, 23 Jun 2021 13:07:08 GMT
       expires:
       - '-1'
       pragma:
@@ -2543,15 +2537,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2560,7 +2554,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:01:04 GMT
+      - Wed, 23 Jun 2021 13:07:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2590,15 +2584,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2607,7 +2601,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:01:34 GMT
+      - Wed, 23 Jun 2021 13:08:08 GMT
       expires:
       - '-1'
       pragma:
@@ -2637,15 +2631,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2654,7 +2648,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:02:04 GMT
+      - Wed, 23 Jun 2021 13:08:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2684,15 +2678,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2701,7 +2695,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:02:34 GMT
+      - Wed, 23 Jun 2021 13:09:08 GMT
       expires:
       - '-1'
       pragma:
@@ -2731,15 +2725,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2748,7 +2742,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:03:04 GMT
+      - Wed, 23 Jun 2021 13:09:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2778,15 +2772,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2795,7 +2789,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:03:35 GMT
+      - Wed, 23 Jun 2021 13:10:09 GMT
       expires:
       - '-1'
       pragma:
@@ -2825,15 +2819,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2842,7 +2836,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:04:05 GMT
+      - Wed, 23 Jun 2021 13:10:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2872,15 +2866,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2889,7 +2883,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:04:35 GMT
+      - Wed, 23 Jun 2021 13:11:09 GMT
       expires:
       - '-1'
       pragma:
@@ -2919,15 +2913,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2936,7 +2930,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:05:05 GMT
+      - Wed, 23 Jun 2021 13:11:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2966,15 +2960,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -2983,7 +2977,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:05:35 GMT
+      - Wed, 23 Jun 2021 13:12:10 GMT
       expires:
       - '-1'
       pragma:
@@ -3013,15 +3007,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3030,7 +3024,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:06:06 GMT
+      - Wed, 23 Jun 2021 13:12:40 GMT
       expires:
       - '-1'
       pragma:
@@ -3060,15 +3054,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3077,7 +3071,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:06:36 GMT
+      - Wed, 23 Jun 2021 13:13:10 GMT
       expires:
       - '-1'
       pragma:
@@ -3107,15 +3101,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3124,7 +3118,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:07:06 GMT
+      - Wed, 23 Jun 2021 13:13:40 GMT
       expires:
       - '-1'
       pragma:
@@ -3154,15 +3148,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3171,7 +3165,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:07:36 GMT
+      - Wed, 23 Jun 2021 13:14:11 GMT
       expires:
       - '-1'
       pragma:
@@ -3201,15 +3195,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3218,7 +3212,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:08:07 GMT
+      - Wed, 23 Jun 2021 13:14:40 GMT
       expires:
       - '-1'
       pragma:
@@ -3248,15 +3242,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3265,7 +3259,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:08:37 GMT
+      - Wed, 23 Jun 2021 13:15:10 GMT
       expires:
       - '-1'
       pragma:
@@ -3295,15 +3289,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3312,7 +3306,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:09:07 GMT
+      - Wed, 23 Jun 2021 13:15:40 GMT
       expires:
       - '-1'
       pragma:
@@ -3342,15 +3336,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3359,7 +3353,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:09:37 GMT
+      - Wed, 23 Jun 2021 13:16:10 GMT
       expires:
       - '-1'
       pragma:
@@ -3389,15 +3383,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3406,7 +3400,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:10:07 GMT
+      - Wed, 23 Jun 2021 13:16:41 GMT
       expires:
       - '-1'
       pragma:
@@ -3436,15 +3430,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3453,7 +3447,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:10:38 GMT
+      - Wed, 23 Jun 2021 13:17:11 GMT
       expires:
       - '-1'
       pragma:
@@ -3483,15 +3477,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3500,7 +3494,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:11:08 GMT
+      - Wed, 23 Jun 2021 13:17:41 GMT
       expires:
       - '-1'
       pragma:
@@ -3530,15 +3524,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3547,7 +3541,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:11:38 GMT
+      - Wed, 23 Jun 2021 13:18:11 GMT
       expires:
       - '-1'
       pragma:
@@ -3577,15 +3571,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3594,7 +3588,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:12:08 GMT
+      - Wed, 23 Jun 2021 13:18:42 GMT
       expires:
       - '-1'
       pragma:
@@ -3624,15 +3618,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3641,7 +3635,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:12:39 GMT
+      - Wed, 23 Jun 2021 13:19:12 GMT
       expires:
       - '-1'
       pragma:
@@ -3671,15 +3665,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3688,7 +3682,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:13:10 GMT
+      - Wed, 23 Jun 2021 13:19:42 GMT
       expires:
       - '-1'
       pragma:
@@ -3718,15 +3712,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3735,7 +3729,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:13:40 GMT
+      - Wed, 23 Jun 2021 13:20:12 GMT
       expires:
       - '-1'
       pragma:
@@ -3765,15 +3759,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3782,7 +3776,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:14:10 GMT
+      - Wed, 23 Jun 2021 13:20:42 GMT
       expires:
       - '-1'
       pragma:
@@ -3812,15 +3806,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3829,7 +3823,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:14:40 GMT
+      - Wed, 23 Jun 2021 13:21:13 GMT
       expires:
       - '-1'
       pragma:
@@ -3859,15 +3853,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3876,7 +3870,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:15:10 GMT
+      - Wed, 23 Jun 2021 13:21:43 GMT
       expires:
       - '-1'
       pragma:
@@ -3906,15 +3900,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3923,7 +3917,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:15:41 GMT
+      - Wed, 23 Jun 2021 13:22:13 GMT
       expires:
       - '-1'
       pragma:
@@ -3953,15 +3947,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -3970,7 +3964,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:16:11 GMT
+      - Wed, 23 Jun 2021 13:22:43 GMT
       expires:
       - '-1'
       pragma:
@@ -4000,15 +3994,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4017,7 +4011,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:16:41 GMT
+      - Wed, 23 Jun 2021 13:23:13 GMT
       expires:
       - '-1'
       pragma:
@@ -4047,15 +4041,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4064,7 +4058,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:17:12 GMT
+      - Wed, 23 Jun 2021 13:23:43 GMT
       expires:
       - '-1'
       pragma:
@@ -4094,15 +4088,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4111,7 +4105,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:17:41 GMT
+      - Wed, 23 Jun 2021 13:24:13 GMT
       expires:
       - '-1'
       pragma:
@@ -4141,15 +4135,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4158,7 +4152,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:18:12 GMT
+      - Wed, 23 Jun 2021 13:24:43 GMT
       expires:
       - '-1'
       pragma:
@@ -4188,15 +4182,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4205,7 +4199,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:18:43 GMT
+      - Wed, 23 Jun 2021 13:25:13 GMT
       expires:
       - '-1'
       pragma:
@@ -4235,15 +4229,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4252,7 +4246,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:19:13 GMT
+      - Wed, 23 Jun 2021 13:25:43 GMT
       expires:
       - '-1'
       pragma:
@@ -4282,15 +4276,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4299,7 +4293,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:19:43 GMT
+      - Wed, 23 Jun 2021 13:26:14 GMT
       expires:
       - '-1'
       pragma:
@@ -4329,15 +4323,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4346,7 +4340,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:20:14 GMT
+      - Wed, 23 Jun 2021 13:26:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4376,15 +4370,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4393,7 +4387,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:20:44 GMT
+      - Wed, 23 Jun 2021 13:27:14 GMT
       expires:
       - '-1'
       pragma:
@@ -4423,15 +4417,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4440,7 +4434,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:21:14 GMT
+      - Wed, 23 Jun 2021 13:27:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4470,15 +4464,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4487,7 +4481,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:21:44 GMT
+      - Wed, 23 Jun 2021 13:28:14 GMT
       expires:
       - '-1'
       pragma:
@@ -4517,15 +4511,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4534,7 +4528,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:22:14 GMT
+      - Wed, 23 Jun 2021 13:28:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4564,15 +4558,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4581,7 +4575,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:22:44 GMT
+      - Wed, 23 Jun 2021 13:29:15 GMT
       expires:
       - '-1'
       pragma:
@@ -4611,15 +4605,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4628,7 +4622,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:23:15 GMT
+      - Wed, 23 Jun 2021 13:29:45 GMT
       expires:
       - '-1'
       pragma:
@@ -4658,15 +4652,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -4675,7 +4669,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:23:45 GMT
+      - Wed, 23 Jun 2021 13:30:15 GMT
       expires:
       - '-1'
       pragma:
@@ -4705,579 +4699,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:24:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:24:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:25:16 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:25:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:26:16 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:26:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:27:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:27:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:28:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:28:48 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:29:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\"\n}\n"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json
-      date:
-      - Fri, 30 Apr 2021 13:29:49 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c?api-version=2020-04-30
-  response:
-    body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n
-        \   \"name\": \"8af8e81c-6f01-4dde-b55c-c332d12d215c\",\n    \"status\": \"Succeeded\",\n
-        \   \"startTime\": \"2021-04-30T12:54:00.191324869Z\",\n    \"endTime\": \"2021-04-30T13:30:04.432402205Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n
+        \   \"name\": \"f1511f8a-14f8-4409-8ca3-d12d37ef40c1\",\n    \"status\": \"Succeeded\",\n
+        \   \"startTime\": \"2021-06-23T13:00:35.870387698Z\",\n    \"endTime\": \"2021-06-23T13:30:39.151468349Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
@@ -5286,7 +4716,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:30:19 GMT
+      - Wed, 23 Jun 2021 13:30:45 GMT
       expires:
       - '-1'
       pragma:
@@ -5316,8 +4746,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
   response:
@@ -5326,28 +4756,28 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"show\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"r7tl89jw\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-r7tl89jw\"\n
-        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.r7tl89jw.eastus.aroapp.io/\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"cvaolo9h\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-cvaolo9h\"\n
+        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.cvaolo9h.eastus.aroapp.io/\"\n
         \       },\n        \"servicePrincipalProfile\": {\n            \"clientId\":
-        \"59abcac5-b298-4b99-b7cd-289a86b19785\"\n        },\n        \"networkProfile\":
+        \"af30ca4c-e204-4dec-9a98-d5be98e90dd5\"\n        },\n        \"networkProfile\":
         {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\":
         \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n            \"vmSize\":
         \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \       },\n        \"workerProfiles\": [\n            {\n                \"name\":
-        \"aro000004-dmh69-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-g7qk9-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-dmh69-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-g7qk9-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-dmh69-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-g7qk9-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            }\n        ],\n        \"apiserverProfile\":
-        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.r7tl89jw.eastus.aroapp.io:6443/\",\n
-        \           \"ip\": \"52.188.44.210\"\n        },\n        \"ingressProfiles\":
+        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.cvaolo9h.eastus.aroapp.io:6443/\",\n
+        \           \"ip\": \"52.191.16.56\"\n        },\n        \"ingressProfiles\":
         [\n            {\n                \"name\": \"default\",\n                \"visibility\":
-        \"Public\",\n                \"ip\": \"20.185.13.82\"\n            }\n        ]\n
+        \"Public\",\n                \"ip\": \"52.191.22.201\"\n            }\n        ]\n
         \   }\n}\n"
     headers:
       cache-control:
@@ -5357,7 +4787,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:30:19 GMT
+      - Wed, 23 Jun 2021 13:30:45 GMT
       expires:
       - '-1'
       pragma:
@@ -5387,8 +4817,8 @@ interactions:
       ParameterSetName:
       - -g -n --subscription --output
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.11-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -5399,28 +4829,28 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"show\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"r7tl89jw\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-r7tl89jw\"\n
-        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.r7tl89jw.eastus.aroapp.io/\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"cvaolo9h\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-cvaolo9h\"\n
+        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.cvaolo9h.eastus.aroapp.io/\"\n
         \       },\n        \"servicePrincipalProfile\": {\n            \"clientId\":
-        \"59abcac5-b298-4b99-b7cd-289a86b19785\"\n        },\n        \"networkProfile\":
+        \"af30ca4c-e204-4dec-9a98-d5be98e90dd5\"\n        },\n        \"networkProfile\":
         {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\":
         \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n            \"vmSize\":
         \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \       },\n        \"workerProfiles\": [\n            {\n                \"name\":
-        \"aro000004-dmh69-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-g7qk9-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-dmh69-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-g7qk9-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-dmh69-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-g7qk9-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_show000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            }\n        ],\n        \"apiserverProfile\":
-        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.r7tl89jw.eastus.aroapp.io:6443/\",\n
-        \           \"ip\": \"52.188.44.210\"\n        },\n        \"ingressProfiles\":
+        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.cvaolo9h.eastus.aroapp.io:6443/\",\n
+        \           \"ip\": \"52.191.16.56\"\n        },\n        \"ingressProfiles\":
         [\n            {\n                \"name\": \"default\",\n                \"visibility\":
-        \"Public\",\n                \"ip\": \"20.185.13.82\"\n            }\n        ]\n
+        \"Public\",\n                \"ip\": \"52.191.22.201\"\n            }\n        ]\n
         \   }\n}\n"
     headers:
       cache-control:
@@ -5430,7 +4860,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:30:20 GMT
+      - Wed, 23 Jun 2021 13:30:47 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_update.yaml
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/test_aro_update.yaml
@@ -13,15 +13,12 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_update000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001","name":"cli_test_aro_update000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:59:55Z","createdAt":"2021-04-30T12:59:56.4094812Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001","name":"cli_test_aro_update000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-17T15:03:15Z","createdAt":"2021-06-17T15:03:16.3947229Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -30,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 12:59:56 GMT
+      - Thu, 17 Jun 2021 15:03:16 GMT
       expires:
       - '-1'
       pragma:
@@ -63,16 +60,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"137910c7-828d-4c38-b977-21dfcee1d8f7\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"f2dd9c8d-e2a2-4345-ae3d-2896d82665b6\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"eb3856e6-585b-4586-a684-0f5b17ab5a24\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"d01b2555-3212-4f0a-8f9a-53a5c5b2757b\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -81,7 +78,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/8648b1ef-e553-4f10-bb70-f333dfcbef81?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/87a007fd-e49f-40ab-8806-a073b27714a2?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
@@ -89,7 +86,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:02 GMT
+      - Thu, 17 Jun 2021 15:03:18 GMT
       expires:
       - '-1'
       pragma:
@@ -102,9 +99,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 88b798d2-42ec-4b35-bc7a-0667c74ff26d
+      - 27edd67a-b69b-4bdf-88a5-86cc8238b024
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -122,9 +119,9 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/8648b1ef-e553-4f10-bb70-f333dfcbef81?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/87a007fd-e49f-40ab-8806-a073b27714a2?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -136,7 +133,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:06 GMT
+      - Thu, 17 Jun 2021 15:03:21 GMT
       expires:
       - '-1'
       pragma:
@@ -153,7 +150,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 3058c6f4-e066-4c0c-b4ef-d7538dab6ec0
+      - a9fd2920-1cff-45d1-8a37-c3ecf9cd645a
     status:
       code: 200
       message: OK
@@ -171,16 +168,16 @@ interactions:
       ParameterSetName:
       - -g -n --address-prefixes
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"249b35f0-06f8-4146-80c4-23897e89e5b4\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"ecd2e651-74d3-4037-8274-77826495e0c3\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"eb3856e6-585b-4586-a684-0f5b17ab5a24\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"d01b2555-3212-4f0a-8f9a-53a5c5b2757b\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -193,9 +190,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:06 GMT
+      - Thu, 17 Jun 2021 15:03:22 GMT
       etag:
-      - W/"249b35f0-06f8-4146-80c4-23897e89e5b4"
+      - W/"ecd2e651-74d3-4037-8274-77826495e0c3"
       expires:
       - '-1'
       pragma:
@@ -212,7 +209,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - a7ff1582-6283-4366-a151-16785245dff1
+      - 043ac841-bfa3-4250-9a50-1891630324f2
     status:
       code: 200
       message: OK
@@ -230,16 +227,16 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"249b35f0-06f8-4146-80c4-23897e89e5b4\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"ecd2e651-74d3-4037-8274-77826495e0c3\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"eb3856e6-585b-4586-a684-0f5b17ab5a24\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"d01b2555-3212-4f0a-8f9a-53a5c5b2757b\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
@@ -252,9 +249,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:07 GMT
+      - Thu, 17 Jun 2021 15:03:22 GMT
       etag:
-      - W/"249b35f0-06f8-4146-80c4-23897e89e5b4"
+      - W/"ecd2e651-74d3-4037-8274-77826495e0c3"
       expires:
       - '-1'
       pragma:
@@ -271,7 +268,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 37b45304-79e5-4586-b7b8-1f3b1cf3fede
+      - 47ed3809-1c01-4f74-a7ce-2f23fb6fdcc9
     status:
       code: 200
       message: OK
@@ -279,281 +276,9 @@ interactions:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
       "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
       ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"name": "dev_master000002",
-      "properties": {"addressPrefix": "10.73.243.0/24", "serviceEndpoints": [{"service":
-      "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings": [], "enableDdosProtection":
-      false}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '515'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"c02be802-6b71-4161-9e35-a7cd6fb3243b\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"eb3856e6-585b-4586-a684-0f5b17ab5a24\",\r\n    \"addressSpace\":
-        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
-        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
-        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"c02be802-6b71-4161-9e35-a7cd6fb3243b\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.73.243.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
-        false\r\n  }\r\n}"
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e4e20c53-88d8-4e59-b3dc-dd5b78ae3e56?api-version=2021-02-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '1584'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 13:00:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - ea0a0492-81af-4254-a945-7404ea68d2f0
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e4e20c53-88d8-4e59-b3dc-dd5b78ae3e56?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '29'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 13:00:11 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - efa4a546-cf19-4801-a517-37c8cdd29644
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"5f2215e5-8cb6-47c7-a955-18e4556e202d\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"eb3856e6-585b-4586-a684-0f5b17ab5a24\",\r\n    \"addressSpace\":
-        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
-        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
-        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"5f2215e5-8cb6-47c7-a955-18e4556e202d\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.73.243.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
-        false\r\n  }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1587'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 13:00:11 GMT
-      etag:
-      - W/"5f2215e5-8cb6-47c7-a955-18e4556e202d"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 47fc19d3-6e56-48f9-9d40-df5a171222b7
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - network vnet subnet create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --vnet-name -n --address-prefixes --service-endpoints
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"5f2215e5-8cb6-47c7-a955-18e4556e202d\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"eb3856e6-585b-4586-a684-0f5b17ab5a24\",\r\n    \"addressSpace\":
-        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
-        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
-        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
-        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"5f2215e5-8cb6-47c7-a955-18e4556e202d\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.73.243.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
-        false\r\n  }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1587'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 13:00:12 GMT
-      etag:
-      - W/"5f2215e5-8cb6-47c7-a955-18e4556e202d"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 6897071f-5b83-4eb0-9a31-f2a3e5b81d11
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
-      "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
-      ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.73.243.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Enabled"}}, {"name": "dev_worker000003", "properties": {"addressPrefix": "10.93.139.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry"}]}}], "virtualNetworkPeerings":
+      "properties": {"addressPrefix": "10.93.225.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
       [], "enableDdosProtection": false}}'
     headers:
       Accept:
@@ -565,40 +290,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '973'
+      - '608'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"53243110-4b9e-4411-b28d-1fd390c7e431\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"dde8b820-4760-463a-aefc-6036fe940a07\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
-        \   \"resourceGuid\": \"eb3856e6-585b-4586-a684-0f5b17ab5a24\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"d01b2555-3212-4f0a-8f9a-53a5c5b2757b\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"53243110-4b9e-4411-b28d-1fd390c7e431\\\"\",\r\n
+        \       \"etag\": \"W/\\\"dde8b820-4760-463a-aefc-6036fe940a07\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.73.243.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"53243110-4b9e-4411-b28d-1fd390c7e431\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
-        \         \"addressPrefix\": \"10.93.139.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.93.225.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -609,15 +323,15 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/67c525ee-411e-4006-b9dd-524b317fe7b8?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/64f72d43-5ed0-4801-a286-c6489acaa755?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
-      - '2474'
+      - '1584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:13 GMT
+      - Thu, 17 Jun 2021 15:03:23 GMT
       expires:
       - '-1'
       pragma:
@@ -634,7 +348,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 07c2309c-e447-43c4-8f91-ae0d539d3587
+      - 8dcb582a-bbfd-4bec-8604-6c65acd7df70
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -654,9 +368,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/67c525ee-411e-4006-b9dd-524b317fe7b8?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/64f72d43-5ed0-4801-a286-c6489acaa755?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -668,7 +382,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:16 GMT
+      - Thu, 17 Jun 2021 15:03:26 GMT
       expires:
       - '-1'
       pragma:
@@ -685,7 +399,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - c73d5a2a-7191-425a-9da4-e7bd21ac0f44
+      - b359a4cc-de5c-4290-a757-9e61e08e90e1
     status:
       code: 200
       message: OK
@@ -703,34 +417,23 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --address-prefixes --service-endpoints
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
-        \ \"etag\": \"W/\\\"e17aab39-ac29-48ca-9e18-1606311476f9\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"a0110e65-87e3-456f-a871-3e3517bcbd9c\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"eb3856e6-585b-4586-a684-0f5b17ab5a24\",\r\n    \"addressSpace\":
+        \   \"resourceGuid\": \"d01b2555-3212-4f0a-8f9a-53a5c5b2757b\",\r\n    \"addressSpace\":
         {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
         \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
         \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \       \"etag\": \"W/\\\"e17aab39-ac29-48ca-9e18-1606311476f9\\\"\",\r\n
+        \       \"etag\": \"W/\\\"a0110e65-87e3-456f-a871-3e3517bcbd9c\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.73.243.0/24\",\r\n          \"serviceEndpoints\":
-        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
-        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
-        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
-        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \       \"etag\": \"W/\\\"e17aab39-ac29-48ca-9e18-1606311476f9\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.93.139.0/24\",\r\n          \"serviceEndpoints\":
+        \         \"addressPrefix\": \"10.93.225.0/24\",\r\n          \"serviceEndpoints\":
         [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
         \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
         [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
@@ -743,13 +446,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2478'
+      - '1587'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:16 GMT
+      - Thu, 17 Jun 2021 15:03:26 GMT
       etag:
-      - W/"e17aab39-ac29-48ca-9e18-1606311476f9"
+      - W/"a0110e65-87e3-456f-a871-3e3517bcbd9c"
       expires:
       - '-1'
       pragma:
@@ -766,7 +469,304 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 8f5558db-3eec-43bc-8023-9c111cfd7949
+      - eafdb14d-af11-4930-b787-45db610e9f9b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
+        \ \"etag\": \"W/\\\"a0110e65-87e3-456f-a871-3e3517bcbd9c\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"d01b2555-3212-4f0a-8f9a-53a5c5b2757b\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \       \"etag\": \"W/\\\"a0110e65-87e3-456f-a871-3e3517bcbd9c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.93.225.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1587'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 15:03:26 GMT
+      etag:
+      - W/"a0110e65-87e3-456f-a871-3e3517bcbd9c"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 668a58ac-5661-4180-9291-d7505a07f6cd
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet",
+      "location": "eastus", "tags": {}, "properties": {"addressSpace": {"addressPrefixes":
+      ["10.0.0.0/9"]}, "dhcpOptions": {"dnsServers": []}, "subnets": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.93.225.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Enabled"}}, {"name": "dev_worker000003",
+      "properties": {"addressPrefix": "10.27.12.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry"}], "privateEndpointNetworkPolicies": "Enabled",
+      "privateLinkServiceNetworkPolicies": "Enabled"}}], "virtualNetworkPeerings":
+      [], "enableDdosProtection": false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1118'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
+        \ \"etag\": \"W/\\\"6d7a7e2e-24b1-4cc1-935a-37841484323d\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
+        \   \"resourceGuid\": \"d01b2555-3212-4f0a-8f9a-53a5c5b2757b\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \       \"etag\": \"W/\\\"6d7a7e2e-24b1-4cc1-935a-37841484323d\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"addressPrefix\": \"10.93.225.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \       \"etag\": \"W/\\\"6d7a7e2e-24b1-4cc1-935a-37841484323d\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n
+        \         \"addressPrefix\": \"10.27.12.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Updating\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e9a60253-24c2-4c2b-bac5-4ff2dd0c1eaa?api-version=2021-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2473'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 15:03:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 86950ee9-58a6-4ac2-9e82-79d89a8d11c3
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/e9a60253-24c2-4c2b-bac5-4ff2dd0c1eaa?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '29'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 15:03:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - b831a5ea-5bf9-4fdb-b7c3-26cbac96fdc5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - network vnet subnet create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --vnet-name -n --address-prefixes --service-endpoints
+      User-Agent:
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev-vnet\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet\",\r\n
+        \ \"etag\": \"W/\\\"faa2f696-4b57-41bd-8970-df8e0f4823ff\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"d01b2555-3212-4f0a-8f9a-53a5c5b2757b\",\r\n    \"addressSpace\":
+        {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/9\"\r\n      ]\r\n
+        \   },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n
+        \   \"subnets\": [\r\n      {\r\n        \"name\": \"dev_master000002\",\r\n
+        \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
+        \       \"etag\": \"W/\\\"faa2f696-4b57-41bd-8970-df8e0f4823ff\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.93.225.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     },\r\n      {\r\n        \"name\": \"dev_worker000003\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \       \"etag\": \"W/\\\"faa2f696-4b57-41bd-8970-df8e0f4823ff\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.27.12.0/24\",\r\n          \"serviceEndpoints\":
+        [\r\n            {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"service\": \"Microsoft.ContainerRegistry\",\r\n              \"locations\":
+        [\r\n                \"*\"\r\n              ]\r\n            }\r\n          ],\r\n
+        \         \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
+        \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
+        \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2477'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 15:03:31 GMT
+      etag:
+      - W/"faa2f696-4b57-41bd-8970-df8e0f4823ff"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 1efea419-0625-4b3d-a897-72ae47599fd9
     status:
       code: 200
       message: OK
@@ -784,14 +784,14 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"e17aab39-ac29-48ca-9e18-1606311476f9\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.73.243.0/24\",\r\n
+        \ \"etag\": \"W/\\\"faa2f696-4b57-41bd-8970-df8e0f4823ff\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.93.225.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -805,9 +805,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:16 GMT
+      - Thu, 17 Jun 2021 15:03:32 GMT
       etag:
-      - W/"e17aab39-ac29-48ca-9e18-1606311476f9"
+      - W/"faa2f696-4b57-41bd-8970-df8e0f4823ff"
       expires:
       - '-1'
       pragma:
@@ -824,16 +824,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 2822e60b-83a1-4dc4-a5a0-b8317367164d
+      - 94d15dad-5a91-4e9e-a065-313d6c567690
     status:
       code: 200
       message: OK
 - request:
     body: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002",
-      "name": "dev_master000002", "properties": {"addressPrefix": "10.73.243.0/24",
-      "serviceEndpoints": [{"service": "Microsoft.ContainerRegistry", "locations":
-      ["*"]}], "delegations": [], "privateEndpointNetworkPolicies": "Enabled", "privateLinkServiceNetworkPolicies":
-      "Disabled"}}'
+      "name": "dev_master000002", "type": "Microsoft.Network/virtualNetworks/subnets",
+      "properties": {"addressPrefix": "10.93.225.0/24", "serviceEndpoints": [{"service":
+      "Microsoft.ContainerRegistry", "locations": ["*"]}], "delegations": [], "privateEndpointNetworkPolicies":
+      "Enabled", "privateLinkServiceNetworkPolicies": "Disabled"}}'
     headers:
       Accept:
       - application/json
@@ -844,20 +844,20 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '457'
+      - '510'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"17a31b8f-a77e-401e-a986-308ca9470ccf\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.73.243.0/24\",\r\n
+        \ \"etag\": \"W/\\\"ef65d5e4-22ec-456c-b976-d29346954d15\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.93.225.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -865,7 +865,7 @@ interactions:
         \"Disabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/19e76b62-b517-4299-9c7a-b56761fcdbdb?api-version=2021-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/70ee2ee7-7e09-41dd-a167-b4a2f7061e39?api-version=2021-02-01
       cache-control:
       - no-cache
       content-length:
@@ -873,7 +873,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:18 GMT
+      - Thu, 17 Jun 2021 15:03:33 GMT
       expires:
       - '-1'
       pragma:
@@ -890,7 +890,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 5ac75a2b-b874-412b-9ecd-62907843039b
+      - 2e425740-154b-4b29-bce1-757c1fc547f8
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -910,9 +910,9 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/19e76b62-b517-4299-9c7a-b56761fcdbdb?api-version=2021-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operations/70ee2ee7-7e09-41dd-a167-b4a2f7061e39?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -924,7 +924,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:21 GMT
+      - Thu, 17 Jun 2021 15:03:36 GMT
       expires:
       - '-1'
       pragma:
@@ -941,7 +941,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 05200887-d300-400f-8c55-b4e3c1e1d899
+      - a236b4ed-2251-413f-a56d-b7258c042cdc
     status:
       code: 200
       message: OK
@@ -959,14 +959,14 @@ interactions:
       ParameterSetName:
       - -g --vnet-name -n --disable-private-link-service-network-policies
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"7f7fd729-2912-4900-ad5a-863a9df6451a\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.73.243.0/24\",\r\n
+        \ \"etag\": \"W/\\\"86f033a5-2028-47c9-a45a-4fd44b245003\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.93.225.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -980,9 +980,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:21 GMT
+      - Thu, 17 Jun 2021 15:03:36 GMT
       etag:
-      - W/"7f7fd729-2912-4900-ad5a-863a9df6451a"
+      - W/"86f033a5-2028-47c9-a45a-4fd44b245003"
       expires:
       - '-1'
       pragma:
@@ -999,7 +999,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - ce35d30a-84da-4189-abb4-182bcc95d8e1
+      - 3954c09b-ba0a-4b86-8c7b-f6d22359b2e8
     status:
       code: 200
       message: OK
@@ -1017,14 +1017,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"7f7fd729-2912-4900-ad5a-863a9df6451a\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.73.243.0/24\",\r\n
+        \ \"etag\": \"W/\\\"86f033a5-2028-47c9-a45a-4fd44b245003\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.93.225.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1038,9 +1038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:22 GMT
+      - Thu, 17 Jun 2021 15:03:36 GMT
       etag:
-      - W/"7f7fd729-2912-4900-ad5a-863a9df6451a"
+      - W/"86f033a5-2028-47c9-a45a-4fd44b245003"
       expires:
       - '-1'
       pragma:
@@ -1057,7 +1057,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 3283d138-0d46-439e-9ef3-733f859a9b73
+      - 2b78a930-d66b-44fd-a17a-c891ff19e3fe
     status:
       code: 200
       message: OK
@@ -1075,14 +1075,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"7f7fd729-2912-4900-ad5a-863a9df6451a\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.93.139.0/24\",\r\n
+        \ \"etag\": \"W/\\\"86f033a5-2028-47c9-a45a-4fd44b245003\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.27.12.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1092,13 +1092,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '755'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:22 GMT
+      - Thu, 17 Jun 2021 15:03:36 GMT
       etag:
-      - W/"7f7fd729-2912-4900-ad5a-863a9df6451a"
+      - W/"86f033a5-2028-47c9-a45a-4fd44b245003"
       expires:
       - '-1'
       pragma:
@@ -1115,7 +1115,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 26814ed4-732f-416f-92a5-c2bb01cadea4
+      - cf148fa2-58d0-4fdc-bc91-d46b13d2c44e
     status:
       code: 200
       message: OK
@@ -1133,15 +1133,12 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_aro_update000001?api-version=2020-10-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001","name":"cli_test_aro_update000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-04-30T12:59:55Z","createdAt":"2021-04-30T12:59:56.4094812Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001","name":"cli_test_aro_update000001","type":"Microsoft.Resources/resourceGroups","location":"eastus","tags":{"product":"azurecli","cause":"automation","date":"2021-06-17T15:03:15Z","createdAt":"2021-06-17T15:03:16.3947229Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1150,7 +1147,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:23 GMT
+      - Thu, 17 Jun 2021 15:03:36 GMT
       expires:
       - '-1'
       pragma:
@@ -1178,10 +1175,7 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-resource/12.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
-      accept-language:
-      - en-US
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.RedHatOpenShift?api-version=2020-10-01
   response:
@@ -1214,7 +1208,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:23 GMT
+      - Thu, 17 Jun 2021 15:03:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1229,10 +1223,10 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"passwordCredentials": [{"startDate": "2021-04-30T13:00:23.782094Z", "endDate":
+    body: '{"passwordCredentials": [{"startDate": "2021-06-17T15:03:38.061278Z", "endDate":
       "2299-12-31T00:00:00.000Z", "value": "ReplacedSPPassword123*", "customKeyIdentifier":
-      "MjAyMS0wNC0zMCAxMzowMDoyMy43ODIwOTQ="}], "displayName": "aro-g1gpmp1e", "identifierUris":
-      ["https://az.aro.azure.com/490c273b-e3fe-4a1b-81fe-66db6d552f6e"]}'
+      "MjAyMS0wNi0xNyAxNTowMzozOC4wNjEyNzg="}], "displayName": "aro-v43koob1", "identifierUris":
+      ["https://az.aro.azure.com/c9c441bf-622f-405d-ac47-508bf44587a8"]}'
     headers:
       Accept:
       - application/json
@@ -1249,8 +1243,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
@@ -1259,29 +1253,29 @@ interactions:
     body:
       string: '{"odata.metadata": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element",
         "odata.type": "Microsoft.DirectoryServices.Application", "objectType": "Application",
-        "objectId": "6c3b730c-f9e7-46e1-bc09-a9871c193636", "deletionTimestamp": null,
-        "acceptMappedClaims": null, "addIns": [], "appId": "bbef1b94-ad31-499a-a513-14b4afc9eef3",
+        "objectId": "beb3dbb7-d8b9-4904-9a13-a2c04139edcc", "deletionTimestamp": null,
+        "acceptMappedClaims": null, "addIns": [], "appId": "06b8ce89-a38c-4bd3-a988-50be85a9eaf5",
         "applicationTemplateId": null, "appRoles": [], "availableToOtherTenants":
-        false, "displayName": "aro-g1gpmp1e", "errorUrl": null, "groupMembershipClaims":
-        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/490c273b-e3fe-4a1b-81fe-66db6d552f6e"],
+        false, "displayName": "aro-v43koob1", "errorUrl": null, "groupMembershipClaims":
+        null, "homepage": null, "identifierUris": ["https://az.aro.azure.com/c9c441bf-622f-405d-ac47-508bf44587a8"],
         "informationalUrls": {"termsOfService": null, "support": null, "privacy":
         null, "marketing": null}, "isDeviceOnlyAuthSupported": null, "keyCredentials":
         [], "knownClientApplications": [], "logoutUrl": null, "logo@odata.mediaEditLink":
-        "directoryObjects/6c3b730c-f9e7-46e1-bc09-a9871c193636/Microsoft.DirectoryServices.Application/logo",
+        "directoryObjects/beb3dbb7-d8b9-4904-9a13-a2c04139edcc/Microsoft.DirectoryServices.Application/logo",
         "logo@odata.mediaContentType": "application/json;odata=minimalmetadata; charset=utf-8",
-        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/6c3b730c-f9e7-46e1-bc09-a9871c193636/Microsoft.DirectoryServices.Application/mainLogo",
+        "logoUrl": null, "mainLogo@odata.mediaEditLink": "directoryObjects/beb3dbb7-d8b9-4904-9a13-a2c04139edcc/Microsoft.DirectoryServices.Application/mainLogo",
         "oauth2AllowIdTokenImplicitFlow": true, "oauth2AllowImplicitFlow": false,
         "oauth2AllowUrlPathMatching": false, "oauth2Permissions": [{"adminConsentDescription":
-        "Allow the application to access aro-g1gpmp1e on behalf of the signed-in user.",
-        "adminConsentDisplayName": "Access aro-g1gpmp1e", "id": "ef182fa6-c6a9-465b-b303-26e1e88fbaab",
+        "Allow the application to access aro-v43koob1 on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Access aro-v43koob1", "id": "88aeb829-8c45-4429-90be-c5c516e8f77d",
         "isEnabled": true, "type": "User", "userConsentDescription": "Allow the application
-        to access aro-g1gpmp1e on your behalf.", "userConsentDisplayName": "Access
-        aro-g1gpmp1e", "value": "user_impersonation"}], "oauth2RequirePostResponse":
+        to access aro-v43koob1 on your behalf.", "userConsentDisplayName": "Access
+        aro-v43koob1", "value": "user_impersonation"}], "oauth2RequirePostResponse":
         false, "optionalClaims": null, "orgRestrictions": [], "parentalControlSettings":
         {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
-        [{"customKeyIdentifier": "MjAyMS0wNC0zMCAxMzowMDoyMy43ODIwOTQ=", "endDate":
-        "2299-12-31T00:00:00Z", "keyId": "231c828f-27fd-4751-baa0-e6117eb344e8", "startDate":
-        "2021-04-30T13:00:23.782094Z", "value": "ReplacedSPPassword123*"}], "publicClient":
+        [{"customKeyIdentifier": "MjAyMS0wNi0xNyAxNTowMzozOC4wNjEyNzg=", "endDate":
+        "2299-12-31T00:00:00Z", "keyId": "028f706d-d11a-47dc-81ec-5e7cde126079", "startDate":
+        "2021-06-17T15:03:38.061278Z", "value": "ReplacedSPPassword123*"}], "publicClient":
         null, "publisherDomain": "rhcuppettgmail.onmicrosoft.com", "recordConsentConditions":
         null, "replyUrls": [], "requiredResourceAccess": [], "samlMetadataUrl": null,
         "signInAudience": "AzureADMyOrg", "tokenEncryptionKeyId": null}'
@@ -1297,21 +1291,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 13:00:24 GMT
+      - Thu, 17 Jun 2021 15:03:39 GMT
       duration:
-      - '5531232'
+      - '2502229'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/6c3b730c-f9e7-46e1-bc09-a9871c193636/Microsoft.DirectoryServices.Application
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/beb3dbb7-d8b9-4904-9a13-a2c04139edcc/Microsoft.DirectoryServices.Application
       ocp-aad-diagnostics-server-name:
-      - c338cGHR4tt4vWq+NJEz0qbIPCMu7YLKMYbXg0UWlcE=
+      - 0KdigVX7NuMH7pnekBokko2ErTrgKo+MxhQI4HW7/6I=
       ocp-aad-session-key:
-      - 3PbV8_KW2BskKRsSbYETcEupvLmRHfoJ62aDC-acU2j5-pg1k7WRjn89e_WP5k2PzMzNo-WmKo44LoSOJjx8DJWX4lOyQCWGbLCmjr75xF0G9bd5iIGnz_9SAcld6c6VcYVkvfqyDt3uFK3hUhaDPBDjBUMJye032i6upez9DouL3ZKGC0owG8r1wVBM7VSPoAhHSloBnSFoaqCrLALXrw.agwixBlvONMj3_yn4UO6-UrsJRebfkqaViqxGxhZ_x4
+      - StTAoAMLjq6v6ww1b-HonDITk3FSdWevcayaLKF-vKLeMa05yhy4_Zx2aIg55J2RT6z14Vq8xsYrQvL5I-ujopAfacB2FInHMg8bsyI7vJlqtRoMT6L0JvolMyZegPMuSGHi2t5-9DH_qr6rC5noSDRHThE84P1SLqUP-oPmFwA.9AVm52fnzzWVpHkWYz9dTS7mpkjcYKQw9WBRrpMwW-M
       pragma:
       - no-cache
       request-id:
-      - e0fbd4ff-2088-45ba-a1ed-942a4b34d4aa
+      - 67b0a07f-1bf5-449a-86a6-f26181609416
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1339,12 +1333,12 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27bbef1b94-ad31-499a-a513-14b4afc9eef3%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%2706b8ce89-a38c-4bd3-a988-50be85a9eaf5%27&api-version=1.6
   response:
     body:
       string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[]}'
@@ -1360,19 +1354,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 13:00:24 GMT
+      - Thu, 17 Jun 2021 15:03:39 GMT
       duration:
-      - '1276742'
+      - '288907'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - DnYxVnLj2RJhYLGQKJt6x/zRa6btzlDmTbJW3kLOFhs=
+      - YPwHQWtk6ceb9LdCtNtYnc1YFf+2pBWqlJ4Pl9qIBQc=
       ocp-aad-session-key:
-      - 1Mwy4QFJdkOHmyFPeq3y3MJ4kwN3Mpy3w-Aud3hYOsHsaVJXUHJJD_PbktNIs4B8laL8ORjCO0vS4QEIhHWRno0iqqOU1DsOl9KI_ohNSeIHJN6ikl556SP3WplLkU6jA-oVvEdmwLq-lZ9Gf0kY2L8d8cUaamY3x00WcrhnqA1WBlqFmKwQ2Pb7PsbCHfZgoajGSj_ixZfF6IvITBZxMQ.Irel7Ky2hHLkMR1YYV7_MLZO9qy9srapIqi1Ta6k8qg
+      - xU42OGnvqrsp0kNbyUKcMMQbjjRxGavG2nQuTG6J-NsZhXDqEmE6Kyk5f5nHd1BJ-1VEJu3KgcOV4Hqq19UvkzQh8eIMnVXMuc0BrUKczEeNtwXcEjJzfz2FavT3M3e7FSeZ41m0jXsZOizUsGIxja2kz7fLZ_782QVwuuzpNQY.P7aXPNkvbMAL4OgD-ItW3MINQQlS5Al1nFGLSLh5jjQ
       pragma:
       - no-cache
       request-id:
-      - ade378e0-fe22-4f67-8b3b-651e31fa8a68
+      - bbe28b94-1f70-432e-b7d0-1c36f408617a
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1387,7 +1381,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"appId": "bbef1b94-ad31-499a-a513-14b4afc9eef3"}'
+    body: '{"appId": "06b8ce89-a38c-4bd3-a988-50be85a9eaf5"}'
     headers:
       Accept:
       - application/json
@@ -1404,20 +1398,20 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"080631c8-b4e2-453d-a301-f991ade51b14","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-g1gpmp1e","appId":"bbef1b94-ad31-499a-a513-14b4afc9eef3","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-g1gpmp1e","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access aro-g1gpmp1e on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        aro-g1gpmp1e","id":"ef182fa6-c6a9-465b-b303-26e1e88fbaab","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access aro-g1gpmp1e on your behalf.","userConsentDisplayName":"Access
-        aro-g1gpmp1e","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
-        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["bbef1b94-ad31-499a-a513-14b4afc9eef3","https://az.aro.azure.com/490c273b-e3fe-4a1b-81fe-66db6d552f6e"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"d962bd40-540d-4f7a-9756-2b3c8f7aab83","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-v43koob1","appId":"06b8ce89-a38c-4bd3-a988-50be85a9eaf5","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-v43koob1","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access aro-v43koob1 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        aro-v43koob1","id":"88aeb829-8c45-4429-90be-c5c516e8f77d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access aro-v43koob1 on your behalf.","userConsentDisplayName":"Access
+        aro-v43koob1","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
+        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["06b8ce89-a38c-4bd3-a988-50be85a9eaf5","https://az.aro.azure.com/c9c441bf-622f-405d-ac47-508bf44587a8"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -1430,21 +1424,21 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 13:00:24 GMT
+      - Thu, 17 Jun 2021 15:03:40 GMT
       duration:
-      - '2141078'
+      - '1678118'
       expires:
       - '-1'
       location:
-      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/080631c8-b4e2-453d-a301-f991ade51b14/Microsoft.DirectoryServices.ServicePrincipal
+      - https://graph.windows.net/00000000-0000-0000-0000-000000000000/directoryObjects/d962bd40-540d-4f7a-9756-2b3c8f7aab83/Microsoft.DirectoryServices.ServicePrincipal
       ocp-aad-diagnostics-server-name:
-      - VE2na4w8IQanQd/Khp1yFAQXH7PU0tYnTI1dyDIO2Jo=
+      - F9wzDnyhgTGpV+xzXHmHZLZ1GtwKLBLPbtJSSPu8ur0=
       ocp-aad-session-key:
-      - 4rqtxGinqxD6uSl-y6LI1K8Ex7x-KqtTLdhs35iapcib3HOPqV9Dlinsn6bItr3qu90dFIJ2L5-TiYLWlSLEIpd46od4mTELMjnxEzmXvcymvapOoaWxtIn6gCeqrJMzFtADOEp9CNiNOCmdox8ErYchcHu2JoqT3G-eyi3bjK0ewxkfpCVS_vfIJ9ZyxTUbmwA0bLOd3jN4s6meHx_0mg.xY7EQjQJLkmX-7U1546EYqMKDqT3choqF_LEaHmqsnA
+      - qBvubRF4merR75URCxLykQ7j6sEArM24Y3EuVSmvYC9V8pq7dt6jGx-hvR37aBlhAyrxCW8jeBsZsgIyNVCAD-a3UTMUYZkeozSRvSGZsN8Iscxai8jH6w6WCADHY6TVhDFSFdGhdJ8YyVNFECo_W5dDIyKQW-77btUb8K9hG2U.titvjZAPDuC8hSHK4T72iW03mJI1qyraZ0CRQ3XPAXE
       pragma:
       - no-cache
       request-id:
-      - 13f6d232-8325-4ece-89f4-2013afcf981a
+      - 871f2008-51df-498b-a601-e950a2c1e5d1
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1472,8 +1466,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -1496,19 +1490,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 13:00:24 GMT
+      - Thu, 17 Jun 2021 15:03:40 GMT
       duration:
-      - '1479779'
+      - '391959'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - mNOnarbFD7OXpuG+xQpELrgzcrdVclVjv1nWT7t5pa0=
+      - ga4fRtM7R3HVypAMPZxE83FXiAIJwME0vk2RPPfchmo=
       ocp-aad-session-key:
-      - VrnGVDUURKNduvvVwodhJCCX6x3FiXHqMKn-xgS3Uow5EeLH2YAzsLxU7KIi5CjBJWrJsAeHoFBZWROPkRu6oF7gqSUIDw8TLPcqnVF9QZpbkV_c2RES9PFSta8_wWfShOppBl6dSIUVha1UX3exBZt2k_kJGWEVG-BfrwoM1SL3PEhHECcACf6YihYgb_rNGG5Fe02iXQ0hZTH4XSdlsw.a-5SOspiS1vP-v074da7P3GAYjfWPsqR2yZSlh45Cr8
+      - UlSQ8vif32pIJKvdeOGOci5AEk4oPlXq8wLacCT9fhqP2wUk-6P1cSjasuIvVcwLylGajqtzcnIoIs3SUIkVK1kOWLTac9_m9cM9mqWNvjf37V5kg4KLfzD7-REaD7hzJ_V_qyudAPnudRLlKYhraZUwvZkIsXPgQVB-v8Fx7q4.QsytH9V9kTMYGERQAlsobFPoOrZfPmpgK-ARUj5vYA4
       pragma:
       - no-cache
       request-id:
-      - 1d18c23d-2850-49ec-9f78-9edbb10de03b
+      - 0a13988d-b67b-4eb7-9a2c-b748b8c7cc15
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -1536,72 +1530,14 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"7f7fd729-2912-4900-ad5a-863a9df6451a\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.93.139.0/24\",\r\n
-        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
-        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
-        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
-        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
-        \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '756'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 13:00:25 GMT
-      etag:
-      - W/"7f7fd729-2912-4900-ad5a-863a9df6451a"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 9356d196-92c0-4c96-bc66-2ac6044d885b
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --master-subnet --worker-subnet --subscription --tags
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"7f7fd729-2912-4900-ad5a-863a9df6451a\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.73.243.0/24\",\r\n
+        \ \"etag\": \"W/\\\"86f033a5-2028-47c9-a45a-4fd44b245003\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.93.225.0/24\",\r\n
         \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
         \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
         [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
@@ -1615,9 +1551,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:25 GMT
+      - Thu, 17 Jun 2021 15:03:41 GMT
       etag:
-      - W/"7f7fd729-2912-4900-ad5a-863a9df6451a"
+      - W/"86f033a5-2028-47c9-a45a-4fd44b245003"
       expires:
       - '-1'
       pragma:
@@ -1634,7 +1570,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 8957233f-58fc-4cf5-9beb-6570d57ba9f7
+      - e36dcab7-76f5-4e93-94a4-85477482ae42
     status:
       code: 200
       message: OK
@@ -1652,24 +1588,82 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \ \"etag\": \"W/\\\"86f033a5-2028-47c9-a45a-4fd44b245003\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.27.12.0/24\",\r\n
+        \   \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"service\": \"Microsoft.ContainerRegistry\",\r\n        \"locations\":
+        [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n    \"delegations\":
+        [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n    \"privateLinkServiceNetworkPolicies\":
+        \"Enabled\"\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '755'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 15:03:41 GMT
+      etag:
+      - W/"86f033a5-2028-47c9-a45a-4fd44b245003"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 0064f0f3-7824-427f-981f-411aa208d872
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '23097'
+      - '24837'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:26 GMT
+      - Thu, 17 Jun 2021 15:03:42 GMT
       expires:
       - '-1'
       pragma:
@@ -1689,7 +1683,7 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
-      "principalId": "080631c8-b4e2-453d-a301-f991ade51b14", "principalType": "ServicePrincipal"}}'
+      "principalId": "d962bd40-540d-4f7a-9756-2b3c8f7aab83", "principalType": "ServicePrincipal"}}'
     headers:
       Accept:
       - application/json
@@ -1706,15 +1700,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"080631c8-b4e2-453d-a301-f991ade51b14","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T13:00:27.2070995Z","updatedOn":"2021-04-30T13:00:28.2221029Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"d962bd40-540d-4f7a-9756-2b3c8f7aab83","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T15:03:43.4354545Z","updatedOn":"2021-06-17T15:03:43.8654839Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"}'
     headers:
       cache-control:
       - no-cache
@@ -1723,7 +1717,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:29 GMT
+      - Thu, 17 Jun 2021 15:03:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1735,7 +1729,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -1753,24 +1747,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"080631c8-b4e2-453d-a301-f991ade51b14","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T13:00:28.4571051Z","updatedOn":"2021-04-30T13:00:28.4571051Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"d962bd40-540d-4f7a-9756-2b3c8f7aab83","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T15:03:43.9754497Z","updatedOn":"2021-06-17T15:03:43.9754497Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '24149'
+      - '25889'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:30 GMT
+      - Thu, 17 Jun 2021 15:03:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1807,15 +1801,15 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T13:00:31.5618046Z","updatedOn":"2021-04-30T13:00:32.1868071Z","createdBy":null,"updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
+      string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T15:03:46.0140547Z","updatedOn":"2021-06-17T15:03:46.4515427Z","createdBy":null,"updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"}'
     headers:
       cache-control:
       - no-cache
@@ -1824,7 +1818,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:00:34 GMT
+      - Thu, 17 Jun 2021 15:03:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1836,15 +1830,15 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
 - request:
     body: '{"tags": {"test": "update"}, "location": "eastus", "properties": {"clusterProfile":
-      {"pullSecret": "", "domain": "g1gpmp1e", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e"},
-      "servicePrincipalProfile": {"clientId": "bbef1b94-ad31-499a-a513-14b4afc9eef3",
-      "clientSecret": "b57d89f1-34e2-43d0-8a1a-3b0fb522c136"}, "networkProfile": {"podCidr":
+      {"pullSecret": "", "domain": "v43koob1", "resourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1"},
+      "servicePrincipalProfile": {"clientId": "06b8ce89-a38c-4bd3-a988-50be85a9eaf5",
+      "clientSecret": "dd66c0b9-1866-4e6f-9a50-8468706816da"}, "networkProfile": {"podCidr":
       "10.128.0.0/14", "serviceCidr": "172.30.0.0/16"}, "masterProfile": {"vmSize":
       "Standard_D8s_v3", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002"},
       "workerProfiles": [{"name": "worker", "vmSize": "Standard_D4s_v3", "diskSizeGB":
@@ -1867,8 +1861,8 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PUT
@@ -1879,10 +1873,10 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"update\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Creating\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"g1gpmp1e\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-g1gpmp1e\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"v43koob1\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-v43koob1\"\n
         \       },\n        \"consoleProfile\": {},\n        \"servicePrincipalProfile\":
-        {\n            \"clientId\": \"bbef1b94-ad31-499a-a513-14b4afc9eef3\"\n        },\n
+        {\n            \"clientId\": \"06b8ce89-a38c-4bd3-a988-50be85a9eaf5\"\n        },\n
         \       \"networkProfile\": {\n            \"podCidr\": \"10.128.0.0/14\",\n
         \           \"serviceCidr\": \"172.30.0.0/16\"\n        },\n        \"masterProfile\":
         {\n            \"vmSize\": \"Standard_D8s_v3\",\n            \"subnetId\":
@@ -1896,7 +1890,7 @@ interactions:
         \"Public\"\n            }\n        ]\n    }\n}\n"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
@@ -1904,7 +1898,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:00:39 GMT
+      - Thu, 17 Jun 2021 15:03:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1932,24 +1926,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:01:09 GMT
+      - Thu, 17 Jun 2021 15:04:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1979,24 +1973,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:01:39 GMT
+      - Thu, 17 Jun 2021 15:04:49 GMT
       expires:
       - '-1'
       pragma:
@@ -2026,24 +2020,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:02:09 GMT
+      - Thu, 17 Jun 2021 15:05:20 GMT
       expires:
       - '-1'
       pragma:
@@ -2073,24 +2067,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:02:40 GMT
+      - Thu, 17 Jun 2021 15:05:49 GMT
       expires:
       - '-1'
       pragma:
@@ -2120,24 +2114,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:03:10 GMT
+      - Thu, 17 Jun 2021 15:06:20 GMT
       expires:
       - '-1'
       pragma:
@@ -2167,24 +2161,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:03:40 GMT
+      - Thu, 17 Jun 2021 15:06:50 GMT
       expires:
       - '-1'
       pragma:
@@ -2214,24 +2208,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:04:11 GMT
+      - Thu, 17 Jun 2021 15:07:20 GMT
       expires:
       - '-1'
       pragma:
@@ -2261,24 +2255,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:04:41 GMT
+      - Thu, 17 Jun 2021 15:07:50 GMT
       expires:
       - '-1'
       pragma:
@@ -2308,24 +2302,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:05:11 GMT
+      - Thu, 17 Jun 2021 15:08:20 GMT
       expires:
       - '-1'
       pragma:
@@ -2355,24 +2349,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:05:41 GMT
+      - Thu, 17 Jun 2021 15:08:50 GMT
       expires:
       - '-1'
       pragma:
@@ -2402,24 +2396,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:06:12 GMT
+      - Thu, 17 Jun 2021 15:09:21 GMT
       expires:
       - '-1'
       pragma:
@@ -2449,24 +2443,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:06:41 GMT
+      - Thu, 17 Jun 2021 15:09:51 GMT
       expires:
       - '-1'
       pragma:
@@ -2496,24 +2490,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:07:11 GMT
+      - Thu, 17 Jun 2021 15:10:21 GMT
       expires:
       - '-1'
       pragma:
@@ -2543,24 +2537,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:07:42 GMT
+      - Thu, 17 Jun 2021 15:10:51 GMT
       expires:
       - '-1'
       pragma:
@@ -2590,24 +2584,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:08:12 GMT
+      - Thu, 17 Jun 2021 15:11:21 GMT
       expires:
       - '-1'
       pragma:
@@ -2637,24 +2631,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:08:42 GMT
+      - Thu, 17 Jun 2021 15:11:52 GMT
       expires:
       - '-1'
       pragma:
@@ -2684,24 +2678,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:09:13 GMT
+      - Thu, 17 Jun 2021 15:12:22 GMT
       expires:
       - '-1'
       pragma:
@@ -2731,24 +2725,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:09:43 GMT
+      - Thu, 17 Jun 2021 15:12:52 GMT
       expires:
       - '-1'
       pragma:
@@ -2778,24 +2772,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:10:13 GMT
+      - Thu, 17 Jun 2021 15:13:22 GMT
       expires:
       - '-1'
       pragma:
@@ -2825,24 +2819,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:10:44 GMT
+      - Thu, 17 Jun 2021 15:13:52 GMT
       expires:
       - '-1'
       pragma:
@@ -2872,24 +2866,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:11:14 GMT
+      - Thu, 17 Jun 2021 15:14:22 GMT
       expires:
       - '-1'
       pragma:
@@ -2919,24 +2913,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:11:44 GMT
+      - Thu, 17 Jun 2021 15:14:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2966,24 +2960,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:12:14 GMT
+      - Thu, 17 Jun 2021 15:15:23 GMT
       expires:
       - '-1'
       pragma:
@@ -3013,24 +3007,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:12:45 GMT
+      - Thu, 17 Jun 2021 15:15:53 GMT
       expires:
       - '-1'
       pragma:
@@ -3060,24 +3054,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:13:15 GMT
+      - Thu, 17 Jun 2021 15:16:23 GMT
       expires:
       - '-1'
       pragma:
@@ -3107,24 +3101,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:13:45 GMT
+      - Thu, 17 Jun 2021 15:16:53 GMT
       expires:
       - '-1'
       pragma:
@@ -3154,24 +3148,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:14:15 GMT
+      - Thu, 17 Jun 2021 15:17:23 GMT
       expires:
       - '-1'
       pragma:
@@ -3201,24 +3195,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:14:46 GMT
+      - Thu, 17 Jun 2021 15:17:54 GMT
       expires:
       - '-1'
       pragma:
@@ -3248,24 +3242,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:15:16 GMT
+      - Thu, 17 Jun 2021 15:18:24 GMT
       expires:
       - '-1'
       pragma:
@@ -3295,24 +3289,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:15:46 GMT
+      - Thu, 17 Jun 2021 15:18:54 GMT
       expires:
       - '-1'
       pragma:
@@ -3342,24 +3336,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:16:17 GMT
+      - Thu, 17 Jun 2021 15:19:24 GMT
       expires:
       - '-1'
       pragma:
@@ -3389,24 +3383,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:16:47 GMT
+      - Thu, 17 Jun 2021 15:19:54 GMT
       expires:
       - '-1'
       pragma:
@@ -3436,24 +3430,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:17:17 GMT
+      - Thu, 17 Jun 2021 15:20:25 GMT
       expires:
       - '-1'
       pragma:
@@ -3483,24 +3477,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:17:48 GMT
+      - Thu, 17 Jun 2021 15:20:55 GMT
       expires:
       - '-1'
       pragma:
@@ -3530,24 +3524,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:18:18 GMT
+      - Thu, 17 Jun 2021 15:21:25 GMT
       expires:
       - '-1'
       pragma:
@@ -3577,24 +3571,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:18:48 GMT
+      - Thu, 17 Jun 2021 15:21:55 GMT
       expires:
       - '-1'
       pragma:
@@ -3624,24 +3618,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:19:18 GMT
+      - Thu, 17 Jun 2021 15:22:25 GMT
       expires:
       - '-1'
       pragma:
@@ -3671,24 +3665,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:19:49 GMT
+      - Thu, 17 Jun 2021 15:22:56 GMT
       expires:
       - '-1'
       pragma:
@@ -3718,24 +3712,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:20:19 GMT
+      - Thu, 17 Jun 2021 15:23:26 GMT
       expires:
       - '-1'
       pragma:
@@ -3765,24 +3759,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:20:49 GMT
+      - Thu, 17 Jun 2021 15:23:56 GMT
       expires:
       - '-1'
       pragma:
@@ -3812,24 +3806,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:21:20 GMT
+      - Thu, 17 Jun 2021 15:24:26 GMT
       expires:
       - '-1'
       pragma:
@@ -3859,24 +3853,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:21:50 GMT
+      - Thu, 17 Jun 2021 15:24:56 GMT
       expires:
       - '-1'
       pragma:
@@ -3906,24 +3900,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:22:20 GMT
+      - Thu, 17 Jun 2021 15:25:27 GMT
       expires:
       - '-1'
       pragma:
@@ -3953,24 +3947,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:22:50 GMT
+      - Thu, 17 Jun 2021 15:25:57 GMT
       expires:
       - '-1'
       pragma:
@@ -4000,24 +3994,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:23:21 GMT
+      - Thu, 17 Jun 2021 15:26:27 GMT
       expires:
       - '-1'
       pragma:
@@ -4047,24 +4041,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:23:51 GMT
+      - Thu, 17 Jun 2021 15:26:57 GMT
       expires:
       - '-1'
       pragma:
@@ -4094,24 +4088,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:24:21 GMT
+      - Thu, 17 Jun 2021 15:27:27 GMT
       expires:
       - '-1'
       pragma:
@@ -4141,24 +4135,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:24:52 GMT
+      - Thu, 17 Jun 2021 15:27:58 GMT
       expires:
       - '-1'
       pragma:
@@ -4188,24 +4182,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:25:22 GMT
+      - Thu, 17 Jun 2021 15:28:28 GMT
       expires:
       - '-1'
       pragma:
@@ -4235,24 +4229,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:25:52 GMT
+      - Thu, 17 Jun 2021 15:28:58 GMT
       expires:
       - '-1'
       pragma:
@@ -4282,24 +4276,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:26:23 GMT
+      - Thu, 17 Jun 2021 15:29:28 GMT
       expires:
       - '-1'
       pragma:
@@ -4329,24 +4323,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:26:52 GMT
+      - Thu, 17 Jun 2021 15:29:59 GMT
       expires:
       - '-1'
       pragma:
@@ -4376,24 +4370,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:27:23 GMT
+      - Thu, 17 Jun 2021 15:30:29 GMT
       expires:
       - '-1'
       pragma:
@@ -4423,24 +4417,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:27:53 GMT
+      - Thu, 17 Jun 2021 15:30:59 GMT
       expires:
       - '-1'
       pragma:
@@ -4470,24 +4464,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:28:24 GMT
+      - Thu, 17 Jun 2021 15:31:29 GMT
       expires:
       - '-1'
       pragma:
@@ -4517,24 +4511,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:28:54 GMT
+      - Thu, 17 Jun 2021 15:32:00 GMT
       expires:
       - '-1'
       pragma:
@@ -4564,24 +4558,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:29:24 GMT
+      - Thu, 17 Jun 2021 15:32:30 GMT
       expires:
       - '-1'
       pragma:
@@ -4611,24 +4605,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:29:55 GMT
+      - Thu, 17 Jun 2021 15:33:00 GMT
       expires:
       - '-1'
       pragma:
@@ -4658,24 +4652,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Creating\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '304'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:30:25 GMT
+      - Thu, 17 Jun 2021 15:33:30 GMT
       expires:
       - '-1'
       pragma:
@@ -4705,24 +4699,24 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n
-        \   \"name\": \"24cd6495-0083-45f1-a1a0-4b22ad75e325\",\n    \"status\": \"Succeeded\",\n
-        \   \"startTime\": \"2021-04-30T13:00:38.648659754Z\",\n    \"endTime\": \"2021-04-30T13:30:34.496329973Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '354'
+      - '303'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:30:55 GMT
+      - Thu, 17 Jun 2021 15:34:00 GMT
       expires:
       - '-1'
       pragma:
@@ -4752,8 +4746,196 @@ interactions:
       ParameterSetName:
       - -g -n --master-subnet --worker-subnet --subscription --tags
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '303'
+      content-type:
+      - application/json
+      date:
+      - Thu, 17 Jun 2021 15:34:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '303'
+      content-type:
+      - application/json
+      date:
+      - Thu, 17 Jun 2021 15:35:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Creating\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '303'
+      content-type:
+      - application/json
+      date:
+      - Thu, 17 Jun 2021 15:35:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5?api-version=2020-04-30
+  response:
+    body:
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/84dd740d-40ed-482e-acf2-7a6d206579b5\",\n
+        \   \"name\": \"84dd740d-40ed-482e-acf2-7a6d206579b5\",\n    \"status\": \"Succeeded\",\n
+        \   \"startTime\": \"2021-06-17T15:03:48.92273525Z\",\n    \"endTime\": \"2021-06-17T15:35:47.847595473Z\"\n}\n"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '353'
+      content-type:
+      - application/json
+      date:
+      - Thu, 17 Jun 2021 15:36:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --master-subnet --worker-subnet --subscription --tags
+      User-Agent:
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
   response:
@@ -4762,38 +4944,38 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"update\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"g1gpmp1e\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-g1gpmp1e\"\n
-        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.g1gpmp1e.eastus.aroapp.io/\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"v43koob1\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-v43koob1\"\n
+        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.v43koob1.eastus.aroapp.io/\"\n
         \       },\n        \"servicePrincipalProfile\": {\n            \"clientId\":
-        \"bbef1b94-ad31-499a-a513-14b4afc9eef3\"\n        },\n        \"networkProfile\":
+        \"06b8ce89-a38c-4bd3-a988-50be85a9eaf5\"\n        },\n        \"networkProfile\":
         {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\":
         \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n            \"vmSize\":
         \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \       },\n        \"workerProfiles\": [\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            }\n        ],\n        \"apiserverProfile\":
-        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.g1gpmp1e.eastus.aroapp.io:6443/\",\n
-        \           \"ip\": \"52.149.202.101\"\n        },\n        \"ingressProfiles\":
+        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.v43koob1.eastus.aroapp.io:6443/\",\n
+        \           \"ip\": \"52.224.143.150\"\n        },\n        \"ingressProfiles\":
         [\n            {\n                \"name\": \"default\",\n                \"visibility\":
-        \"Public\",\n                \"ip\": \"20.42.37.109\"\n            }\n        ]\n
+        \"Public\",\n                \"ip\": \"52.224.143.232\"\n            }\n        ]\n
         \   }\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2867'
+      - '2869'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:30:55 GMT
+      - Thu, 17 Jun 2021 15:36:01 GMT
       expires:
       - '-1'
       pragma:
@@ -4823,8 +5005,8 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -4835,38 +5017,38 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"update\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"g1gpmp1e\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-g1gpmp1e\"\n
-        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.g1gpmp1e.eastus.aroapp.io/\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"v43koob1\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-v43koob1\"\n
+        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.v43koob1.eastus.aroapp.io/\"\n
         \       },\n        \"servicePrincipalProfile\": {\n            \"clientId\":
-        \"bbef1b94-ad31-499a-a513-14b4afc9eef3\"\n        },\n        \"networkProfile\":
+        \"06b8ce89-a38c-4bd3-a988-50be85a9eaf5\"\n        },\n        \"networkProfile\":
         {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\":
         \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n            \"vmSize\":
         \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \       },\n        \"workerProfiles\": [\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            }\n        ],\n        \"apiserverProfile\":
-        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.g1gpmp1e.eastus.aroapp.io:6443/\",\n
-        \           \"ip\": \"52.149.202.101\"\n        },\n        \"ingressProfiles\":
+        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.v43koob1.eastus.aroapp.io:6443/\",\n
+        \           \"ip\": \"52.224.143.150\"\n        },\n        \"ingressProfiles\":
         [\n            {\n                \"name\": \"default\",\n                \"visibility\":
-        \"Public\",\n                \"ip\": \"20.42.37.109\"\n            }\n        ]\n
+        \"Public\",\n                \"ip\": \"52.224.143.232\"\n            }\n        ]\n
         \   }\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2867'
+      - '2869'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:30:56 GMT
+      - Thu, 17 Jun 2021 15:36:02 GMT
       expires:
       - '-1'
       pragma:
@@ -4896,8 +5078,8 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
@@ -4920,19 +5102,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 13:30:56 GMT
+      - Thu, 17 Jun 2021 15:36:04 GMT
       duration:
-      - '1456833'
+      - '341904'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - e3eVKn2EcLy4tscvz2DFsy9gRpEZMCAysevYqfB9wTg=
+      - Fy7889hDnQSgrarjz8Q22Z6DgdFs0C+QBM0X01BgjcA=
       ocp-aad-session-key:
-      - rH0p3yy_xW_VFPRJAhdQzkEYKvvEJL4rRfwXTJuF8ZwP7n_xyoJ0945dKGcBhk431h8pdZ1OqlG9o1--nIIP8iXcl37M8H8_yiZgdISJzmpYFuuBI0rWQ60mRvNgYYwVOa3imOH4x498yxWLmYk9zQ4SM8zJf7ghBx1JQ0whfaLiZcMh8TRUZcf4l8CIy8W4hxkTeZtIiQOszCDYq1yUdQ.vaWmjp3DVj4dHdj-cnHI2UDXY7HnMXMPT7TecBZb21A
+      - 2iPeHXnazNPAEr73NaYbF413UxUHP8mHJMvI9GZ3S49ZoFfwpupCFqX3vW6TvuZgyCj3zEKEZNW-FubN9YgfNokYbcXkTTTuXSBbIqwxbgk1K95rTReTqfz7l0NzzE4r5a0BeKzxh9HUBDp3oYm4EF2N3onepqsOG8bgjTelFi0.hZHfxnu95m5QlZpCjidkTOgdJIKIs9JzIXouX1-196Q
       pragma:
       - no-cache
       request-id:
-      - 92401b01-43c2-4a9f-a493-e75b17a0c4b3
+      - c350d895-4545-4fc1-889e-934ce2b68b30
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -4960,20 +5142,20 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-graphrbac/0.60.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%27bbef1b94-ad31-499a-a513-14b4afc9eef3%27&api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=appId%20eq%20%2706b8ce89-a38c-4bd3-a988-50be85a9eaf5%27&api-version=1.6
   response:
     body:
-      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"080631c8-b4e2-453d-a301-f991ade51b14","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-g1gpmp1e","appId":"bbef1b94-ad31-499a-a513-14b4afc9eef3","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-g1gpmp1e","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access aro-g1gpmp1e on behalf of the signed-in user.","adminConsentDisplayName":"Access
-        aro-g1gpmp1e","id":"ef182fa6-c6a9-465b-b303-26e1e88fbaab","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access aro-g1gpmp1e on your behalf.","userConsentDisplayName":"Access
-        aro-g1gpmp1e","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
-        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["https://az.aro.azure.com/490c273b-e3fe-4a1b-81fe-66db6d552f6e","bbef1b94-ad31-499a-a513-14b4afc9eef3"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
+      string: '{"odata.metadata":"https://graph.windows.net/00000000-0000-0000-0000-000000000000/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"d962bd40-540d-4f7a-9756-2b3c8f7aab83","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"aro-v43koob1","appId":"06b8ce89-a38c-4bd3-a988-50be85a9eaf5","applicationTemplateId":null,"appOwnerTenantId":"7a1815fb-63ba-4af7-8f33-e7333e421980","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"aro-v43koob1","errorUrl":null,"homepage":null,"informationalUrls":{"termsOfService":null,"support":null,"privacy":null,"marketing":null},"keyCredentials":[],"logoutUrl":null,"notificationEmailAddresses":[],"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access aro-v43koob1 on behalf of the signed-in user.","adminConsentDisplayName":"Access
+        aro-v43koob1","id":"88aeb829-8c45-4429-90be-c5c516e8f77d","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access aro-v43koob1 on your behalf.","userConsentDisplayName":"Access
+        aro-v43koob1","value":"user_impersonation"}],"passwordCredentials":[],"preferredSingleSignOnMode":null,"preferredTokenSigningKeyEndDateTime":null,"preferredTokenSigningKeyThumbprint":null,"publisherName":"Azure
+        Red Hat OpenShift (Red Hat)","replyUrls":[],"samlMetadataUrl":null,"samlSingleSignOnSettings":null,"servicePrincipalNames":["https://az.aro.azure.com/c9c441bf-622f-405d-ac47-508bf44587a8","06b8ce89-a38c-4bd3-a988-50be85a9eaf5"],"servicePrincipalType":"Application","signInAudience":"AzureADMyOrg","tags":[],"tokenEncryptionKeyId":null}]}'
     headers:
       access-control-allow-origin:
       - '*'
@@ -4986,19 +5168,19 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Fri, 30 Apr 2021 13:30:57 GMT
+      - Thu, 17 Jun 2021 15:36:04 GMT
       duration:
-      - '1253118'
+      - '358241'
       expires:
       - '-1'
       ocp-aad-diagnostics-server-name:
-      - 4sXo12GJp7xAj2y/HdoWmayXv9xKPaH8zevNYQrOqNk=
+      - gas68AfCISdifww/odopqmYLOPjvU8uxh3bkWP0cMYE=
       ocp-aad-session-key:
-      - Duh5WFbVMDvgIzQHBi9_oahsHdeHMxQ32-fNAaqeUaMMwjGHPseebPlVAz4YeMJBIfSoPzto1kmckpC6ypkiACw4-63kubX8lUo65-lz6heChvqqEOUte6LVTSdrQnXXtp-DKmPN4oAaD2yyF4uBFJIgrAnWQYxbukpVWANWOQQcwLQRqpBIAteJZrAYlgkhaHWDn2yO5JPYssMQ7PRIgA.ttbODev1bhQLPkaBwQsQKnFLParSi5kcxrqIbzE-9cA
+      - UqVdmTQlrTKjg7y7JCly3YXDqm85HcKY3oEMeyAAbNCNgDNAePxafH8yQaCaEn0kUN4gMeBUT06jkZlOOWZ8nWh0OVYjwccx6YHewXGRxfGlcgD7nCqtvgL7Wd7_sfOR_6j4nQVQeBQRVY_S6ta8YGoXylHLwFI3a4OxH1d0vBQ.7JF2lSASHhDBjd4pHJ-xgN2gn0X1GYPJ-gOwn-V-S0I
       pragma:
       - no-cache
       request-id:
-      - b1f9046b-e9d6-4e9a-8e9f-76b94614cf02
+      - 9e33ea06-41d5-40a3-8fd9-ae7c459c95ee
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-aspnet-version:
@@ -5026,84 +5208,21 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
-        \ \"etag\": \"W/\\\"1d6eb709-b145-4fdb-8806-7f27d7a02e73\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.93.139.0/24\",\r\n
-        \   \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e/providers/Microsoft.Network/networkSecurityGroups/aro000004-zs9w8-nsg\"\r\n
-        \   },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e/providers/Microsoft.Network/networkInterfaces/aro000004-zs9w8-worker-eastus1-kqrsx-nic/ipConfigurations/pipConfig\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e/providers/Microsoft.Network/networkInterfaces/aro000004-zs9w8-worker-eastus2-wwjwx-nic/ipConfigurations/pipConfig\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e/providers/Microsoft.Network/networkInterfaces/aro000004-zs9w8-worker-eastus3-ktwgh-nic/ipConfigurations/pipConfig\"\r\n
-        \     }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\":
-        \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\",\r\n
-        \       \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n
-        \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
-        \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
-        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1704'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Fri, 30 Apr 2021 13:30:57 GMT
-      etag:
-      - W/"1d6eb709-b145-4fdb-8806-7f27d7a02e73"
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-arm-service-request-id:
-      - 37c6dded-99c6-4994-a5ad-7ad92ad8e76c
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aro update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -n --subscription
-      User-Agent:
-      - AZURECLI/2.22.1 azsdk-python-azure-mgmt-network/18.0.0 Python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32)
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002?api-version=2021-02-01
   response:
     body:
       string: "{\r\n  \"name\": \"dev_master000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\",\r\n
-        \ \"etag\": \"W/\\\"1d6eb709-b145-4fdb-8806-7f27d7a02e73\\\"\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.73.243.0/24\",\r\n
-        \   \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e/providers/Microsoft.Network/networkSecurityGroups/aro000004-zs9w8-nsg\"\r\n
-        \   },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e/providers/Microsoft.Network/loadBalancers/aro000004-zs9w8-internal/frontendIPConfigurations/internal-lb-ip-v4\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e/providers/Microsoft.Network/networkInterfaces/aro000004-zs9w8-pls.nic.70503db0-5c51-4818-83f4-a6bf1b91763d/ipConfigurations/aro000004-zs9w8-pls-nic\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e/providers/Microsoft.Network/privateLinkServices/aro000004-zs9w8-pls/ipConfigurations/aro000004-zs9w8-pls-nic\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e/providers/Microsoft.Network/networkInterfaces/aro000004-zs9w8-master2-nic/ipConfigurations/pipConfig\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e/providers/Microsoft.Network/networkInterfaces/aro000004-zs9w8-master0-nic/ipConfigurations/pipConfig\"\r\n
-        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-g1gpmp1e/providers/Microsoft.Network/networkInterfaces/aro000004-zs9w8-master1-nic/ipConfigurations/pipConfig\"\r\n
+        \ \"etag\": \"W/\\\"664757a9-e71d-4937-ab13-4ae301a6f0bb\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.93.225.0/24\",\r\n
+        \   \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1/providers/Microsoft.Network/networkSecurityGroups/aro000004-6j248-nsg\"\r\n
+        \   },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1/providers/Microsoft.Network/loadBalancers/aro000004-6j248-internal/frontendIPConfigurations/internal-lb-ip-v4\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1/providers/Microsoft.Network/networkInterfaces/aro000004-6j248-pls.nic.c9b50c96-c142-4ff7-92ed-ee455cbaffb0/ipConfigurations/aro000004-6j248-pls-nic\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1/providers/Microsoft.Network/privateLinkServices/aro000004-6j248-pls/ipConfigurations/aro000004-6j248-pls-nic\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1/providers/Microsoft.Network/networkInterfaces/aro000004-6j248-master2-nic/ipConfigurations/pipConfig\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1/providers/Microsoft.Network/networkInterfaces/aro000004-6j248-master1-nic/ipConfigurations/pipConfig\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1/providers/Microsoft.Network/networkInterfaces/aro000004-6j248-master0-nic/ipConfigurations/pipConfig\"\r\n
         \     }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\":
         \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\",\r\n
         \       \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n
@@ -5118,9 +5237,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:30:57 GMT
+      - Thu, 17 Jun 2021 15:36:04 GMT
       etag:
-      - W/"1d6eb709-b145-4fdb-8806-7f27d7a02e73"
+      - W/"664757a9-e71d-4937-ab13-4ae301a6f0bb"
       expires:
       - '-1'
       pragma:
@@ -5137,7 +5256,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 480a8a8f-b78d-4014-92d4-fb3469b7627d
+      - 67573426-9255-4b79-808d-9a3096ec44a4
     status:
       code: 200
       message: OK
@@ -5155,24 +5274,87 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-network/19.0.0 Python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003?api-version=2021-02-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"dev_worker000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\r\n
+        \ \"etag\": \"W/\\\"664757a9-e71d-4937-ab13-4ae301a6f0bb\\\"\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.27.12.0/24\",\r\n
+        \   \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1/providers/Microsoft.Network/networkSecurityGroups/aro000004-6j248-nsg\"\r\n
+        \   },\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1/providers/Microsoft.Network/networkInterfaces/aro000004-6j248-worker-eastus1-vsp4t-nic/ipConfigurations/pipConfig\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1/providers/Microsoft.Network/networkInterfaces/aro000004-6j248-worker-eastus2-nhw7b-nic/ipConfigurations/pipConfig\"\r\n
+        \     },\r\n      {\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-v43koob1/providers/Microsoft.Network/networkInterfaces/aro000004-6j248-worker-eastus3-d4n9w-nic/ipConfigurations/pipConfig\"\r\n
+        \     }\r\n    ],\r\n    \"serviceEndpoints\": [\r\n      {\r\n        \"provisioningState\":
+        \"Succeeded\",\r\n        \"service\": \"Microsoft.ContainerRegistry\",\r\n
+        \       \"locations\": [\r\n          \"*\"\r\n        ]\r\n      }\r\n    ],\r\n
+        \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
+        \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1703'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 17 Jun 2021 15:36:05 GMT
+      etag:
+      - W/"664757a9-e71d-4937-ab13-4ae301a6f0bb"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - bc04adac-f219-4dde-95af-0ead79af464d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aro update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --subscription
+      User-Agent:
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"080631c8-b4e2-453d-a301-f991ade51b14","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T13:00:28.4571051Z","updatedOn":"2021-04-30T13:00:28.4571051Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T13:00:32.4218074Z","updatedOn":"2021-04-30T13:00:32.4218074Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"d962bd40-540d-4f7a-9756-2b3c8f7aab83","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T15:03:43.9754497Z","updatedOn":"2021-06-17T15:03:43.9754497Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T15:03:46.5573091Z","updatedOn":"2021-06-17T15:03:46.5573091Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '25201'
+      - '26941'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:30:58 GMT
+      - Thu, 17 Jun 2021 15:36:05 GMT
       expires:
       - '-1'
       pragma:
@@ -5204,24 +5386,24 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-authorization/0.61.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments?api-version=2020-04-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"080631c8-b4e2-453d-a301-f991ade51b14","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T13:00:28.4571051Z","updatedOn":"2021-04-30T13:00:28.4571051Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-04-30T13:00:32.4218074Z","updatedOn":"2021-04-30T13:00:32.4218074Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"60fa24bb-762f-4b64-a636-a208bc10682d","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-10T23:57:07.6230203Z","updatedOn":"2019-04-10T23:57:07.6230203Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c30610d-ef78-48b3-ad32-8e81e1787d16","type":"Microsoft.Authorization/roleAssignments","name":"6c30610d-ef78-48b3-ad32-8e81e1787d16"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"bf8d4da8-e513-4cf2-a875-11b836188bdf","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-03-15T16:31:50.3066599Z","updatedOn":"2021-03-15T16:31:50.3066599Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1","type":"Microsoft.Authorization/roleAssignments","name":"da55e4b2-247f-4ebd-9ce6-7acf1d99f1b1"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"b818ab73-3cdd-4b22-a06d-cf5427c39104","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-11-11T13:42:59.1494340Z","updatedOn":"2020-11-11T13:42:59.1494340Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/f902341a-35db-4ebf-bf8a-059f6534d176","type":"Microsoft.Authorization/roleAssignments","name":"f902341a-35db-4ebf-bf8a-059f6534d176"}]}'
+      string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"d962bd40-540d-4f7a-9756-2b3c8f7aab83","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T15:03:43.9754497Z","updatedOn":"2021-06-17T15:03:43.9754497Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000001","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000001"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7","principalId":"b9bc1545-a684-4e50-9a4d-2e2ee90bed6a","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet","condition":null,"conditionVersion":null,"createdOn":"2021-06-17T15:03:46.5573091Z","updatedOn":"2021-06-17T15:03:46.5573091Z","createdBy":"a733a73f-b768-4787-88aa-2980a97f76be","updatedBy":"a733a73f-b768-4787-88aa-2980a97f76be","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/providers/Microsoft.Authorization/roleAssignments/88888888-0000-0000-0000-000000000002","type":"Microsoft.Authorization/roleAssignments","name":"88888888-0000-0000-0000-000000000002"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"0255bd8a-9115-4fcd-9f3a-c00337edbb0b","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:12.1938451Z","updatedOn":"2020-07-27T14:50:21.0338163Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/412173a9-cd67-5814-a6e6-ec7d981d60f4","type":"Microsoft.Authorization/roleAssignments","name":"412173a9-cd67-5814-a6e6-ec7d981d60f4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"6e66c155-e3cf-4390-88ca-e2c9218a2cb0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:08.1004410Z","updatedOn":"2020-05-20T06:44:08.1004410Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7","type":"Microsoft.Authorization/roleAssignments","name":"73da04de-ae1b-44f5-aaa1-b2f3dd88dcb7"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/79ed474a-7267-4ff8-b226-96140be062a2","principalId":"bc46cb3a-97e9-4d05-8e76-d2659a531a33","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-28T19:20:19.3094857Z","updatedOn":"2020-07-27T14:50:22.6913874Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/61a4af72-ff9c-5194-952c-74d2402f159c","type":"Microsoft.Authorization/roleAssignments","name":"61a4af72-ff9c-5194-952c-74d2402f159c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/9bc35064-26cf-4536-8e65-40bd22a41071","principalId":"a61eb105-31fd-47d2-aa03-5a3ca28136f6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:33.3348247Z","updatedOn":"2019-04-01T17:41:33.3348247Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f","type":"Microsoft.Authorization/roleAssignments","name":"0e9dbaee-e53f-4d0c-88af-b8c304ab8c7f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0f7a3a14-e15a-4e65-8dde-855ce6555ec8","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:41:39.0322809Z","updatedOn":"2020-05-27T06:41:39.0322809Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/09de0457-f9e2-4aea-a507-4f6c605d23cf","type":"Microsoft.Authorization/roleAssignments","name":"09de0457-f9e2-4aea-a507-4f6c605d23cf"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"0eb36474-7cdd-4cf8-aac2-183fa5169d69","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-27T06:34:17.1724594Z","updatedOn":"2020-05-27T06:34:17.1724594Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6bdc978e-5759-4ea6-b046-eea920ef6f63","type":"Microsoft.Authorization/roleAssignments","name":"6bdc978e-5759-4ea6-b046-eea920ef6f63"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-01-03T17:14:59.7587336Z","updatedOn":"2020-01-03T17:14:59.7587336Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aecdd90e-a4fc-4817-87ff-a998ff823a71","type":"Microsoft.Authorization/roleAssignments","name":"aecdd90e-a4fc-4817-87ff-a998ff823a71"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"9346e863-0839-4280-8f2e-71cc5d2b0234","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-12-05T14:40:48.3228382Z","updatedOn":"2019-12-05T14:40:48.3228382Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/af6ddb51-ede7-42de-8742-58b6510fb74d","type":"Microsoft.Authorization/roleAssignments","name":"af6ddb51-ede7-42de-8742-58b6510fb74d"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/7c1a95fb-9825-4039-b67c-a3644e872c04","principalId":"711515c9-e6da-48e7-8ea1-ec06d9f63479","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-01T17:41:48.9447150Z","updatedOn":"2019-04-01T17:41:48.9447150Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/126b9267-d091-4f12-a1c8-31aef091dc2c","type":"Microsoft.Authorization/roleAssignments","name":"126b9267-d091-4f12-a1c8-31aef091dc2c"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"95c23d82-b2c1-4624-8958-9530d0f470bb","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-12T12:49:56.1678828Z","updatedOn":"2020-05-12T12:49:56.1678828Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/320b5c37-2c2d-4f15-a725-4ea65a0741ed","type":"Microsoft.Authorization/roleAssignments","name":"320b5c37-2c2d-4f15-a725-4ea65a0741ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"9e4f44bd-90a1-44b2-b89a-ed9884662958","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2018-07-02T15:27:42.7799758Z","updatedOn":"2018-07-02T15:27:42.4591259Z","createdBy":"28786167-841e-46dd-8897-66649dc5df2e","updatedBy":"28786167-841e-46dd-8897-66649dc5df2e","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/daffce38-f7dd-4096-86ee-09e915c0b320","type":"Microsoft.Authorization/roleAssignments","name":"daffce38-f7dd-4096-86ee-09e915c0b320"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"35a61e42-516a-4543-803d-8cd639192a33","principalType":"User","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-06-16T16:25:39.5401427Z","updatedOn":"2020-06-16T16:25:39.5401427Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/aa375d03-ea3b-4b57-9547-eeb14e380e74","type":"Microsoft.Authorization/roleAssignments","name":"aa375d03-ea3b-4b57-9547-eeb14e380e74"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:55:05.5085738Z","updatedOn":"2020-05-21T10:55:05.5085738Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/18010ec8-8e36-402c-a181-9ad88807db20","type":"Microsoft.Authorization/roleAssignments","name":"18010ec8-8e36-402c-a181-9ad88807db20"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5b803d09-562b-4e33-a78e-b0d62961fc09","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-26T13:25:31.1169669Z","updatedOn":"2020-05-26T13:25:31.1169669Z","createdBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","updatedBy":"4c54536b-2384-4e61-ad52-0e4daf2c064c","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/96e611c8-38ec-47a4-9888-a067db0101fe","type":"Microsoft.Authorization/roleAssignments","name":"96e611c8-38ec-47a4-9888-a067db0101fe"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"1dabfb0c-aae8-43e2-9c16-a888d00901b5","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-21T10:53:54.5328741Z","updatedOn":"2020-05-21T10:53:54.5328741Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/10bdb440-168c-4f24-b8d9-52afde326b2f","type":"Microsoft.Authorization/roleAssignments","name":"10bdb440-168c-4f24-b8d9-52afde326b2f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"31c76b4a-629e-4d5d-8bdd-37dbc7eb76de","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2019-04-06T01:22:46.3953179Z","updatedOn":"2019-04-06T01:22:46.3953179Z","createdBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","updatedBy":"114cb5e7-ffb7-4384-ae67-3c56a544c7ad","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5e85db35-bf43-4f15-9663-db7ce8f06316","type":"Microsoft.Authorization/roleAssignments","name":"5e85db35-bf43-4f15-9663-db7ce8f06316"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"a993a6e3-565a-4be4-a03d-bfc6bcb8cc46","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-05-20T06:44:25.8744454Z","updatedOn":"2020-05-20T06:44:25.8744454Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5ffd2af0-64d4-4665-90ca-e67ccb760551","type":"Microsoft.Authorization/roleAssignments","name":"5ffd2af0-64d4-4665-90ca-e67ccb760551"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:53.3359003Z","updatedOn":"2020-07-27T14:50:21.0280951Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4ada4e10-8bd0-59e5-a225-4f7cdf439f07","type":"Microsoft.Authorization/roleAssignments","name":"4ada4e10-8bd0-59e5-a225-4f7cdf439f07"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5eef8841-17e7-4e00-9fa7-9d2a25545fd0","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-07-01T15:29:54.4354117Z","updatedOn":"2020-07-27T14:50:21.0173842Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/5754bc19-65bd-55d3-a80f-bda63cb1388e","type":"Microsoft.Authorization/roleAssignments","name":"5754bc19-65bd-55d3-a80f-bda63cb1388e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635","principalId":"77afb319-5f1b-499f-94b0-fdbf317d9cd1","principalType":"Group","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-04-07T17:37:23.3570280Z","updatedOn":"2021-04-07T17:37:23.3570280Z","createdBy":"60fa24bb-762f-4b64-a636-a208bc10682d","updatedBy":"60fa24bb-762f-4b64-a636-a208bc10682d","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6f7402a1-d8b0-41db-bf50-1316c75686e6","type":"Microsoft.Authorization/roleAssignments","name":"6f7402a1-d8b0-41db-bf50-1316c75686e6"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:53:45.2042688Z","updatedOn":"2021-06-09T17:53:45.2042688Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/51fb99a1-aefe-4df4-a00f-b19f44c40a45","type":"Microsoft.Authorization/roleAssignments","name":"51fb99a1-aefe-4df4-a00f-b19f44c40a45"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"c2411219-426d-4ddb-af2e-e7b3f31e47e6","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-09T17:57:30.1494304Z","updatedOn":"2021-06-09T17:57:30.1494304Z","createdBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","updatedBy":"3b752c20-adfb-4f5f-97e0-8b7856fedc40","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/df17143a-e88b-4fcc-84a2-2cc53fdc9dd4","type":"Microsoft.Authorization/roleAssignments","name":"df17143a-e88b-4fcc-84a2-2cc53fdc9dd4"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"48518808-ff59-43df-9769-1b89553bd146","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-14T19:44:46.6007468Z","updatedOn":"2021-06-14T19:44:46.6007468Z","createdBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","updatedBy":"b87feec9-5842-4518-9be0-a44b77f8a70a","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/b40551bb-a82e-4ba0-a075-a72c5423c96f","type":"Microsoft.Authorization/roleAssignments","name":"b40551bb-a82e-4ba0-a075-a72c5423c96f"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d4c9754b-23f4-4803-8d07-7bf11aaf6e87","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:06:53.5089696Z","updatedOn":"2021-06-16T19:06:53.5089696Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/d371c434-71b7-4ddb-8dab-a8a8de0fe5ed","type":"Microsoft.Authorization/roleAssignments","name":"d371c434-71b7-4ddb-8dab-a8a8de0fe5ed"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"dd614393-35e7-48dc-8683-60e83fbbc2c3","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2021-06-16T19:07:19.7325354Z","updatedOn":"2021-06-16T19:07:19.7325354Z","createdBy":"e2cb0076-d441-4109-9902-b8f06b964c50","updatedBy":"e2cb0076-d441-4109-9902-b8f06b964c50","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/97ff3783-94cf-4e58-bc40-63891c731c48","type":"Microsoft.Authorization/roleAssignments","name":"97ff3783-94cf-4e58-bc40-63891c731c48"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5ee5eb64-11f1-4831-890c-010aa7921c5d","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T08:19:26.1556445Z","updatedOn":"2020-09-10T08:19:26.1556445Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/8658a2da-ffe9-46a7-a643-650ac9e1a701","type":"Microsoft.Authorization/roleAssignments","name":"8658a2da-ffe9-46a7-a643-650ac9e1a701"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:10.0490288Z","updatedOn":"2020-09-10T14:46:10.0490288Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3a9ad183-fa01-42bd-9839-a4bfd927a186","type":"Microsoft.Authorization/roleAssignments","name":"3a9ad183-fa01-42bd-9839-a4bfd927a186"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9","principalId":"d00ec4f4-dbf9-491a-8bea-bfce57e66e79","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-10T14:46:15.2094099Z","updatedOn":"2020-09-10T14:46:15.2094099Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/6c110bee-ee0c-46b3-bd66-fbc4c3d2acab","type":"Microsoft.Authorization/roleAssignments","name":"6c110bee-ee0c-46b3-bd66-fbc4c3d2acab"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"d9edae9a-dcca-436d-a285-1f3651ff2112","principalType":"ServicePrincipal","scope":"/subscriptions/00000000-0000-0000-0000-000000000000","condition":null,"conditionVersion":null,"createdOn":"2020-09-11T10:42:57.9023785Z","updatedOn":"2020-09-11T10:42:57.9023785Z","createdBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","updatedBy":"687b0b99-0a1f-4a48-a4f7-a58fc76b3530","delegatedManagedIdentityResourceId":null,"description":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/1661bb97-adb2-4ae5-8ef8-a2c092ac8f67","type":"Microsoft.Authorization/roleAssignments","name":"1661bb97-adb2-4ae5-8ef8-a2c092ac8f67"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '25201'
+      - '26941'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 30 Apr 2021 13:30:58 GMT
+      - Thu, 17 Jun 2021 15:36:05 GMT
       expires:
       - '-1'
       pragma:
@@ -5257,8 +5439,8 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
       accept-language:
       - en-US
     method: PATCH
@@ -5269,40 +5451,40 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"update\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Updating\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"g1gpmp1e\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-g1gpmp1e\"\n
-        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.g1gpmp1e.eastus.aroapp.io/\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"v43koob1\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-v43koob1\"\n
+        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.v43koob1.eastus.aroapp.io/\"\n
         \       },\n        \"servicePrincipalProfile\": {\n            \"clientId\":
-        \"bbef1b94-ad31-499a-a513-14b4afc9eef3\"\n        },\n        \"networkProfile\":
+        \"06b8ce89-a38c-4bd3-a988-50be85a9eaf5\"\n        },\n        \"networkProfile\":
         {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\":
         \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n            \"vmSize\":
         \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \       },\n        \"workerProfiles\": [\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            }\n        ],\n        \"apiserverProfile\":
-        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.g1gpmp1e.eastus.aroapp.io:6443/\",\n
-        \           \"ip\": \"52.149.202.101\"\n        },\n        \"ingressProfiles\":
+        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.v43koob1.eastus.aroapp.io:6443/\",\n
+        \           \"ip\": \"52.224.143.150\"\n        },\n        \"ingressProfiles\":
         [\n            {\n                \"name\": \"default\",\n                \"visibility\":
-        \"Public\",\n                \"ip\": \"20.42.37.109\"\n            }\n        ]\n
+        \"Public\",\n                \"ip\": \"52.224.143.232\"\n            }\n        ]\n
         \   }\n}\n"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f9a9e61b-d7a5-447d-bba7-7e9efce6cd87?api-version=2020-04-30
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/64b0a99c-7ed9-479d-a55b-4490ca805098?api-version=2020-04-30
       cache-control:
       - no-cache
       content-length:
-      - '2866'
+      - '2868'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:31:00 GMT
+      - Thu, 17 Jun 2021 15:36:06 GMT
       expires:
       - '-1'
       pragma:
@@ -5334,24 +5516,24 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f9a9e61b-d7a5-447d-bba7-7e9efce6cd87?api-version=2020-04-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/64b0a99c-7ed9-479d-a55b-4490ca805098?api-version=2020-04-30
   response:
     body:
-      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/f9a9e61b-d7a5-447d-bba7-7e9efce6cd87\",\n
-        \   \"name\": \"f9a9e61b-d7a5-447d-bba7-7e9efce6cd87\",\n    \"status\": \"Succeeded\",\n
-        \   \"startTime\": \"2021-04-30T13:31:00.536757104Z\",\n    \"endTime\": \"2021-04-30T13:31:16.207731931Z\"\n}\n"
+      string: "{\n    \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.redhatopenshift/locations/eastus/operationsstatus/64b0a99c-7ed9-479d-a55b-4490ca805098\",\n
+        \   \"name\": \"64b0a99c-7ed9-479d-a55b-4490ca805098\",\n    \"status\": \"Succeeded\",\n
+        \   \"startTime\": \"2021-06-17T15:36:07.068522985Z\",\n    \"endTime\": \"2021-06-17T15:36:21.04855459Z\"\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '354'
+      - '353'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:31:31 GMT
+      - Thu, 17 Jun 2021 15:36:37 GMT
       expires:
       - '-1'
       pragma:
@@ -5381,8 +5563,8 @@ interactions:
       ParameterSetName:
       - -g -n --subscription
       User-Agent:
-      - python/3.9.2 (Linux-5.11.8-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
-        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.22.1
+      - python/3.9.5 (Linux-5.12.7-200.fc33.x86_64-x86_64-with-glibc2.32) msrest/0.6.21
+        msrest_azure/0.6.3 azure-mgmt-redhatopenshift/0.1.0 Azure-SDK-For-Python AZURECLI/2.25.0
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.RedHatOpenShift/openShiftClusters/aro000004?api-version=2020-04-30
   response:
@@ -5391,38 +5573,38 @@ interactions:
         \   \"name\": \"aro000004\",\n    \"type\": \"Microsoft.RedHatOpenShift/openShiftClusters\",\n
         \   \"location\": \"eastus\",\n    \"tags\": {\n        \"test\": \"update\"\n
         \   },\n    \"properties\": {\n        \"provisioningState\": \"Succeeded\",\n
-        \       \"clusterProfile\": {\n            \"domain\": \"g1gpmp1e\",\n            \"version\":
-        \"4.6.21\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-g1gpmp1e\"\n
-        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.g1gpmp1e.eastus.aroapp.io/\"\n
+        \       \"clusterProfile\": {\n            \"domain\": \"v43koob1\",\n            \"version\":
+        \"4.6.26\",\n            \"resourceGroupId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/aro-v43koob1\"\n
+        \       },\n        \"consoleProfile\": {\n            \"url\": \"https://console-openshift-console.apps.v43koob1.eastus.aroapp.io/\"\n
         \       },\n        \"servicePrincipalProfile\": {\n            \"clientId\":
-        \"bbef1b94-ad31-499a-a513-14b4afc9eef3\"\n        },\n        \"networkProfile\":
+        \"06b8ce89-a38c-4bd3-a988-50be85a9eaf5\"\n        },\n        \"networkProfile\":
         {\n            \"podCidr\": \"10.128.0.0/14\",\n            \"serviceCidr\":
         \"172.30.0.0/16\"\n        },\n        \"masterProfile\": {\n            \"vmSize\":
         \"Standard_D8s_v3\",\n            \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_master000002\"\n
         \       },\n        \"workerProfiles\": [\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus1\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus2\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            },\n            {\n                \"name\":
-        \"aro000004-zs9w8-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
+        \"aro000004-6j248-worker-eastus3\",\n                \"vmSize\": \"Standard_D4s_v3\",\n
         \               \"diskSizeGB\": 128,\n                \"subnetId\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_aro_update000001/providers/Microsoft.Network/virtualNetworks/dev-vnet/subnets/dev_worker000003\",\n
         \               \"count\": 1\n            }\n        ],\n        \"apiserverProfile\":
-        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.g1gpmp1e.eastus.aroapp.io:6443/\",\n
-        \           \"ip\": \"52.149.202.101\"\n        },\n        \"ingressProfiles\":
+        {\n            \"visibility\": \"Public\",\n            \"url\": \"https://api.v43koob1.eastus.aroapp.io:6443/\",\n
+        \           \"ip\": \"52.224.143.150\"\n        },\n        \"ingressProfiles\":
         [\n            {\n                \"name\": \"default\",\n                \"visibility\":
-        \"Public\",\n                \"ip\": \"20.42.37.109\"\n            }\n        ]\n
+        \"Public\",\n                \"ip\": \"52.224.143.232\"\n            }\n        ]\n
         \   }\n}\n"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2867'
+      - '2869'
       content-type:
       - application/json
       date:
-      - Fri, 30 Apr 2021 13:31:31 GMT
+      - Thu, 17 Jun 2021 15:36:37 GMT
       expires:
       - '-1'
       pragma:


### PR DESCRIPTION
**Description**<!--Mandatory-->
If someone calls `az aro delete` on a non-existing resource, print out a helpful error instead of a stack trace.  
#18501 

**Testing Guide**
`az aro delete -g non-existing -n non-existing` should now raise a ResourceNotFoundError
