### PR TITLE
[AKS] az aks get-credentials: Add a check for KUBECONFIG environmental variable

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2488,14 +2488,11 @@ def aks_get_credentials(cmd, client, resource_group_name, name, admin=False,
             resource_group_name, name)
 
     # Check if KUBECONFIG environmental variable is set
-    path = os.environ.get(
-        "KUBECONFIG",
-        os.path.join(
-            os.path.expanduser('~'),
-            '.kube',
-            'config'
-        )
-    )
+    # If path is different than default then that means -f/--file is passed
+    # in which case we ignore the KUBECONFIG variable
+    if "KUBECONFIG" in os.environ and path == os.path.join(os.path.expanduser('~'), '.kube', 'config'):
+        path = os.environ["KUBECONFIG"]
+
     if not credentialResults:
         raise CLIError("No Kubernetes credentials found.")
     try:

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2487,6 +2487,15 @@ def aks_get_credentials(cmd, client, resource_group_name, name, admin=False,
         credentialResults = client.list_cluster_user_credentials(
             resource_group_name, name)
 
+    # Check if KUBECONFIG environmental variable is set
+    path = os.environ.get(
+        "KUBECONFIG",
+        os.path.join(
+            os.path.expanduser('~'),
+            '.kube',
+            'config'
+        )
+    )
     if not credentialResults:
         raise CLIError("No Kubernetes credentials found.")
     try:


### PR DESCRIPTION
**Description**<!--Mandatory-->
`az aks get-credentials` does not check for the `KUBECONFIG` variable when creating/merging credentials. This PR fixes that and adds a check.

**Testing Guide**
```bash
touch ~/testconfig
export KUBECONFIG=~/testconfig
az aks get-credentials -n <cluster name> -g <resource group>
```

Fixes #18700
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
