### PR TITLE
{Packaging} Drop `mock` library

### DIFF
--- a/doc/sphinx/azhelpgen/azhelpgen.py
+++ b/doc/sphinx/azhelpgen/azhelpgen.py
@@ -5,7 +5,7 @@
 
 import argparse
 import json
-from mock import patch
+from unittest.mock import patch
 from os.path import expanduser
 from docutils import nodes
 from docutils.statemachine import ViewList
@@ -51,7 +51,7 @@ class AzHelpGenDirective(Directive):
             if help_file.deprecate_info:
                 yield '{}:deprecated: {}'.format(INDENT, help_file.deprecate_info._get_message(help_file.deprecate_info))
             if not is_command:
-                top_group_name = help_file.command.split()[0] if help_file.command else 'az' 
+                top_group_name = help_file.command.split()[0] if help_file.command else 'az'
                 yield '{}:docsource: {}'.format(INDENT, doc_source_map[top_group_name] if top_group_name in doc_source_map else '')
             else:
                 top_command_name = help_file.command.split()[0] if help_file.command else ''
@@ -61,7 +61,7 @@ class AzHelpGenDirective(Directive):
 
             if is_command and help_file.parameters:
                group_registry = ArgumentGroupRegistry(
-                  [p.group_name for p in help_file.parameters if p.group_name]) 
+                  [p.group_name for p in help_file.parameters if p.group_name])
 
                for arg in sorted(help_file.parameters,
                                 key=lambda p: group_registry.get_group_priority(p.group_name)

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/__init__.py
@@ -7,7 +7,7 @@ import os
 import unittest
 import tempfile
 import shutil
-import mock
+from unittest import mock
 
 
 def get_test_data_file(filename):

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 import shutil
 import hashlib
-import mock
+from unittest import mock
 import sys
 
 from azure.cli.core.util import CLIError

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_index_get.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_index_get.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import os
-import mock
+from unittest import mock
 import unittest
 from requests.exceptions import ConnectionError, HTTPError
 from azure.cli.core.util import CLIError

--- a/src/azure-cli-core/azure/cli/core/tests/test_adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_adal_authentication.py
@@ -6,7 +6,7 @@
 # pylint: disable=line-too-long
 import datetime
 import unittest
-import unittest.mock as mock
+from unittest import mock
 from unittest.mock import MagicMock
 
 from azure.cli.core.adal_authentication import AdalAuthentication, _try_scopes_to_resource

--- a/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_api_profiles.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.core.profiles import (ResourceType, PROFILE_TYPE, CustomResourceType,
                                      get_api_version, supported_api_version, register_resource_type)

--- a/src/azure-cli-core/azure/cli/core/tests/test_application.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_application.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 import os
 import tempfile
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
@@ -5,7 +5,7 @@
 
 import tempfile
 import unittest
-import mock
+from unittest import mock
 import multiprocessing
 import configparser
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_recommender.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_recommender.py
@@ -45,7 +45,7 @@ class TestCommandRecommender(unittest.TestCase):
             self.assertEqual(result_error_type, expected_error_type.value)
 
     def test_get_parameter_mappings(self):
-        import mock
+        from unittest import mock
         from azure.cli.core import AzCommandsLoader
         from azure.cli.core.mock import DummyCli
         from azure.cli.core.command_recommender import get_parameter_mappings

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -5,7 +5,7 @@
 
 import sys
 import logging
-import mock
+from unittest import mock
 import unittest
 from collections import namedtuple
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_connection_verify.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_connection_verify.py
@@ -6,10 +6,7 @@
 import os
 import logging
 import unittest
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 import azure.cli.core._debug as _debug
 import azure.cli.core.util as cli_util

--- a/src/azure-cli-core/azure/cli/core/tests/test_extension.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_extension.py
@@ -8,7 +8,7 @@ import unittest
 import shutil
 import zipfile
 
-import mock
+from unittest import mock
 
 from azure.cli.core.extension import (get_extensions, build_extension_path, extension_exists,
                                       get_extension, get_extension_names, get_extension_modname, ext_compat_with_cli,

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -9,7 +9,7 @@ import inspect
 from inspect import getmembers as inspect_getmembers
 
 import unittest
-import mock
+from unittest import mock
 import tempfile
 
 from knack.help import GroupHelpFile, HelpAuthoringException

--- a/src/azure-cli-core/azure/cli/core/tests/test_keys.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_keys.py
@@ -11,7 +11,7 @@ import io
 import os
 import shutil
 from knack.util import CLIError
-import mock
+from unittest import mock
 
 from azure.cli.core.keys import generate_ssh_keys
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_local_context.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_local_context.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import mock
+from unittest import mock
 import unittest
 
 from azure.cli.core.local_context import AzCLILocalContext, ALL

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import mock
+from unittest import mock
 import unittest
 import difflib
 from io import StringIO

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 import unittest
-import mock
+from unittest import mock
 import re
 
 from copy import deepcopy

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile_v2016_06_01.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile_v2016_06_01.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 import unittest
-import mock
+from unittest import mock
 import re
 
 from copy import deepcopy

--- a/src/azure-cli-core/azure/cli/core/tests/test_telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_telemetry.py
@@ -41,7 +41,7 @@ class TestCoreTelemetry(unittest.TestCase):
         self.assertEqual(['-g', '--name', '-d', '--debug'], AzCliCommandInvoker._extract_parameter_names(args))
 
     def test_cloud_forbid_telemetry(self):
-        import mock
+        from unittest import mock
         import azure.cli.core.telemetry as telemetry
         from azure.cli.core.mock import DummyCli
         from knack.completion import ARGCOMPLETE_ENV_NAME

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 import os
 import sys
 import unittest
-import mock
+from unittest import mock
 import tempfile
 import json
 
@@ -270,20 +270,20 @@ class TestUtils(unittest.TestCase):
                          generated_client_request_id_name=None)
 
         get_raw_token_mock.assert_not_called()
-        request = send_mock.call_args.args[1]
+        request = send_mock.call_args[0][1]
         self.assertEqual(request.method, 'PUT')
         self.assertEqual(request.url, 'https://myaccount.blob.core.windows.net/mycontainer/myblob?timeout=30&sv=2019-02-02&srt=s&ss=bf')
         self.assertEqual(request.body, '{"b1": "v1"}')
         # Verify no Authorization header
         self.assertDictEqual(dict(request.headers), expected_header)
-        self.assertEqual(send_mock.call_args.kwargs["verify"], not should_disable_connection_verify())
+        self.assertEqual(send_mock.call_args[1]["verify"], not should_disable_connection_verify())
 
         # Test Authorization header is skipped
         send_raw_request(cli_ctx, 'GET', full_arm_rest_url, body=test_body, skip_authorization_header=True,
                          generated_client_request_id_name=None)
 
         get_raw_token_mock.assert_not_called()
-        request = send_mock.call_args.args[1]
+        request = send_mock.call_args[0][1]
         self.assertDictEqual(dict(request.headers), expected_header)
 
         # Test Authorization header is already provided
@@ -292,7 +292,7 @@ class TestUtils(unittest.TestCase):
                          generated_client_request_id_name=None)
 
         get_raw_token_mock.assert_not_called()
-        request = send_mock.call_args.args[1]
+        request = send_mock.call_args[0][1]
         self.assertDictEqual(dict(request.headers), {**expected_header, 'Authorization': 'Basic ABCDE'})
 
         # Test Authorization header is auto appended
@@ -301,7 +301,7 @@ class TestUtils(unittest.TestCase):
                          generated_client_request_id_name=None)
 
         get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id, subscription=subscription_id)
-        request = send_mock.call_args.args[1]
+        request = send_mock.call_args[0][1]
         self.assertDictEqual(dict(request.headers), expected_header_with_auth)
 
         # Test ARM Subscriptions - List
@@ -311,7 +311,7 @@ class TestUtils(unittest.TestCase):
                          generated_client_request_id_name=None)
 
         get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
-        request = send_mock.call_args.args[1]
+        request = send_mock.call_args[0][1]
         self.assertEqual(request.url, test_arm_endpoint.rstrip('/') + '/subscriptions?api-version=2020-01-01')
         self.assertDictEqual(dict(request.headers), expected_header_with_auth)
 
@@ -322,7 +322,7 @@ class TestUtils(unittest.TestCase):
                          generated_client_request_id_name=None)
 
         get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id)
-        request = send_mock.call_args.args[1]
+        request = send_mock.call_args[0][1]
         self.assertEqual(request.url, test_arm_endpoint.rstrip('/') + '/tenants?api-version=2020-01-01')
         self.assertDictEqual(dict(request.headers), expected_header_with_auth)
 
@@ -332,7 +332,7 @@ class TestUtils(unittest.TestCase):
                          generated_client_request_id_name=None)
 
         get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id, subscription=subscription_id)
-        request = send_mock.call_args.args[1]
+        request = send_mock.call_args[0][1]
         self.assertEqual(request.url, full_arm_rest_url)
         self.assertDictEqual(dict(request.headers), expected_header_with_auth)
 
@@ -341,7 +341,7 @@ class TestUtils(unittest.TestCase):
         send_raw_request(cli_ctx, 'GET', full_arm_rest_url)
 
         get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id, subscription=subscription_id)
-        request = send_mock.call_args.args[1]
+        request = send_mock.call_args[0][1]
         self.assertEqual(request.url, full_arm_rest_url)
 
         # Test full ARM URL with port
@@ -351,7 +351,7 @@ class TestUtils(unittest.TestCase):
         send_raw_request(cli_ctx, 'GET', full_arm_rest_url_with_port)
 
         get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id, subscription=subscription_id)
-        request = send_mock.call_args.args[1]
+        request = send_mock.call_args[0][1]
         self.assertEqual(request.url, 'https://management.azure.com:443/subscriptions/00000001-0000-0000-0000-000000000000/resourcegroups/02?api-version=2019-07-01')
 
         # Test non-ARM APIs
@@ -360,7 +360,7 @@ class TestUtils(unittest.TestCase):
         url = 'https://graph.windows.net/00000002-0000-0000-0000-000000000000/applications/00000003-0000-0000-0000-000000000000?api-version=1.6'
         send_raw_request(cli_ctx, 'PATCH', url, body=test_body, generated_client_request_id_name=None)
         get_raw_token_mock.assert_called_with(mock.ANY, 'https://graph.windows.net/')
-        request = send_mock.call_args.args[1]
+        request = send_mock.call_args[0][1]
         self.assertEqual(request.method, 'PATCH')
         self.assertEqual(request.url, url)
 
@@ -368,7 +368,7 @@ class TestUtils(unittest.TestCase):
         url = 'https://graph.microsoft.com/beta/appRoleAssignments/01'
         send_raw_request(cli_ctx, 'PATCH', url, body=test_body, generated_client_request_id_name=None)
         get_raw_token_mock.assert_called_with(mock.ANY, 'https://graph.microsoft.com/')
-        request = send_mock.call_args.args[1]
+        request = send_mock.call_args[0][1]
         self.assertEqual(request.method, 'PATCH')
         self.assertEqual(request.url, url)
 
@@ -377,7 +377,7 @@ class TestUtils(unittest.TestCase):
             send_raw_request(cli_ctx, 'GET', full_arm_rest_url, headers={'user-agent=ARG-UA'})
 
             get_raw_token_mock.assert_called_with(mock.ANY, test_arm_active_directory_resource_id, subscription=subscription_id)
-            request = send_mock.call_args.args[1]
+            request = send_mock.call_args[0][1]
             self.assertEqual(request.headers['User-Agent'], get_az_rest_user_agent() + ' env-ua ARG-UA')
 
     def test_scopes_to_resource(self):
@@ -496,7 +496,7 @@ class TestHandleException(unittest.TestCase):
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertIn(err_msg, mock_logger_error.call_args.args[0])
+        self.assertIn(err_msg, mock_logger_error.call_args[0][0])
         self.assertEqual(ex_result, 1)
 
     @mock.patch('azure.cli.core.azclierror.logger.error', autospec=True)
@@ -514,7 +514,7 @@ class TestHandleException(unittest.TestCase):
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertIn(mock_cloud_error.args[0], mock_logger_error.call_args.args[0])
+        self.assertIn(mock_cloud_error.args[0], mock_logger_error.call_args[0][0])
         self.assertEqual(ex_result, 1)
 
     @mock.patch('azure.cli.core.azclierror.logger.error', autospec=True)
@@ -531,8 +531,8 @@ class TestHandleException(unittest.TestCase):
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertIn(err_msg, mock_logger_error.call_args.args[0])
-        self.assertIn(err_code, mock_logger_error.call_args.args[0])
+        self.assertIn(err_msg, mock_logger_error.call_args[0][0])
+        self.assertIn(err_code, mock_logger_error.call_args[0][0])
         self.assertEqual(ex_result, 1)
 
     @mock.patch('azure.cli.core.azclierror.logger.error', autospec=True)
@@ -552,7 +552,7 @@ class TestHandleException(unittest.TestCase):
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertIn(expected_message, mock_logger_error.call_args.args[0])
+        self.assertIn(expected_message, mock_logger_error.call_args[0][0])
         self.assertEqual(ex_result, 1)
 
     @mock.patch('azure.cli.core.azclierror.logger.error', autospec=True)
@@ -570,7 +570,7 @@ class TestHandleException(unittest.TestCase):
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertIn(str(mock.call(mock_http_error).args[0]), mock_logger_error.call_args.args[0])
+        self.assertIs(str(mock_http_error), mock_logger_error.call_args[0][0])
         self.assertEqual(ex_result, 1)
 
     @mock.patch('azure.cli.core.azclierror.logger.error', autospec=True)
@@ -587,7 +587,7 @@ class TestHandleException(unittest.TestCase):
 
         # test behavior
         self.assertTrue(mock_logger_error.called)
-        self.assertIn(str(mock.call(mock_http_error).args[0]), mock_logger_error.call_args.args[0])
+        self.assertIn(str(mock_http_error), mock_logger_error.call_args[0][0])
         self.assertEqual(ex_result, 1)
 
     @staticmethod

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -66,9 +66,6 @@ DEPENDENCIES = [
 if not sys.platform.startswith('cygwin'):
     DEPENDENCIES.append('psutil~=5.8')
 
-TESTS_REQUIRE = [
-    'mock'
-]
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()
@@ -87,9 +84,5 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests", "azure", "azure.cli"]),
     install_requires=DEPENDENCIES,
     python_requires='>=3.6.0',
-    extras_require={
-        "test": TESTS_REQUIRE,
-    },
-    tests_require=TESTS_REQUIRE,
     package_data={'azure.cli.core': ['auth_landing_pages/*.html']}
 )

--- a/src/azure-cli-core/tox.ini
+++ b/src/azure-cli-core/tox.ini
@@ -4,7 +4,6 @@ skip_missing_interpreters = True
 
 [testenv]
 deps = pytest
-       mock
        pip
        -e ../azure-cli-telemetry
 commands = pytest

--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -46,8 +46,5 @@ setup(
     packages=[
         'azure.cli.telemetry',
         'azure.cli.telemetry.components'
-    ],
-    test_requires=[
-        'mock'
     ]
 )

--- a/src/azure-cli-telemetry/tox.ini
+++ b/src/azure-cli-telemetry/tox.ini
@@ -4,5 +4,4 @@ skip_missing_interpreters = True
 
 [testenv]
 deps = pytest
-       mock
 commands = pytest

--- a/src/azure-cli-testsdk/setup.py
+++ b/src/azure-cli-testsdk/setup.py
@@ -24,7 +24,6 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'jmespath',
-    'mock',
     'vcrpy>=1.10.3',
     'azure-devtools==1.2.0',
     'pytest'

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -9,7 +9,7 @@ except ImportError:
     from urllib import urlencode
 import json
 import unittest
-import mock
+from unittest import mock
 import sys
 
 from azure.mgmt.containerregistry.v2019_05_01.models import Registry, Sku

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_acs_client.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_acs_client.py
@@ -5,7 +5,7 @@
 
 # pylint: skip-file
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.command_modules.acs.acs_client import ACSClient
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -4407,7 +4407,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         })
 
         # assign
-        import mock
+        from unittest import mock
         with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
             assignment = self.cmd(
                 'role assignment create --assignee-object-id={identity_id} --role "Private DNS Zone Contributor" --scope={zone_id} --assignee-principal-type ServicePrincipal').get_output_in_json()

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: skip-file
-import mock
+from unittest import mock
 import os
 import platform
 import requests

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_helpers.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 
 from knack import CLI
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_loadbalancer.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_loadbalancer.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import unittest
-import mock
+from unittest import mock
 
 from knack import CLI
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_service_principals.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_service_principals.py
@@ -6,7 +6,7 @@
 import os
 import tempfile
 import unittest
-import mock
+from unittest import mock
 
 from knack.util import CLIError
 from azure.cli.command_modules.acs.custom import (

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import unittest
-import mock
+from unittest import mock
 
 from knack import CLI
 

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_job_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_job_scenarios.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import mock
+from unittest import mock
 import time
 
 from azure.cli.core.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_sp_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_sp_scenarios.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import mock
+from unittest import mock
 
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
 from azure_devtools.scenario_tests import AllowLargeResponse

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
@@ -7,7 +7,7 @@
 # pylint: disable=too-few-public-methods
 
 import unittest
-import mock
+from unittest import mock
 from azure.cli.core.azclierror import ValidationError
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_devops_build_commands_thru_mock.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from knack.util import CLIError
 from azure.cli.core.mock import DummyCli
 from azure.cli.command_modules.appservice.azure_devops_build_interactive import (

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 import json
 import unittest
-import mock
+from unittest import mock
 import os
 import time
 import tempfile

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import unittest
-import mock
+from unittest import mock
 import os
 
 from azure.mgmt.web import WebSiteManagementClient

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -98,7 +98,7 @@ class TestStaticAppCommands(unittest.TestCase):
             tags=tags)
 
         self.staticapp_client.create_or_update_static_site.assert_called_once()
-        arg_list = self.staticapp_client.create_or_update_static_site.call_args.kwargs
+        arg_list = self.staticapp_client.create_or_update_static_site.call_args[1]
         self.assertEqual(self.name1, arg_list["name"])
         self.assertEqual(self.rg1, arg_list["resource_group_name"])
         self.assertEqual(self.location1, arg_list["static_site_envelope"].location)
@@ -119,7 +119,7 @@ class TestStaticAppCommands(unittest.TestCase):
             self.source1, self.branch1, self.token1, sku='standard')
 
         self.staticapp_client.create_or_update_static_site.assert_called_once()
-        arg_list = self.staticapp_client.create_or_update_static_site.call_args.kwargs
+        arg_list = self.staticapp_client.create_or_update_static_site.call_args[1]
         self.assertEqual('Standard', arg_list["static_site_envelope"].sku.name)
 
     def test_create_staticapp_missing_token(self):
@@ -146,7 +146,7 @@ class TestStaticAppCommands(unittest.TestCase):
         update_staticsite(self.mock_cmd, self.name1, self.source2, self.branch2, self.token2, tags=tags, sku=sku)
 
         self.staticapp_client.update_static_site.assert_called_once()
-        arg_list = self.staticapp_client.update_static_site.call_args.kwargs
+        arg_list = self.staticapp_client.update_static_site.call_args[1]
         self.assertEqual(self.name1, arg_list["name"])
         self.assertEqual(self.source2, arg_list["static_site_envelope"].repository_url)
         self.assertEqual(self.branch2, arg_list["static_site_envelope"].branch)
@@ -163,7 +163,7 @@ class TestStaticAppCommands(unittest.TestCase):
         update_staticsite(self.mock_cmd, self.name1)
 
         self.staticapp_client.update_static_site.assert_called_once()
-        arg_list = self.staticapp_client.update_static_site.call_args.kwargs
+        arg_list = self.staticapp_client.update_static_site.call_args[1]
         self.assertEqual(self.name1, arg_list["name"])
         self.assertEqual(self.source1, arg_list["static_site_envelope"].repository_url)
         self.assertEqual(self.branch1, arg_list["static_site_envelope"].branch)
@@ -379,7 +379,7 @@ class TestStaticAppCommands(unittest.TestCase):
         invite_staticsite_users(self.mock_cmd, self.name1, authentication_provider, user_details, self.hostname1,
                                 roles, invitation_expiration_in_hours, self.rg1)
 
-        arg_list = self.staticapp_client.create_user_roles_invitation_link.call_args.args
+        arg_list = self.staticapp_client.create_user_roles_invitation_link.call_args[0]
 
         self.assertEqual(self.rg1, arg_list[0])
         self.assertEqual(self.name1, arg_list[1])
@@ -400,7 +400,7 @@ class TestStaticAppCommands(unittest.TestCase):
         invite_staticsite_users(self.mock_cmd, self.name1, authentication_provider, user_details, self.hostname1,
                                 roles, invitation_expiration_in_hours)
 
-        arg_list = self.staticapp_client.create_user_roles_invitation_link.call_args.args
+        arg_list = self.staticapp_client.create_user_roles_invitation_link.call_args[0]
 
         self.assertEqual(self.rg1, arg_list[0])
         self.assertEqual(self.name1, arg_list[1])

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.command_modules.appservice.static_sites import \
     list_staticsites, show_staticsite, delete_staticsite, create_staticsites, CLIError, disconnect_staticsite, \

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 import json
 import unittest
-import mock
+from unittest import mock
 import os
 import time
 import tempfile

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import unittest
-import mock
+from unittest import mock
 
 from msrestazure.azure_exceptions import CloudError
 

--- a/src/azure-cli/azure/cli/command_modules/aro/tests/latest/test_aro_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/tests/latest/test_aro_commands.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 from random import randint
-import mock
+from unittest import mock
 
 
 from knack.log import get_logger

--- a/src/azure-cli/azure/cli/command_modules/batch/tests/latest/test_batch_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/tests/latest/test_batch_commands.py
@@ -7,7 +7,7 @@ import os
 import unittest
 import datetime
 import isodate
-import mock
+from unittest import mock
 
 from azure.batch import models, operations, BatchServiceClient
 from azure.batch.batch_auth import SharedKeyCredentials

--- a/src/azure-cli/azure/cli/command_modules/batchai/tests/latest/test_batchai_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/batchai/tests/latest/test_batchai_custom.py
@@ -30,7 +30,7 @@ from azure.mgmt.batchai.models import (
     SshConfiguration, ImageReference, ScaleSettings, ManualScaleSettings, AutoScaleSettings, ResourceId, SetupTask
 )
 # Some valid ssh public key value.
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 SSH_KEY = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKUDnWeK6rx36apNE9ij1iAXn68FKXLTW0009XK/7dyMewlNfXi6Z2opnxHDD' \
           'YWucMluU0dsvBR22OuYH2RHriPJTi1jN3aZ0zZSrlH/W4MSNQKlG/AnrjJPA3xfYjIKLGuKBqSIvMsmrkuDfIfMaDnPcxb+GzM1' \

--- a/src/azure-cli/azure/cli/command_modules/batchai/tests/latest/test_batchai_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/batchai/tests/latest/test_batchai_scenario.py
@@ -9,10 +9,7 @@ from contextlib import contextmanager
 import os
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from azure.cli.testsdk import JMESPathCheck, JMESPathCheckExists, StringContainCheck
 from azure_devtools.scenario_tests import AllowLargeResponse

--- a/src/azure-cli/azure/cli/command_modules/botservice/tests/latest/test_bot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/tests/latest/test_bot_commands.py
@@ -12,10 +12,7 @@ import unittest
 
 from azure.cli.core.azclierror import MutuallyExclusiveArgumentError
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 import requests
 from azure.cli.command_modules.botservice.custom import prepare_webapp_deploy
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, LiveScenarioTest, live_only

--- a/src/azure-cli/azure/cli/command_modules/cdn/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/cdn/tests/latest/test_validators.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import unittest
-import mock
+from unittest import mock
 from azure.cli.command_modules.cdn._validators import validate_origin
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/dla/tests/latest/test_dla_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/dla/tests/latest/test_dla_commands.py
@@ -4,10 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 # pylint: disable=line-too-long
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
 

--- a/src/azure-cli/azure/cli/command_modules/dls/tests/latest/test_dls_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/dls/tests/latest/test_dls_commands.py
@@ -119,10 +119,7 @@ class DataLakeStoreFileAccessScenarioTest(ScenarioTest):
 class DataLakeStoreFileScenarioTest(ScenarioTest):
 
     def setUp(self):
-        try:
-            import unittest.mock as mock
-        except ImportError:
-            import mock
+        from unittest import mock
         import uuid
 
         def const_uuid():

--- a/src/azure-cli/azure/cli/command_modules/find/tests/latest/test_find.py
+++ b/src/azure-cli/azure/cli/command_modules/find/tests/latest/test_find.py
@@ -5,7 +5,7 @@
 
 import json
 import unittest
-import mock
+from unittest import mock
 import requests
 
 from azure.cli.command_modules.find.custom import (Example, call_aladdin_service,

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 # pylint: disable=too-many-statements
 
-import mock
+from unittest import mock
 
 from azure.cli.testsdk import ResourceGroupPreparer, ScenarioTest, StorageAccountPreparer
 from azure_devtools.scenario_tests import AllowLargeResponse

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_general_operations.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, StorageAccountPreparer, live_only
-import mock
+from unittest import mock
 import unittest
 from msrestazure.tools import resource_id
 

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_unittest.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_unittest.py
@@ -5,10 +5,7 @@
 
 import unittest
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/network/tests/hybrid_2018_03_01/test_network_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/hybrid_2018_03_01/test_network_commands.py
@@ -1873,7 +1873,7 @@ class NetworkVpnClientPackageScenarioTest(LiveScenarioTest):
 
 # convert to ScenarioTest and re-record when #6009 is fixed
 class NetworkWatcherScenarioTest(LiveScenarioTest):
-    import mock
+    from unittest import mock
 
     def _mock_thread_count():
         return 1

--- a/src/azure-cli/azure/cli/command_modules/network/tests/hybrid_2018_03_01/test_network_unit_tests.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/hybrid_2018_03_01/test_network_unit_tests.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -4565,7 +4565,7 @@ class NetworkWatcherConfigureScenarioTest(LiveScenarioTest):
 
 
 class NetworkWatcherScenarioTest(ScenarioTest):
-    import mock
+    from unittest import mock
 
     def _mock_thread_count():
         return 1

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_unit_tests.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-import mock
+from unittest import mock
 
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.command_modules.profile.custom import list_subscriptions, get_access_token, login
 from azure.cli.core.mock import DummyCli

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_api_check.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_api_check.py
@@ -4,11 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 from knack.util import CLIError
 from azure.cli.command_modules.resource.custom import (_ResourceUtils, _validate_resource_inputs,

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_resource_custom.py
@@ -10,10 +10,7 @@ import unittest
 from six.moves.urllib.request import pathname2url  # pylint: disable=import-error
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from azure.cli.core.util import CLIError, get_file_json, shell_safe_json_parse
 from azure.cli.command_modules.resource.custom import \

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_resource_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_resource_validators.py
@@ -5,7 +5,7 @@
 
 import unittest
 import os.path
-import mock
+from unittest import mock
 from six import StringIO
 
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_api_check.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_api_check.py
@@ -4,11 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 from knack.util import CLIError
 from azure.cli.command_modules.resource.custom import (_ResourceUtils, _validate_resource_inputs,

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_resource.py
@@ -6,7 +6,7 @@
 import json
 import os
 import time
-import mock
+from unittest import mock
 import unittest
 
 from azure_devtools.scenario_tests.const import MOCKED_SUBSCRIPTION_ID

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_resource_custom.py
@@ -10,10 +10,7 @@ import unittest
 from six.moves.urllib.request import pathname2url  # pylint: disable=import-error
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from azure.cli.core.util import CLIError, get_file_json, shell_safe_json_parse
 from azure.cli.command_modules.resource.custom import \

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_resource_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_resource_validators.py
@@ -5,7 +5,7 @@
 
 import unittest
 import os.path
-import mock
+from unittest import mock
 from six import StringIO
 
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_api_check.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_api_check.py
@@ -4,11 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 from knack.util import CLIError
 from azure.cli.command_modules.resource.custom import (_ResourceUtils, _validate_resource_inputs,

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -8,7 +8,7 @@ import os
 import platform
 import shutil
 import time
-import mock
+from unittest import mock
 import unittest
 from pathlib import Path
 

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
@@ -6,7 +6,7 @@
 import os
 import contextlib
 import unittest
-import mock
+from unittest import mock
 
 from knack.util import CLIError
 from azure.cli.command_modules.resource._bicep import (

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -11,10 +11,7 @@ from six.moves.urllib.request import pathname2url  # pylint: disable=import-erro
 from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 from six import assertRaisesRegex
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from azure.cli.core.util import CLIError, get_file_json, shell_safe_json_parse
 from azure.cli.command_modules.resource.custom import (

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_validators.py
@@ -5,7 +5,7 @@
 
 import unittest
 import os.path
-import mock
+from unittest import mock
 from six import StringIO
 
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/role/tests/hybrid_2018_03_01/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/hybrid_2018_03_01/test_role.py
@@ -9,7 +9,7 @@ import os
 import tempfile
 import time
 import datetime
-import mock
+from unittest import mock
 import unittest
 
 from azure_devtools.scenario_tests import AllowLargeResponse, record_only

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import json
-import mock
+from unittest import mock
 import unittest
 import datetime
 import dateutil

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -9,7 +9,7 @@ import os
 import tempfile
 import time
 import datetime
-import mock
+from unittest import mock
 import unittest
 
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role_commands_thru_mock.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 import unittest
 import uuid
-import mock
+from unittest import mock
 
 from azure.cli.core.mock import DummyCli
 

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role_custom.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.command_modules.role.custom import _resolve_role_id
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2018_03_01/test_storage_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2018_03_01/test_storage_validators.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 from argparse import Namespace
 from six import StringIO
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2019_03_01/test_storage_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2019_03_01/test_storage_validators.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 from argparse import Namespace
 from six import StringIO
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2020_09_01/test_storage_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2020_09_01/test_storage_validators.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 from argparse import Namespace
 from six import StringIO
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 from argparse import (Namespace, ArgumentError)
 from six import StringIO
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_custom_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_custom_vm_commands.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_actions.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import tempfile
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.core.keys import is_valid_ssh_rsa_public_key
 from azure.cli.command_modules.vm._validators import (validate_ssh_key,

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_commands.py
@@ -10,7 +10,7 @@ import platform
 import tempfile
 import time
 import unittest
-import mock
+from unittest import mock
 import uuid
 
 import six

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_defaults.py
@@ -7,10 +7,7 @@
 
 import argparse
 import unittest
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_image.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_image.py
@@ -5,7 +5,7 @@
 
 import os.path
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.core.cloud import CloudEndpointNotSetException
 from azure.cli.core.mock import DummyCli

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_parameters.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_parameters.py
@@ -4,10 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 def mock_echo_args(command_name, parameters):

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_custom_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_custom_vm_commands.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_template_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_template_builder.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.command_modules.vm._template_builder import build_load_balancer_resource
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_actions.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import tempfile
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.core.keys import is_valid_ssh_rsa_public_key
 from azure.cli.command_modules.vm._validators import (validate_ssh_key,

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_commands.py
@@ -10,7 +10,7 @@ import platform
 import tempfile
 import time
 import unittest
-import mock
+from unittest import mock
 import uuid
 
 import six

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_defaults.py
@@ -7,10 +7,7 @@
 
 import argparse
 import unittest
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_image.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_image.py
@@ -5,7 +5,7 @@
 
 import os.path
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.core.cloud import CloudEndpointNotSetException
 from azure.cli.core.mock import DummyCli

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_parameters.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_parameters.py
@@ -4,10 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 def mock_echo_args(command_name, parameters):

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_custom_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_custom_vm_commands.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_template_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_template_builder.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.command_modules.vm._template_builder import build_load_balancer_resource
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_actions.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import tempfile
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.core.keys import is_valid_ssh_rsa_public_key
 from azure.cli.command_modules.vm._validators import (validate_ssh_key,

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_commands.py
@@ -10,7 +10,7 @@ import platform
 import tempfile
 import time
 import unittest
-import mock
+from unittest import mock
 import uuid
 
 import six

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_defaults.py
@@ -7,10 +7,7 @@
 
 import argparse
 import unittest
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_image.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_image.py
@@ -5,7 +5,7 @@
 
 import os.path
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.core.cloud import CloudEndpointNotSetException
 from azure.cli.core.mock import DummyCli

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_parameters.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_parameters.py
@@ -4,10 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 def mock_echo_args(command_name, parameters):

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_custom_vm_commands.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_image_builder_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_image_builder_commands.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 import time
 import unittest
-import mock
+from unittest import mock
 from knack.testsdk import record_only
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_template_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_template_builder.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.command_modules.vm._template_builder import build_load_balancer_resource
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import tempfile
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.core.keys import is_valid_ssh_rsa_public_key
 from azure.cli.command_modules.vm._validators import (validate_ssh_key,

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -10,7 +10,7 @@ import platform
 import tempfile
 import time
 import unittest
-import mock
+from unittest import mock
 import uuid
 
 from azure.cli.testsdk.exceptions import JMESPathCheckAssertionError

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_defaults.py
@@ -7,10 +7,7 @@
 
 import argparse
 import unittest
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from knack.util import CLIError
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_image.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_image.py
@@ -5,7 +5,7 @@
 
 import os.path
 import unittest
-import mock
+from unittest import mock
 
 from azure.cli.core.cloud import CloudEndpointNotSetException
 from azure.cli.core.mock import DummyCli

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_parameters.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_parameters.py
@@ -4,10 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 def mock_echo_args(command_name, parameters):

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -108,7 +108,6 @@ jmespath==0.9.5
 jsmin==2.2.2
 knack==0.8.2
 MarkupSafe==1.1.1
-mock==4.0.2
 msal==1.10.0
 msrest==0.6.21
 msrestazure==0.6.3

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -108,7 +108,6 @@ jmespath==0.9.5
 jsmin==2.2.2
 knack==0.8.2
 MarkupSafe==1.1.1
-mock==4.0.2
 msal==1.10.0
 msrest==0.6.21
 msrestazure==0.6.3

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -107,7 +107,6 @@ jmespath==0.9.5
 jsmin==2.2.2
 knack==0.8.2
 MarkupSafe==1.1.1
-mock==4.0.2
 msal==1.10.0
 msrest==0.6.21
 msrestazure==0.6.3

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -149,9 +149,6 @@ DEPENDENCIES = [
     'xmltodict~=0.12'
 ]
 
-TESTS_REQUIRE = [
-    'mock~=4.0'
-]
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()

--- a/tools/automation/cli_linter/rules/help_rules.py
+++ b/tools/automation/cli_linter/rules/help_rules.py
@@ -7,7 +7,7 @@ from ..rule_decorators import help_file_entry_rule
 from ..linter import RuleError
 from ..util import LinterError
 import shlex
-import mock
+from unittest import mock
 import re
 
 # 'az' space then repeating runs of quoted tokens or non quoted characters

--- a/tools/automation/cli_linter/tests/test_linter.py
+++ b/tools/automation/cli_linter/tests/test_linter.py
@@ -6,7 +6,7 @@
 import os
 import unittest
 import argparse
-import mock
+from unittest import mock
 from automation.cli_linter import main
 from automation.cli_linter.linter import LinterScope, RuleError
 from azure.cli.core.commands import AzCliCommand, ExtensionCommandSource


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix https://github.com/Azure/azure-cli/issues/18976

Per https://pypi.org/project/mock/:

> mock is now part of the Python standard library, available as `unittest.mock` in Python 3.3 onwards.

As Azure CLI requires Python >= 3.6, we can drop `mock`. 
