### PR TITLE
{test} Add subscription to resource group preparer

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -86,9 +86,12 @@ class ResourceGroupPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
         return {self.parameter_name: name, self.parameter_name_for_location: self.location}
 
     def remove_resource(self, name, **kwargs):
+        template = 'az group delete --name {} --yes --no-wait'
+        if self.subscription:
+            template += '--subscription '.format(self.subscription)
         # delete group if test is being recorded and if the group is not a dev rg
         if not self.dev_setting_name:
-            self.live_only_execute(self.cli_ctx, 'az group delete --name {} --yes --no-wait'.format(name))
+            self.live_only_execute(self.cli_ctx, template.format(name))
 
 
 # Storage Account Preparer and its shorthand decorator

--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -86,11 +86,11 @@ class ResourceGroupPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
         return {self.parameter_name: name, self.parameter_name_for_location: self.location}
 
     def remove_resource(self, name, **kwargs):
-        template = 'az group delete --name {} --yes --no-wait'
-        if self.subscription:
-            template += '--subscription '.format(self.subscription)
         # delete group if test is being recorded and if the group is not a dev rg
         if not self.dev_setting_name:
+            template = 'az group delete --name {} --yes --no-wait '
+            if self.subscription:
+                template += '--subscription '.format(self.subscription)
             self.live_only_execute(self.cli_ctx, template.format(name))
 
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -79,7 +79,7 @@ class ResourceGroupPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
         tags = ' '.join(['{}={}'.format(key, value) for key, value in tags.items()])
         template = 'az group create --location {} --name {} --tag ' + tags
         if self.subscription:
-            template += '--subscription '.format(self.subscription)
+            template += ' --subscription {} '.format(self.subscription)
         self.live_only_execute(self.cli_ctx, template.format(self.location, name))
 
         self.test_class_instance.kwargs[self.key] = name
@@ -90,7 +90,7 @@ class ResourceGroupPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
         if not self.dev_setting_name:
             template = 'az group delete --name {} --yes --no-wait '
             if self.subscription:
-                template += '--subscription '.format(self.subscription)
+                template += ' --subscription {} '.format(self.subscription)
             self.live_only_execute(self.cli_ctx, template.format(name))
 
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/preparers.py
@@ -53,12 +53,13 @@ class ResourceGroupPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
                  parameter_name_for_location='resource_group_location', location='westus',
                  dev_setting_name='AZURE_CLI_TEST_DEV_RESOURCE_GROUP_NAME',
                  dev_setting_location='AZURE_CLI_TEST_DEV_RESOURCE_GROUP_LOCATION',
-                 random_name_length=75, key='rg'):
+                 random_name_length=75, key='rg', subscription=None):
         if ' ' in name_prefix:
             raise CliTestError('Error: Space character in resource group name prefix \'%s\'' % name_prefix)
         super(ResourceGroupPreparer, self).__init__(name_prefix, random_name_length)
         self.cli_ctx = get_dummy_cli()
         self.location = location
+        self.subscription = subscription
         self.parameter_name = parameter_name
         self.parameter_name_for_location = parameter_name_for_location
         self.key = key
@@ -77,6 +78,8 @@ class ResourceGroupPreparer(NoTrafficRecordingPreparer, SingleValueReplacer):
             tags['job'] = os.environ['ENV_JOB_NAME']
         tags = ' '.join(['{}={}'.format(key, value) for key, value in tags.items()])
         template = 'az group create --location {} --name {} --tag ' + tags
+        if self.subscription:
+            template += '--subscription '.format(self.subscription)
         self.live_only_execute(self.cli_ctx, template.format(self.location, name))
 
         self.test_class_instance.kwargs[self.key] = name


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Add `subscription` to allow users to customize subscription for resource group

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
