### PR TITLE
{Core} Log `_get_attr` exceptions

### DIFF
--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -8,6 +8,11 @@ from enum import Enum
 from functools import total_ordering
 from importlib import import_module
 
+from knack.log import get_logger
+
+
+logger = get_logger(__name__)
+
 
 class APIVersionException(Exception):
     def __init__(self, type_name, api_profile):
@@ -573,6 +578,8 @@ def _get_attr(sdk_path, mod_attr_path, checked=True):
                 op = getattr(op, part)
         return op
     except (ImportError, AttributeError) as ex:
+        import traceback
+        logger.debug(traceback.format_exc())
         if checked:
             return None
         raise ex


### PR DESCRIPTION
## Description

Without logging the original `ImportError`, it is very difficult to identify the actual cause for a failure, such as #18159:

> ModuleNotFoundError: No module named '_cffi_backend'

In the current code, when `ImportError` occurs, `get_sdk` returns `None`, thus hiding the original error with

> TypeError: 'NoneType' object is not callable


## Testing Guide

Rename `<venv_name>\Lib\site-packages\_cffi_backend.cp39-win_amd64.pyd` to something else, then run

```
az storage blob list --account-name myst --account-key xxx --container-name test --debug
...
  File "D:\cli\py39\lib\site-packages\azure\multiapi\storage\v2018_11_09\blob\__init__.py", line 6, in <module>
    from .appendblobservice import AppendBlobService
  File "D:\cli\py39\lib\site-packages\azure\multiapi\storage\v2018_11_09\blob\appendblobservice.py", line 30, in <module>
    from ._deserialization import (
  File "D:\cli\py39\lib\site-packages\azure\multiapi\storage\v2018_11_09\blob\_deserialization.py", line 41, in <module>
    from ._encryption import _decrypt_blob
  File "D:\cli\py39\lib\site-packages\azure\multiapi\storage\v2018_11_09\blob\_encryption.py", line 13, in <module>
    from cryptography.hazmat.primitives.padding import PKCS7
  File "D:\cli\py39\lib\site-packages\cryptography\hazmat\primitives\padding.py", line 13, in <module>
    from cryptography.hazmat.bindings._padding import lib
ModuleNotFoundError: No module named '_cffi_backend'
```
