### PR TITLE
{CI} Add `post` to wheel versions except for `release` branch

### DIFF
--- a/scripts/release/pypi/build.sh
+++ b/scripts/release/pypi/build.sh
@@ -22,7 +22,7 @@ pip list
 
 script_dir=`cd $(dirname $BASH_SOURCE[0]); pwd`
 
-if [[ "$branch" == "dev" ]]; then
+if [[ "$branch" != "release" ]]; then
     . $script_dir/../../ci/version.sh post`date -u '+%Y%m%d%H%M%S'`
 fi
 


### PR DESCRIPTION
## Symptom

`az self-test` in CI fails with

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1008867&view=logs&jobId=b46c874b-707d-54de-7733-46667ab6d730&j=b46c874b-707d-54de-7733-46667ab6d730&t=e06b2869-1ba8-5188-52df-72c2650a8e19

```
  File "/usr/local/lib/python3.6/site-packages/azure/cli/core/commands/command_operation.py", line 66, in get_op_handler
    raise ValueError("The operation '{}' is invalid.".format(op_path))
ValueError: The operation 'azure.mgmt.redis.operations#FirewallRulesOperations.list_by_redis_resource' is invalid.
```

## Causes

The bug is triggered by below logic:

1. The commit is submitted to main Azure CLI repo on branch [`vkukke/bugfix`](https://github.com/Azure/azure-cli/tree/vkukke/bugfix)
2. -> `BuildPythonWheel` doesn't build the wheel with version `postxxx`
3. -> `TestPythonWheel` installs `azure-cli` `2.26.1` from PyPI, not from local
4. -> A SDK dependency bug on `azure-mgmt-redis` of `azure-cli` `2.26.1` is triggered

### 1. Why the branch is submitted to the main repo

Directly submitting to main repo's branches is against our workflow and should be forbidden.

### 2. Why the wheel is not built with version `postxxx`

After the commit is directly submitted into the main Azure CLI repo on branch `vkukke/bugfix`, `BuildPythonWheel` finds it is neither on `dev` nor a PR targeting `dev`, so it doesn't change the version to `postxxx`.

https://github.com/Azure/azure-cli/blob/dbc6a1dcc70f063afe47c41cadf86b553bb24993/azure-pipelines.yml#L315-L320

### 3. Why `TestPythonWheel` doesn't install from local

The `pip install` command in CI uses `--find-links`. Per https://pip.pypa.io/en/stable/cli/pip_install/#finding-packages,

> pip looks for packages in a number of places: on PyPI (if not disabled via `--no-index`), in the local filesystem, and in any additional repositories specified via `--find-links` or `--index-url`. There is no ordering in the locations that are searched. 

When CI is triggered on `dev` branch, the wheel is also built with the same version `2.26.1`. `pip` doesn't install the built wheel from local `/mnt/pypi` at all - it installs `2.16.1` from PyPI. Therefore, no matter how `dev` branch is updated, the failure remains. (https://github.com/pypa/pip/issues/4321)


### 4. Why `azure-mgmt-redis` Python SDK triggers a bug on `azure-cli` `2.26.1`

Azure CLI `2.26.1` relies on

https://github.com/Azure/azure-cli/blob/c176259c03406fbb10cb261d165fcdfe54d8a056/src/azure-cli/setup.py#L113

After `azure-mgmt-redis` `7.0.0` is released, `7.0.0` will be installed instead of `7.0.0rc1`, according to [PEP 440](https://www.python.org/dev/peps/pep-0440/#compatible-release).

However, `azure-mgmt-redis` `7.0.0` introduced a breaking change that removed `azure.mgmt.redis.operations#FirewallRulesOperations.list_by_redis_resource`, which causes the failure of `az self-test`.

In order words, `azure-cli` `2.26.1` on PyPI has this bug in `redis` module when installed with `pip` (using `setup.py`).

## Change

This PR changes the `BuildPythonWheel` logic so that any commit from branches except `release` will generate a wheel with version `postxxx`.

## Testing Guide

Push this branch to the main repo or your forked repo with CI enabled, and see the failure is gone.

https://dev.azure.com/azure-sdk/playground/_build/results?buildId=1027320&view=logs&j=15c91363-8619-578d-3fff-3c1a2fde03cd&t=ee38afd6-1b4d-5825-7e58-257e999d4abd&l=65

```
CLI self-test completed: OK
azure-cli                2.27.0.post20210802041943
```