### PR TITLE
[App Service] `az appservice ase create`: Command changes for ASE v3 GA

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2169,7 +2169,7 @@ helps['appservice ase show'] = """
 
 helps['appservice ase list-addresses'] = """
     type: command
-    short-summary: List VIPs associated with an app service environment.
+    short-summary: List VIPs associated with an app service environment v2.
     examples:
     - name: List VIPs for an app service environments.
       text: az appservice ase list-addresses --name MyAseName
@@ -2191,52 +2191,59 @@ helps['appservice ase create'] = """
       text: |
           az group create -g MyResourceGroup --location westeurope
 
-          az network vnet create -g MyResourceGroup -n MyVirtualNetwork --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/24
+          az network vnet create -g MyResourceGroup -n MyVirtualNetwork \\
+            --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/24
 
-          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork --subnet MyAseSubnet
+          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
+            --subnet MyAseSubnet
     - name: Create External app service environments v2 with large front-ends and scale factor of 10 in existing resource group and vNet.
       text: |
-          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork --subnet MyAseSubnet --front-end-sku I3 --front-end-scale-factor 10 --virtual-ip-type External
+          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
+            --subnet MyAseSubnet --front-end-sku I3 --front-end-scale-factor 10 --virtual-ip-type External
     - name: Create vNet and app service environment v2, but do not create network security group and route table in existing resource group.
       text: |
-          az network vnet create -g MyResourceGroup -n MyVirtualNetwork --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/24
+          az network vnet create -g MyResourceGroup -n MyVirtualNetwork \\
+            --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/24
 
-          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork --subnet MyAseSubnet --ignore-network-security-group --ignore-route-table
+          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
+            --subnet MyAseSubnet --ignore-network-security-group --ignore-route-table
     - name: Create vNet and app service environment v2 in a smaller than recommended subnet in existing resource group.
       text: |
-          az network vnet create -g MyResourceGroup -n MyVirtualNetwork --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/26
+          az network vnet create -g MyResourceGroup -n MyVirtualNetwork \\
+            --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/26
 
-          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork --subnet MyAseSubnet --ignore-subnet-size-validation
+          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
+            --subnet MyAseSubnet --ignore-subnet-size-validation
     - name: Create Resource Group, vNet and app service environment v3 with default values.
       text: |
           az group create -g ASEv3ResourceGroup --location westeurope
 
-          az network vnet create -g ASEv3ResourceGroup -n MyASEv3VirtualNetwork --address-prefixes 10.0.0.0/16 --subnet-name MyASEv3Subnet --subnet-prefixes 10.0.0.0/24
+          az network vnet create -g ASEv3ResourceGroup -n MyASEv3VirtualNetwork \\
+            --address-prefixes 10.0.0.0/16 --subnet-name MyASEv3Subnet --subnet-prefixes 10.0.0.0/24
 
-          az appservice ase create -n MyASEv3Name -g ASEv3ResourceGroup --vnet-name MyASEv3VirtualNetwork --subnet MyASEv3Subnet --kind asev3
+          az appservice ase create -n MyASEv3Name -g ASEv3ResourceGroup \\
+            --vnet-name MyASEv3VirtualNetwork --subnet MyASEv3Subnet --kind asev3
     - name: Create External zone redundant app service environment v3 with default values.
       text: |
-          az appservice ase create -n MyASEv3Name -g ASEv3ResourceGroup --vnet-name MyASEv3VirtualNetwork --subnet MyASEv3Subnet --kind asev3 --zone-redundant --virtual-ip-type External
+          az appservice ase create -n MyASEv3Name -g ASEv3ResourceGroup \\
+            --vnet-name MyASEv3VirtualNetwork --subnet MyASEv3Subnet --kind asev3 \\
+            --zone-redundant --virtual-ip-type External
 """
 
 helps['appservice ase create-inbound-services'] = """
     type: command
-    short-summary: Create the inbound services needed in preview for ASEv3 (private endpoint and DNS) or Private DNS Zone for Internal ASEv2.
+    short-summary: Private DNS Zone for Internal ASEv2.
     examples:
-    - name: Create private endpoint, Private DNS Zone, A records and ensure subnet network policy.
+    - name: Create Private DNS Zone and A records.
       text: |
           az appservice ase create-inbound-services -n MyASEName -g ASEResourceGroup \\
             --vnet-name MyASEVirtualNetwork --subnet MyAseSubnet
-    - name: Create private endpoint and ensure subnet network policy (ASEv3), but do not create DNS Zone and records.
-      text: |
-          az appservice ase create-inbound-services -n MyASEv3Name -g ASEv3ResourceGroup \\
-            --vnet-name MyASEv3VirtualNetwork --subnet Inbound --skip-dns
 """
 
 
 helps['appservice ase update'] = """
     type: command
-    short-summary: Update app service environment.
+    short-summary: Update app service environment v2.
     examples:
     - name: Update app service environment with medium front-ends and scale factor of 10.
       text: |

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -1870,6 +1870,11 @@ examples:
     text: az webapp log deployment list --name MyWebApp --resource-group MyResourceGroup
 """
 
+helps['functionapp log'] = """
+type: group
+short-summary: Manage function app logs.
+"""
+
 helps['functionapp log deployment'] = """
 type: group
 short-summary: Manage function app deployment logs.
@@ -2141,7 +2146,7 @@ examples:
 
 helps['appservice ase'] = """
 type: group
-short-summary: Manage App Service Environments v2
+short-summary: Manage App Service Environments
 """
 
 helps['appservice ase list'] = """
@@ -2186,42 +2191,32 @@ helps['appservice ase create'] = """
       text: |
           az group create -g MyResourceGroup --location westeurope
 
-          az network vnet create -g MyResourceGroup -n MyVirtualNetwork \\
-            --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/24
+          az network vnet create -g MyResourceGroup -n MyVirtualNetwork --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/24
 
-          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
-            --subnet MyAseSubnet
+          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork --subnet MyAseSubnet
     - name: Create External app service environments v2 with large front-ends and scale factor of 10 in existing resource group and vNet.
       text: |
-          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
-            --subnet MyAseSubnet --front-end-sku I3 --front-end-scale-factor 10 \\
-            --virtual-ip-type External
+          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork --subnet MyAseSubnet --front-end-sku I3 --front-end-scale-factor 10 --virtual-ip-type External
     - name: Create vNet and app service environment v2, but do not create network security group and route table in existing resource group.
       text: |
-          az network vnet create -g MyResourceGroup -n MyVirtualNetwork \\
-            --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/24
+          az network vnet create -g MyResourceGroup -n MyVirtualNetwork --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/24
 
-          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
-            --subnet MyAseSubnet --ignore-network-security-group --ignore-route-table
+          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork --subnet MyAseSubnet --ignore-network-security-group --ignore-route-table
     - name: Create vNet and app service environment v2 in a smaller than recommended subnet in existing resource group.
       text: |
-          az network vnet create -g MyResourceGroup -n MyVirtualNetwork \\
-            --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/26
+          az network vnet create -g MyResourceGroup -n MyVirtualNetwork --address-prefixes 10.0.0.0/16 --subnet-name MyAseSubnet --subnet-prefixes 10.0.0.0/26
 
-          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork \\
-            --subnet MyAseSubnet --ignore-subnet-size-validation
+          az appservice ase create -n MyAseName -g MyResourceGroup --vnet-name MyVirtualNetwork --subnet MyAseSubnet --ignore-subnet-size-validation
     - name: Create Resource Group, vNet and app service environment v3 with default values.
       text: |
           az group create -g ASEv3ResourceGroup --location westeurope
 
-          az network vnet create -g ASEv3ResourceGroup -n MyASEv3VirtualNetwork \\
-            --address-prefixes 10.0.0.0/16 --subnet-name Inbound --subnet-prefixes 10.0.0.0/24
+          az network vnet create -g ASEv3ResourceGroup -n MyASEv3VirtualNetwork --address-prefixes 10.0.0.0/16 --subnet-name MyASEv3Subnet --subnet-prefixes 10.0.0.0/24
 
-          az network vnet subnet create -g ASEv3ResourceGroup --vnet-name MyASEv3VirtualNetwork \\
-            --name Outbound --address-prefixes 10.0.1.0/24
-
-          az appservice ase create -n MyASEv3Name -g ASEv3ResourceGroup \\
-            --vnet-name MyASEv3VirtualNetwork --subnet Outbound --kind asev3
+          az appservice ase create -n MyASEv3Name -g ASEv3ResourceGroup --vnet-name MyASEv3VirtualNetwork --subnet MyASEv3Subnet --kind asev3
+    - name: Create External zone redundant app service environment v3 with default values.
+      text: |
+          az appservice ase create -n MyASEv3Name -g ASEv3ResourceGroup --vnet-name MyASEv3VirtualNetwork --subnet MyASEv3Subnet --kind asev3 --zone-redundant --virtual-ip-type External
 """
 
 helps['appservice ase create-inbound-services'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -924,19 +924,21 @@ def load_arguments(self, _):
         c.argument('ignore_subnet_size_validation', arg_type=get_three_state_flag(),
                    help='Do not check if subnet is sized according to recommendations.')
         c.argument('ignore_route_table', arg_type=get_three_state_flag(),
-                   help='Configure route table manually.')
+                   help='Configure route table manually. Applies to ASEv2 only.')
         c.argument('ignore_network_security_group', arg_type=get_three_state_flag(),
-                   help='Configure network security group manually.')
+                   help='Configure network security group manually. Applies to ASEv2 only.')
         c.argument('force_route_table', arg_type=get_three_state_flag(),
-                   help='Override route table for subnet')
+                   help='Override route table for subnet. Applies to ASEv2 only.')
         c.argument('force_network_security_group', arg_type=get_three_state_flag(),
-                   help='Override network security group for subnet')
+                   help='Override network security group for subnet. Applies to ASEv2 only.')
         c.argument('front_end_scale_factor', type=int, validator=validate_front_end_scale_factor,
-                   help='Scale of front ends to app service plan instance ratio.', default=15)
+                   help='Scale of front ends to app service plan instance ratio. Applies to ASEv2 only.', default=15)
         c.argument('front_end_sku', arg_type=isolated_sku_arg_type, default='I1',
-                   help='Size of front end servers.')
+                   help='Size of front end servers. Applies to ASEv2 only.')
         c.argument('os_preference', arg_type=get_enum_type(ASE_OS_PREFERENCE_TYPES),
                    help='Determine if app service environment should start with Linux workers. Applies to ASEv2 only.')
+        c.argument('zone_redundant', arg_type=get_three_state_flag(),
+                   help='Configure App Service Environment as Zone Redundant. Applies to ASEv3 only.')
     with self.argument_context('appservice ase delete') as c:
         c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment')
     with self.argument_context('appservice ase update') as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -162,7 +162,6 @@ def create_ase_inbound_services(cmd, resource_group_name, name, subnet, vnet_nam
 def _get_ase_client_factory(cli_ctx, api_version=None):
     client = get_mgmt_service_client(cli_ctx, WebSiteManagementClient).app_service_environments
     if api_version:
-        logger.warning(api_version)
         client.api_version = api_version
     else:
         client.api_version = VERSION_2019_08_01

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
@@ -218,6 +218,43 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
         self.assertEqual(call_args[0][0], rg_name)
         self.assertEqual(call_args[0][1], deployment_name)
 
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_unique_deployment_name', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_resource_client_factory', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_network_client_factory', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_ase_client_factory', autospec=True)
+    def test_app_service_environment_v3_zone_create(self, ase_client_factory_mock, network_client_factory_mock,
+                                               resource_client_factory_mock, deployment_name_mock):
+        ase_name = 'mock_ase_name'
+        rg_name = 'mock_rg_name'
+        vnet_name = 'mock_vnet_name'
+        subnet_name = 'mock_subnet_name'
+        deployment_name = 'mock_deployment_name'
+
+        ase_client = mock.MagicMock()
+        ase_client_factory_mock.return_value = ase_client
+
+        resource_client_mock = mock.MagicMock()
+        resource_client_factory_mock.return_value = resource_client_mock
+
+        deployment_name_mock.return_value = deployment_name
+
+        network_client = mock.MagicMock()
+        network_client_factory_mock.return_value = network_client
+
+        subnet = Subnet(id=1, address_prefix='10.10.10.10/24')
+        hosting_delegation = Delegation(id=1, service_name='Microsoft.Web/hostingEnvironments')
+        subnet.delegations = [hosting_delegation]
+        network_client.subnets.get.return_value = subnet
+        create_appserviceenvironment_arm(self.mock_cmd, resource_group_name=rg_name, name=ase_name,
+                                         subnet=subnet_name, vnet_name=vnet_name, kind='ASEv3',
+                                         location='westeurope', zone_redundant=True)
+
+        # Assert begin_create_or_update is called with correct rg and deployment name
+        resource_client_mock.deployments.begin_create_or_update.assert_called_once()
+        call_args = resource_client_mock.deployments.begin_create_or_update.call_args
+        self.assertEqual(call_args[0][0], rg_name)
+        self.assertEqual(call_args[0][1], deployment_name)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description**<!--Mandatory-->
For ASEv3 GA, there are some changes, most noticeably that External ASE and Zone redundancy is now supported, and the need for private endpoint for inbound traffic is removed and now using an Azure Load Balancer like ASEv2.

ase create-inbound-services will now only create a Private DNS Zone thus the --skip-dns is not relevant. The API for getting inbound IP for ASEv3 is in azure-mgmt-web 3.0.0 and require an SDK upgrade before this can be supported.

**Testing Guide**
az appservice ase create --kind asev3 [--zone-redundant] ...

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AppService] az appservice ase create: Support for ASEv3 External and Zone redundancy

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
