### PR TITLE
[Role] `az role assignment create`: Support `ForeignGroup` for `--assignee-principal-type`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -214,6 +214,7 @@ def load_arguments(self, _):
             user = "User"
             group = "Group"
             service_principal = "ServicePrincipal"
+            foreign_group = "ForeignGroup"
 
         c.argument('assignee_principal_type', min_api='2018-09-01-preview', arg_type=get_enum_type(PrincipalType),
                    help='use with --assignee-object-id to avoid errors caused by propagation latency in AAD Graph')


### PR DESCRIPTION
## Description

Fix https://github.com/Azure/azure-cli/issues/18616

`az role assignment create`: Support `ForeignGroup` for `--assignee-principal-type`

Azure CLI overrides `PrincipalType` in #16056 because of REST spec issue https://github.com/Azure/azure-rest-api-specs/issues/11830.

The code is copied from Python SDK `azure.mgmt.authorization.v2020_04_01_preview.models._authorization_management_client_enums.PrincipalType`

```
foreign_group = "ForeignGroup"
```

This PR is still a workaround and the ultimate solution should be the fix for https://github.com/Azure/azure-rest-api-specs/issues/11830.

## Testing Guide

```
> az role assignment create -h

    --assignee-principal-type     : Use with --assignee-object-id to avoid errors caused by
                                    propagation latency in AAD Graph.  Allowed values: ForeignGroup,
                                    Group, ServicePrincipal, User.
```
