### PR TITLE
{Resources} az deployment group what-if: Remove trailing period from URL in output

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -72,7 +72,7 @@ def format_what_if_operation_result(what_if_operation_result, enable_color=True)
 def _format_noise_notice(builder):
     builder.append_line(
         """Note: The result may contain false positive predictions (noise).
-You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues."""
+You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues"""
     )
     builder.append_line()
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When using the Azure CLI to run the ARM template what-if command, there is a link to report noise (unexpected what-if results) in the output. The link directs to https://aka.ms/WhatIfIssues but this is followed by a period. Some UIs, including Azure PowerShell and Windows Terminal, detect this as https://aka.ms/WhatIfIssues. (including the period), which isn't a valid URL and opens Bing instead of the expected location.

This PR simply removes the trailing period, ensuring the link is valid.

**Testing Guide**
<!--Example commands with explanations.-->

Run the `az deployment group what-if` command with a valid resource group and template file, and notice the period is no longer present.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

{Resources} az deployment group what-if: Remove trailing period.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
