### PR TITLE
{Core} Add `-NoProfile` when calling `powershell.exe`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -657,7 +657,7 @@ def open_page_in_browser(url):
         try:
             # https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe
             # Ampersand (&) should be quoted
-            return subprocess.Popen(['powershell.exe', '-Command', 'Start-Process "{}"'.format(url)])
+            return subprocess.Popen(['powershell.exe', '-NoProfile', '-Command', 'Start-Process "{}"'.format(url)])
         except OSError:  # WSL might be too old  # FileNotFoundError introduced in Python 3
             pass
     elif platform_name == 'darwin':


### PR DESCRIPTION
## Description

Fix #14711

Migrate the work from #15361, #15455

When calling `powershell.exe` from WSL, the [PowerShell profile](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-5.1) is executed, causing additional irrelevant PowerShell script to be executed.

This PR adds `-NoProfile` when calling `powershell.exe` so that the PowerShell profile execution is skipped.

## Testing Guide

To repro

1. Create `C:\Users\<user>\Documents\WindowsPowerShell\Profile.ps1` with
    ```pwsh
    Write-Host test_profile
    ```
2. Run `az login`. Notice the terminal will show
    ```
    test_profile
    ```

After the change, `test_profile` is no longer shown.

## Additional information

There was an attempt #15454 to extract a common `start_powershell_process` but it adds more complexity.
