### PR TITLE
[ARM] Fix #19124: `az deployment what-if`: Handle unsupported and no effect change types

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -18,6 +18,8 @@ _change_type_to_color = {
     ChangeType.deploy: Color.BLUE,
     ChangeType.no_change: Color.RESET,
     ChangeType.ignore: Color.GRAY,
+    ChangeType.unsupported: Color.GRAY,
+    PropertyChangeType.no_effect: Color.GRAY,
 }
 
 _property_change_type_to_color = {
@@ -25,6 +27,7 @@ _property_change_type_to_color = {
     PropertyChangeType.delete: Color.ORANGE,
     PropertyChangeType.modify: Color.PURPLE,
     PropertyChangeType.array: Color.PURPLE,
+    PropertyChangeType.no_effect: Color.GRAY,
 }
 
 _change_type_to_symbol = {
@@ -34,6 +37,8 @@ _change_type_to_symbol = {
     ChangeType.deploy: Symbol.EXCLAMATION_POINT,
     ChangeType.no_change: Symbol.EQUAL,
     ChangeType.ignore: Symbol.ASTERISK,
+    ChangeType.unsupported: Symbol.CROSS,
+    PropertyChangeType.no_effect: Symbol.CROSS,
 }
 
 _property_change_type_to_symbol = {
@@ -41,6 +46,7 @@ _property_change_type_to_symbol = {
     PropertyChangeType.delete: Symbol.MINUS,
     PropertyChangeType.modify: Symbol.TILDE,
     PropertyChangeType.array: Symbol.TILDE,
+    PropertyChangeType.no_effect: Symbol.CROSS,
 }
 
 _change_type_to_weight = {
@@ -49,7 +55,9 @@ _change_type_to_weight = {
     ChangeType.deploy: 2,
     ChangeType.modify: 3,
     ChangeType.no_change: 4,
-    ChangeType.ignore: 5,
+    ChangeType.unsupported: 5,
+    ChangeType.ignore: 6,
+    PropertyChangeType.no_effect: 7,
 }
 
 _property_change_type_to_weight = {
@@ -57,6 +65,7 @@ _property_change_type_to_weight = {
     PropertyChangeType.create: 1,
     PropertyChangeType.modify: 2,
     PropertyChangeType.array: 2,
+    PropertyChangeType.no_effect: 3,
 }
 
 
@@ -127,7 +136,7 @@ def _format_resource_changes_stats(builder, resource_changes):
     builder.append(", ".join(change_type_stats)).append(".")
 
 
-def _format_change_type_count(change_type, count):
+def _format_change_type_count(change_type, count):  # pylint: disable=too-many-return-statements
     if change_type == ChangeType.create:
         return f"{count} to create"
     if change_type == ChangeType.delete:
@@ -140,6 +149,8 @@ def _format_change_type_count(change_type, count):
         return f"{count} to ignore"
     if change_type == ChangeType.no_change:
         return f"{count} no change"
+    if change_type == ChangeType.unsupported:
+        return f"{count} unsupported"
 
     raise ValueError(f"Invalid ChangeType: {change_type}")
 
@@ -190,7 +201,7 @@ def _format_resource_change(builder, resource_change, is_last):
     elif change_type == ChangeType.delete and resource_change.before:
         _format_json(builder, resource_change.before, indent_level=2)
 
-    elif change_type == ChangeType.modify and resource_change.delta:
+    elif resource_change.delta:
         with builder.new_color_scope(Color.RESET):
             builder.append_line()
             _format_property_changes(
@@ -256,6 +267,9 @@ def _format_property_change(builder, property_change, max_path_length, indent_le
     elif property_change_type == PropertyChangeType.array:
         _format_property_change_path(builder, property_change, "children", max_path_length, indent_level)
         _format_property_array_change(builder, children, indent_level + 1)
+    elif property_change_type == PropertyChangeType.no_effect:
+        _format_property_change_path(builder, property_change, "after", max_path_length, indent_level)
+        _format_property_no_effect(builder, after, indent_level + 1)
     else:
         raise ValueError(f"Unknown property change type: {property_change_type}.")
 
@@ -288,6 +302,11 @@ def _format_property_change_type(builder, property_change_type):
     property_change_symbol = _property_change_type_to_symbol[property_change_type]
     property_change_color = _property_change_type_to_color[property_change_type]
     builder.append(property_change_symbol, property_change_color).append(Symbol.WHITE_SPACE)
+
+
+def _format_property_no_effect(builder, value, indent_level):
+    with builder.new_color_scope(_property_change_type_to_color[PropertyChangeType.no_effect]):
+        _format_json(builder, value, indent_level=indent_level)
 
 
 def _format_property_create(builder, value, indent_level):

--- a/src/azure-cli/azure/cli/command_modules/resource/_symbol.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_symbol.py
@@ -19,6 +19,7 @@ class Symbol(Enum):
     MINUS = "-"
     TILDE = "~"
     EXCLAMATION_POINT = "!"
+    CROSS = "x"
 
     def __str__(self):
         return self.value

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
@@ -264,6 +264,10 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000002/resourceGroups/rg2
                 resource_id="/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1/providers/p7/foo",
                 change_type=ChangeType.delete,
             ),
+            WhatIfChange(
+                resource_id="/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1/providers/p8/foo",
+                change_type=ChangeType.unsupported,
+            ),
         ]
 
         expected = f"""
@@ -275,6 +279,7 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
   + p2/foo{Color.RESET}{Color.BLUE}
   ! p4/foo{Color.RESET}{Color.RESET}
   = p3/foo{Color.RESET}{Color.GRAY}
+  x p8/foo{Color.RESET}{Color.GRAY}
   * p1/foo
 {Color.RESET}"""
         result = format_what_if_operation_result(WhatIfOperationResult(changes=changes))
@@ -360,6 +365,11 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
                         },
                     ),
                     WhatIfPropertyChange(
+                        path="path.a.to.change3",
+                        property_change_type=PropertyChangeType.no_effect,
+                        after=12345,
+                    ),
+                    WhatIfPropertyChange(
                         path="path.b.to.nested.change",
                         property_change_type=PropertyChangeType.array,
                         children=[
@@ -393,7 +403,7 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
 Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
 {Color.PURPLE}
   ~ p1/foo{Color.RESET}
-    {Color.PURPLE}~{Color.RESET} path.a.to.change{Color.RESET}:{Color.RESET} {Color.ORANGE}"foo"{Color.RESET} => {Color.GREEN}"bar"{Color.RESET}
+    {Color.PURPLE}~{Color.RESET} path.a.to.change{Color.RESET}:{Color.RESET}  {Color.ORANGE}"foo"{Color.RESET} => {Color.GREEN}"bar"{Color.RESET}
     {Color.PURPLE}~{Color.RESET} path.a.to.change2{Color.RESET}:{Color.RESET}{Color.ORANGE}
 
         tag1{Color.RESET}:{Color.ORANGE} "value"
@@ -413,6 +423,7 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
 
       {Color.ORANGE}-{Color.RESET} 5{Color.RESET}:{Color.RESET} {Color.ORANGE}12345{Color.RESET}
       ]
+    {Color.GRAY}x{Color.RESET} path.a.to.change3{Color.RESET}:{Color.RESET} {Color.GRAY}12345{Color.RESET}
 {Color.PURPLE}{Color.RESET}"""
 
         result = format_what_if_operation_result(WhatIfOperationResult(changes=changes))


### PR DESCRIPTION
**Description**<!--Mandatory-->
Fixes #19124.

**Testing Guide**
```
az deployment group/sub/mg/tenant what-if ...
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
