### PR TITLE
[App Service] `az webapp hybrid-connection add`: Improve error/help message for hybrid connections

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -692,7 +692,7 @@ short-summary: methods that list, add and remove hybrid-connections from functio
 
 helps['functionapp hybrid-connection add'] = """
 type: command
-short-summary: add a hybrid-connection to a functionapp
+short-summary: add an existing hybrid-connection to a functionapp
 examples:
   - name: add a hybrid-connection to a functionapp
     text: az functionapp hybrid-connection add -g MyResourceGroup -n MyWebapp --namespace [HybridConnectionNamespace] --hybrid-connection [HybridConnectionName] -s [slot]
@@ -1751,7 +1751,7 @@ short-summary: methods that list, add and remove hybrid-connections from webapps
 
 helps['webapp hybrid-connection add'] = """
 type: command
-short-summary: add a hybrid-connection to a webapp
+short-summary: add an existing hybrid-connection to a webapp
 examples:
   - name: add a hybrid-connection to a webapp
     text: az webapp hybrid-connection add -g MyResourceGroup -n MyWebapp --namespace [HybridConnectionNamespace] --hybrid-connection [HybridConnectionName] -s [slot]

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3317,10 +3317,6 @@ def list_hc(cmd, name, resource_group_name, slot=None):
 
 def add_hc(cmd, name, resource_group_name, namespace, hybrid_connection, slot=None):
     HybridConnection = cmd.get_models('HybridConnection')
-    linux_webapp = show_webapp(cmd, resource_group_name, name, slot)
-    is_linux = linux_webapp.reserved
-    if is_linux:
-        return logger.warning("hybrid connections not supported on a linux app.")
 
     web_client = web_client_factory(cmd.cli_ctx)
     hy_co_client = hycos_mgmt_client_factory(cmd.cli_ctx, cmd.cli_ctx)
@@ -3328,8 +3324,12 @@ def add_hc(cmd, name, resource_group_name, namespace, hybrid_connection, slot=No
 
     hy_co_id = ''
     for n in namespace_client.list():
+        logger.warning(n.name)
         if n.name == namespace:
             hy_co_id = n.id
+
+    if hy_co_id == '':
+        raise ResourceNotFoundError('Azure Service Bus Relay namespace {} was not found.'.format(namespace))
 
     i = 0
     hy_co_resource_group = ''


### PR DESCRIPTION
**Description**<!--Mandatory-->
Customer requested improved error message when hybrid connection does not exist - as the command will only add an existing hybrid connection and not create a new. Currently the error message is "Parameter 'resource_group_name' must have length greater than 1".
The PR also adds support for Linux, which has been possible for a while.

**Testing Guide**
az webapp hybrid-connection add -g -n --namespace --hybrid-connection

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AppService] az webapp hybrid-connection add: Improve help/error message and unblock Linux

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
