### PR TITLE
[Packaging] Add licenses to all Python packages

### DIFF
--- a/src/azure-cli-core/LICENSE.txt
+++ b/src/azure-cli-core/LICENSE.txt
@@ -1,0 +1,13 @@
+Azure CLI
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/azure-cli-core/MANIFEST.in
+++ b/src/azure-cli-core/MANIFEST.in
@@ -1,4 +1,4 @@
+include LICENSE.txt
 include *.rst
 include azure/__init__.py
 include azure/cli/__init__.py
-include LICENSE.txt

--- a/src/azure-cli-core/MANIFEST.in
+++ b/src/azure-cli-core/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.rst
 include azure/__init__.py
 include azure/cli/__init__.py
+include LICENSE.txt

--- a/src/azure-cli-telemetry/LICENSE.txt
+++ b/src/azure-cli-telemetry/LICENSE.txt
@@ -1,0 +1,13 @@
+Azure CLI
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/azure-cli-telemetry/MANIFEST.in
+++ b/src/azure-cli-telemetry/MANIFEST.in
@@ -1,4 +1,4 @@
+include LICENSE.txt
 include *.rst
 include azure/__init__.py
 include azure/cli/__init__.py
-include LICENSE.txt

--- a/src/azure-cli-telemetry/MANIFEST.in
+++ b/src/azure-cli-telemetry/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.rst
 include azure/__init__.py
 include azure/cli/__init__.py
+include LICENSE.txt

--- a/src/azure-cli-testsdk/LICENSE.txt
+++ b/src/azure-cli-testsdk/LICENSE.txt
@@ -1,0 +1,13 @@
+Azure CLI
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/azure-cli-testsdk/MANIFEST.in
+++ b/src/azure-cli-testsdk/MANIFEST.in
@@ -1,4 +1,4 @@
+include LICENSE.txt
 include *.rst
 include azure/__init__.py
 include azure/cli/__init__.py
-include LICENSE.txt

--- a/src/azure-cli-testsdk/MANIFEST.in
+++ b/src/azure-cli-testsdk/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.rst
 include azure/__init__.py
 include azure/cli/__init__.py
+include LICENSE.txt


### PR DESCRIPTION
**Description**<!--Mandatory-->
I'm packaging Azure CLI and its dependencies in Fedora, but one of the requirements is that each package has a license file included. This change adds license files to each Python package and includes it in the manifest for each as well.

**Testing Guide**
No testing changes needed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
