### PR TITLE
[Packaging] Add SOCKS Proxy Support

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -57,7 +57,7 @@ DEPENDENCIES = [
     'pkginfo>=1.5.0.1',
     'PyJWT>=2.1.0',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
-    'requests~=2.25.1',
+    'requests[socks]~=2.25.1',
     'six~=1.12',
     'urllib3[secure]>=1.26.5',
 ]

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -126,7 +126,7 @@ pyOpenSSL==19.0.0
 python-dateutil==2.8.0
 pytz==2019.1
 requests-oauthlib==1.2.0
-requests==2.25.1
+requests[socks]==2.25.1
 scp==0.13.2
 semver==2.13.0
 six==1.14.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -126,7 +126,7 @@ pyOpenSSL==19.0.0
 python-dateutil==2.8.0
 pytz==2019.1
 requests-oauthlib==1.2.0
-requests==2.25.1
+requests[socks]==2.25.1
 scp==0.13.2
 semver==2.13.0
 six==1.14.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -127,7 +127,7 @@ python-dateutil==2.8.0
 pytz==2019.1
 pywin32==300
 requests-oauthlib==1.2.0
-requests==2.25.1
+requests[socks]==2.25.1
 scp==0.13.2
 semver==2.13.0
 six==1.14.0


### PR DESCRIPTION
Add the extra `[socks]` require for requests to add socks libraries to the
dependancies.

**Description**<!--Mandatory-->
This adds SOCKS Proxy support to requests which allows AZ CLI to operate behind a SOCKS proxy - this fixes #18930 

**Testing Guide**
- `export ALL_PROXY=socks5h://<host>:<port>`
- Run any `az` command that makes a network call

**History Notes**
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
