### PR TITLE
{Packaging} Use `python:3.9.6-alpine3.14` as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-ARG PYTHON_VERSION="3.8.9"
+ARG PYTHON_VERSION="3.9.6"
 
-FROM python:${PYTHON_VERSION}-alpine3.13
+FROM python:${PYTHON_VERSION}-alpine3.14
 
 ARG CLI_VERSION
 

--- a/scripts/release/docker/pipeline.sh
+++ b/scripts/release/docker/pipeline.sh
@@ -1,3 +1,11 @@
+#!/usr/bin/env bash
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
+set -evx
+
 IMAGE_NAME=clibuild$BUILD_BUILDNUMBER
 CLI_VERSION=`cat src/azure-cli/azure/cli/__main__.py | grep __version__ | sed s/' '//g | sed s/'__version__='// |  sed s/\"//g`
 


### PR DESCRIPTION
## Description

Fix #19281

`python:3.9.6-alpine3.14` has 2 CVEs:

```
+-----------+------------------+----------+-------------------+---------------+---------------------------------------+
|  LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+-----------+------------------+----------+-------------------+---------------+---------------------------------------+
| apk-tools | CVE-2021-36159   | CRITICAL | 2.12.5-r0         | 2.12.6-r0     | libfetch before 2021-07-26, as        |
|           |                  |          |                   |               | used in apk-tools, xbps, and          |
|           |                  |          |                   |               | other products, mishandles...         |
|           |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-36159 |
+-----------+------------------+----------+-------------------+---------------+---------------------------------------+
| krb5-libs | CVE-2021-36222   | HIGH     | 1.18.3-r1         | 1.18.4-r0     | krb5: sending a request containing    |
|           |                  |          |                   |               | a PA-ENCRYPTED-CHALLENGE padata       |
|           |                  |          |                   |               | element without using FAST...         |
|           |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-36222 |
+-----------+------------------+----------+-------------------+---------------+---------------------------------------+
```

`CVE-2021-36159` is fixed by Alpine 3.14.1 according to https://www.alpinelinux.org/posts/Alpine-3.14.1-released.html

> This release includes a fix for apk-tools CVE-2021-36159.

Alpine 3.14.1 already uses `krb5-libs` 1.18.4, which fixes `CVE-2021-36222`

```
# apk list | grep krb5-libs
krb5-libs-1.18.4-r0 x86_64 {krb5} (MIT) [installed]
```

## Testing guide

Download the built docker image from https://dev.azure.com/azure-sdk/playground/_build/results?buildId=1058243&view=artifacts&pathAsName=false&type=publishedArtifacts, run

```
docker load --input .\docker-azure-cli-2.27.1.tar
docker run -it clibuild20210819.1:latest
```

`20210819.1` is the build number as shown in ADO: https://dev.azure.com/azure-sdk/playground/_build/results?buildId=1058243&view=results.


