### PR TITLE
[Compute] `az ssh vm`: Raise error for managed identity and Cloud Shell

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -630,6 +630,19 @@ class Profile:
         import posixpath
         authority = posixpath.join(self.cli_ctx.cloud.endpoints.active_directory, tenant)
 
+        # Raise error for managed identity and Cloud Shell
+        not_support_message = "VM SSH currently doesn't support {}."
+
+        # managed identity
+        managed_identity_type, _ = Profile._try_parse_msi_account_name(account)
+        if managed_identity_type:
+            raise CLIError(not_support_message.format("managed identity"))
+
+        # Cloud Shell
+        if in_cloud_console() and account[_USER_ENTITY].get(_CLOUD_SHELL_ID):
+            raise CLIError(not_support_message.format("Cloud Shell"))
+
+        # user
         if identity_type == _USER:
             # Use ARM as resource to get the refresh token from ADAL token cache
             resource = self.cli_ctx.cloud.endpoints.active_directory_resource_id
@@ -649,6 +662,7 @@ class Profile:
                 token_entry = self._login_with_authorization_code_flow(tenant, scopes_to_resource(scopes))
                 result = cred.acquire_token_by_refresh_token(token_entry['refreshToken'], scopes, data=data)
 
+        # service principal
         elif identity_type == _SERVICE_PRINCIPAL:
             from azure.cli.core.msal_authentication import ServicePrincipalCredential
 
@@ -656,8 +670,9 @@ class Profile:
             sp_credential = self._creds_cache.retrieve_cred_for_service_principal(sp_id)
             cred = ServicePrincipalCredential(sp_id, secret_or_certificate=sp_credential, authority=authority)
             result = cred.get_token(scopes=scopes, data=data)
+
         else:
-            raise CLIError("Identity type {} is currently unsupported".format(identity_type))
+            raise CLIError("Unknown identity type {}".format(identity_type))
 
         if 'error' in result:
             from azure.cli.core.adal_authentication import aad_error_handler


### PR DESCRIPTION
## Description

Fix #19048, Email: _Unable to use MSI credentials for logging into a VM_

As discussed with VM team, VM SSH currently doesn't support **managed identity** and **Cloud Shell**.

Currently, with managed identity, the command fails with

```
$ az ssh vm --resource-group vm-ssh-rg --vm-name myvm
No matched service principal found
```

In Cloud Shell, the command fails with

```
$ az ssh vm --resource-group vm-ssh-rg --vm-name myvm
Could not retrieve token from local cache.
```

This PR replaces these obscure error messages with more definitive ones.

## Testing Guide

Run `az ssh vm` on a VM with managed identity:

```
$ az ssh vm --resource-group vm-ssh-rg --vm-name myvm
VM SSH currently doesn't support managed identity.
```

In Cloud Shell:

```
$ az ssh vm --resource-group vm-ssh-rg --vm-name myvm
VM SSH currently doesn't support Cloud Shell.
```
