### PR TITLE
[Redis] Add `--redis-version` param to `az redis create` and `az redis update`

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -20,6 +20,10 @@ Release History
 * Hotfix: `az storage fs directory download`: Fix the issue with `--sas-token` to generate valid sas url (#18811)
 * Hotfix: `az storage blob copy start`: Fix the issue in copy from different account (#18730)
 
+**Redis**
+
+*Add param `--redis-version` to `az redis create` and `az redis update` commands
+
 2.26.0
 ++++++
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -20,10 +20,6 @@ Release History
 * Hotfix: `az storage fs directory download`: Fix the issue with `--sas-token` to generate valid sas url (#18811)
 * Hotfix: `az storage blob copy start`: Fix the issue in copy from different account (#18730)
 
-**Redis**
-
-*Add param `--redis-version` to `az redis create` and `az redis update` commands
-
 2.26.0
 ++++++
 

--- a/src/azure-cli/azure/cli/command_modules/redis/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/_params.py
@@ -42,7 +42,7 @@ def load_arguments(self, _):
         c.argument('vm_size', arg_type=get_enum_type(allowed_c_family_sizes + allowed_p_family_sizes), help='Size of Redis cache to deploy. Basic and Standard Cache sizes start with C. Premium Cache sizes start with P')
         c.argument('enable_non_ssl_port', action='store_true', help='If specified, then the non-ssl redis server port (6379) will be enabled.')
         c.argument('replicas_per_master', help='The number of replicas to be created per master.')
-        c.argument('redis_version', help='Redis version.Redis version. Only major version will be used in create/update request with current valid values: (4, 6)')
+        c.argument('redis_version', help='Redis version. Only major version will be used in create/update request with current valid values: (4, 6)')
 
     with self.argument_context('redis firewall-rules list') as c:
         c.argument('cache_name', arg_type=cache_name, id_part=None)

--- a/src/azure-cli/azure/cli/command_modules/redis/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/_params.py
@@ -41,7 +41,8 @@ def load_arguments(self, _):
         c.argument('minimum_tls_version', help='Specifies the TLS version required by clients to connect to cache', arg_type=get_enum_type(TlsVersion))
         c.argument('vm_size', arg_type=get_enum_type(allowed_c_family_sizes + allowed_p_family_sizes), help='Size of Redis cache to deploy. Basic and Standard Cache sizes start with C. Premium Cache sizes start with P')
         c.argument('enable_non_ssl_port', action='store_true', help='If specified, then the non-ssl redis server port (6379) will be enabled.')
-        c.argument('replicas_per_master', help='The number of replicas to be created per master.', is_preview=True)
+        c.argument('replicas_per_master', help='The number of replicas to be created per master.')
+        c.argument('redis_version', help='Redis version.Redis version. Only major version will be used in create/update request with current valid values: (4, 6)')
 
     with self.argument_context('redis firewall-rules list') as c:
         c.argument('cache_name', arg_type=cache_name, id_part=None)

--- a/src/azure-cli/azure/cli/command_modules/redis/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/commands.py
@@ -60,7 +60,7 @@ def load_command_table(self, _):
         g.custom_command('update', 'cli_redis_firewall_create')
         g.command('delete', 'delete')
         g.show_command('show', 'get')
-        g.command('list', 'list_by_redis_resource')
+        g.command('list', 'list')
 
     with self.command_group('redis server-link', redis_linked_server, custom_command_type=redis_linked_server_custom) as g:
         g.custom_command('create', 'cli_redis_create_server_link')

--- a/src/azure-cli/azure/cli/command_modules/redis/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/custom.py
@@ -146,7 +146,7 @@ def cli_redis_patch_schedule_delete(client, resource_group_name, name):
 
 def cli_redis_list_cache(client, resource_group_name=None):
     cache_list = client.list_by_resource_group(resource_group_name=resource_group_name) \
-        if resource_group_name else client.list()
+        if resource_group_name else client.list_by_subscription()
     return list(cache_list)
 
 

--- a/src/azure-cli/azure/cli/command_modules/redis/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/custom.py
@@ -61,6 +61,7 @@ def cli_redis_update(cmd, instance, sku=None, vm_size=None):
         tenant_settings=instance.tenant_settings,
         shard_count=instance.shard_count,
         minimum_tls_version=instance.minimum_tls_version,
+        redis_version=instance.redis_version,
         sku=instance.sku,
         tags=instance.tags
     )
@@ -72,7 +73,7 @@ def cli_redis_create(cmd, client,
                      resource_group_name, name, location, sku, vm_size, tags=None,
                      redis_configuration=None, enable_non_ssl_port=None, tenant_settings=None,
                      shard_count=None, minimum_tls_version=None, subnet_id=None, static_ip=None,
-                     zones=None, replicas_per_master=None):
+                     zones=None, replicas_per_master=None, redis_version=None):
     # pylint:disable=line-too-long
     if ((sku.lower() in ['standard', 'basic'] and vm_size.lower() not in allowed_c_family_sizes) or (sku.lower() in ['premium'] and vm_size.lower() not in allowed_p_family_sizes)):
         raise wrong_vmsize_error
@@ -94,6 +95,7 @@ def cli_redis_create(cmd, client,
         subnet_id=subnet_id,
         static_ip=static_ip,
         zones=zones,
+        redis_version=redis_version,
         tags=tags)
     return client.begin_create(resource_group_name, name, params)
 

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_export_import.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_export_import.yaml
@@ -23,10 +23,10 @@ interactions:
       accept-language:
       - en-US
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002","location":"West
         US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
@@ -40,7 +40,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -73,10 +73,10 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002","location":"West
         US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
@@ -129,7 +129,7 @@ interactions:
       accept-language:
       - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/export?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/export?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -143,7 +143,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a56e19b2-68eb-4c15-a5cd-3ccb1986f2ae?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a56e19b2-68eb-4c15-a5cd-3ccb1986f2ae?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -176,7 +176,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a56e19b2-68eb-4c15-a5cd-3ccb1986f2ae?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a56e19b2-68eb-4c15-a5cd-3ccb1986f2ae?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -190,7 +190,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a56e19b2-68eb-4c15-a5cd-3ccb1986f2ae?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a56e19b2-68eb-4c15-a5cd-3ccb1986f2ae?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -221,7 +221,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a56e19b2-68eb-4c15-a5cd-3ccb1986f2ae?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a56e19b2-68eb-4c15-a5cd-3ccb1986f2ae?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -270,7 +270,7 @@ interactions:
       accept-language:
       - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/import?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/import?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -284,7 +284,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -317,7 +317,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -331,7 +331,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -362,7 +362,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -376,7 +376,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -407,7 +407,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/a128cfe4-dff1-43ca-8938-5d98a1c14a81?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -456,7 +456,7 @@ interactions:
       accept-language:
       - en-US
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/import?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/import?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -470,7 +470,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -503,7 +503,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -517,7 +517,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -548,7 +548,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -562,7 +562,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -593,7 +593,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -607,7 +607,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -638,7 +638,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b4dc003f-1a91-42f2-af9a-39566342a103?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -685,7 +685,7 @@ interactions:
       accept-language:
       - en-US
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -699,7 +699,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -732,7 +732,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -746,7 +746,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -777,7 +777,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -791,7 +791,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -822,7 +822,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -836,7 +836,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -867,7 +867,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -881,7 +881,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -912,7 +912,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -926,7 +926,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -957,7 +957,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -971,7 +971,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1002,7 +1002,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1016,7 +1016,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1047,7 +1047,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1061,7 +1061,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1092,7 +1092,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1106,7 +1106,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1137,7 +1137,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1151,7 +1151,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1182,7 +1182,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1196,7 +1196,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1227,7 +1227,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1241,7 +1241,7 @@ interactions:
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1272,7 +1272,7 @@ interactions:
       - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
         azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/45674bde-ffb2-4829-a348-91cfa978b875?api-version=2020-12-01
   response:
     body:
       string: ''

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_firewall.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_firewall.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"properties": {"tenantSettings": {}, "sku": {"name": "Premium", "family":
-      "p", "capacity": 1}}, "location": "WestUS2"}'
+    body: '{"location": "WestUS2", "properties": {"tenantSettings": {}, "sku": {"name":
+      "Premium", "family": "p", "capacity": 1}}}'
     headers:
       Accept:
       - application/json
@@ -14,33 +14,30 @@ interactions:
       Content-Length:
       - '119'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '935'
+      - '1003'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:39:21 GMT
+      - Tue, 27 Jul 2021 04:48:05 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -52,7 +49,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -60,7 +57,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -70,23 +67,22 @@ interactions:
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '816'
+      - '884'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:39:52 GMT
+      - Tue, 27 Jul 2021 04:48:35 GMT
       expires:
       - '-1'
       pragma:
@@ -102,7 +98,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -120,16 +116,13 @@ interactions:
       Content-Length:
       - '62'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g --start-ip --end-ip --rule-name
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/firewallRules/test?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/firewallRules/test?api-version=2020-12-01
   response:
     body:
       string: '{"properties":{"startIP":"127.0.0.1","endIP":"127.0.0.1"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/firewallRules/test","name":"cliredis000002/test","type":"Microsoft.Cache/redis/firewallRules"}'
@@ -141,11 +134,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:59:54 GMT
+      - Tue, 27 Jul 2021 05:08:36 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/firewallRules/test?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/firewallRules/test?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -157,7 +150,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -175,16 +168,13 @@ interactions:
       Content-Length:
       - '62'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g --start-ip --end-ip --rule-name
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/firewallRules/test?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/firewallRules/test?api-version=2020-12-01
   response:
     body:
       string: '{"properties":{"startIP":"127.0.0.0","endIP":"127.0.0.1"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/firewallRules/test","name":"cliredis000002/test","type":"Microsoft.Cache/redis/firewallRules"}'
@@ -196,7 +186,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:59:55 GMT
+      - Tue, 27 Jul 2021 05:08:36 GMT
       expires:
       - '-1'
       pragma:
@@ -214,7 +204,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -232,12 +222,9 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/firewallRules?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/firewallRules?api-version=2020-12-01
   response:
     body:
       string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/firewallRules/test","name":"cliredis000002/test","type":"Microsoft.Cache/Redis/firewallRules","properties":{"startIP":"127.0.0.0","endIP":"127.0.0.1"}}]}'
@@ -249,7 +236,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:59:56 GMT
+      - Tue, 27 Jul 2021 05:08:37 GMT
       expires:
       - '-1'
       pragma:
@@ -265,7 +252,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -283,12 +270,9 @@ interactions:
       ParameterSetName:
       - -n -g --rule-name
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/firewallRules/test?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/firewallRules/test?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/firewallRules/test","name":"cliredis000002/test","type":"Microsoft.Cache/Redis/firewallRules","properties":{"startIP":"127.0.0.0","endIP":"127.0.0.1"}}'
@@ -300,7 +284,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:59:57 GMT
+      - Tue, 27 Jul 2021 05:08:37 GMT
       expires:
       - '-1'
       pragma:
@@ -316,7 +300,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -336,12 +320,9 @@ interactions:
       ParameterSetName:
       - -n -g --rule-name
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/firewallRules/test?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/firewallRules/test?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -351,7 +332,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 11:59:58 GMT
+      - Tue, 27 Jul 2021 05:08:38 GMT
       expires:
       - '-1'
       pragma:
@@ -365,7 +346,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-deletes:
       - '14999'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -385,12 +366,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -400,11 +378,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:00:00 GMT
+      - Tue, 27 Jul 2021 05:08:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -416,7 +394,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-deletes:
       - '14999'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -424,7 +402,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -434,10 +412,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -447,11 +424,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:00:31 GMT
+      - Tue, 27 Jul 2021 05:09:08 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -461,7 +438,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -469,7 +446,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -479,10 +456,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -492,11 +468,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:01:01 GMT
+      - Tue, 27 Jul 2021 05:09:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -506,7 +482,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -514,7 +490,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -524,10 +500,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -537,11 +512,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:01:32 GMT
+      - Tue, 27 Jul 2021 05:10:08 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -551,7 +526,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -559,7 +534,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -569,10 +544,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -582,11 +556,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:02:02 GMT
+      - Tue, 27 Jul 2021 05:10:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -596,7 +570,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -604,7 +578,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -614,10 +588,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -627,11 +600,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:02:32 GMT
+      - Tue, 27 Jul 2021 05:11:09 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -641,7 +614,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -649,7 +622,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -659,10 +632,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -672,11 +644,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:03:03 GMT
+      - Tue, 27 Jul 2021 05:11:39 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -686,7 +658,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -694,7 +666,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -704,10 +676,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -717,11 +688,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:03:33 GMT
+      - Tue, 27 Jul 2021 05:12:09 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -731,7 +702,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -739,7 +710,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -749,10 +720,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -762,11 +732,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:04:03 GMT
+      - Tue, 27 Jul 2021 05:12:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -776,7 +746,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -784,7 +754,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -794,10 +764,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -807,11 +776,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:04:34 GMT
+      - Tue, 27 Jul 2021 05:13:08 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -821,7 +790,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -829,7 +798,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -839,10 +808,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -852,11 +820,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:05:04 GMT
+      - Tue, 27 Jul 2021 05:13:39 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -866,7 +834,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -874,7 +842,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -884,10 +852,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -897,11 +864,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:05:34 GMT
+      - Tue, 27 Jul 2021 05:14:09 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -911,7 +878,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -919,7 +886,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -929,10 +896,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/82fcd6cd-8490-4bcf-aa4d-c3eb5b684503?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -942,7 +908,95 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:06:05 GMT
+      - Tue, 27 Jul 2021 05:14:39 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:15:10 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/b526e857-6861-4b51-8b1a-fefa3b8dc0ff?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:15:39 GMT
       expires:
       - '-1'
       pragma:
@@ -954,7 +1008,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_list_keys.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_list_keys.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"properties": {"tenantSettings": {}, "sku": {"name": "Basic", "family":
-      "c", "capacity": 0}}, "location": "WestUS2"}'
+    body: '{"location": "WestUS2", "properties": {"tenantSettings": {}, "sku": {"name":
+      "Basic", "family": "c", "capacity": 0}}}'
     headers:
       Accept:
       - application/json
@@ -14,33 +14,30 @@ interactions:
       Content-Length:
       - '117'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000}],"tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '875'
+      - '942'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:50:41 GMT
+      - Tue, 27 Jul 2021 00:55:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -52,7 +49,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -60,7 +57,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -70,23 +67,22 @@ interactions:
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000}],"tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '823'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:11 GMT
+      - Tue, 27 Jul 2021 00:55:59 GMT
       expires:
       - '-1'
       pragma:
@@ -102,7 +98,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -122,12 +118,9 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/listKeys?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/listKeys?api-version=2020-12-01
   response:
     body:
       string: '{"primaryKey":"*****","secondaryKey":"*****"}'
@@ -139,7 +132,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:12 GMT
+      - Tue, 27 Jul 2021 00:55:59 GMT
       expires:
       - '-1'
       pragma:
@@ -157,7 +150,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_list_works.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_list_works.yaml
@@ -11,47 +11,29 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/Redis?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/redis?api-version=2020-12-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mechandr/providers/Microsoft.Cache/Redis/rdbcli","location":"Central
-        US","name":"rdbcli","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000},{"sslPort":15001}],"minimumTlsVersion":"1.2","redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","aof-backup-enabled":"false","rdb-backup-enabled":"True","rdb-backup-frequency":"60","rdb-backup-max-snapshot-count":"1","maxmemory-delta":"200","rdb-storage-connection-string":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=rdbaccount;AccountKey=[key
-        hidden]","aof-storage-connection-string-0":"DefaultEndpointsProtocol=https;BlobEndpoint=https://rdbaccount.blob.core.windows.net/;AccountName=rdbaccount;AccountKey=[key
-        hidden]","aof-storage-connection-string-1":"DefaultEndpointsProtocol=https;BlobEndpoint=https://aofrdb.blob.core.windows.net/;AccountName=aofrdb;AccountKey=[key
-        hidden]"},"accessKeys":null,"hostName":"rdbcli.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mechandr/providers/Microsoft.Cache/Redis/basicupdates","location":"Central
-        US","name":"basicupdates","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Standard","family":"C","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000},{"sslPort":15001}],"minimumTlsVersion":"1.1","redisConfiguration":{"maxclients":"1000","maxmemory-reserved":"50","maxfragmentationmemory-reserved":"50","maxmemory-delta":"50"},"accessKeys":null,"hostName":"basicupdates.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mechandr/providers/Microsoft.Cache/Redis/basicupdate","location":"Central
-        US","name":"basicupdate","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000}],"minimumTlsVersion":"1.1","redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"basicupdate.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mechandr/providers/Microsoft.Cache/Redis/zonereplicascale","location":"Central
-        US","name":"zonereplicascale","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"zone":"1"},{"sslPort":15001,"zone":"2"},{"sslPort":15002,"zone":"1"}],"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200","zonal-configuration":"{\r\n  \"preferredPrimaryZoneId\":
-        \"1\",\r\n  \"zoneNodeTopology\": {\r\n    \"1\": [\r\n      \"0\",\r\n      \"2\"\r\n    ],\r\n    \"2\":
-        [\r\n      \"1\"\r\n    ]\r\n  }\r\n}"},"accessKeys":null,"hostName":"zonereplicascale.redis.cache.windows.net","port":6379,"sslPort":6380,"replicasPerMaster":2,"linkedServers":[]},"zones":["1","2"]},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mechandr/providers/Microsoft.Cache/Redis/clireplica","location":"Central
-        US","name":"clireplica","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000},{"sslPort":15001}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"clireplica.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mechandr/providers/Microsoft.Cache/Redis/clireplica2","location":"Central
-        US","name":"clireplica2","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000},{"sslPort":15001},{"sslPort":15002}],"minimumTlsVersion":"1.2","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"clireplica2.redis.cache.windows.net","port":6379,"sslPort":6380,"replicasPerMaster":2,"linkedServers":[]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mechandr/providers/Microsoft.Cache/Redis/clireplica1","location":"Central
-        US","name":"clireplica1","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Scaling","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000},{"sslPort":15001}],"minimumTlsVersion":"1.2","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"clireplica1.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mechandr/providers/Microsoft.Cache/Redis/replicascale","location":"Central
-        US","name":"replicascale","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Failed","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000},{"sslPort":15001},{"sslPort":15002}],"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"96","maxfragmentationmemory-reserved":"144","maxmemory-delta":"96"},"accessKeys":null,"hostName":"replicascale.redis.cache.windows.net","port":6379,"sslPort":6380,"shardCount":1,"replicasPerMaster":2,"linkedServers":[]}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redisraymcbbfgoxrhljynnan62qvkulxlsrgh3tqpcwme6mratl4f5ajkwakhaj56/providers/Microsoft.Cache/Redis/clirediscdcu6v7x43mb2y74","location":"West
+        US 2","name":"clirediscdcu6v7x43mb2y74","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"clirediscdcu6v7x43mb2y74.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redisxkw4l6rguwjp2kbczzpfj4ssyfphswzvailrc6rptic32ubqimb4ls7wwiehf/providers/Microsoft.Cache/Redis/cliredisbcau4oefluvorr66","location":"West
+        US 2","name":"cliredisbcau4oefluvorr66","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.3","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredisbcau4oefluvorr66.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '6426'
+      - '1645'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:50:41 GMT
+      - Tue, 27 Jul 2021 00:55:29 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:
@@ -75,12 +57,9 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis?api-version=2020-12-01
   response:
     body:
       string: '{"value":[]}'
@@ -92,7 +71,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:50:41 GMT
+      - Tue, 27 Jul 2021 00:55:30 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_patch_schedule.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_patch_schedule.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"properties": {"tenantSettings": {}, "sku": {"name": "Premium", "family":
-      "p", "capacity": 1}}, "location": "WestUS2"}'
+    body: '{"location": "WestUS2", "properties": {"tenantSettings": {}, "sku": {"name":
+      "Premium", "family": "p", "capacity": 1}}}'
     headers:
       Accept:
       - application/json
@@ -14,33 +14,30 @@ interactions:
       Content-Length:
       - '119'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000},{"sslPort":15001}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '901'
+      - '1003'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:50:41 GMT
+      - Tue, 27 Jul 2021 00:55:28 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -52,7 +49,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -60,7 +57,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -70,23 +67,22 @@ interactions:
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000},{"sslPort":15001}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '782'
+      - '884'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:11 GMT
+      - Tue, 27 Jul 2021 00:55:59 GMT
       expires:
       - '-1'
       pragma:
@@ -102,7 +98,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -121,16 +117,13 @@ interactions:
       Content-Length:
       - '110'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g --schedule-entries
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/patchSchedules/default?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/patchSchedules/default?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/patchSchedules/default","location":"West
@@ -143,7 +136,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:13 GMT
+      - Tue, 27 Jul 2021 00:55:59 GMT
       expires:
       - '-1'
       pragma:
@@ -161,7 +154,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -180,16 +173,13 @@ interactions:
       Content-Length:
       - '112'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g --schedule-entries
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/patchSchedules/default?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/patchSchedules/default?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/patchSchedules/default","location":"West
@@ -202,7 +192,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:14 GMT
+      - Tue, 27 Jul 2021 00:56:00 GMT
       expires:
       - '-1'
       pragma:
@@ -220,7 +210,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -238,12 +228,9 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/patchSchedules/default?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/patchSchedules/default?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/patchSchedules/default","location":"West
@@ -256,7 +243,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:14 GMT
+      - Tue, 27 Jul 2021 00:56:00 GMT
       expires:
       - '-1'
       pragma:
@@ -272,7 +259,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -292,12 +279,9 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/patchSchedules/default?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/patchSchedules/default?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -307,7 +291,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 06 Dec 2019 23:51:14 GMT
+      - Tue, 27 Jul 2021 00:56:00 GMT
       expires:
       - '-1'
       pragma:
@@ -321,7 +305,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-deletes:
       - '14999'
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_reboot.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_reboot.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"properties": {"tenantSettings": {}, "sku": {"name": "Premium", "family":
-      "p", "capacity": 1}}, "location": "WestUS2"}'
+    body: '{"location": "WestUS2", "properties": {"tenantSettings": {}, "sku": {"name":
+      "Premium", "family": "p", "capacity": 1}}}'
     headers:
       Accept:
       - application/json
@@ -14,33 +14,30 @@ interactions:
       Content-Length:
       - '119'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '935'
+      - '1003'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:39:21 GMT
+      - Tue, 27 Jul 2021 03:35:20 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -52,7 +49,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -60,7 +57,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -70,23 +67,22 @@ interactions:
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '816'
+      - '884'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:39:52 GMT
+      - Tue, 27 Jul 2021 03:35:50 GMT
       expires:
       - '-1'
       pragma:
@@ -102,7 +98,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -120,16 +116,13 @@ interactions:
       Content-Length:
       - '26'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g --reboot-type
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/forceReboot?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/forceReboot?api-version=2020-12-01
   response:
     body:
       string: "{\r\n  \"message\": \"The requested reboot operation for 'Value' has
@@ -142,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:59:55 GMT
+      - Tue, 27 Jul 2021 03:55:51 GMT
       expires:
       - '-1'
       pragma:
@@ -160,7 +153,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -178,16 +171,13 @@ interactions:
       Content-Length:
       - '29'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g --reboot-type
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/forceReboot?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/forceReboot?api-version=2020-12-01
   response:
     body:
       string: "{\r\n  \"message\": \"The requested reboot operation for 'Value' has
@@ -200,7 +190,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:01:56 GMT
+      - Tue, 27 Jul 2021 03:57:52 GMT
       expires:
       - '-1'
       pragma:
@@ -218,7 +208,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -236,16 +226,13 @@ interactions:
       Content-Length:
       - '31'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g --reboot-type
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/forceReboot?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/forceReboot?api-version=2020-12-01
   response:
     body:
       string: "{\r\n  \"message\": \"The requested reboot operation for 'Value' has
@@ -258,7 +245,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:03:58 GMT
+      - Tue, 27 Jul 2021 03:59:53 GMT
       expires:
       - '-1'
       pragma:
@@ -276,7 +263,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -296,12 +283,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -311,11 +295,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:06:00 GMT
+      - Tue, 27 Jul 2021 04:01:53 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -327,7 +311,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-deletes:
       - '14999'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -335,7 +319,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -345,10 +329,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -358,11 +341,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:06:31 GMT
+      - Tue, 27 Jul 2021 04:02:23 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -372,7 +355,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -380,7 +363,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -390,10 +373,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -403,11 +385,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:07:01 GMT
+      - Tue, 27 Jul 2021 04:02:54 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -417,7 +399,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -425,7 +407,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -435,10 +417,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -448,11 +429,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:07:32 GMT
+      - Tue, 27 Jul 2021 04:03:24 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -462,7 +443,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -470,7 +451,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -480,10 +461,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -493,11 +473,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:08:01 GMT
+      - Tue, 27 Jul 2021 04:03:54 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -507,7 +487,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -515,7 +495,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -525,10 +505,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -538,11 +517,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:08:32 GMT
+      - Tue, 27 Jul 2021 04:04:24 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -552,7 +531,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -560,7 +539,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -570,10 +549,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -583,11 +561,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:09:02 GMT
+      - Tue, 27 Jul 2021 04:04:54 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -597,7 +575,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -605,7 +583,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -615,10 +593,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -628,11 +605,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:09:32 GMT
+      - Tue, 27 Jul 2021 04:05:24 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -642,7 +619,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -650,7 +627,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -660,10 +637,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -673,11 +649,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:10:03 GMT
+      - Tue, 27 Jul 2021 04:05:55 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -687,7 +663,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -695,7 +671,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -705,10 +681,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -718,11 +693,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:10:33 GMT
+      - Tue, 27 Jul 2021 04:06:25 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -732,7 +707,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -740,7 +715,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -750,10 +725,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -763,11 +737,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:11:07 GMT
+      - Tue, 27 Jul 2021 04:06:54 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -777,7 +751,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -785,7 +759,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -795,10 +769,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -808,11 +781,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:11:37 GMT
+      - Tue, 27 Jul 2021 04:07:24 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -822,7 +795,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -830,7 +803,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -840,10 +813,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/0099fe20-5af5-4d7d-a4e0-11cb2a249086?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -853,7 +825,51 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:12:08 GMT
+      - Tue, 27 Jul 2021 04:07:55 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/953e32ab-fab2-4dfd-a084-895b3e31a6d9?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 04:08:25 GMT
       expires:
       - '-1'
       pragma:
@@ -865,7 +881,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_regenerate_key_update_tags.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_regenerate_key_update_tags.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"properties": {"tenantSettings": {}, "sku": {"name": "Premium", "family":
-      "p", "capacity": 1}}, "location": "WestUS2"}'
+    body: '{"location": "WestUS2", "properties": {"tenantSettings": {}, "sku": {"name":
+      "Premium", "family": "p", "capacity": 1}}}'
     headers:
       Accept:
       - application/json
@@ -14,33 +14,30 @@ interactions:
       Content-Length:
       - '119'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '935'
+      - '1003'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:39:21 GMT
+      - Tue, 27 Jul 2021 04:48:06 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -50,9 +47,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -60,7 +57,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -70,23 +67,22 @@ interactions:
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '816'
+      - '884'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:39:52 GMT
+      - Tue, 27 Jul 2021 04:48:36 GMT
       expires:
       - '-1'
       pragma:
@@ -102,7 +98,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -120,16 +116,13 @@ interactions:
       Content-Length:
       - '22'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g --key-type
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/regenerateKey?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/regenerateKey?api-version=2020-12-01
   response:
     body:
       string: '{"primaryKey":"*****","secondaryKey":"*****"}'
@@ -141,7 +134,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:59:55 GMT
+      - Tue, 27 Jul 2021 05:08:37 GMT
       expires:
       - '-1'
       pragma:
@@ -159,7 +152,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -177,16 +170,13 @@ interactions:
       Content-Length:
       - '24'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g --key-type
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/regenerateKey?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/regenerateKey?api-version=2020-12-01
   response:
     body:
       string: '{"primaryKey":"*****","secondaryKey":"*****"}'
@@ -198,7 +188,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:59:56 GMT
+      - Tue, 27 Jul 2021 05:08:37 GMT
       expires:
       - '-1'
       pragma:
@@ -216,7 +206,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -234,25 +224,22 @@ interactions:
       ParameterSetName:
       - -n -g --set
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '816'
+      - '883'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 11:59:57 GMT
+      - Tue, 27 Jul 2021 05:08:38 GMT
       expires:
       - '-1'
       pragma:
@@ -268,15 +255,16 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"redisConfiguration": {"maxclients": "7500", "maxmemory-reserved":
-      "200", "maxfragmentationmemory-reserved": "300", "maxmemory-delta": "200"},
-      "enableNonSslPort": false, "tenantSettings": {}, "sku": {"name": "Premium",
-      "family": "P", "capacity": 1}}, "tags": {"mytag": "mytagval"}}'
+    body: '{"tags": {"mytag": "mytagval"}, "properties": {"redisConfiguration": {"maxclients":
+      "7500", "maxmemory-reserved": "200", "maxfragmentationmemory-reserved": "300",
+      "maxmemory-delta": "200"}, "redisVersion": "4.0.14", "enableNonSslPort": false,
+      "tenantSettings": {}, "sku": {"name": "Premium", "family": "P", "capacity":
+      1}}}'
     headers:
       Accept:
       - application/json
@@ -287,31 +275,28 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '297'
+      - '323'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g --set
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{"mytag":"mytagval"},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{"mytag":"mytagval"},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '834'
+      - '901'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:00:05 GMT
+      - Tue, 27 Jul 2021 05:08:40 GMT
       expires:
       - '-1'
       pragma:
@@ -327,9 +312,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -349,12 +334,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -364,11 +346,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:00:07 GMT
+      - Tue, 27 Jul 2021 05:08:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -380,7 +362,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-deletes:
       - '14999'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -388,7 +370,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -398,10 +380,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -411,11 +392,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:00:38 GMT
+      - Tue, 27 Jul 2021 05:09:10 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -425,7 +406,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -433,7 +414,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -443,10 +424,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -456,11 +436,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:01:08 GMT
+      - Tue, 27 Jul 2021 05:09:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -470,7 +450,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -478,7 +458,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -488,10 +468,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -501,11 +480,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:01:39 GMT
+      - Tue, 27 Jul 2021 05:10:10 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -515,7 +494,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -523,7 +502,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -533,10 +512,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -546,11 +524,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:02:09 GMT
+      - Tue, 27 Jul 2021 05:10:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -560,7 +538,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -568,7 +546,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -578,10 +556,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -591,11 +568,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:02:39 GMT
+      - Tue, 27 Jul 2021 05:11:11 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -605,7 +582,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -613,7 +590,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -623,10 +600,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -636,11 +612,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:03:09 GMT
+      - Tue, 27 Jul 2021 05:11:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -650,7 +626,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -658,7 +634,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -668,10 +644,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -681,11 +656,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:03:39 GMT
+      - Tue, 27 Jul 2021 05:12:11 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -695,7 +670,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -703,7 +678,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -713,10 +688,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -726,11 +700,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:04:10 GMT
+      - Tue, 27 Jul 2021 05:12:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -740,7 +714,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -748,7 +722,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -758,10 +732,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -771,11 +744,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:04:40 GMT
+      - Tue, 27 Jul 2021 05:13:11 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -785,7 +758,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -793,7 +766,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -803,10 +776,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -816,11 +788,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:05:10 GMT
+      - Tue, 27 Jul 2021 05:13:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -830,7 +802,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -838,7 +810,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -848,10 +820,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -861,11 +832,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:05:40 GMT
+      - Tue, 27 Jul 2021 05:14:11 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -875,7 +846,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -883,7 +854,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -893,10 +864,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/7a4c0269-08bd-4b65-abfe-da691c8211a6?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -906,52 +876,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 12:06:11 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/f9d02c26-7f36-4f43-9731-6ca2124ac8d7?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 12:06:42 GMT
+      - Tue, 27 Jul 2021 05:14:41 GMT
       expires:
       - '-1'
       pragma:
@@ -963,7 +888,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_server_link.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_server_link.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"properties": {"tenantSettings": {}, "sku": {"name": "Premium", "family":
-      "p", "capacity": 1}}, "location": "WestUS2"}'
+    body: '{"location": "WestUS2", "properties": {"tenantSettings": {}, "sku": {"name":
+      "Premium", "family": "p", "capacity": 1}}}'
     headers:
       Accept:
       - application/json
@@ -14,33 +14,30 @@ interactions:
       Content-Length:
       - '119'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '935'
+      - '1003'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:21:26 GMT
+      - Tue, 27 Jul 2021 04:48:05 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -50,9 +47,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -60,7 +57,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -70,23 +67,22 @@ interactions:
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '816'
+      - '884'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:21:57 GMT
+      - Tue, 27 Jul 2021 04:48:35 GMT
       expires:
       - '-1'
       pragma:
@@ -102,13 +98,13 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"tenantSettings": {}, "sku": {"name": "Premium", "family":
-      "p", "capacity": 1}}, "location": "EastUS"}'
+    body: '{"location": "EastUS", "properties": {"tenantSettings": {}, "sku": {"name":
+      "Premium", "family": "p", "capacity": 1}}}'
     headers:
       Accept:
       - application/json
@@ -121,33 +117,30 @@ interactions:
       Content-Length:
       - '118'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","location":"East
-        US","name":"cliredis000002sec","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002sec.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US","name":"cliredis000002sec","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002sec.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '942'
+      - '1010'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:22:05 GMT
+      - Tue, 27 Jul 2021 04:48:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002sec?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002sec?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -159,7 +152,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -167,7 +160,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -177,23 +170,22 @@ interactions:
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","location":"East
-        US","name":"cliredis000002sec","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002sec.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US","name":"cliredis000002sec","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002sec.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '823'
+      - '891'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:22:37 GMT
+      - Tue, 27 Jul 2021 04:49:09 GMT
       expires:
       - '-1'
       pragma:
@@ -209,7 +201,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -227,25 +219,22 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","location":"East
-        US","name":"cliredis000002sec","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true},{"sslPort":15001,"isMaster":false}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002sec.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US","name":"cliredis000002sec","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002sec.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '823'
+      - '890'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:42:39 GMT
+      - Tue, 27 Jul 2021 05:09:10 GMT
       expires:
       - '-1'
       pragma:
@@ -261,7 +250,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -280,16 +269,13 @@ interactions:
       Content-Length:
       - '310'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec\",\r\n
@@ -305,7 +291,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:42:40 GMT
+      - Tue, 27 Jul 2021 05:09:11 GMT
       expires:
       - '-1'
       pragma:
@@ -319,7 +305,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -327,7 +313,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -337,10 +323,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -353,7 +338,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:43:12 GMT
+      - Tue, 27 Jul 2021 05:09:41 GMT
       expires:
       - '-1'
       pragma:
@@ -369,7 +354,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -377,7 +362,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -387,10 +372,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -403,7 +387,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:43:43 GMT
+      - Tue, 27 Jul 2021 05:10:12 GMT
       expires:
       - '-1'
       pragma:
@@ -419,7 +403,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -427,7 +411,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -437,10 +421,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -453,7 +436,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:44:13 GMT
+      - Tue, 27 Jul 2021 05:10:47 GMT
       expires:
       - '-1'
       pragma:
@@ -469,7 +452,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -477,7 +460,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -487,10 +470,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -503,7 +485,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:44:43 GMT
+      - Tue, 27 Jul 2021 05:11:18 GMT
       expires:
       - '-1'
       pragma:
@@ -519,7 +501,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -527,7 +509,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -537,10 +519,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -553,7 +534,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:45:15 GMT
+      - Tue, 27 Jul 2021 05:11:48 GMT
       expires:
       - '-1'
       pragma:
@@ -569,7 +550,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -577,7 +558,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -587,10 +568,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -603,7 +583,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:45:45 GMT
+      - Tue, 27 Jul 2021 05:12:19 GMT
       expires:
       - '-1'
       pragma:
@@ -619,7 +599,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -627,7 +607,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -637,10 +617,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -653,7 +632,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:46:15 GMT
+      - Tue, 27 Jul 2021 05:12:49 GMT
       expires:
       - '-1'
       pragma:
@@ -669,7 +648,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -677,7 +656,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -687,10 +666,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -703,7 +681,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:46:46 GMT
+      - Tue, 27 Jul 2021 05:13:19 GMT
       expires:
       - '-1'
       pragma:
@@ -719,7 +697,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -727,7 +705,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -737,10 +715,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -753,7 +730,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:47:16 GMT
+      - Tue, 27 Jul 2021 05:13:51 GMT
       expires:
       - '-1'
       pragma:
@@ -769,7 +746,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -777,7 +754,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -787,10 +764,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -803,7 +779,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:47:47 GMT
+      - Tue, 27 Jul 2021 05:14:21 GMT
       expires:
       - '-1'
       pragma:
@@ -819,7 +795,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -827,7 +803,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -837,10 +813,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -853,7 +828,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:48:19 GMT
+      - Tue, 27 Jul 2021 05:14:51 GMT
       expires:
       - '-1'
       pragma:
@@ -869,7 +844,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -877,7 +852,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -887,10 +862,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -903,7 +877,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:48:49 GMT
+      - Tue, 27 Jul 2021 05:15:21 GMT
       expires:
       - '-1'
       pragma:
@@ -919,7 +893,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -927,7 +901,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -937,10 +911,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -953,7 +926,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:49:19 GMT
+      - Tue, 27 Jul 2021 05:15:51 GMT
       expires:
       - '-1'
       pragma:
@@ -969,7 +942,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -977,7 +950,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -987,10 +960,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -1003,7 +975,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:49:51 GMT
+      - Tue, 27 Jul 2021 05:16:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1019,7 +991,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -1027,7 +999,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1037,10 +1009,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -1053,7 +1024,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:50:21 GMT
+      - Tue, 27 Jul 2021 05:16:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1069,7 +1040,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -1077,7 +1048,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1087,210 +1058,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
-        US","serverRole":"Secondary","provisioningState":"Creating"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '666'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 12 Jul 2021 12:50:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis server-link create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --replication-role --server-to-link
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
-        US","serverRole":"Secondary","provisioningState":"Creating"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '666'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 12 Jul 2021 12:51:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis server-link create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --replication-role --server-to-link
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
-        US","serverRole":"Secondary","provisioningState":"Creating"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '666'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 12 Jul 2021 12:51:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis server-link create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --replication-role --server-to-link
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
-        US","serverRole":"Secondary","provisioningState":"Creating"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '666'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 12 Jul 2021 12:52:24 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis server-link create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --replication-role --server-to-link
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -1303,7 +1073,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:52:56 GMT
+      - Tue, 27 Jul 2021 05:17:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1319,7 +1089,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -1327,7 +1097,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1337,10 +1107,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -1353,7 +1122,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:53:26 GMT
+      - Tue, 27 Jul 2021 05:17:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1369,7 +1138,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -1377,7 +1146,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1387,10 +1156,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -1403,7 +1171,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:53:56 GMT
+      - Tue, 27 Jul 2021 05:18:25 GMT
       expires:
       - '-1'
       pragma:
@@ -1419,7 +1187,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -1427,7 +1195,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1437,10 +1205,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -1453,7 +1220,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:54:27 GMT
+      - Tue, 27 Jul 2021 05:18:55 GMT
       expires:
       - '-1'
       pragma:
@@ -1469,7 +1236,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -1477,7 +1244,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1487,10 +1254,9 @@ interactions:
       ParameterSetName:
       - -n -g --replication-role --server-to-link
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -1503,7 +1269,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 12:54:59 GMT
+      - Tue, 27 Jul 2021 05:19:25 GMT
       expires:
       - '-1'
       pragma:
@@ -1519,7 +1285,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -1537,12 +1303,9 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers?api-version=2020-12-01
   response:
     body:
       string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -1555,7 +1318,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 13:00:01 GMT
+      - Tue, 27 Jul 2021 05:24:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1571,7 +1334,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -1589,12 +1352,54 @@ interactions:
       ParameterSetName:
       - -n -g --linked-server-name
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
+  response:
+    body:
+      string: '{"error":{"code":"GatewayTimeout","message":"The gateway did not receive
+        a response from ''Microsoft.Cache'' within the specified time period."}}'
+    headers:
+      cache-control:
+      - no-cache
+      connection:
+      - close
+      content-length:
+      - '143'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jul 2021 05:25:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - service
+    status:
+      code: 504
+      message: Gateway Timeout
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis server-link show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --linked-server-name
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec","name":"cliredis000002sec","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec","linkedRedisCacheLocation":"East
@@ -1607,7 +1412,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 12 Jul 2021 13:00:02 GMT
+      - Tue, 27 Jul 2021 05:25:26 GMT
       expires:
       - '-1'
       pragma:
@@ -1623,7 +1428,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -1643,22 +1448,17 @@ interactions:
       ParameterSetName:
       - -n -g --linked-server-name
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: ''
     headers:
       cache-control:
       - no-cache
-      content-length:
-      - '0'
       date:
-      - Mon, 12 Jul 2021 13:00:02 GMT
+      - Tue, 27 Jul 2021 05:25:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1672,7 +1472,581 @@ interactions:
       x-ms-ratelimit-remaining-subscription-deletes:
       - '14999'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:30:27 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:30:57 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:31:28 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:31:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:32:28 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:32:57 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:33:28 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:33:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:34:28 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:34:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:35:28 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:35:59 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - redis delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g -y
+      User-Agent:
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ba116b16-3c13-49b3-ac6d-c56cfd64e520?api-version=2020-12-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Tue, 27 Jul 2021 05:36:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-rp-server-mvid:
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -1692,12 +2066,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002sec?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1707,11 +2078,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:05:05 GMT
+      - Tue, 27 Jul 2021 05:36:31 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1723,7 +2094,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-deletes:
       - '14999'
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -1731,7 +2102,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1741,10 +2112,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1754,11 +2124,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:05:36 GMT
+      - Tue, 27 Jul 2021 05:37:01 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1768,7 +2138,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -1776,7 +2146,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1786,10 +2156,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1799,11 +2168,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:06:06 GMT
+      - Tue, 27 Jul 2021 05:37:31 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1813,7 +2182,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -1821,7 +2190,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1831,10 +2200,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1844,11 +2212,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:06:36 GMT
+      - Tue, 27 Jul 2021 05:38:01 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1858,7 +2226,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -1866,7 +2234,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1876,10 +2244,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1889,11 +2256,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:07:07 GMT
+      - Tue, 27 Jul 2021 05:38:31 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1903,7 +2270,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -1911,7 +2278,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1921,10 +2288,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1934,11 +2300,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:07:37 GMT
+      - Tue, 27 Jul 2021 05:39:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1948,7 +2314,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -1956,7 +2322,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1966,10 +2332,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -1979,11 +2344,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:08:08 GMT
+      - Tue, 27 Jul 2021 05:39:32 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -1993,7 +2358,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -2001,7 +2366,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -2011,10 +2376,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -2024,11 +2388,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:08:37 GMT
+      - Tue, 27 Jul 2021 05:40:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -2038,7 +2402,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -2046,7 +2410,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -2056,10 +2420,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -2069,11 +2432,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:09:07 GMT
+      - Tue, 27 Jul 2021 05:40:32 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -2083,7 +2446,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -2091,7 +2454,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -2101,10 +2464,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -2114,11 +2476,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:09:38 GMT
+      - Tue, 27 Jul 2021 05:41:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -2128,7 +2490,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -2136,7 +2498,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -2146,10 +2508,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -2159,11 +2520,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:10:08 GMT
+      - Tue, 27 Jul 2021 05:41:33 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -2173,7 +2534,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -2181,7 +2542,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -2191,10 +2552,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -2204,11 +2564,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:10:38 GMT
+      - Tue, 27 Jul 2021 05:42:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -2218,7 +2578,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -2226,7 +2586,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -2236,10 +2596,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -2249,11 +2608,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:11:12 GMT
+      - Tue, 27 Jul 2021 05:42:32 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -2263,7 +2622,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -2271,7 +2630,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -2281,10 +2640,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/ca4c9396-a6e8-4385-af73-f562e64f10d3?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -2294,105 +2652,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:11:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-      accept-language:
-      - en-US
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002sec?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:11:44 GMT
+      - Tue, 27 Jul 2021 05:43:03 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-deletes:
-      - '14999'
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:12:15 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -2402,7 +2666,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 202
       message: Accepted
@@ -2410,7 +2674,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -2420,10 +2684,9 @@ interactions:
       ParameterSetName:
       - -n -g -y
       User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/959f7ac1-9e35-44f6-ab79-aaa76343f383?api-version=2020-12-01
   response:
     body:
       string: ''
@@ -2433,502 +2696,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 12 Jul 2021 13:12:45 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:13:16 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:13:47 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:14:17 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:14:47 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:15:19 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:15:49 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:16:21 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:16:51 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:17:21 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:17:52 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g -y
-      User-Agent:
-      - python/3.9.6 (Windows-10-10.0.19043-SP0) msrest/0.6.21 msrest_azure/0.6.3
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.26.0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/East%20US/operationresults/a15ab5a5-82b7-4312-bd93-5fe9a231ee10?api-version=2019-07-01
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 12 Jul 2021 13:18:23 GMT
+      - Tue, 27 Jul 2021 05:43:33 GMT
       expires:
       - '-1'
       pragma:
@@ -2940,7 +2708,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - fdfce2aa-7929-4c5c-a405-e26b6c06ad98
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_with_mandatory_args.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_with_mandatory_args.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"properties": {"tenantSettings": {}, "sku": {"name": "Basic", "family":
-      "c", "capacity": 0}}, "location": "WestUS2"}'
+    body: '{"location": "WestUS2", "properties": {"tenantSettings": {}, "sku": {"name":
+      "Basic", "family": "c", "capacity": 0}}}'
     headers:
       Accept:
       - application/json
@@ -14,33 +14,30 @@ interactions:
       Content-Length:
       - '117'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000}],"tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '875'
+      - '942'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:50:41 GMT
+      - Tue, 27 Jul 2021 00:56:01 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -52,7 +49,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -60,7 +57,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -70,23 +67,22 @@ interactions:
       ParameterSetName:
       - -n -g -l --sku --vm-size
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000}],"tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '823'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:11 GMT
+      - Tue, 27 Jul 2021 00:56:31 GMT
       expires:
       - '-1'
       pragma:
@@ -102,7 +98,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -120,25 +116,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000}],"tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '756'
+      - '823'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:13 GMT
+      - Tue, 27 Jul 2021 00:56:33 GMT
       expires:
       - '-1'
       pragma:
@@ -154,7 +147,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_with_redisversion.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_with_redisversion.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"location": "WestUS2", "properties": {"tenantSettings": {}, "sku": {"name":
-      "Premium", "family": "p", "capacity": 1}}}'
+    body: '{"location": "WestUS2", "properties": {"redisVersion": "6", "tenantSettings":
+      {}, "sku": {"name": "Basic", "family": "c", "capacity": 0}}}'
     headers:
       Accept:
       - application/json
@@ -12,11 +12,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '119'
+      - '138'
       Content-Type:
       - application/json
       ParameterSetName:
-      - -n -g -l --sku --vm-size
+      - -n -g -l --sku --vm-size --redis-version
       User-Agent:
       - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
@@ -24,16 +24,16 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.3","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1003'
+      - '941'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 27 Jul 2021 00:55:29 GMT
+      - Tue, 27 Jul 2021 00:55:32 GMT
       expires:
       - '-1'
       location:
@@ -65,7 +65,7 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g -l --sku --vm-size
+      - -n -g -l --sku --vm-size --redis-version
       User-Agent:
       - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
@@ -73,16 +73,16 @@ interactions:
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.3","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '884'
+      - '822'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 27 Jul 2021 00:55:59 GMT
+      - Tue, 27 Jul 2021 00:56:02 GMT
       expires:
       - '-1'
       pragma:
@@ -110,7 +110,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - redis firewall-rules list
+      - redis show
       Connection:
       - keep-alive
       ParameterSetName:
@@ -118,67 +118,20 @@ interactions:
       User-Agent:
       - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/firewallRules?api-version=2020-12-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
-      string: '{"value":[]}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.3","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '12'
+      - '822'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 27 Jul 2021 00:56:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-rp-server-mvid:
-      - c3683564-281d-4923-9674-19b300a088a1
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - redis server-link list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g
-      User-Agent:
-      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002/linkedServers?api-version=2020-12-01
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 27 Jul 2021 00:56:01 GMT
+      - Tue, 27 Jul 2021 00:56:03 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_with_tags_and_zones.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_with_tags_and_zones.yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
-    body: '{"properties": {"tenantSettings": {}, "sku": {"name": "Premium", "family":
-      "p", "capacity": 1}}, "zones": ["1", "2"], "location": "WestUS2", "tags": {"test":
-      "tryingzones"}}'
+    body: '{"zones": ["1", "2"], "location": "WestUS2", "tags": {"test": "tryingzones"},
+      "properties": {"tenantSettings": {}, "sku": {"name": "Premium", "family": "p",
+      "capacity": 1}}}'
     headers:
       Accept:
       - application/json
@@ -15,33 +15,30 @@ interactions:
       Content-Length:
       - '173'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g -l --sku --vm-size --tags --zones
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{"test":"tryingzones"},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000},{"sslPort":15001}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"replicasPerMaster":1,"linkedServers":[]},"zones":["1","2"]}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{"test":"tryingzones"},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"replicasPerMaster":1,"linkedServers":[],"replicasPerPrimary":1},"zones":["1","2"]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '961'
+      - '1086'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:50:41 GMT
+      - Tue, 27 Jul 2021 00:56:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -53,7 +50,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -61,7 +58,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -71,23 +68,22 @@ interactions:
       ParameterSetName:
       - -n -g -l --sku --vm-size --tags --zones
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{"test":"tryingzones"},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000},{"sslPort":15001}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"replicasPerMaster":1,"linkedServers":[]},"zones":["1","2"]}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{"test":"tryingzones"},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"replicasPerMaster":1,"linkedServers":[],"replicasPerPrimary":1},"zones":["1","2"]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '842'
+      - '967'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:11 GMT
+      - Tue, 27 Jul 2021 00:56:32 GMT
       expires:
       - '-1'
       pragma:
@@ -103,7 +99,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -121,25 +117,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{"test":"tryingzones"},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000},{"sslPort":15001}],"tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"replicasPerMaster":1,"linkedServers":[]},"zones":["1","2"]}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{"test":"tryingzones"},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"publicNetworkAccess":"Enabled","tenantSettings":{},"redisConfiguration":{"maxclients":"7500","maxmemory-reserved":"200","maxfragmentationmemory-reserved":"300","maxmemory-delta":"200"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"replicasPerMaster":1,"linkedServers":[],"replicasPerPrimary":1},"zones":["1","2"]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '842'
+      - '967'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:13 GMT
+      - Tue, 27 Jul 2021 00:56:33 GMT
       expires:
       - '-1'
       pragma:
@@ -155,7 +148,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_with_tlsversion_and_settings.yaml
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/recordings/test_redis_cache_with_tlsversion_and_settings.yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
-    body: '{"properties": {"tenantSettings": {"hello": "1"}, "minimumTlsVersion":
-      "1.2", "sku": {"name": "Basic", "family": "c", "capacity": 0}}, "location":
-      "WestUS2"}'
+    body: '{"location": "WestUS2", "properties": {"tenantSettings": {"hello": "1"},
+      "minimumTlsVersion": "1.2", "sku": {"name": "Basic", "family": "c", "capacity":
+      0}}}'
     headers:
       Accept:
       - application/json
@@ -15,33 +15,30 @@ interactions:
       Content-Length:
       - '157'
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       ParameterSetName:
       - -n -g -l --sku --vm-size --minimum-tls-version --tenant-settings
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000}],"minimumTlsVersion":"1.2","tenantSettings":{"hello":"1"},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","tenantSettings":{"hello":"1"},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":{"primaryKey":"*****","secondaryKey":"*****"},"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '912'
+      - '979'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:50:41 GMT
+      - Tue, 27 Jul 2021 00:56:04 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
       pragma:
       - no-cache
       server:
@@ -53,7 +50,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 201
       message: Created
@@ -61,7 +58,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -71,23 +68,22 @@ interactions:
       ParameterSetName:
       - -n -g -l --sku --vm-size --minimum-tls-version --tenant-settings
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000}],"minimumTlsVersion":"1.2","tenantSettings":{"hello":"1"},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","tenantSettings":{"hello":"1"},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '793'
+      - '860'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:11 GMT
+      - Tue, 27 Jul 2021 00:56:33 GMT
       expires:
       - '-1'
       pragma:
@@ -103,7 +99,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK
@@ -121,25 +117,22 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - python/3.7.1 (Windows-10-10.0.18362-SP0) msrest/0.6.10 msrest_azure/0.6.2
-        azure-mgmt-redis/7.0.0rc1 Azure-SDK-For-Python AZURECLI/2.0.77
-      accept-language:
-      - en-US
+      - AZURECLI/2.26.1 azsdk-python-mgmt-redis/13.0.0 Python/3.7.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002?api-version=2019-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/redis/cliredis000002?api-version=2020-12-01
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_redis000001/providers/Microsoft.Cache/Redis/cliredis000002","location":"West
-        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000}],"minimumTlsVersion":"1.2","tenantSettings":{"hello":"1"},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+        US 2","name":"cliredis000002","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"4.0.14","sku":{"name":"Basic","family":"C","capacity":0},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","tenantSettings":{"hello":"1"},"redisConfiguration":{"maxclients":"256","maxmemory-reserved":"2","maxfragmentationmemory-reserved":"12","maxmemory-delta":"2"},"accessKeys":null,"hostName":"cliredis000002.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '793'
+      - '860'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 06 Dec 2019 23:51:12 GMT
+      - Tue, 27 Jul 2021 00:56:35 GMT
       expires:
       - '-1'
       pragma:
@@ -155,7 +148,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-rp-server-mvid:
-      - d4a16663-d537-49d1-8ba4-e2fdb635702d
+      - c3683564-281d-4923-9674-19b300a088a1
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/test_redis_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/test_redis_scenario.py
@@ -99,14 +99,14 @@ class RedisCacheTests(ScenarioTest):
         }
 
         self.cmd('az redis create -n {name} -g {rg} -l {location} --sku {sku} --vm-size {size} --redis-version {redis_version}')
-        self.cmd('az redis show -n {name} -g {rg}', checks=[
+        result = self.cmd('az redis show -n {name} -g {rg}', checks=[
             self.check('name', '{name}'),
             self.check('provisioningState', 'Creating'),
             self.check('sku.name', '{sku}'),
             self.check('sku.family', basic_size[0]),
-            self.check('sku.capacity', basic_size[1:]),
-            self.check('redisVersion.split(".")[0]', '{redis_version}')
-        ])
+            self.check('sku.capacity', basic_size[1:])
+        ]).get_output_in_json()
+        self.check(result['redisVersion'].split('.')[0], '{redis_version}')
 
     @ResourceGroupPreparer(name_prefix='cli_test_redis')
     def test_redis_cache_list_works(self, resource_group):

--- a/src/azure-cli/azure/cli/command_modules/redis/tests/latest/test_redis_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/tests/latest/test_redis_scenario.py
@@ -87,10 +87,32 @@ class RedisCacheTests(ScenarioTest):
         ])
 
     @ResourceGroupPreparer(name_prefix='cli_test_redis')
+    def test_redis_cache_with_redisversion(self, resource_group):
+
+        self.kwargs = {
+            'rg': resource_group,
+            'name': self.create_random_name(prefix=name_prefix, length=24),
+            'location': location,
+            'sku': basic_sku,
+            'size': basic_size,
+            'redis_version': '6'
+        }
+
+        self.cmd('az redis create -n {name} -g {rg} -l {location} --sku {sku} --vm-size {size} --redis-version {redis_version}')
+        self.cmd('az redis show -n {name} -g {rg}', checks=[
+            self.check('name', '{name}'),
+            self.check('provisioningState', 'Creating'),
+            self.check('sku.name', '{sku}'),
+            self.check('sku.family', basic_size[0]),
+            self.check('sku.capacity', basic_size[1:]),
+            self.check('redisVersion.split(".")[0]', '{redis_version}')
+        ])
+
+    @ResourceGroupPreparer(name_prefix='cli_test_redis')
     def test_redis_cache_list_works(self, resource_group):
         self.cmd('az redis list')
         self.cmd('az redis list -g {rg}')
-        
+
     @ResourceGroupPreparer(name_prefix='cli_test_redis')
     def test_redis_cache_list_keys(self, resource_group):
 
@@ -165,19 +187,18 @@ class RedisCacheTests(ScenarioTest):
         self.cmd('az redis create -n {name} -g {rg} -l {location} --sku {sku} --vm-size {size}')
 
         if self.is_live:
-            time.sleep(20*60)
-        
+            time.sleep(20 * 60)
+
         self.cmd('az redis export -n {name} -g {rg} --prefix {prefix} --container "{containersasURL}"')
         if self.is_live:
-            time.sleep(5*60)
+            time.sleep(5 * 60)
         self.cmd('az redis import-method -n {name} -g {rg} --files "{filesasURL}"')
         if self.is_live:
-            time.sleep(5*60)
+            time.sleep(5 * 60)
         self.cmd('az redis import -n {name} -g {rg} --files "{filesasURL}"')
         if self.is_live:
-            time.sleep(5*60)
+            time.sleep(5 * 60)
         self.cmd('az redis delete -n {name} -g {rg} -y')
-
 
     @ResourceGroupPreparer(name_prefix='cli_test_redis')
     def test_redis_cache_firewall(self, resource_group):
@@ -194,8 +215,8 @@ class RedisCacheTests(ScenarioTest):
         self.cmd('az redis create -n {name} -g {rg} -l {location} --sku {sku} --vm-size {size}')
 
         if self.is_live:
-            time.sleep(20*60)
-        
+            time.sleep(20 * 60)
+
         self.cmd('az redis firewall-rules create -n {name} -g {rg} --start-ip 127.0.0.1 --end-ip 127.0.0.1 --rule-name {rulename}')
         self.cmd('az redis firewall-rules update -n {name} -g {rg} --start-ip 127.0.0.0 --end-ip 127.0.0.1 --rule-name {rulename}')
         self.cmd('az redis firewall-rules list -n {name} -g {rg}')
@@ -217,17 +238,17 @@ class RedisCacheTests(ScenarioTest):
         self.cmd('az redis create -n {name} -g {rg} -l {location} --sku {sku} --vm-size {size}')
 
         if self.is_live:
-            time.sleep(20*60)
-        
+            time.sleep(20 * 60)
+
         self.cmd('az redis force-reboot -n {name} -g {rg} --reboot-type AllNodes')
         if self.is_live:
-            time.sleep(2*60)
+            time.sleep(2 * 60)
         self.cmd('az redis force-reboot -n {name} -g {rg} --reboot-type PrimaryNode')
         if self.is_live:
-            time.sleep(2*60)
+            time.sleep(2 * 60)
         self.cmd('az redis force-reboot -n {name} -g {rg} --reboot-type SecondaryNode')
         if self.is_live:
-            time.sleep(2*60)
+            time.sleep(2 * 60)
         self.cmd('az redis delete -n {name} -g {rg} -y')
 
     @ResourceGroupPreparer(name_prefix='cli_test_redis')
@@ -244,8 +265,8 @@ class RedisCacheTests(ScenarioTest):
         self.cmd('az redis create -n {name} -g {rg} -l {location} --sku {sku} --vm-size {size}')
 
         if self.is_live:
-            time.sleep(20*60)
-        
+            time.sleep(20 * 60)
+
         self.cmd('az redis regenerate-keys -n {name} -g {rg} --key-type Primary')
         self.cmd('az redis regenerate-keys -n {name} -g {rg} --key-type Secondary')
         self.cmd('az redis update -n {name} -g {rg} --set "tags.mytag=mytagval"')
@@ -258,7 +279,7 @@ class RedisCacheTests(ScenarioTest):
         self.kwargs = {
             'rg': resource_group,
             'name': name,
-            'secname': name+'sec',
+            'secname': name + 'sec',
             'location': location,
             'seclocation': seclocation,
             'sku': premium_sku,
@@ -269,15 +290,15 @@ class RedisCacheTests(ScenarioTest):
         self.cmd('az redis create -n {secname} -g {rg} -l {seclocation} --sku {sku} --vm-size {size}')
 
         if self.is_live:
-            time.sleep(20*60)
-        
+            time.sleep(20 * 60)
+
         self.cmd('az redis server-link create -n {name} -g {rg} --replication-role Secondary --server-to-link {secname}')
         if self.is_live:
-            time.sleep(5*60)
+            time.sleep(5 * 60)
         self.cmd('az redis server-link list -n {name} -g {rg}')
         self.cmd('az redis server-link show -n {name} -g {rg} --linked-server-name {secname}')
         self.cmd('az redis server-link delete -n {name} -g {rg} --linked-server-name {secname}')
         if self.is_live:
-            time.sleep(5*60)
+            time.sleep(5 * 60)
         self.cmd('az redis delete -n {name} -g {rg} -y')
         self.cmd('az redis delete -n {secname} -g {rg} -y')

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -69,7 +69,7 @@ azure-mgmt-rdbms==8.1.0b4
 azure-mgmt-recoveryservices==2.0.0
 azure-mgmt-recoveryservicesbackup==0.12.0
 azure-mgmt-redhatopenshift==0.1.0
-azure-mgmt-redis==12.0.0
+azure-mgmt-redis==13.0.0
 azure-mgmt-relay==0.1.0
 azure-mgmt-reservations==0.6.0
 azure-mgmt-resource==18.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -69,7 +69,7 @@ azure-mgmt-rdbms==8.1.0b4
 azure-mgmt-recoveryservices==2.0.0
 azure-mgmt-recoveryservicesbackup==0.12.0
 azure-mgmt-redhatopenshift==0.1.0
-azure-mgmt-redis==12.0.0
+azure-mgmt-redis==13.0.0
 azure-mgmt-relay==0.1.0
 azure-mgmt-reservations==0.6.0
 azure-mgmt-resource==18.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -69,7 +69,7 @@ azure-mgmt-rdbms==8.1.0b4
 azure-mgmt-recoveryservices==2.0.0
 azure-mgmt-recoveryservicesbackup==0.12.0
 azure-mgmt-redhatopenshift==0.1.0
-azure-mgmt-redis==12.0.0
+azure-mgmt-redis==13.0.0
 azure-mgmt-relay==0.1.0
 azure-mgmt-reservations==0.6.0
 azure-mgmt-resource==18.0.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -112,7 +112,7 @@ DEPENDENCIES = [
     'azure-mgmt-recoveryservicesbackup~=0.12.0',
     'azure-mgmt-recoveryservices~=2.0.0',
     'azure-mgmt-redhatopenshift==0.1.0',
-    'azure-mgmt-redis~=12.0.0',
+    'azure-mgmt-redis~=13.0.0',
     'azure-mgmt-relay~=0.1.0',
     'azure-mgmt-reservations==0.6.0',  # TODO: Use requirements.txt instead of '==' #9781
     'azure-mgmt-resource==18.0.0',


### PR DESCRIPTION
**Description**<!--Mandatory-->
Upgrade azure-mgmt-redis library version from 12.0.0 to 13.0.0
Add `--redis-version` param to `az redis create`  and `az redis update` commands

**Testing Guide**
`az redis create -n {name} -g {rg} -l {location} --sku {sku} --vm-size {size} --redis-version {redis_version}`

**History Notes**
Add `--redis-version` param to `az redis create`  and `az redis update` commands

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
