### PR TITLE
[ARM] `az ts create`: Fix issue where creating a template spec with inner deployments that reference a common template fails

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
@@ -108,11 +108,15 @@ def _pack_artifacts(cmd, template_abs_file_path, context):
             # an artifact elsewhere, we'll do so here...
 
             as_relative_path = _absolute_to_relative_path(getattr(context, 'RootTemplateDirectory'), abs_local_path)
+            duplicateFile = False
             for prev_added_artifact in getattr(context, 'Artifact'):
                 prev_added_artifact = os.path.join(getattr(context, 'RootTemplateDirectory'),
                                                    getattr(prev_added_artifact, 'path'))
                 if os.path.samefile(prev_added_artifact, abs_local_path):
+                    duplicateFile = True
                     continue
+            if duplicateFile:
+                continue
             _pack_artifacts(cmd, abs_local_path, context)
             LinkedTemplateArtifact = get_sdk(cmd.cli_ctx, ResourceType.MGMT_RESOURCE_TEMPLATESPECS,
                                              'LinkedTemplateArtifact', mod='models')

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_create_template_specs_with_artifacts.yaml
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_create_template_specs_with_artifacts.yaml
@@ -13,7 +13,8 @@ interactions:
       ParameterSetName:
       - -g -n -v -l -f --ui-form-definition -d --description --version-description
       User-Agent:
-      - AZURECLI/2.26.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.3 (Windows-10-10.0.18362-SP0)
+      - AZURECLI/2.27.1 (MSI) azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.10
+        (Windows-10-10.0.19043-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0?api-version=2021-05-01
   response:
@@ -29,7 +30,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 07 Jul 2021 08:32:50 GMT
+      - Mon, 23 Aug 2021 17:23:02 GMT
       expires:
       - '-1'
       pragma:
@@ -57,7 +58,8 @@ interactions:
       ParameterSetName:
       - -g -n -v -l -f --ui-form-definition -d --description --version-description
       User-Agent:
-      - AZURECLI/2.26.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.3 (Windows-10-10.0.18362-SP0)
+      - AZURECLI/2.27.1 (MSI) azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.10
+        (Windows-10-10.0.19043-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002?api-version=2021-05-01
   response:
@@ -73,7 +75,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 07 Jul 2021 08:32:51 GMT
+      - Mon, 23 Aug 2021 17:23:03 GMT
       expires:
       - '-1'
       pragma:
@@ -106,18 +108,19 @@ interactions:
       ParameterSetName:
       - -g -n -v -l -f --ui-form-definition -d --description --version-description
       User-Agent:
-      - AZURECLI/2.26.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.3 (Windows-10-10.0.18362-SP0)
+      - AZURECLI/2.27.1 (MSI) azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.10
+        (Windows-10-10.0.19043-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"v-kaisun@microsoft.com\",\r\n    \"createdByType\":
-        \"User\",\r\n    \"createdAt\": \"2021-07-07T08:32:52.7031944Z\",\r\n    \"lastModifiedBy\":
-        \"v-kaisun@microsoft.com\",\r\n    \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\":
-        \"2021-07-07T08:32:52.7031944Z\"\r\n  },\r\n  \"properties\": {\r\n    \"displayName\":
-        \"create-spec000003\",\r\n    \"description\": \"AzCLI test root template
-        spec\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002\",\r\n
+      string: "{\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\":
+        {\r\n    \"displayName\": \"create-spec000003\",\r\n    \"description\": \"AzCLI
+        test root template spec\"\r\n  },\r\n  \"systemData\": {\r\n    \"createdBy\":
+        \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
+        \"2021-08-23T17:23:05.5671736Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
+        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2021-08-23T17:23:05.5671736Z\"\r\n
+        \ },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002\",\r\n
         \ \"type\": \"Microsoft.Resources/templateSpecs\",\r\n  \"name\": \"cli-test-create-template-spec000002\"\r\n}"
     headers:
       cache-control:
@@ -127,7 +130,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 07 Jul 2021 08:32:53 GMT
+      - Mon, 23 Aug 2021 17:23:05 GMT
       expires:
       - '-1'
       pragma:
@@ -139,7 +142,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1195'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -195,25 +198,30 @@ interactions:
       "apiVersion": "2019-10-01", "name": "keyVaultAndSecret", "resourceGroup": "[parameters(''rgName'')]",
       "dependsOn": ["deploymentRg"], "properties": {"mode": "Incremental", "templateLink":
       {"relativePath": "artifacts/createKeyVaultWithSecret.json", "contentVersion":
-      "1.0.0.0"}, "parameters": {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}}}}],
-      "outputs": {}}, "uiFormDefinition": {"$schema": "createFormUI.schema.json",
-      "view": {"kind": "Form", "properties": {"title": "titleFooRG", "steps": [{"name":
-      "basics", "label": "Basics", "elements": [{"name": "resourceScope", "type":
-      "Microsoft.Common.ResourceScope", "subscription": {"constraints": {"validations":
-      [{"isValid": "[expression for checking]", "message": "Please select a valid\u202fsubscription."},
-      {"permission": "<Resource Provider>/<Action>", "message": "Must have correct
-      permission to complete this step."}]}, "resourceProviders": ["<Resource Provider>"]},
-      "resourceGroup": {"constraints": {"validations": [{"isValid": "[expression for
-      checking]", "message": "Please select a valid\u202fresource\u202fgroup."}]},
-      "allowExisting": true}, "location": {"label": "Custom label for location", "toolTip":
-      "provide\u202fa\u202fuseful\u202ftooltip", "resourceTypes": ["Microsoft.Compute/virtualMachines"],
-      "allowedValues": ["eastus", "westus2"]}}], "description": "Customized description
-      with **markdown**, see [more](https://www.microsoft.com)."}, {"name": "storageConfig",
-      "label": "Storage settings", "elements": [{"name": "storageAccounts", "type":
-      "Microsoft.Storage.MultiStorageAccountCombo", "label": {"prefix": "Storage account
-      name prefix", "type": "Storage account type"}, "defaultValue": {"prefix": "stracct",
-      "type": "Standard_LRS"}, "constraints": {"allowedTypes": ["Premium_LRS", "Standard_LRS",
-      "Standard_GRS"]}, "count": 2, "scope": {"subscriptionId": "[steps(''basics'').resourceScope.subscription.subscriptionId]",
+      "1.0.0.0"}, "parameters": {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}}}},
+      {"type": "Microsoft.Resources/deployments", "apiVersion": "2019-10-01", "name":
+      "duplicateRelativePath", "resourceGroup": "[parameters(''rgName'')]", "dependsOn":
+      ["deploymentRg"], "properties": {"mode": "Incremental", "templateLink": {"relativePath":
+      "artifacts/createKeyVaultWithSecret.json", "contentVersion": "1.0.0.0"}, "parameters":
+      {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}}}}], "outputs":
+      {}}, "uiFormDefinition": {"$schema": "createFormUI.schema.json", "view": {"kind":
+      "Form", "properties": {"title": "titleFooRG", "steps": [{"name": "basics", "label":
+      "Basics", "elements": [{"name": "resourceScope", "type": "Microsoft.Common.ResourceScope",
+      "subscription": {"constraints": {"validations": [{"isValid": "[expression for
+      checking]", "message": "Please select a valid\u202fsubscription."}, {"permission":
+      "<Resource Provider>/<Action>", "message": "Must have correct permission to
+      complete this step."}]}, "resourceProviders": ["<Resource Provider>"]}, "resourceGroup":
+      {"constraints": {"validations": [{"isValid": "[expression for checking]", "message":
+      "Please select a valid\u202fresource\u202fgroup."}]}, "allowExisting": true},
+      "location": {"label": "Custom label for location", "toolTip": "provide\u202fa\u202fuseful\u202ftooltip",
+      "resourceTypes": ["Microsoft.Compute/virtualMachines"], "allowedValues": ["eastus",
+      "westus2"]}}], "description": "Customized description with **markdown**, see
+      [more](https://www.microsoft.com)."}, {"name": "storageConfig", "label": "Storage
+      settings", "elements": [{"name": "storageAccounts", "type": "Microsoft.Storage.MultiStorageAccountCombo",
+      "label": {"prefix": "Storage account name prefix", "type": "Storage account
+      type"}, "defaultValue": {"prefix": "stracct", "type": "Standard_LRS"}, "constraints":
+      {"allowedTypes": ["Premium_LRS", "Standard_LRS", "Standard_GRS"]}, "count":
+      2, "scope": {"subscriptionId": "[steps(''basics'').resourceScope.subscription.subscriptionId]",
       "resourceGroupName": "[steps(''basics'').resourceScope.resourceGroup.name]",
       "location": "[steps(''basics'').resourceScope.location.name]"}}]}, {"name":
       "tags", "label": "Tags", "elements": [{"name": "tagsByResource", "type": "Microsoft.Common.TagsByResource",
@@ -234,47 +242,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '6956'
+      - '7356'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n -v -l -f --ui-form-definition -d --description --version-description
       User-Agent:
-      - AZURECLI/2.26.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.3 (Windows-10-10.0.18362-SP0)
+      - AZURECLI/2.27.1 (MSI) azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.10
+        (Windows-10-10.0.19043-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"v-kaisun@microsoft.com\",\r\n    \"createdByType\":
-        \"User\",\r\n    \"createdAt\": \"2021-07-07T08:32:55.263192Z\",\r\n    \"lastModifiedBy\":
-        \"v-kaisun@microsoft.com\",\r\n    \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\":
-        \"2021-07-07T08:32:55.263192Z\"\r\n  },\r\n  \"properties\": {\r\n    \"description\":
-        \"AzCLI test version of root template spec\",\r\n    \"uiFormDefinition\":
-        {\r\n      \"$schema\": \"createFormUI.schema.json\",\r\n      \"view\": {\r\n
-        \       \"kind\": \"Form\",\r\n        \"properties\": {\r\n          \"title\":
-        \"titleFooRG\",\r\n          \"steps\": [\r\n            {\r\n              \"name\":
-        \"basics\",\r\n              \"label\": \"Basics\",\r\n              \"elements\":
-        [\r\n                {\r\n                  \"name\": \"resourceScope\",\r\n
-        \                 \"type\": \"Microsoft.Common.ResourceScope\",\r\n                  \"subscription\":
-        {\r\n                    \"constraints\": {\r\n                      \"validations\":
-        [\r\n                        {\r\n                          \"isValid\": \"[expression
-        for checking]\",\r\n                          \"message\": \"Please select
-        a valid\u202Fsubscription.\"\r\n                        },\r\n                        {\r\n
-        \                         \"permission\": \"<Resource Provider>/<Action>\",\r\n
-        \                         \"message\": \"Must have correct permission to complete
-        this step.\"\r\n                        }\r\n                      ]\r\n                    },\r\n
-        \                   \"resourceProviders\": [\r\n                      \"<Resource
-        Provider>\"\r\n                    ]\r\n                  },\r\n                  \"resourceGroup\":
-        {\r\n                    \"constraints\": {\r\n                      \"validations\":
-        [\r\n                        {\r\n                          \"isValid\": \"[expression
-        for checking]\",\r\n                          \"message\": \"Please select
-        a valid\u202Fresource\u202Fgroup.\"\r\n                        }\r\n                      ]\r\n
-        \                   },\r\n                    \"allowExisting\": true\r\n
-        \                 },\r\n                  \"location\": {\r\n                    \"label\":
-        \"Custom label for location\",\r\n                    \"toolTip\": \"provide\u202Fa\u202Fuseful\u202Ftooltip\",\r\n
-        \                   \"resourceTypes\": [\r\n                      \"Microsoft.Compute/virtualMachines\"\r\n
-        \                   ],\r\n                    \"allowedValues\": [\r\n                      \"eastus\",\r\n
+      string: "{\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\":
+        {\r\n    \"description\": \"AzCLI test version of root template spec\",\r\n
+        \   \"uiFormDefinition\": {\r\n      \"$schema\": \"createFormUI.schema.json\",\r\n
+        \     \"view\": {\r\n        \"kind\": \"Form\",\r\n        \"properties\":
+        {\r\n          \"title\": \"titleFooRG\",\r\n          \"steps\": [\r\n            {\r\n
+        \             \"name\": \"basics\",\r\n              \"label\": \"Basics\",\r\n
+        \             \"elements\": [\r\n                {\r\n                  \"name\":
+        \"resourceScope\",\r\n                  \"type\": \"Microsoft.Common.ResourceScope\",\r\n
+        \                 \"subscription\": {\r\n                    \"constraints\":
+        {\r\n                      \"validations\": [\r\n                        {\r\n
+        \                         \"isValid\": \"[expression for checking]\",\r\n
+        \                         \"message\": \"Please select a valid\u202Fsubscription.\"\r\n
+        \                       },\r\n                        {\r\n                          \"permission\":
+        \"<Resource Provider>/<Action>\",\r\n                          \"message\":
+        \"Must have correct permission to complete this step.\"\r\n                        }\r\n
+        \                     ]\r\n                    },\r\n                    \"resourceProviders\":
+        [\r\n                      \"<Resource Provider>\"\r\n                    ]\r\n
+        \                 },\r\n                  \"resourceGroup\": {\r\n                    \"constraints\":
+        {\r\n                      \"validations\": [\r\n                        {\r\n
+        \                         \"isValid\": \"[expression for checking]\",\r\n
+        \                         \"message\": \"Please select a valid\u202Fresource\u202Fgroup.\"\r\n
+        \                       }\r\n                      ]\r\n                    },\r\n
+        \                   \"allowExisting\": true\r\n                  },\r\n                  \"location\":
+        {\r\n                    \"label\": \"Custom label for location\",\r\n                    \"toolTip\":
+        \"provide\u202Fa\u202Fuseful\u202Ftooltip\",\r\n                    \"resourceTypes\":
+        [\r\n                      \"Microsoft.Compute/virtualMachines\"\r\n                    ],\r\n
+        \                   \"allowedValues\": [\r\n                      \"eastus\",\r\n
         \                     \"westus2\"\r\n                    ]\r\n                  }\r\n
         \               }\r\n              ],\r\n              \"description\": \"Customized
         description with **markdown**, see [more](https://www.microsoft.com).\"\r\n
@@ -330,6 +336,14 @@ interactions:
         [\r\n            \"deploymentRg\"\r\n          ],\r\n          \"properties\":
         {\r\n            \"mode\": \"Incremental\",\r\n            \"templateLink\":
         {\r\n              \"relativePath\": \"artifacts/createKeyVaultWithSecret.json\",\r\n
+        \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
+        {\r\n              \"keyVaultName\": {\r\n                \"value\": \"[parameters('keyVaultName')]\"\r\n
+        \             }\r\n            }\r\n          }\r\n        },\r\n        {\r\n
+        \         \"type\": \"Microsoft.Resources/deployments\",\r\n          \"apiVersion\":
+        \"2019-10-01\",\r\n          \"name\": \"duplicateRelativePath\",\r\n          \"resourceGroup\":
+        \"[parameters('rgName')]\",\r\n          \"dependsOn\": [\r\n            \"deploymentRg\"\r\n
+        \         ],\r\n          \"properties\": {\r\n            \"mode\": \"Incremental\",\r\n
+        \           \"templateLink\": {\r\n              \"relativePath\": \"artifacts/createKeyVaultWithSecret.json\",\r\n
         \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
         {\r\n              \"keyVaultName\": {\r\n                \"value\": \"[parameters('keyVaultName')]\"\r\n
         \             }\r\n            }\r\n          }\r\n        }\r\n      ],\r\n
@@ -420,18 +434,22 @@ interactions:
         \             \"dependsOn\": [\r\n                \"keyVault\"\r\n              ],\r\n
         \             \"properties\": {\r\n                \"value\": \"mySecretValue\"\r\n
         \             }\r\n            }\r\n          ],\r\n          \"outputs\":
-        {}\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0\",\r\n
+        {}\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"systemData\": {\r\n    \"createdBy\":
+        \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
+        \"2021-08-23T17:23:07.3771712Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
+        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2021-08-23T17:23:07.3771712Z\"\r\n
+        \ },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0\",\r\n
         \ \"type\": \"Microsoft.Resources/templateSpecs/versions\",\r\n  \"name\":
         \"1.0\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '13918'
+      - '14593'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 07 Jul 2021 08:32:56 GMT
+      - Mon, 23 Aug 2021 17:23:07 GMT
       expires:
       - '-1'
       pragma:
@@ -443,7 +461,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1194'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -461,12 +479,13 @@ interactions:
       ParameterSetName:
       - -g -n -v -f --yes
       User-Agent:
-      - AZURECLI/2.26.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.3 (Windows-10-10.0.18362-SP0)
+      - AZURECLI/2.27.1 (MSI) azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.10
+        (Windows-10-10.0.19043-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_template_specs000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001","name":"cli_test_template_specs000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-07-07T08:32:47Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001","name":"cli_test_template_specs000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-08-23T17:23:01Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -475,7 +494,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 07 Jul 2021 08:32:56 GMT
+      - Mon, 23 Aug 2021 17:23:07 GMT
       expires:
       - '-1'
       pragma:
@@ -503,28 +522,29 @@ interactions:
       ParameterSetName:
       - -g -n -v -f --yes
       User-Agent:
-      - AZURECLI/2.26.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.3 (Windows-10-10.0.18362-SP0)
+      - AZURECLI/2.27.1 (MSI) azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.10
+        (Windows-10-10.0.19043-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"v-kaisun@microsoft.com\",\r\n    \"createdByType\":
-        \"User\",\r\n    \"createdAt\": \"2021-07-07T08:32:52.7031944Z\",\r\n    \"lastModifiedBy\":
-        \"v-kaisun@microsoft.com\",\r\n    \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\":
-        \"2021-07-07T08:32:55.263192Z\"\r\n  },\r\n  \"properties\": {\r\n    \"displayName\":
-        \"create-spec000003\",\r\n    \"description\": \"AzCLI test root template
-        spec\"\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002\",\r\n
+      string: "{\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\":
+        {\r\n    \"displayName\": \"create-spec000003\",\r\n    \"description\": \"AzCLI
+        test root template spec\"\r\n  },\r\n  \"systemData\": {\r\n    \"createdBy\":
+        \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
+        \"2021-08-23T17:23:05.5671736Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
+        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2021-08-23T17:23:07.3771712Z\"\r\n
+        \ },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002\",\r\n
         \ \"type\": \"Microsoft.Resources/templateSpecs\",\r\n  \"name\": \"cli-test-create-template-spec000002\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '833'
+      - '834'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 07 Jul 2021 08:32:56 GMT
+      - Mon, 23 Aug 2021 17:23:10 GMT
       expires:
       - '-1'
       pragma:
@@ -593,8 +613,13 @@ interactions:
       "apiVersion": "2019-10-01", "name": "keyVaultAndSecret", "resourceGroup": "[parameters(''rgName'')]",
       "dependsOn": ["deploymentRg"], "properties": {"mode": "Incremental", "templateLink":
       {"relativePath": "artifacts/createKeyVaultWithSecret.json", "contentVersion":
-      "1.0.0.0"}, "parameters": {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}}}}],
-      "outputs": {}}}}'
+      "1.0.0.0"}, "parameters": {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}}}},
+      {"type": "Microsoft.Resources/deployments", "apiVersion": "2019-10-01", "name":
+      "duplicateRelativePath", "resourceGroup": "[parameters(''rgName'')]", "dependsOn":
+      ["deploymentRg"], "properties": {"mode": "Incremental", "templateLink": {"relativePath":
+      "artifacts/createKeyVaultWithSecret.json", "contentVersion": "1.0.0.0"}, "parameters":
+      {"keyVaultName": {"value": "[parameters(''keyVaultName'')]"}}}}], "outputs":
+      {}}}}'
     headers:
       Accept:
       - application/json
@@ -605,46 +630,44 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '4499'
+      - '4899'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n -v -f --yes
       User-Agent:
-      - AZURECLI/2.26.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.3 (Windows-10-10.0.18362-SP0)
+      - AZURECLI/2.27.1 (MSI) azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.10
+        (Windows-10-10.0.19043-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"v-kaisun@microsoft.com\",\r\n    \"createdByType\":
-        \"User\",\r\n    \"createdAt\": \"2021-07-07T08:32:55.263192Z\",\r\n    \"lastModifiedBy\":
-        \"v-kaisun@microsoft.com\",\r\n    \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\":
-        \"2021-07-07T08:32:57.657453Z\"\r\n  },\r\n  \"properties\": {\r\n    \"uiFormDefinition\":
-        {\r\n      \"$schema\": \"createFormUI.schema.json\",\r\n      \"view\": {\r\n
-        \       \"kind\": \"Form\",\r\n        \"properties\": {\r\n          \"title\":
-        \"titleFooRG\",\r\n          \"steps\": [\r\n            {\r\n              \"name\":
-        \"basics\",\r\n              \"label\": \"Basics\",\r\n              \"elements\":
-        [\r\n                {\r\n                  \"name\": \"resourceScope\",\r\n
-        \                 \"type\": \"Microsoft.Common.ResourceScope\",\r\n                  \"subscription\":
-        {\r\n                    \"constraints\": {\r\n                      \"validations\":
-        [\r\n                        {\r\n                          \"isValid\": \"[expression
-        for checking]\",\r\n                          \"message\": \"Please select
-        a valid\u202Fsubscription.\"\r\n                        },\r\n                        {\r\n
-        \                         \"permission\": \"<Resource Provider>/<Action>\",\r\n
-        \                         \"message\": \"Must have correct permission to complete
-        this step.\"\r\n                        }\r\n                      ]\r\n                    },\r\n
-        \                   \"resourceProviders\": [\r\n                      \"<Resource
-        Provider>\"\r\n                    ]\r\n                  },\r\n                  \"resourceGroup\":
-        {\r\n                    \"constraints\": {\r\n                      \"validations\":
-        [\r\n                        {\r\n                          \"isValid\": \"[expression
-        for checking]\",\r\n                          \"message\": \"Please select
-        a valid\u202Fresource\u202Fgroup.\"\r\n                        }\r\n                      ]\r\n
-        \                   },\r\n                    \"allowExisting\": true\r\n
-        \                 },\r\n                  \"location\": {\r\n                    \"label\":
-        \"Custom label for location\",\r\n                    \"toolTip\": \"provide\u202Fa\u202Fuseful\u202Ftooltip\",\r\n
-        \                   \"resourceTypes\": [\r\n                      \"Microsoft.Compute/virtualMachines\"\r\n
-        \                   ],\r\n                    \"allowedValues\": [\r\n                      \"eastus\",\r\n
+      string: "{\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\":
+        {\r\n    \"uiFormDefinition\": {\r\n      \"$schema\": \"createFormUI.schema.json\",\r\n
+        \     \"view\": {\r\n        \"kind\": \"Form\",\r\n        \"properties\":
+        {\r\n          \"title\": \"titleFooRG\",\r\n          \"steps\": [\r\n            {\r\n
+        \             \"name\": \"basics\",\r\n              \"label\": \"Basics\",\r\n
+        \             \"elements\": [\r\n                {\r\n                  \"name\":
+        \"resourceScope\",\r\n                  \"type\": \"Microsoft.Common.ResourceScope\",\r\n
+        \                 \"subscription\": {\r\n                    \"constraints\":
+        {\r\n                      \"validations\": [\r\n                        {\r\n
+        \                         \"isValid\": \"[expression for checking]\",\r\n
+        \                         \"message\": \"Please select a valid\u202Fsubscription.\"\r\n
+        \                       },\r\n                        {\r\n                          \"permission\":
+        \"<Resource Provider>/<Action>\",\r\n                          \"message\":
+        \"Must have correct permission to complete this step.\"\r\n                        }\r\n
+        \                     ]\r\n                    },\r\n                    \"resourceProviders\":
+        [\r\n                      \"<Resource Provider>\"\r\n                    ]\r\n
+        \                 },\r\n                  \"resourceGroup\": {\r\n                    \"constraints\":
+        {\r\n                      \"validations\": [\r\n                        {\r\n
+        \                         \"isValid\": \"[expression for checking]\",\r\n
+        \                         \"message\": \"Please select a valid\u202Fresource\u202Fgroup.\"\r\n
+        \                       }\r\n                      ]\r\n                    },\r\n
+        \                   \"allowExisting\": true\r\n                  },\r\n                  \"location\":
+        {\r\n                    \"label\": \"Custom label for location\",\r\n                    \"toolTip\":
+        \"provide\u202Fa\u202Fuseful\u202Ftooltip\",\r\n                    \"resourceTypes\":
+        [\r\n                      \"Microsoft.Compute/virtualMachines\"\r\n                    ],\r\n
+        \                   \"allowedValues\": [\r\n                      \"eastus\",\r\n
         \                     \"westus2\"\r\n                    ]\r\n                  }\r\n
         \               }\r\n              ],\r\n              \"description\": \"Customized
         description with **markdown**, see [more](https://www.microsoft.com).\"\r\n
@@ -700,6 +723,14 @@ interactions:
         [\r\n            \"deploymentRg\"\r\n          ],\r\n          \"properties\":
         {\r\n            \"mode\": \"Incremental\",\r\n            \"templateLink\":
         {\r\n              \"relativePath\": \"artifacts/createKeyVaultWithSecret.json\",\r\n
+        \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
+        {\r\n              \"keyVaultName\": {\r\n                \"value\": \"[parameters('keyVaultName')]\"\r\n
+        \             }\r\n            }\r\n          }\r\n        },\r\n        {\r\n
+        \         \"type\": \"Microsoft.Resources/deployments\",\r\n          \"apiVersion\":
+        \"2019-10-01\",\r\n          \"name\": \"duplicateRelativePath\",\r\n          \"resourceGroup\":
+        \"[parameters('rgName')]\",\r\n          \"dependsOn\": [\r\n            \"deploymentRg\"\r\n
+        \         ],\r\n          \"properties\": {\r\n            \"mode\": \"Incremental\",\r\n
+        \           \"templateLink\": {\r\n              \"relativePath\": \"artifacts/createKeyVaultWithSecret.json\",\r\n
         \             \"contentVersion\": \"1.0.0.0\"\r\n            },\r\n            \"parameters\":
         {\r\n              \"keyVaultName\": {\r\n                \"value\": \"[parameters('keyVaultName')]\"\r\n
         \             }\r\n            }\r\n          }\r\n        }\r\n      ],\r\n
@@ -790,18 +821,22 @@ interactions:
         \             \"dependsOn\": [\r\n                \"keyVault\"\r\n              ],\r\n
         \             \"properties\": {\r\n                \"value\": \"mySecretValue\"\r\n
         \             }\r\n            }\r\n          ],\r\n          \"outputs\":
-        {}\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0\",\r\n
+        {}\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"systemData\": {\r\n    \"createdBy\":
+        \"daetienn@microsoft.com\",\r\n    \"createdByType\": \"User\",\r\n    \"createdAt\":
+        \"2021-08-23T17:23:07.3771712Z\",\r\n    \"lastModifiedBy\": \"daetienn@microsoft.com\",\r\n
+        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2021-08-23T17:23:11.0278361Z\"\r\n
+        \ },\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002/versions/1.0\",\r\n
         \ \"type\": \"Microsoft.Resources/templateSpecs/versions\",\r\n  \"name\":
         \"1.0\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '13854'
+      - '14529'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 07 Jul 2021 08:32:56 GMT
+      - Mon, 23 Aug 2021 17:23:10 GMT
       expires:
       - '-1'
       pragma:
@@ -813,7 +848,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -833,7 +868,8 @@ interactions:
       ParameterSetName:
       - --template-spec --yes
       User-Agent:
-      - AZURECLI/2.26.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.3 (Windows-10-10.0.18362-SP0)
+      - AZURECLI/2.27.1 (MSI) azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.10
+        (Windows-10-10.0.19043-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_template_specs000001/providers/Microsoft.Resources/templateSpecs/cli-test-create-template-spec000002?api-version=2021-05-01
   response:
@@ -845,7 +881,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 07 Jul 2021 08:33:00 GMT
+      - Mon, 23 Aug 2021 17:23:12 GMT
       expires:
       - '-1'
       pragma:
@@ -857,7 +893,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
+      - '14999'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/template_spec_with_artifacts.json
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/template_spec_with_artifacts.json
@@ -49,6 +49,25 @@
             "keyVaultName":{"value": "[parameters('keyVaultName')]"}
         }
       }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "duplicateRelativePath",
+      "resourceGroup": "[parameters('rgName')]",
+      "dependsOn": [
+        "deploymentRg"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "relativePath":"artifacts/createKeyVaultWithSecret.json",
+          "contentVersion":"1.0.0.0"
+        },
+        "parameters": {
+            "keyVaultName":{"value": "[parameters('keyVaultName')]"}
+        }
+      }
     }
   ],
   "outputs": {}


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR addresses template spec issue https://github.com/Azure/template-specs/issues/49  - where creating a template spec version that contains at least two inner deployments that each depend on a common template (referenced via a relative path) results in the error "TemplateSpecVersionInvalidArtifactPath: The artifact path 'Microsoft.Resources/deploymentScripts.json' is not supported. An artifact path should be unique and not contain any expressions."

**Testing Guide**

Executing the following command using a template with inner deployments referencing a common template as shown succeed. (For a template please see the file _src/azure-cli/azure/cli/command_modules/resource/tests/latest/template_spec_with_artifacts.json_ included in this PR) 

`az ts create --name {TemplateSpecName}  --resource-group {ResourceGroupName}  --template-file 'nestedTemplateSpec.json' --version '1.0.0' --yes`
