### PR TITLE
[Compute] Add the hint to suggest users use the standard public IP when creating VM

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -753,13 +753,10 @@ def create_vm(cmd, vm_name, resource_group_name, image=None, size='Standard_DS1_
     from msrestazure.tools import resource_id, is_valid_resource_id, parse_resource_id
     from azure.cli.core.profiles import AZURE_API_PROFILES
 
-    # In the latest profile and the profiles that use the same api-version as latest profile,
-    # the default public IP used for VM creation will be expected to be changed from Basic to Standard.
-    # In order to avoid breaking change which has a big impact on users,
+    # In the latest profile, the default public IP will be expected to be changed from Basic to Standard.
+    # In order to avoid breaking change which has a big impact to users,
     # we use the hint to guide users to use Standard public IP to create VM in the first stage.
-    api_version_for_latest_profile = AZURE_API_PROFILES['latest'][ResourceType.MGMT_COMPUTE].default_api_version
-    if public_ip_sku is None and cmd.supported_api_version(ResourceType.MGMT_COMPUTE,
-                                                           min_api=api_version_for_latest_profile):
+    if public_ip_sku is None and cmd.cli_ctx.cloud.profile == 'latest':
         logger.warning(
             'It is recommended to use parameter "--public-ip-sku Standard" to create new VM with Standard public IP. '
             'Please note that the default public IP used for VM creation will be changed from Basic to Standard '

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -751,6 +751,19 @@ def create_vm(cmd, vm_name, resource_group_name, image=None, size='Standard_DS1_
                                                                 build_vm_windows_log_analytics_workspace_agent)
     from azure.cli.command_modules.vm._vm_utils import ArmTemplateBuilder20190401
     from msrestazure.tools import resource_id, is_valid_resource_id, parse_resource_id
+    from azure.cli.core.profiles import AZURE_API_PROFILES
+
+    # In the latest profile and the profiles that use the same api-version as latest profile,
+    # the default public IP used for VM creation will be expected to be changed from Basic to Standard.
+    # In order to avoid breaking change which has a big impact on users,
+    # we use the hint to guide users to use Standard public IP to create VM in the first stage.
+    api_version_for_latest_profile = AZURE_API_PROFILES['latest'][ResourceType.MGMT_COMPUTE].default_api_version
+    if public_ip_sku is None and cmd.supported_api_version(ResourceType.MGMT_COMPUTE,
+                                                           min_api=api_version_for_latest_profile):
+        logger.warning(
+            'It is recommended to use parameter "--public-ip-sku Standard" to create new VM with Standard public IP. '
+            'Please note that the default public IP used for VM creation will be changed from Basic to Standard '
+            'in the future.')
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
 

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -751,7 +751,6 @@ def create_vm(cmd, vm_name, resource_group_name, image=None, size='Standard_DS1_
                                                                 build_vm_windows_log_analytics_workspace_agent)
     from azure.cli.command_modules.vm._vm_utils import ArmTemplateBuilder20190401
     from msrestazure.tools import resource_id, is_valid_resource_id, parse_resource_id
-    from azure.cli.core.profiles import AZURE_API_PROFILES
 
     # In the latest profile, the default public IP will be expected to be changed from Basic to Standard.
     # In order to avoid breaking change which has a big impact to users,


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In the latest profile and the profiles that use the same api-version as latest profile, the default public IP used for VM creation will be expected to be changed from Basic to Standard. 
In order to avoid breaking change which has a big impact on users, we use the hint to guide users to use Standard public IP to create VM in the first stage.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
