### PR TITLE
[AppConfig] Stop overwriting KeyVault reference content type during import

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -390,7 +390,7 @@ def __is_feature_flag(kv):
 
 
 def __is_key_vault_ref(kv):
-    return (kv and kv.content_type and kv.content_type.lower() == KeyVaultConstants.KEYVAULT_CONTENT_TYPE)
+    return kv and kv.content_type and kv.content_type.lower() == KeyVaultConstants.KEYVAULT_CONTENT_TYPE
 
 
 def __discard_features_from_retrieved_kv(src_kvs):


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
While importing Key Vault references from AppService or AppConfig, we were overwriting the KVR content type with user specified content type. If the source key-value is recognized as a Key Vault reference, we should preserve it in destination too.


**Testing Guide**
<!--Example commands with explanations.-->
`az appconfig kv import -s appconfig -n store2 --src-name store1 --content-type text`

This command would import everything from store1 to store2 with content-type 'text'. All Key Vault References in store1 would be converted to regular key-values in store2 with content-type 'text'.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
