### PR TITLE
{Core} Ignore `psutil.AccessDenied` in `_get_parent_proc_name`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/style.py
+++ b/src/azure-cli-core/azure/cli/core/style.py
@@ -152,12 +152,15 @@ def format_styled_text(styled_text, theme=None):
     if isinstance(theme, str):
         theme = get_theme_dict(theme)
 
-    # Cache the value of is_legacy_powershell
-    if not hasattr(format_styled_text, "_is_legacy_powershell"):
-        from azure.cli.core.util import get_parent_proc_name
-        is_legacy_powershell = not is_modern_terminal() and get_parent_proc_name() == "powershell.exe"
-        setattr(format_styled_text, "_is_legacy_powershell", is_legacy_powershell)
-    is_legacy_powershell = getattr(format_styled_text, "_is_legacy_powershell")
+    # If style is enabled, cache the value of is_legacy_powershell.
+    # Otherwise if theme is None, is_legacy_powershell is meaningless.
+    is_legacy_powershell = None
+    if theme:
+        if not hasattr(format_styled_text, "_is_legacy_powershell"):
+            from azure.cli.core.util import get_parent_proc_name
+            is_legacy_powershell = not is_modern_terminal() and get_parent_proc_name() == "powershell.exe"
+            setattr(format_styled_text, "_is_legacy_powershell", is_legacy_powershell)
+        is_legacy_powershell = getattr(format_styled_text, "_is_legacy_powershell")
 
     # https://python-prompt-toolkit.readthedocs.io/en/stable/pages/printing_text.html#style-text-tuples
     formatted_parts = []

--- a/src/azure-cli-core/azure/cli/core/tests/test_style.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_style.py
@@ -56,6 +56,27 @@ class TestStyle(unittest.TestCase):
         excepted = "\x1b[0mPrimary text color\x1b[0m"
         self.assertEqual(formatted, excepted)
 
+    @mock.patch('azure.cli.core.util.get_parent_proc_name', return_value='powershell.exe')
+    @mock.patch('azure.cli.core.style.is_modern_terminal', return_value=False)
+    def test_format_styled_text_legacy_powershell(self, is_modern_terminal_mock, get_parent_proc_name_mock):
+        """Verify bright/dark blue is replaced with the default color in legacy powershell.exe terminal."""
+        styled_text = [
+            (Style.ACTION, "Blue: Commands, parameters, and system inputs")
+        ]
+
+        # When theme is 'none', no need to call is_modern_terminal and get_parent_proc_name
+        formatted = format_styled_text(styled_text, theme='none')
+        is_modern_terminal_mock.assert_not_called()
+        get_parent_proc_name_mock.assert_not_called()
+        assert formatted == """Blue: Commands, parameters, and system inputs"""
+
+        excepted = """\x1b[0mBlue: Commands, parameters, and system inputs\x1b[0m"""
+        formatted = format_styled_text(styled_text, theme='dark')
+        assert formatted == excepted
+
+        formatted = format_styled_text(styled_text, theme='light')
+        assert formatted == excepted
+
     def test_format_styled_text_on_error(self):
         # Test invalid style
         from azure.cli.core.azclierror import CLIInternalError

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1252,9 +1252,8 @@ def _get_parent_proc_name():
             # if powershell.exe or pwsh.exe is not the grandparent, simply return the parent's name.
             return parent.name()
     except psutil.AccessDenied as ex:
-        logger.debug(ex)
         # Ignore due to https://github.com/giampaolo/psutil/issues/1980
-        pass
+        logger.debug(ex)
     return None
 
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -4,17 +4,18 @@
 # --------------------------------------------------------------------------------------------
 # pylint: disable=too-many-lines
 
-import sys
-import json
-import getpass
 import base64
 import binascii
-import platform
-import ssl
-import re
+import getpass
+import json
 import logging
-
+import os
+import platform
+import re
+import ssl
+import sys
 from urllib.request import urlopen
+
 from knack.log import get_logger
 from knack.util import CLIError, to_snake_case
 
@@ -379,7 +380,6 @@ def get_az_version_string(use_cache=False):  # pylint: disable=too-many-statemen
             else:
                 _print(ext.name.ljust(20) + (ext.version or 'Unknown').rjust(20))
         _print()
-    import os
     _print("Python location '{}'".format(os.path.abspath(sys.executable)))
     _print("Extensions directory '{}'".format(EXTENSIONS_DIR))
     if os.path.isdir(EXTENSIONS_SYS_DIR) and os.listdir(EXTENSIONS_SYS_DIR):
@@ -581,7 +581,6 @@ def hash_string(value, length=16, force_lower=False):
 
 
 def in_cloud_console():
-    import os
     return os.environ.get('ACC_CLOUD', None)
 
 
@@ -610,7 +609,6 @@ DISABLE_VERIFY_VARIABLE_NAME = "AZURE_CLI_DISABLE_CONNECTION_VERIFICATION"
 
 
 def should_disable_connection_verify():
-    import os
     return bool(os.environ.get(DISABLE_VERIFY_VARIABLE_NAME))
 
 
@@ -695,7 +693,6 @@ def is_windows():
 
 
 def can_launch_browser():
-    import os
     import webbrowser
     platform_name, _ = _get_platform_info()
     if is_wsl() or platform_name != 'linux':
@@ -829,7 +826,6 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
     # Borrow AZURE_HTTP_USER_AGENT from msrest
     # https://github.com/Azure/msrest-for-python/blob/4cc8bc84e96036f03b34716466230fb257e27b36/msrest/pipeline/universal.py#L70
     _ENV_ADDITIONAL_USER_AGENT = 'AZURE_HTTP_USER_AGENT'
-    import os
     if _ENV_ADDITIONAL_USER_AGENT in os.environ:
         agents.append(os.environ[_ENV_ADDITIONAL_USER_AGENT])
 
@@ -1097,7 +1093,6 @@ def get_az_user_agent():
 
     agents = ["AZURECLI/{}".format(core_version)]
 
-    import os
     from azure.cli.core._environment import _ENV_AZ_INSTALLER
     if _ENV_AZ_INSTALLER in os.environ:
         agents.append('({})'.format(os.environ[_ENV_AZ_INSTALLER]))
@@ -1240,22 +1235,26 @@ def _get_parent_proc_name():
         logger.debug(ex)
         return None
 
-    import os
-    parent = psutil.Process(os.getpid()).parent()
+    try:
+        parent = psutil.Process(os.getpid()).parent()
 
-    # On Windows, when CLI is run inside a virtual env, there will be 2 python.exe.
-    if parent and parent.name().lower() == 'python.exe':
-        parent = parent.parent()
+        # On Windows, when CLI is run inside a virtual env, there will be 2 python.exe.
+        if parent and parent.name().lower() == 'python.exe':
+            parent = parent.parent()
 
-    if parent:
-        # On Windows, powershell.exe launches cmd.exe to launch python.exe.
-        grandparent = parent.parent()
-        if grandparent:
-            grandparent_name = grandparent.name().lower()
-            if grandparent_name in ("powershell.exe", "pwsh.exe"):
-                return grandparent.name()
-        # if powershell.exe or pwsh.exe is not the grandparent, simply return the parent's name.
-        return parent.name()
+        if parent:
+            # On Windows, powershell.exe launches cmd.exe to launch python.exe.
+            grandparent = parent.parent()
+            if grandparent:
+                grandparent_name = grandparent.name().lower()
+                if grandparent_name in ("powershell.exe", "pwsh.exe"):
+                    return grandparent.name()
+            # if powershell.exe or pwsh.exe is not the grandparent, simply return the parent's name.
+            return parent.name()
+    except psutil.AccessDenied as ex:
+        logger.debug(ex)
+        # Ignore due to https://github.com/giampaolo/psutil/issues/1980
+        pass
     return None
 
 


### PR DESCRIPTION
## Description

Fix #19193

When parent or grandparent process path is too long, `psutil` used by Azure CLI fails:

```
Traceback (most recent call last):
File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\knack/cli.py", line 223, in invoke
File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/init.py", line 132, in show_version
File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/style.py", line 131, in print_styled_text
File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/style.py", line 131, in
File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/style.py", line 158, in format_styled_text
File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/util.py", line 1266, in get_parent_proc_name
File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/util.py", line 1254, in _get_parent_proc_name
File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\psutil/init.py", line 617, in name
File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\psutil/_pswindows.py", line 750, in name
File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\psutil/_pswindows.py", line 681, in wrapper
psutil.AccessDenied: psutil.AccessDenied (pid=1080)
```

The `psutil` issue is tracked at https://github.com/giampaolo/psutil/issues/1980

## Change

This PR ignores `psutil.AccessDenied` so that `get_parent_proc_name` won't fail.

## Testing Guide

Use legacy Windows PowerShell terminal `powershell.exe` to launch Azure CLI with a very long path:

```
D:\cli\py38-32\Scripts\pythonloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.exe -m azure.cli --version --debug
```

- After this PR, `get_parent_proc_name` won't fail as we ignore `psutil.AccessDenied`
- In addition, if CLI is run in a no-TTY environment, like ADO, color will be disabled automatically and `get_parent_proc_name` won't be called at all.

