### PR TITLE
[App Service] `az webapp deployment slot create`: configuration source and cloning a slot settings

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -376,7 +376,11 @@ def load_arguments(self, _):
         c.argument('preserve_vnet', help="preserve Virtual Network to the slot during swap, default to 'true'",
                    arg_type=get_three_state_flag(return_label=True))
     with self.argument_context('webapp deployment slot create') as c:
-        c.argument('configuration_source',
+        c.argument('
+                   
+                   
+                   
+                   ',
                    help="source slot to clone configurations from. Use web app's name to refer to the production slot")
     with self.argument_context('webapp deployment slot swap') as c:
         c.argument('action',
@@ -810,7 +814,8 @@ def load_arguments(self, _):
                    arg_type=get_three_state_flag(return_label=True))
     with self.argument_context('functionapp deployment slot create') as c:
         c.argument('configuration_source',
-                   help="source slot to clone configurations from. Use function app's name to refer to the production slot")
+                   help="source slot to clone configurations from. Use function app's name to refer to the production slot."
+                   "A setting marked as a Deployment slot setting in the source slot will not be cloned.")
     with self.argument_context('functionapp deployment slot swap') as c:
         c.argument('action',
                    help="swap types. use 'preview' to apply target slot's settings on the source slot first; use 'swap' to complete it; use 'reset' to reset the swap",

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -811,7 +811,7 @@ def load_arguments(self, _):
     with self.argument_context('functionapp deployment slot create') as c:
         c.argument('configuration_source',
                    help="source slot to clone configurations from. Use function app's name to refer to the production slot."
-                   "A setting marked as a Deployment slot setting in the source slot will not be cloned.")
+                   "A setting marked as a Deployment slot setting in the source slot will not be cloned")
     with self.argument_context('functionapp deployment slot swap') as c:
         c.argument('action',
                    help="swap types. use 'preview' to apply target slot's settings on the source slot first; use 'swap' to complete it; use 'reset' to reset the swap",

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -376,11 +376,7 @@ def load_arguments(self, _):
         c.argument('preserve_vnet', help="preserve Virtual Network to the slot during swap, default to 'true'",
                    arg_type=get_three_state_flag(return_label=True))
     with self.argument_context('webapp deployment slot create') as c:
-        c.argument('
-                   
-                   
-                   
-                   ',
+        c.argument('configuration_source',
                    help="source slot to clone configurations from. Use web app's name to refer to the production slot")
     with self.argument_context('webapp deployment slot swap') as c:
         c.argument('action',


### PR DESCRIPTION
When creating a deployment slot and using the `--configuration-source` argument, it is not clear that settings marked as 'slot settings' are not propagated to the newly created deployment slot.
Some issues were opened following the lack of documentation around it: https://github.com/Azure/azure-cli/issues/6638, https://github.com/Azure/azure-cli/issues/17531
 
- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
