### PR TITLE
[ARM]: Fix ARM What-If formatter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -315,7 +315,7 @@ def _format_property_modify(builder, before, after, children, indent_level):
         # Space before =>
         if _is_non_empty_object(before):
             builder.append_line()
-            _format_indent(indent_level)
+            _format_indent(builder, indent_level)
         else:
             builder.append(Symbol.WHITE_SPACE)
 

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
@@ -350,6 +350,16 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
                         after="bar",
                     ),
                     WhatIfPropertyChange(
+                        path="path.a.to.change2",
+                        property_change_type=PropertyChangeType.modify,
+                        before={
+                            "tag1": "value"
+                        },
+                        after={
+                            "tag2": "value"
+                        },
+                    ),
+                    WhatIfPropertyChange(
                         path="path.b.to.nested.change",
                         property_change_type=PropertyChangeType.array,
                         children=[
@@ -384,6 +394,14 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
 {Color.PURPLE}
   ~ p1/foo{Color.RESET}
     {Color.PURPLE}~{Color.RESET} path.a.to.change{Color.RESET}:{Color.RESET} {Color.ORANGE}"foo"{Color.RESET} => {Color.GREEN}"bar"{Color.RESET}
+    {Color.PURPLE}~{Color.RESET} path.a.to.change2{Color.RESET}:{Color.RESET}{Color.ORANGE}
+
+        tag1{Color.RESET}:{Color.ORANGE} "value"
+{Color.RESET}
+      =>{Color.GREEN}
+
+        tag2{Color.RESET}:{Color.GREEN} "value"
+{Color.RESET}
     {Color.PURPLE}~{Color.RESET} path.b.to.nested.change{Color.RESET}:{Color.RESET} [
       {Color.PURPLE}~{Color.RESET} 4{Color.RESET}:{Color.RESET}
 


### PR DESCRIPTION
added missing parameter in method call

**Description**<!--Mandatory-->
Fixes #18720 

**Testing Guide**
`az deployment what-if ...`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[arm] az what-if: Fix output formatting 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
