### PR TITLE
{Core} Add `__init__.py` to `azure.cli.core.auth`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/auth/__init__.py
@@ -1,0 +1,4 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Description**<!--Mandatory-->

CI fails with 

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1058229&view=logs&j=c846b3e8-69b8-5dbd-1a39-4905d81e6a95&t=9ebb608a-8a51-5834-bad0-46e2c03d2282&l=4756

```
________________ ERROR collecting tests/latest/test_auth_e2e.py ________________
ImportError while importing test module '/opt/az/lib/python3.6/site-packages/azure/cli/command_modules/profile/tests/latest/test_auth_e2e.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/az/lib/python3.6/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
/opt/az/lib/python3.6/site-packages/azure/cli/command_modules/profile/tests/latest/test_auth_e2e.py:8: in <module>
    from azure.cli.core.auth.util import decode_access_token
E   ModuleNotFoundError: No module named 'azure.cli.core.auth'
```

This is because `__init__.py` is missing from `azure.cli.core.auth`, similar to #17817.
