### PR TITLE
decode binary string as utf-8 in win branch

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/container/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/container/custom.py
@@ -641,6 +641,8 @@ def _start_exec_pipe_win(web_socket_uri, password):
 
 
 def _on_ws_msg(ws, msg):
+    if isinstance(msg, bytes):
+        msg = msg.decode('utf-8')
     sys.stdout.write(msg)
     sys.stdout.flush()
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
The websocket response can be a string for text or bytes for an utf-8 string. utf-8 was not handled properly. This pr adds detection of bytes and decoding as utf-8 string before writing to the console.
This is the same fix as https://github.com/Azure/azure-cli/pull/18384 applied to the windows code as well.

Fixes: https://github.com/Azure/azure-cli/issues/18251#issuecomment-885091314

**Testing Guide**
- start a container e.g. with `az container create` with a long living container on a Windows system
- try to execute a shell inside the container with `az container exec --exec-command "/bin/bash" ...`
- currently it just exits without an error or shell

**History Notes**
[container] az container exec: decode received bytes as utf-8 string (Windows as well now)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
