### PR TITLE
[Container] `az container exec`: Fix and improve terminal experience

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/container/_vt_helper.py
+++ b/src/azure-cli/azure/cli/command_modules/container/_vt_helper.py
@@ -1,0 +1,95 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from ctypes import WinDLL, get_last_error, byref
+from ctypes.wintypes import HANDLE, LPDWORD, DWORD
+from msvcrt import get_osfhandle  # pylint: disable=import-error
+from knack.log import get_logger
+
+logger = get_logger(__name__)
+
+ERROR_INVALID_PARAMETER = 0x0057
+
+ENABLE_PROCESSED_OUTPUT = 0x0001
+ENABLE_WRAP_AT_EOL_OUTPUT = 0x0002
+ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+DISABLE_NEWLINE_AUTO_RETURN = 0x0008
+ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200
+
+def _check_zero(result, _, args):
+    if not result:
+        raise OSError(get_last_error())
+    return args
+
+
+# See:
+# - https://docs.microsoft.com/en-us/windows/console/getconsolemode
+# - https://docs.microsoft.com/en-us/windows/console/setconsolemode
+kernel32 = WinDLL("kernel32", use_last_error=True)
+kernel32.GetConsoleMode.errcheck = _check_zero
+kernel32.GetConsoleMode.argtypes = (HANDLE, LPDWORD)
+kernel32.SetConsoleMode.errcheck = _check_zero
+kernel32.SetConsoleMode.argtypes = (HANDLE, DWORD)
+
+
+def _get_conout_mode():
+    with open("CONOUT$", "w") as conout:
+        mode = DWORD()
+        conout_handle = get_osfhandle(conout.fileno())
+        kernel32.GetConsoleMode(conout_handle, byref(mode))
+        return mode.value
+
+
+def _set_conout_mode(mode):
+    with open("CONOUT$", "w") as conout:
+        conout_handle = get_osfhandle(conout.fileno())
+        kernel32.SetConsoleMode(conout_handle, mode)
+
+
+def _get_conin_mode():
+    with open("CONIN$", "r") as conin:
+        mode = DWORD()
+        conin_handle = get_osfhandle(conin.fileno())
+        kernel32.GetConsoleMode(conin_handle, byref(mode))
+        return mode.value
+
+
+def _set_conin_mode(mode):
+    with open("CONIN$", "r") as conin:
+        conin_handle = get_osfhandle(conin.fileno())
+        kernel32.SetConsoleMode(conin_handle, mode)
+
+
+def _update_conout_mode():
+    old_mode = _get_conout_mode()
+    logger.debug("conout old: %i", old_mode)
+    mode = old_mode | ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT |\
+        ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN  # pylint: disable=unsupported-binary-operation
+    logger.debug("conout new: %i", mode)
+    _set_conout_mode(mode)
+
+
+def _update_conin_mode():
+    old_mode = _get_conin_mode()
+    logger.debug("conin old: %i", old_mode)
+    mode = old_mode | ENABLE_VIRTUAL_TERMINAL_INPUT  # pylint: disable=unsupported-binary-operation
+    logger.debug("conin new: %i", mode)
+    _set_conin_mode(mode)
+
+
+def enable_vt_mode():
+    """Enables virtual terminal mode for Windows 10 console.
+    Windows 10 supports VT (virtual terminal) / ANSI escape sequences since version 1607.
+    cmd.exe enables VT mode, but only for itself. It disables VT mode before starting other programs,
+    and also at shutdown (See: https://bugs.python.org/issue30075).
+    """
+    try:
+        _update_conout_mode()
+        _update_conin_mode()
+    except OSError as e:
+        if e.errno == ERROR_INVALID_PARAMETER:
+            logger.debug("Unable to enable virtual terminal processing for legacy Windows terminal.")
+        else:
+            logger.debug("Unable to enable virtual terminal processing: %s.", e.errno)

--- a/src/azure-cli/azure/cli/command_modules/container/_vt_helper.py
+++ b/src/azure-cli/azure/cli/command_modules/container/_vt_helper.py
@@ -18,6 +18,7 @@ ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
 DISABLE_NEWLINE_AUTO_RETURN = 0x0008
 ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200
 
+
 def _check_zero(result, _, args):
     if not result:
         raise OSError(get_last_error())

--- a/src/azure-cli/azure/cli/command_modules/container/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/container/custom.py
@@ -20,7 +20,6 @@ import sys
 import threading
 import time
 try:
-    import fcntl
     import termios
     import tty
 except ImportError:
@@ -48,6 +47,7 @@ AZURE_FILE_VOLUME_NAME = 'azurefile'
 SECRETS_VOLUME_NAME = 'secrets'
 GITREPO_VOLUME_NAME = 'gitrepo'
 MSI_LOCAL_ID = '[system]'
+
 
 def list_containers(client, resource_group_name=None):
     """List all container groups in a resource group. """
@@ -635,6 +635,7 @@ def _start_exec_pipe_windows(web_socket_uri, password):
     enable_vt_mode()
     buff = bytearray()
     lock = threading.Lock()
+
     def _on_ws_open_windows(ws):
         ws.send(password)
         readKeyboard = threading.Thread(target=_capture_stdin, args=[_getch_windows, buff, lock], daemon=True)
@@ -650,7 +651,7 @@ def _start_exec_pipe_windows(web_socket_uri, password):
             time.sleep(0.01)
         except KeyboardInterrupt:
             try:
-                ws.send(b'\x03')# CTRL-C character (ETX character)
+                ws.send(b'\x03')  # CTRL-C character (ETX character)
             finally:
                 pass
     colorama.reinit()
@@ -664,6 +665,7 @@ def _start_exec_pipe_linux(web_socket_uri, password):
     tty.setcbreak(stdin_fd)
     buff = bytearray()
     lock = threading.Lock()
+
     def _on_ws_open_linux(ws):
         ws.send(password)
         readKeyboard = threading.Thread(target=_capture_stdin, args=[_getch_linux, buff, lock], daemon=True)
@@ -707,11 +709,11 @@ def _flush_stdin(ws, buff, lock):
             x = bytes(buff)
             buff.clear()
             lock.release()
-            ws.send(x, opcode=0x2) # OPCODE_BINARY = 0x2
+            ws.send(x, opcode=0x2)  # OPCODE_BINARY = 0x2
         except (OSError, IOError, websocket.WebSocketConnectionClosedException) as e:
             if isinstance(e, websocket.WebSocketConnectionClosedException):
                 pass
-            elif e.errno == 9: # [Errno 9] Bad file descriptor
+            elif e.errno == 9:  # [Errno 9] Bad file descriptor
                 pass
             elif e.args and e.args[0] == errno.EINTR:
                 pass


### PR DESCRIPTION
**Description**
There were a few issues with the container exec experience:
1. terminal characters where not being handled correctly. I have added enabling virtual terminal mode to fix this.
2. on windows handling of bytes type messages ran into exceptions. use the stdout.buffer to be able to write bytes directly instead of decoding to str.
3. the logic between linux and windows was too different. Converge on a similar model for both linux and windows.
4. arrow keys and ctrl+c did not work on windows. This is fixed now


**Testing Guide**
az container exec -n {cgname} -g {rgname} --exec-command {/bin/bash or /bin/sh or cmd or pwsh}
Run exec sessions with different images (both linux and windows) and see if the terminal window behaves ok
Arrow keys and ctrl+c should also work in both linux and windows

I don't own a Mac device so wasn't able to validate the changes there

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
