### PR TITLE
[ARM] `az deployment group/sub/mg/tenant create`: Add `--what-if` and `--proceed-if-no-change` parameters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -62,11 +62,11 @@ def load_arguments(self, _):
                                 'When the value is true, the prompt requiring users to provide missing parameter will be ignored. The default value is false.')
 
     deployment_what_if_type = CLIArgumentType(options_list=['--what-if', '-w'], action='store_true',
-                                                           help='Instruct the command to run deployment What-If.',
-                                                           min_api='2019-07-01')
+                                              help='Instruct the command to run deployment What-If.',
+                                              min_api='2019-07-01')
     deployment_what_if_proceed_if_no_change_type = CLIArgumentType(options_list=['--proceed-if-no-change'], action='store_true',
-                                                           help='Instruct the command to execute the deployment if the What-If result contains no resource changes. Applicable when --confirm-with-what-if is set.',
-                                                           min_api='2019-07-01')
+                                                                   help='Instruct the command to execute the deployment if the What-If result contains no resource changes. Applicable when --confirm-with-what-if is set.',
+                                                                   min_api='2019-07-01')
     deployment_what_if_result_format_type = CLIArgumentType(options_list=['--result-format', '-r'],
                                                             arg_type=get_enum_type(WhatIfResultFormat, "FullResourcePayloads"),
                                                             min_api='2019-07-01')

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -61,6 +61,12 @@ def load_arguments(self, _):
     no_prompt = CLIArgumentType(arg_type=get_three_state_flag(), help='The option to disable the prompt of missing parameters for ARM template. '
                                 'When the value is true, the prompt requiring users to provide missing parameter will be ignored. The default value is false.')
 
+    deployment_what_if_type = CLIArgumentType(options_list=['--what-if', '-w'], action='store_true',
+                                                           help='Instruct the command to run deployment What-If.',
+                                                           min_api='2019-07-01')
+    deployment_what_if_proceed_if_no_change_type = CLIArgumentType(options_list=['--proceed-if-no-change'], action='store_true',
+                                                           help='Instruct the command to execute the deployment if the What-If result contains no resource changes. Applicable when --confirm-with-what-if is set.',
+                                                           min_api='2019-07-01')
     deployment_what_if_result_format_type = CLIArgumentType(options_list=['--result-format', '-r'],
                                                             arg_type=get_enum_type(WhatIfResultFormat, "FullResourcePayloads"),
                                                             min_api='2019-07-01')
@@ -304,6 +310,8 @@ def load_arguments(self, _):
         c.argument('what_if_exclude_change_types', options_list=['--what-if-exclude-change-types', '-x'],
                    arg_type=deployment_what_if_exclude_change_types_type,
                    help="Space-separated list of resource change types to be excluded from What-If results. Applicable when --confirm-with-what-if is set.")
+        c.argument('what_if', arg_type=deployment_what_if_type)
+        c.argument('proceed_if_no_change', arg_type=deployment_what_if_proceed_if_no_change_type)
 
     with self.argument_context('deployment validate') as c:
         c.argument('deployment_name', arg_type=deployment_create_name_type)
@@ -331,6 +339,8 @@ def load_arguments(self, _):
         c.argument('what_if_exclude_change_types', options_list=['--what-if-exclude-change-types', '-x'],
                    arg_type=deployment_what_if_exclude_change_types_type,
                    help="Space-separated list of resource change types to be excluded from What-If results. Applicable when --confirm-with-what-if is set.")
+        c.argument('what_if', arg_type=deployment_what_if_type)
+        c.argument('proceed_if_no_change', arg_type=deployment_what_if_proceed_if_no_change_type)
 
     with self.argument_context('deployment sub what-if') as c:
         c.argument('deployment_name', arg_type=deployment_create_name_type)
@@ -370,6 +380,8 @@ def load_arguments(self, _):
         c.argument('what_if_exclude_change_types', options_list=['--what-if-exclude-change-types', '-x'],
                    arg_type=deployment_what_if_exclude_change_types_type,
                    help="Space-separated list of resource change types to be excluded from What-If results. Applicable when --confirm-with-what-if is set.")
+        c.argument('what_if', arg_type=deployment_what_if_type)
+        c.argument('proceed_if_no_change', arg_type=deployment_what_if_proceed_if_no_change_type)
 
     with self.argument_context('deployment group what-if') as c:
         c.argument('deployment_name', arg_type=deployment_create_name_type)
@@ -406,6 +418,8 @@ def load_arguments(self, _):
                    arg_type=deployment_what_if_exclude_change_types_type,
                    help="Space-separated list of resource change types to be excluded from What-If results. Applicable when --confirm-with-what-if is set.",
                    min_api="2019-10-01")
+        c.argument('what_if', arg_type=deployment_what_if_type)
+        c.argument('proceed_if_no_change', arg_type=deployment_what_if_proceed_if_no_change_type)
 
     with self.argument_context('deployment mg what-if') as c:
         c.argument('deployment_name', arg_type=deployment_create_name_type)
@@ -441,6 +455,8 @@ def load_arguments(self, _):
                    arg_type=deployment_what_if_exclude_change_types_type,
                    help="Space-separated list of resource change types to be excluded from What-If results. Applicable when --confirm-with-what-if is set.",
                    min_api="2019-10-01")
+        c.argument('what_if', arg_type=deployment_what_if_type)
+        c.argument('proceed_if_no_change', arg_type=deployment_what_if_proceed_if_no_change_type)
 
     with self.argument_context('deployment tenant what-if') as c:
         c.argument('deployment_name', arg_type=deployment_create_name_type)

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -429,14 +429,14 @@ def deploy_arm_template_at_subscription_scope(cmd,
                                               what_if_exclude_change_types=None, template_spec=None, query_string=None,
                                               what_if=None, proceed_if_no_change=None):
     if confirm_with_what_if or what_if:
-        what_if_result = what_if_deploy_arm_template_at_subscription_scope(cmd,
-                                                                           template_file=template_file, template_uri=template_uri,
-                                                                           parameters=parameters, deployment_name=deployment_name,
-                                                                           deployment_location=deployment_location,
-                                                                           result_format=what_if_result_format,
-                                                                           exclude_change_types=what_if_exclude_change_types,
-                                                                           no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
-                                                                           return_result=True)
+        what_if_result = _what_if_deploy_arm_template_at_subscription_scope_core(cmd,
+                                                                                 template_file=template_file, template_uri=template_uri,
+                                                                                 parameters=parameters, deployment_name=deployment_name,
+                                                                                 deployment_location=deployment_location,
+                                                                                 result_format=what_if_result_format,
+                                                                                 exclude_change_types=what_if_exclude_change_types,
+                                                                                 no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
+                                                                                 return_result=True)
         if what_if:
             return None
 
@@ -513,14 +513,14 @@ def deploy_arm_template_at_resource_group(cmd,
                                           what_if_exclude_change_types=None, template_spec=None, query_string=None,
                                           what_if=None, proceed_if_no_change=None):
     if confirm_with_what_if or what_if:
-        what_if_result = what_if_deploy_arm_template_at_resource_group(cmd,
-                                                                       resource_group_name=resource_group_name,
-                                                                       template_file=template_file, template_uri=template_uri,
-                                                                       parameters=parameters, deployment_name=deployment_name, mode=mode,
-                                                                       aux_tenants=aux_tenants, result_format=what_if_result_format,
-                                                                       exclude_change_types=what_if_exclude_change_types,
-                                                                       no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
-                                                                       return_result=True)
+        what_if_result = _what_if_deploy_arm_template_at_resource_group_core(cmd,
+                                                                             resource_group_name=resource_group_name,
+                                                                             template_file=template_file, template_uri=template_uri,
+                                                                             parameters=parameters, deployment_name=deployment_name, mode=mode,
+                                                                             aux_tenants=aux_tenants, result_format=what_if_result_format,
+                                                                             exclude_change_types=what_if_exclude_change_types,
+                                                                             no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
+                                                                             return_result=True)
         if what_if:
             return None
 
@@ -601,16 +601,16 @@ def deploy_arm_template_at_management_group(cmd,
                                             confirm_with_what_if=None, what_if_result_format=None,
                                             what_if_exclude_change_types=None, template_spec=None, query_string=None,
                                             what_if=None, proceed_if_no_change=None):
-    if confirm_with_what_if:
-        what_if_result = what_if_deploy_arm_template_at_management_group(cmd,
-                                                                         management_group_id=management_group_id,
-                                                                         template_file=template_file, template_uri=template_uri,
-                                                                         parameters=parameters, deployment_name=deployment_name,
-                                                                         deployment_location=deployment_location,
-                                                                         result_format=what_if_result_format,
-                                                                         exclude_change_types=what_if_exclude_change_types,
-                                                                         no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
-                                                                         return_result=True)
+    if confirm_with_what_if or what_if:
+        what_if_result = _what_if_deploy_arm_template_at_management_group_core(cmd,
+                                                                               management_group_id=management_group_id,
+                                                                               template_file=template_file, template_uri=template_uri,
+                                                                               parameters=parameters, deployment_name=deployment_name,
+                                                                               deployment_location=deployment_location,
+                                                                               result_format=what_if_result_format,
+                                                                               exclude_change_types=what_if_exclude_change_types,
+                                                                               no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
+                                                                               return_result=True)
         if what_if:
             return None
 
@@ -690,15 +690,15 @@ def deploy_arm_template_at_tenant_scope(cmd,
                                         confirm_with_what_if=None, what_if_result_format=None,
                                         what_if_exclude_change_types=None, template_spec=None, query_string=None,
                                         what_if=None, proceed_if_no_change=None):
-    if confirm_with_what_if:
-        what_if_result = what_if_deploy_arm_template_at_tenant_scope(cmd,
-                                                                     template_file=template_file, template_uri=template_uri,
-                                                                     parameters=parameters, deployment_name=deployment_name,
-                                                                     deployment_location=deployment_location,
-                                                                     result_format=what_if_result_format,
-                                                                     exclude_change_types=what_if_exclude_change_types,
-                                                                     no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
-                                                                     return_result=True)
+    if confirm_with_what_if or what_if:
+        what_if_result = _what_if_deploy_arm_template_at_tenant_scope_core(cmd,
+                                                                           template_file=template_file, template_uri=template_uri,
+                                                                           parameters=parameters, deployment_name=deployment_name,
+                                                                           deployment_location=deployment_location,
+                                                                           result_format=what_if_result_format,
+                                                                           exclude_change_types=what_if_exclude_change_types,
+                                                                           no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
+                                                                           return_result=True)
         if what_if:
             return None
 
@@ -769,8 +769,22 @@ def what_if_deploy_arm_template_at_resource_group(cmd, resource_group_name,
                                                   deployment_name=None, mode=DeploymentMode.incremental,
                                                   aux_tenants=None, result_format=None,
                                                   no_pretty_print=None, no_prompt=False,
-                                                  exclude_change_types=None, template_spec=None, query_string=None,
-                                                  return_result=None):
+                                                  exclude_change_types=None, template_spec=None, query_string=None):
+    return _what_if_deploy_arm_template_at_resource_group_core(cmd, resource_group_name,
+                                                               template_file, template_uri, parameters,
+                                                               deployment_name, DeploymentMode.incremental,
+                                                               aux_tenants, result_format,
+                                                               no_pretty_print, no_prompt,
+                                                               exclude_change_types, template_spec, query_string)
+
+
+def _what_if_deploy_arm_template_at_resource_group_core(cmd, resource_group_name,
+                                                        template_file=None, template_uri=None, parameters=None,
+                                                        deployment_name=None, mode=DeploymentMode.incremental,
+                                                        aux_tenants=None, result_format=None,
+                                                        no_pretty_print=None, no_prompt=False,
+                                                        exclude_change_types=None, template_spec=None, query_string=None,
+                                                        return_result=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, 'resourceGroup', template_file, template_uri,
                                                                 parameters, mode, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, aux_tenants=aux_tenants,
@@ -788,8 +802,20 @@ def what_if_deploy_arm_template_at_subscription_scope(cmd,
                                                       template_file=None, template_uri=None, parameters=None,
                                                       deployment_name=None, deployment_location=None,
                                                       result_format=None, no_pretty_print=None, no_prompt=False,
-                                                      exclude_change_types=None, template_spec=None, query_string=None,
-                                                      return_result=None):
+                                                      exclude_change_types=None, template_spec=None, query_string=None):
+    return _what_if_deploy_arm_template_at_subscription_scope_core(cmd,
+                                                                   template_file, template_uri, parameters,
+                                                                   deployment_name, deployment_location,
+                                                                   result_format, no_pretty_print, no_prompt,
+                                                                   exclude_change_types, template_spec, query_string)
+
+
+def _what_if_deploy_arm_template_at_subscription_scope_core(cmd,
+                                                            template_file=None, template_uri=None, parameters=None,
+                                                            deployment_name=None, deployment_location=None,
+                                                            result_format=None, no_pretty_print=None, no_prompt=False,
+                                                            exclude_change_types=None, template_spec=None, query_string=None,
+                                                            return_result=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, 'subscription', template_file, template_uri, parameters,
                                                                 DeploymentMode.incremental, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
@@ -806,8 +832,20 @@ def what_if_deploy_arm_template_at_management_group(cmd, management_group_id=Non
                                                     template_file=None, template_uri=None, parameters=None,
                                                     deployment_name=None, deployment_location=None,
                                                     result_format=None, no_pretty_print=None, no_prompt=False,
-                                                    exclude_change_types=None, template_spec=None, query_string=None,
-                                                    return_result=None):
+                                                    exclude_change_types=None, template_spec=None, query_string=None):
+    return _what_if_deploy_arm_template_at_management_group_core(cmd, management_group_id,
+                                                                 template_file, template_uri, parameters,
+                                                                 deployment_name, deployment_location,
+                                                                 result_format, no_pretty_print, no_prompt,
+                                                                 exclude_change_types, template_spec, query_string)
+
+
+def _what_if_deploy_arm_template_at_management_group_core(cmd, management_group_id=None,
+                                                          template_file=None, template_uri=None, parameters=None,
+                                                          deployment_name=None, deployment_location=None,
+                                                          result_format=None, no_pretty_print=None, no_prompt=False,
+                                                          exclude_change_types=None, template_spec=None, query_string=None,
+                                                          return_result=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, 'managementGroup', template_file, template_uri, parameters,
                                                                 DeploymentMode.incremental, result_format, no_prompt, template_spec=template_spec, query_string=query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
@@ -824,8 +862,20 @@ def what_if_deploy_arm_template_at_tenant_scope(cmd,
                                                 template_file=None, template_uri=None, parameters=None,
                                                 deployment_name=None, deployment_location=None,
                                                 result_format=None, no_pretty_print=None, no_prompt=False,
-                                                exclude_change_types=None, template_spec=None, query_string=None,
-                                                return_result=None):
+                                                exclude_change_types=None, template_spec=None, query_string=None):
+    return _what_if_deploy_arm_template_at_tenant_scope_core(cmd,
+                                                             template_file, template_uri, parameters,
+                                                             deployment_name, deployment_location,
+                                                             result_format, no_pretty_print, no_prompt,
+                                                             exclude_change_types, template_spec, query_string)
+
+
+def _what_if_deploy_arm_template_at_tenant_scope_core(cmd,
+                                                      template_file=None, template_uri=None, parameters=None,
+                                                      deployment_name=None, deployment_location=None,
+                                                      result_format=None, no_pretty_print=None, no_prompt=False,
+                                                      exclude_change_types=None, template_spec=None, query_string=None,
+                                                      return_result=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, 'tenant', template_file, template_uri, parameters,
                                                                 DeploymentMode.incremental, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -426,19 +426,28 @@ def deploy_arm_template_at_subscription_scope(cmd,
                                               deployment_name=None, deployment_location=None,
                                               no_wait=False, handle_extended_json_format=None, no_prompt=False,
                                               confirm_with_what_if=None, what_if_result_format=None,
-                                              what_if_exclude_change_types=None, template_spec=None, query_string=None):
-    if confirm_with_what_if:
-        what_if_deploy_arm_template_at_subscription_scope(cmd,
-                                                          template_file=template_file, template_uri=template_uri,
-                                                          parameters=parameters, deployment_name=deployment_name,
-                                                          deployment_location=deployment_location,
-                                                          result_format=what_if_result_format,
-                                                          exclude_change_types=what_if_exclude_change_types,
-                                                          no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
-        from knack.prompting import prompt_y_n
-
-        if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
+                                              what_if_exclude_change_types=None, template_spec=None, query_string=None,
+                                              what_if=None, proceed_if_no_change=None):
+    if confirm_with_what_if or what_if:
+        what_if_result = what_if_deploy_arm_template_at_subscription_scope(cmd,
+                                                                           template_file=template_file, template_uri=template_uri,
+                                                                           parameters=parameters, deployment_name=deployment_name,
+                                                                           deployment_location=deployment_location,
+                                                                           result_format=what_if_result_format,
+                                                                           exclude_change_types=what_if_exclude_change_types,
+                                                                           no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
+                                                                           return_result=True)
+        if what_if:
             return None
+
+        ChangeType = cmd.get_models('ChangeType')
+        has_change = any(change.change_type not in [ChangeType.no_change, ChangeType.ignore] for change in what_if_result.changes)
+
+        if not proceed_if_no_change or has_change:
+            from knack.prompting import prompt_y_n
+
+            if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
+                return None
 
     return _deploy_arm_template_at_subscription_scope(cmd=cmd,
                                                       template_file=template_file, template_uri=template_uri, parameters=parameters,
@@ -501,19 +510,28 @@ def deploy_arm_template_at_resource_group(cmd,
                                           no_wait=False, handle_extended_json_format=None,
                                           aux_subscriptions=None, aux_tenants=None, no_prompt=False,
                                           confirm_with_what_if=None, what_if_result_format=None,
-                                          what_if_exclude_change_types=None, template_spec=None, query_string=None):
-    if confirm_with_what_if:
-        what_if_deploy_arm_template_at_resource_group(cmd,
-                                                      resource_group_name=resource_group_name,
-                                                      template_file=template_file, template_uri=template_uri,
-                                                      parameters=parameters, deployment_name=deployment_name, mode=mode,
-                                                      aux_tenants=aux_tenants, result_format=what_if_result_format,
-                                                      exclude_change_types=what_if_exclude_change_types,
-                                                      no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
-        from knack.prompting import prompt_y_n
-
-        if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
+                                          what_if_exclude_change_types=None, template_spec=None, query_string=None,
+                                          what_if=None, proceed_if_no_change=None):
+    if confirm_with_what_if or what_if:
+        what_if_result = what_if_deploy_arm_template_at_resource_group(cmd,
+                                                                       resource_group_name=resource_group_name,
+                                                                       template_file=template_file, template_uri=template_uri,
+                                                                       parameters=parameters, deployment_name=deployment_name, mode=mode,
+                                                                       aux_tenants=aux_tenants, result_format=what_if_result_format,
+                                                                       exclude_change_types=what_if_exclude_change_types,
+                                                                       no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
+                                                                       return_result=True)
+        if what_if:
             return None
+
+        ChangeType = cmd.get_models('ChangeType')
+        has_change = any(change.change_type not in [ChangeType.no_change, ChangeType.ignore] for change in what_if_result.changes)
+
+        if not proceed_if_no_change or has_change:
+            from knack.prompting import prompt_y_n
+
+            if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
+                return None
 
     return _deploy_arm_template_at_resource_group(cmd=cmd,
                                                   resource_group_name=resource_group_name,
@@ -581,20 +599,29 @@ def deploy_arm_template_at_management_group(cmd,
                                             deployment_name=None, deployment_location=None,
                                             no_wait=False, handle_extended_json_format=None, no_prompt=False,
                                             confirm_with_what_if=None, what_if_result_format=None,
-                                            what_if_exclude_change_types=None, template_spec=None, query_string=None):
+                                            what_if_exclude_change_types=None, template_spec=None, query_string=None,
+                                            what_if=None, proceed_if_no_change=None):
     if confirm_with_what_if:
-        what_if_deploy_arm_template_at_management_group(cmd,
-                                                        management_group_id=management_group_id,
-                                                        template_file=template_file, template_uri=template_uri,
-                                                        parameters=parameters, deployment_name=deployment_name,
-                                                        deployment_location=deployment_location,
-                                                        result_format=what_if_result_format,
-                                                        exclude_change_types=what_if_exclude_change_types,
-                                                        no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
-        from knack.prompting import prompt_y_n
-
-        if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
+        what_if_result = what_if_deploy_arm_template_at_management_group(cmd,
+                                                                         management_group_id=management_group_id,
+                                                                         template_file=template_file, template_uri=template_uri,
+                                                                         parameters=parameters, deployment_name=deployment_name,
+                                                                         deployment_location=deployment_location,
+                                                                         result_format=what_if_result_format,
+                                                                         exclude_change_types=what_if_exclude_change_types,
+                                                                         no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
+                                                                         return_result=True)
+        if what_if:
             return None
+
+        ChangeType = cmd.get_models('ChangeType')
+        has_change = any(change.change_type not in [ChangeType.no_change, ChangeType.ignore] for change in what_if_result.changes)
+
+        if not proceed_if_no_change or has_change:
+            from knack.prompting import prompt_y_n
+
+            if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
+                return None
 
     return _deploy_arm_template_at_management_group(cmd=cmd,
                                                     management_group_id=management_group_id,
@@ -661,19 +688,28 @@ def deploy_arm_template_at_tenant_scope(cmd,
                                         deployment_name=None, deployment_location=None,
                                         no_wait=False, handle_extended_json_format=None, no_prompt=False,
                                         confirm_with_what_if=None, what_if_result_format=None,
-                                        what_if_exclude_change_types=None, template_spec=None, query_string=None):
+                                        what_if_exclude_change_types=None, template_spec=None, query_string=None,
+                                        what_if=None, proceed_if_no_change=None):
     if confirm_with_what_if:
-        what_if_deploy_arm_template_at_tenant_scope(cmd,
-                                                    template_file=template_file, template_uri=template_uri,
-                                                    parameters=parameters, deployment_name=deployment_name,
-                                                    deployment_location=deployment_location,
-                                                    result_format=what_if_result_format,
-                                                    exclude_change_types=what_if_exclude_change_types,
-                                                    no_prompt=no_prompt, template_spec=template_spec, query_string=query_string)
-        from knack.prompting import prompt_y_n
-
-        if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
+        what_if_result = what_if_deploy_arm_template_at_tenant_scope(cmd,
+                                                                     template_file=template_file, template_uri=template_uri,
+                                                                     parameters=parameters, deployment_name=deployment_name,
+                                                                     deployment_location=deployment_location,
+                                                                     result_format=what_if_result_format,
+                                                                     exclude_change_types=what_if_exclude_change_types,
+                                                                     no_prompt=no_prompt, template_spec=template_spec, query_string=query_string,
+                                                                     return_result=True)
+        if what_if:
             return None
+
+        ChangeType = cmd.get_models('ChangeType')
+        has_change = any(change.change_type not in [ChangeType.no_change, ChangeType.ignore] for change in what_if_result.changes)
+
+        if not proceed_if_no_change or has_change:
+            from knack.prompting import prompt_y_n
+
+            if not prompt_y_n("\nAre you sure you want to execute the deployment?"):
+                return None
 
     return _deploy_arm_template_at_tenant_scope(cmd=cmd,
                                                 template_file=template_file, template_uri=template_uri, parameters=parameters,
@@ -733,7 +769,8 @@ def what_if_deploy_arm_template_at_resource_group(cmd, resource_group_name,
                                                   deployment_name=None, mode=DeploymentMode.incremental,
                                                   aux_tenants=None, result_format=None,
                                                   no_pretty_print=None, no_prompt=False,
-                                                  exclude_change_types=None, template_spec=None, query_string=None):
+                                                  exclude_change_types=None, template_spec=None, query_string=None,
+                                                  return_result=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, 'resourceGroup', template_file, template_uri,
                                                                 parameters, mode, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, aux_tenants=aux_tenants,
@@ -742,15 +779,17 @@ def what_if_deploy_arm_template_at_resource_group(cmd, resource_group_name,
     deployment_what_if = DeploymentWhatIf(properties=what_if_properties)
     what_if_poller = mgmt_client.begin_what_if(resource_group_name, deployment_name,
                                                parameters=deployment_what_if)
+    what_if_result = _what_if_deploy_arm_template_core(cmd.cli_ctx, what_if_poller, no_pretty_print, exclude_change_types)
 
-    return _what_if_deploy_arm_template_core(cmd.cli_ctx, what_if_poller, no_pretty_print, exclude_change_types)
+    return what_if_result if no_pretty_print or return_result else None
 
 
 def what_if_deploy_arm_template_at_subscription_scope(cmd,
                                                       template_file=None, template_uri=None, parameters=None,
                                                       deployment_name=None, deployment_location=None,
                                                       result_format=None, no_pretty_print=None, no_prompt=False,
-                                                      exclude_change_types=None, template_spec=None, query_string=None):
+                                                      exclude_change_types=None, template_spec=None, query_string=None,
+                                                      return_result=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, 'subscription', template_file, template_uri, parameters,
                                                                 DeploymentMode.incremental, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
@@ -758,15 +797,17 @@ def what_if_deploy_arm_template_at_subscription_scope(cmd,
     scoped_deployment_what_if = ScopedDeploymentWhatIf(location=deployment_location, properties=what_if_properties)
     what_if_poller = mgmt_client.begin_what_if_at_subscription_scope(deployment_name,
                                                                      parameters=scoped_deployment_what_if)
+    what_if_result = _what_if_deploy_arm_template_core(cmd.cli_ctx, what_if_poller, no_pretty_print, exclude_change_types)
 
-    return _what_if_deploy_arm_template_core(cmd.cli_ctx, what_if_poller, no_pretty_print, exclude_change_types)
+    return what_if_result if no_pretty_print or return_result else None
 
 
 def what_if_deploy_arm_template_at_management_group(cmd, management_group_id=None,
                                                     template_file=None, template_uri=None, parameters=None,
                                                     deployment_name=None, deployment_location=None,
                                                     result_format=None, no_pretty_print=None, no_prompt=False,
-                                                    exclude_change_types=None, template_spec=None, query_string=None):
+                                                    exclude_change_types=None, template_spec=None, query_string=None,
+                                                    return_result=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, 'managementGroup', template_file, template_uri, parameters,
                                                                 DeploymentMode.incremental, result_format, no_prompt, template_spec=template_spec, query_string=query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
@@ -774,23 +815,26 @@ def what_if_deploy_arm_template_at_management_group(cmd, management_group_id=Non
     scoped_deployment_what_if = ScopedDeploymentWhatIf(location=deployment_location, properties=what_if_properties)
     what_if_poller = mgmt_client.begin_what_if_at_management_group_scope(management_group_id, deployment_name,
                                                                          parameters=scoped_deployment_what_if)
+    what_if_result = _what_if_deploy_arm_template_core(cmd.cli_ctx, what_if_poller, no_pretty_print, exclude_change_types)
 
-    return _what_if_deploy_arm_template_core(cmd.cli_ctx, what_if_poller, no_pretty_print, exclude_change_types)
+    return what_if_result if no_pretty_print or return_result else None
 
 
 def what_if_deploy_arm_template_at_tenant_scope(cmd,
                                                 template_file=None, template_uri=None, parameters=None,
                                                 deployment_name=None, deployment_location=None,
                                                 result_format=None, no_pretty_print=None, no_prompt=False,
-                                                exclude_change_types=None, template_spec=None, query_string=None):
+                                                exclude_change_types=None, template_spec=None, query_string=None,
+                                                return_result=None):
     what_if_properties = _prepare_deployment_what_if_properties(cmd, 'tenant', template_file, template_uri, parameters,
                                                                 DeploymentMode.incremental, result_format, no_prompt, template_spec, query_string)
     mgmt_client = _get_deployment_management_client(cmd.cli_ctx, plug_pipeline=(template_uri is None and template_spec is None))
     ScopedDeploymentWhatIf = cmd.get_models('ScopedDeploymentWhatIf')
     scoped_deployment_what_if = ScopedDeploymentWhatIf(location=deployment_location, properties=what_if_properties)
     what_if_poller = mgmt_client.begin_what_if_at_tenant_scope(deployment_name, parameters=scoped_deployment_what_if)
+    what_if_result = _what_if_deploy_arm_template_core(cmd.cli_ctx, what_if_poller, no_pretty_print, exclude_change_types)
 
-    return _what_if_deploy_arm_template_core(cmd.cli_ctx, what_if_poller, no_pretty_print, exclude_change_types)
+    return what_if_result if no_pretty_print or return_result else None
 
 
 def _what_if_deploy_arm_template_core(cli_ctx, what_if_poller, no_pretty_print, exclude_change_types):
@@ -830,7 +874,7 @@ def _what_if_deploy_arm_template_core(cli_ctx, what_if_poller, no_pretty_print, 
             from colorama import init
             init()
 
-    return None
+    return what_if_result
 
 
 def _build_preflight_error_message(preflight_error):

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -358,7 +358,7 @@ class TestCustom(unittest.TestCase):
         self.assertTrue(str(list(results.keys())) in param_alpha_order)
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_resource_group", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_resource_group_core", autospec=True)
     def test_confirm_with_what_if_prompt_at_resource_group(self, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
         prompt_y_n_mock.return_value = False
@@ -369,7 +369,7 @@ class TestCustom(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_resource_group", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_resource_group_core", autospec=True)
     def test_proceed_if_no_change_prompt_at_resource_group(self, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
         what_if_command_mock.return_value = WhatIfOperationResult(changes=[
@@ -384,7 +384,7 @@ class TestCustom(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_resource_group", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_resource_group_core", autospec=True)
     @mock.patch("azure.cli.command_modules.resource.custom._deploy_arm_template_at_resource_group", autospec=True)
     def test_proceed_if_no_change_skip_prompt_at_resource_group(self, deploy_template_mock, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
@@ -399,7 +399,7 @@ class TestCustom(unittest.TestCase):
         deploy_template_mock.assert_called_once()
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_subscription_scope", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_subscription_scope_core", autospec=True)
     def test_confirm_with_what_if_prompt_at_subscription_scope(self, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
         prompt_y_n_mock.return_value = False
@@ -410,7 +410,7 @@ class TestCustom(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_subscription_scope", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_subscription_scope_core", autospec=True)
     def test_proceed_if_no_change_prompt_at_subscription_scope(self, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
         what_if_command_mock.return_value = WhatIfOperationResult(changes=[
@@ -425,7 +425,7 @@ class TestCustom(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_subscription_scope", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_subscription_scope_core", autospec=True)
     @mock.patch("azure.cli.command_modules.resource.custom._deploy_arm_template_at_subscription_scope", autospec=True)
     def test_proceed_if_no_change_skip_prompt_at_subscription_scope(self, deploy_template_mock, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
@@ -440,7 +440,7 @@ class TestCustom(unittest.TestCase):
         deploy_template_mock.assert_called_once()
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_management_group", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_management_group_core", autospec=True)
     def test_confirm_with_what_if_prompt_at_management_group(self, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
         prompt_y_n_mock.return_value = False
@@ -451,7 +451,7 @@ class TestCustom(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_management_group", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_management_group_core", autospec=True)
     def test_proceed_if_no_change_prompt_at_management_group(self, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
         what_if_command_mock.return_value = WhatIfOperationResult(changes=[
@@ -466,7 +466,7 @@ class TestCustom(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_management_group", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_management_group_core", autospec=True)
     @mock.patch("azure.cli.command_modules.resource.custom._deploy_arm_template_at_management_group", autospec=True)
     def test_proceed_if_no_change_skip_prompt_at_management_group(self, deploy_template_mock, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
@@ -481,7 +481,7 @@ class TestCustom(unittest.TestCase):
         deploy_template_mock.assert_called_once()
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_tenant_scope", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_tenant_scope_core", autospec=True)
     def test_confirm_with_what_if_prompt_at_tenant_scope(self, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
         prompt_y_n_mock.return_value = False
@@ -492,7 +492,7 @@ class TestCustom(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_tenant_scope", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_tenant_scope_core", autospec=True)
     def test_proceed_if_no_change_prompt_at_tenant_scope(self, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
         what_if_command_mock.return_value = WhatIfOperationResult(changes=[
@@ -507,7 +507,7 @@ class TestCustom(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
-    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_tenant_scope", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._what_if_deploy_arm_template_at_tenant_scope_core", autospec=True)
     @mock.patch("azure.cli.command_modules.resource.custom._deploy_arm_template_at_tenant_scope", autospec=True)
     def test_proceed_if_no_change_skip_prompt_at_tenant_scope(self, deploy_template_mock, what_if_command_mock, prompt_y_n_mock):
         # Arrange.

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -31,6 +31,20 @@ from azure.cli.command_modules.resource.custom import (
     deploy_arm_template_at_tenant_scope,
 )
 
+from azure.cli.core.mock import DummyCli
+from azure.cli.core import AzCommandsLoader
+from azure.cli.core.commands import AzCliCommand
+from azure.cli.core.profiles._shared import ResourceType
+
+cli_ctx = DummyCli()
+loader = AzCommandsLoader(cli_ctx, resource_type=ResourceType.MGMT_RESOURCE_RESOURCES)
+cmd = AzCliCommand(loader, 'test', None)
+cmd.command_kwargs = {'resource_type': ResourceType.MGMT_RESOURCE_RESOURCES}
+cmd.cli_ctx = cli_ctx
+
+WhatIfOperationResult, WhatIfChange, ChangeType = cmd.get_models(
+    'WhatIfOperationResult', 'WhatIfChange', 'ChangeType'
+)
 
 def _simulate_no_tty():
     from knack.prompting import NoTTYException
@@ -355,6 +369,36 @@ class TestCustom(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_resource_group", autospec=True)
+    def test_proceed_if_no_change_prompt_at_resource_group(self, what_if_command_mock, prompt_y_n_mock):
+        # Arrange.
+        what_if_command_mock.return_value = WhatIfOperationResult(changes=[
+            WhatIfChange(resource_id='resource1', change_type=ChangeType.modify),
+            WhatIfChange(resource_id='resource2', change_type=ChangeType.ignore),
+        ])
+        prompt_y_n_mock.return_value = False
+        # Act.
+        result = deploy_arm_template_at_resource_group(mock.MagicMock(), confirm_with_what_if=True, proceed_if_no_change=True)
+        # Assert.
+        prompt_y_n_mock.assert_called_once_with("\nAre you sure you want to execute the deployment?")
+        self.assertIsNone(result)
+
+    @mock.patch("knack.prompting.prompt_y_n", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_resource_group", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._deploy_arm_template_at_resource_group", autospec=True)
+    def test_proceed_if_no_change_skip_prompt_at_resource_group(self, deploy_template_mock, what_if_command_mock, prompt_y_n_mock):
+        # Arrange.
+        what_if_command_mock.return_value = WhatIfOperationResult(changes=[
+            WhatIfChange(resource_id='resource1', change_type=ChangeType.no_change),
+            WhatIfChange(resource_id='resource2', change_type=ChangeType.ignore),
+        ])
+        # Act.
+        deploy_arm_template_at_resource_group(cmd, mock.MagicMock(), confirm_with_what_if=True, proceed_if_no_change=True)
+        # Assert.
+        prompt_y_n_mock.assert_not_called()
+        deploy_template_mock.assert_called_once()
+
+    @mock.patch("knack.prompting.prompt_y_n", autospec=True)
     @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_subscription_scope", autospec=True)
     def test_confirm_with_what_if_prompt_at_subscription_scope(self, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
@@ -364,6 +408,36 @@ class TestCustom(unittest.TestCase):
         # Assert.
         prompt_y_n_mock.assert_called_once_with("\nAre you sure you want to execute the deployment?")
         self.assertIsNone(result)
+
+    @mock.patch("knack.prompting.prompt_y_n", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_subscription_scope", autospec=True)
+    def test_proceed_if_no_change_prompt_at_subscription_scope(self, what_if_command_mock, prompt_y_n_mock):
+        # Arrange.
+        what_if_command_mock.return_value = WhatIfOperationResult(changes=[
+            WhatIfChange(resource_id='resource1', change_type=ChangeType.modify),
+            WhatIfChange(resource_id='resource2', change_type=ChangeType.ignore),
+        ])
+        prompt_y_n_mock.return_value = False
+        # Act.
+        result = deploy_arm_template_at_subscription_scope(mock.MagicMock(), confirm_with_what_if=True, proceed_if_no_change=True)
+        # Assert.
+        prompt_y_n_mock.assert_called_once_with("\nAre you sure you want to execute the deployment?")
+        self.assertIsNone(result)
+
+    @mock.patch("knack.prompting.prompt_y_n", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_subscription_scope", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._deploy_arm_template_at_subscription_scope", autospec=True)
+    def test_proceed_if_no_change_skip_prompt_at_subscription_scope(self, deploy_template_mock, what_if_command_mock, prompt_y_n_mock):
+        # Arrange.
+        what_if_command_mock.return_value = WhatIfOperationResult(changes=[
+            WhatIfChange(resource_id='resource1', change_type=ChangeType.no_change),
+            WhatIfChange(resource_id='resource2', change_type=ChangeType.ignore),
+        ])
+        # Act.
+        deploy_arm_template_at_subscription_scope(cmd, mock.MagicMock(), confirm_with_what_if=True, proceed_if_no_change=True)
+        # Assert.
+        prompt_y_n_mock.assert_not_called()
+        deploy_template_mock.assert_called_once()
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
     @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_management_group", autospec=True)
@@ -377,6 +451,36 @@ class TestCustom(unittest.TestCase):
         self.assertIsNone(result)
 
     @mock.patch("knack.prompting.prompt_y_n", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_management_group", autospec=True)
+    def test_proceed_if_no_change_prompt_at_management_group(self, what_if_command_mock, prompt_y_n_mock):
+        # Arrange.
+        what_if_command_mock.return_value = WhatIfOperationResult(changes=[
+            WhatIfChange(resource_id='resource1', change_type=ChangeType.modify),
+            WhatIfChange(resource_id='resource2', change_type=ChangeType.ignore),
+        ])
+        prompt_y_n_mock.return_value = False
+        # Act.
+        result = deploy_arm_template_at_management_group(mock.MagicMock(), confirm_with_what_if=True, proceed_if_no_change=True)
+        # Assert.
+        prompt_y_n_mock.assert_called_once_with("\nAre you sure you want to execute the deployment?")
+        self.assertIsNone(result)
+
+    @mock.patch("knack.prompting.prompt_y_n", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_management_group", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._deploy_arm_template_at_management_group", autospec=True)
+    def test_proceed_if_no_change_skip_prompt_at_management_group(self, deploy_template_mock, what_if_command_mock, prompt_y_n_mock):
+        # Arrange.
+        what_if_command_mock.return_value = WhatIfOperationResult(changes=[
+            WhatIfChange(resource_id='resource1', change_type=ChangeType.no_change),
+            WhatIfChange(resource_id='resource2', change_type=ChangeType.ignore),
+        ])
+        # Act.
+        deploy_arm_template_at_management_group(cmd, mock.MagicMock(), confirm_with_what_if=True, proceed_if_no_change=True)
+        # Assert.
+        prompt_y_n_mock.assert_not_called()
+        deploy_template_mock.assert_called_once()
+
+    @mock.patch("knack.prompting.prompt_y_n", autospec=True)
     @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_tenant_scope", autospec=True)
     def test_confirm_with_what_if_prompt_at_tenant_scope(self, what_if_command_mock, prompt_y_n_mock):
         # Arrange.
@@ -387,24 +491,39 @@ class TestCustom(unittest.TestCase):
         prompt_y_n_mock.assert_called_once_with("\nAre you sure you want to execute the deployment?")
         self.assertIsNone(result)
 
+    @mock.patch("knack.prompting.prompt_y_n", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_tenant_scope", autospec=True)
+    def test_proceed_if_no_change_prompt_at_tenant_scope(self, what_if_command_mock, prompt_y_n_mock):
+        # Arrange.
+        what_if_command_mock.return_value = WhatIfOperationResult(changes=[
+            WhatIfChange(resource_id='resource1', change_type=ChangeType.modify),
+            WhatIfChange(resource_id='resource2', change_type=ChangeType.ignore),
+        ])
+        prompt_y_n_mock.return_value = False
+        # Act.
+        result = deploy_arm_template_at_tenant_scope(mock.MagicMock(), confirm_with_what_if=True, proceed_if_no_change=True)
+        # Assert.
+        prompt_y_n_mock.assert_called_once_with("\nAre you sure you want to execute the deployment?")
+        self.assertIsNone(result)
+
+    @mock.patch("knack.prompting.prompt_y_n", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom.what_if_deploy_arm_template_at_tenant_scope", autospec=True)
+    @mock.patch("azure.cli.command_modules.resource.custom._deploy_arm_template_at_tenant_scope", autospec=True)
+    def test_proceed_if_no_change_skip_prompt_at_tenant_scope(self, deploy_template_mock, what_if_command_mock, prompt_y_n_mock):
+        # Arrange.
+        what_if_command_mock.return_value = WhatIfOperationResult(changes=[
+            WhatIfChange(resource_id='resource1', change_type=ChangeType.no_change),
+            WhatIfChange(resource_id='resource2', change_type=ChangeType.ignore),
+        ])
+        # Act.
+        deploy_arm_template_at_tenant_scope(cmd, mock.MagicMock(), confirm_with_what_if=True, proceed_if_no_change=True)
+        # Assert.
+        prompt_y_n_mock.assert_not_called()
+        deploy_template_mock.assert_called_once()
+
     @mock.patch("azure.cli.command_modules.resource.custom.LongRunningOperation.__call__", autospec=True)
     def test_what_if_exclude_change_types(self, long_running_operation_stub):
         # Arrange.
-        from azure.cli.core.mock import DummyCli
-        from azure.cli.core import AzCommandsLoader
-        from azure.cli.core.commands import AzCliCommand
-        from azure.cli.core.profiles._shared import ResourceType
-
-        cli_ctx = DummyCli()
-        loader = AzCommandsLoader(cli_ctx, resource_type=ResourceType.MGMT_RESOURCE_RESOURCES)
-        cmd = AzCliCommand(loader, 'test', None)
-        cmd.command_kwargs = {'resource_type': ResourceType.MGMT_RESOURCE_RESOURCES}
-        cmd.cli_ctx = cli_ctx
-
-        WhatIfOperationResult, WhatIfChange, ChangeType = cmd.get_models(
-            'WhatIfOperationResult', 'WhatIfChange', 'ChangeType'
-        )
-
         long_running_operation_stub.return_value = WhatIfOperationResult(changes=[
             WhatIfChange(resource_id='resource0', change_type=ChangeType.create),
             WhatIfChange(resource_id='resource1', change_type=ChangeType.modify),


### PR DESCRIPTION
**Description**<!--Mandatory-->
Closes #18481.
Closes https://github.com/Azure/bicep/issues/2923

**Testing Guide**
```
az deployment sub -l westus -f ./deploy.json --what-if
az deployment sub -l westus -f ./deploy.json --confirm-with-what-if --proceed-if-no-change
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARM] az deployment group/sub/mg/tenant create: Add --what-if parameter for invoking What-If with the deployment create commands.
[ARM] az deployment group/sub/mg/tenant create: Add --proceed-if-no-change parameter to skip confirmation when --confirm-with-what-if is set and there's no changes in What-If results.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
