### PR TITLE
[AKS] `az aks check-acr`: Fix the crashes when kubectl minor version includes non-numeric chars

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1557,7 +1557,8 @@ def aks_check_acr(cmd, client, resource_group_name, name, acr):
         output = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         jsonS, _ = output.communicate()
         kubectl_version = json.loads(jsonS)
-        kubectl_minor_version = int(kubectl_version["clientVersion"]["minor"])
+        # Remove any non-numeric characters like + from minor version
+        kubectl_minor_version = int(re.sub(r"\D", "", kubectl_version["clientVersion"]["minor"]))
         kubectl_server_minor_version = int(
             kubectl_version["serverVersion"]["minor"])
         kubectl_server_patch = int(


### PR DESCRIPTION
**Description**
In some cases, the `kubectl` minor version can include non-numeric characters`20+`. (For example, #17769) This causes an issue parsing the minor version. This PR makes it so that all non-numeric characters are stripped out before parsing the version.

**Testing Guide**
`az aks check-acr --name {} --resource-group {} --acr {}`

**History Notes**
[AKS] az aks check-acr: Fix issues parsing certain client minor versions

Closes #17769
Closes #18314
Closes #18263
Closes #16936

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
