### PR TITLE
Replace deprecated 'az configure' with 'az config' and update syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Here are a few features and concepts that can help you get the most out of the A
 
 ![Azure CLI Highlight Reel](doc/assets/AzBlogAnimation4.gif)
 
-The following examples are showing using the `--output table` format, you can change your default using the `az configure` command.
+The following examples are showing using the `--output table` format, you can change your default using the `az config` command.
 
 #### Tab completion
 

--- a/doc/authoring_tests.md
+++ b/doc/authoring_tests.md
@@ -77,7 +77,7 @@ Here are some issues that may occur when authoring tests that you should be awar
   2. check your parameter aliasing (particularly if it complains that a required parameter is missing that you know is there)
  If your command makes use of concurrency, consider using unit tests, LiveScenarioTest, or, if practical, forcing the test to operate on a single thread for recording and playback.
 * **Paths**: When including paths in your tests as parameter values, always wrap them in double quotes. While this isn't necessary when running from the command line (depending on your shell environment), it will likely cause issues with the test framework.
-* **Defaults**: Ensure you don't have any defaults configured with `az configure` prior to running tests. Defaults can interfere with the expected test flow.
+* **Defaults**: Ensure you don't have any defaults configured with `az config` prior to running tests. Defaults can interfere with the expected test flow.
 
 ## Sample Scenario Tests
 

--- a/doc/classic_cli_migration.md
+++ b/doc/classic_cli_migration.md
@@ -44,7 +44,7 @@ we recommend downloading the latest installer to upgrade.
 To install the latest Azure CLI, follow the steps for your preferred platform or
 environment in our [Installation Guide](https://docs.microsoft.com/cli/azure/install-azure-cli).
 
-Once installed, you run `az configure` and follow the steps to setup your default output format.  
+Once installed, you run `az config` and follow the steps to setup your default output format.  
 
 Then run `az login` to login using device authentication.  Once this step is complete you should be authenticated to use both CLIs.  
 
@@ -53,7 +53,7 @@ Then run `az login` to login using device authentication.  Once this step is com
 Here is a quick list of some new and changed concepts that can help you understand the new tool.
 
 * Interactive Concepts
-  * Use `az configure` to setup your default output format
+  * Use `az config` to setup your default output format
   * You will find help to be generally more useful, try `az vm create -h` for an example
   * Positional parameters are not supported, use `az vm list -g MyGroup` instead of `azure vm list MyGroup`
 * Automation and Scripting Concepts
@@ -151,7 +151,7 @@ The Azure CLI supports 4 primary output formats:
 3. tsv   - provides "UNIX-style" output (fields delimited with tabs, records with newlines)
 4. table - simplified human-readable output
 
-You can set your default output format with the `az configure` command or on a
+You can set your default output format with the `az config` command or on a
 by-command basis using `--out` parameter.  
 
 Tips:

--- a/doc/command_guidelines.md
+++ b/doc/command_guidelines.md
@@ -390,7 +390,7 @@ Several services support the concept of network rules. To drive consistency acro
 Arguments
     --name -n [Required]      : The name of the [PARENT RESOURCE].
     --resource-group -g       : Name of resource group. You can configure the default group using `az
-                                configure --defaults group=<name>`.
+                                config set defaults.group=<name>`.
 
 IP Address Rule Arguments
     --ip-address              : IPv4 address or CIDR range.
@@ -409,7 +409,7 @@ Virtual Network Rule Arguments
 Arguments
     --name -n [Required]         : The name of the [PARENT RESOURCE].
     --resource-group -g          : Name of resource group. You can configure the default group using
-                                   `az configure --defaults group=<name>`.
+                                   `az config set defaults.group=<name>`.
 
 IP Address Rule Arguments
     --ip-address                 : IPv4 address or CIDR range.


### PR DESCRIPTION
**Description** The purpose of the PR is to replace instances of the deprecated 'az configure' with 'az config' and update the syntax in any code examples.

This work is for story [1844036](https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1844036). 