### PR TITLE
{Telemetry} Import unittest.mock in telemetry test

### DIFF
--- a/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_telemetry_client.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_telemetry_client.py
@@ -4,10 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import json
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 import os
 import unittest
 

--- a/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_telemetry_client.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_telemetry_client.py
@@ -4,7 +4,10 @@
 # --------------------------------------------------------------------------------------------
 
 import json
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import os
 import unittest
 


### PR DESCRIPTION
Mock is deprecated in recent python versions. Try to import `unittest.mock` if it is available on the system.

Fixes: azure/azure-cli#18976

**Description**<!--Mandatory-->
Try to import `unittest.mock` and fall back to importing `mock`. This allows tests to run in Python 3.10 and in older Python versions.

**Testing Guide**
Run the tests as you normally would.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
