### PR TITLE
{Upgrade} Retrieve latest version from `main` branch

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -271,7 +271,7 @@ def get_installed_cli_distributions():
 def get_latest_from_github(package_path='azure-cli'):
     try:
         import requests
-        git_url = "https://raw.githubusercontent.com/Azure/azure-cli/master/src/{}/setup.py".format(package_path)
+        git_url = "https://raw.githubusercontent.com/Azure/azure-cli/main/src/{}/setup.py".format(package_path)
         response = requests.get(git_url, timeout=10)
         if response.status_code != 200:
             logger.info("Failed to fetch the latest version from '%s' with status code '%s' and reason '%s'",


### PR DESCRIPTION
**Description**<!--Mandatory-->

Due to the renaming of `master` to `main`, `master` branch is no longer maintained.

`az upgrade` should fetch the version from `main` branch instead.