### PR TITLE
[ACR] `az acr build`: Make .dockerignore include directories with `!` 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
@@ -128,7 +128,6 @@ class IgnoreRule:  # pylint: disable=too-few-public-methods
             rule = rule[1:]  # remove !
             # load path without leading slash in linux and windows 
             # environments (interferes with dockerignore file)
-            logger.warning('here')
             if rule.startswith('/'):
                 rule = rule[1:] # remove beginning '/'
 

--- a/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
@@ -126,10 +126,10 @@ class IgnoreRule:  # pylint: disable=too-few-public-methods
         if rule.startswith('!'):
             self.ignore = False
             rule = rule[1:]  # remove !
-            # load path without leading slash in linux and windows 
+            # load path without leading slash in linux and windows
             # environments (interferes with dockerignore file)
             if rule.startswith('/'):
-                rule = rule[1:] # remove beginning '/'
+                rule = rule[1:]  # remove beginning '/'
 
         self.pattern = "^"
         tokens = rule.split('/')

--- a/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
@@ -126,6 +126,11 @@ class IgnoreRule:  # pylint: disable=too-few-public-methods
         if rule.startswith('!'):
             self.ignore = False
             rule = rule[1:]  # remove !
+            # load path without leading slash in linux and windows 
+            # environments (interferes with dockerignore file)
+            logger.warning('here')
+            if rule.startswith('/'):
+                rule = rule[1:] # remove beginning '/'
 
         self.pattern = "^"
         tokens = rule.split('/')


### PR DESCRIPTION
Fixes #17493

In the .dockerignore file, the leading slash for include (!) files interferes with building the file's path in both Windows and Linux environments. By removing that slash, acr build can correctly compare files in its ignore_list to the files that need to be included.

**Testing Guide**
run ```"acr build --image hello-world --registry <registry_name> --file <filepath> ``` on Dockerfile whos .dockerignore contains folders ignored and files within ignored folders that should be included:

### .dockerignore examples : 
```
main
!/main/main.py
``` 
```
main
!main/main.py
``` 
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
