### PR TITLE
{CI} Increase TestYumPackage's timeoutInMinutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -682,7 +682,7 @@ jobs:
 
 - job: TestYumPackage
   displayName: Test Yum Package
-
+  timeoutInMinutes: 120
   dependsOn: BuildYumPackage
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
   pool:


### PR DESCRIPTION
**Description**<!--Mandatory-->

Job `TestYumPackage` keeps timing out:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1025054&view=logs&j=b1448c29-704b-5199-1998-7fb1cec36b60&s=b15d9194-8f26-5328-b47f-5968c76b37e7

```
##[error]The job running on agent Azure Pipelines 18 ran longer than the maximum time of 60 minutes. For more information, see https://go.microsoft.com/fwlink/?linkid=2077134
Agent: Azure Pipelines 18
Started: Today at 5:39 PM
Duration: 1h 0m 6s
```

This seems to be caused by slow agent. It succeeded on `dev` branch:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1024948&view=logs&j=1e6fba43-bdcf-51f0-a062-3712c33fbb51

```
Pool: Azure Pipelines
Image: ubuntu-20.04
Agent: Azure Pipelines 23
Started: Today at 3:30 PM
Duration: 41m 31s
```

This PR increases `timeoutInMinutes` so that `TestYumPackage` can take longer to finish.

