### PR TITLE
{Core} Check return value of `get_parent_proc_name`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -522,8 +522,8 @@ def shell_safe_json_parse(json_or_dict_string, preserve_order=False, strict=True
                              "https://docs.microsoft.com/cli/azure/use-cli-effectively#quoting-issues"
 
             # Recommendation especially for PowerShell
-            parent_proc = get_parent_proc_name().lower()
-            if parent_proc in ("powershell.exe", "pwsh.exe"):
+            parent_proc = get_parent_proc_name()
+            if parent_proc and parent_proc.lower() in ("powershell.exe", "pwsh.exe"):
                 recommendation += "\nPowerShell requires additional quoting rules. See " \
                                   "https://github.com/Azure/azure-cli/blob/dev/doc/quoting-issues-with-powershell.md"
 
@@ -1262,6 +1262,8 @@ def _get_parent_proc_name():
 def get_parent_proc_name():
     # This function wraps _get_parent_proc_name, as psutil calls are time-consuming, so use a
     # function-level cache to save the result.
+    # NOTE: The return value may be None if getting parent proc name fails, so always remember to
+    # check it first before calling string methods like lower().
     if not hasattr(get_parent_proc_name, "return_value"):
         parent_proc_name = _get_parent_proc_name()
         setattr(get_parent_proc_name, "return_value", parent_proc_name)


### PR DESCRIPTION
## Description

Fix an edge-case bug introduced by #17445

`az functionapp create` fails with `AttributeError: 'NoneType' object has no attribute 'lower'`

The user runs `az functionapp create` in a container but it fails with:

```
cli.azure.cli.core.util: Traceback (most recent call last):
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/util.py", line 506, in shell_safe_json_parse
    return json.loads(json_or_dict_string, strict=strict)
  File "/usr/local/python/python3.9/lib/python3.9/json/__init__.py", line 359, in loads
    return cls(**kw).decode(s)
  File "/usr/local/python/python3.9/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/python/python3.9/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/util.py", line 512, in shell_safe_json_parse
    return ast.literal_eval(json_or_dict_string)
  File "/usr/local/python/python3.9/lib/python3.9/ast.py", line 62, in literal_eval
    node_or_string = parse(node_or_string, mode='eval')
  File "/usr/local/python/python3.9/lib/python3.9/ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
  File "<unknown>", line 1
    AzureWebJobsDashboard=DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=xxx;AccountKey=<cx account key>
                         ^
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/az/lib/python3.6/site-packages/knack/cli.py", line 231, in invoke
    cmd_result = self.invocation.execute(args)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/__init__.py", line 657, in execute
    raise ex
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/__init__.py", line 720, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/__init__.py", line 712, in _run_job
    return cmd_copy.exception_handler(ex)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/command_modules/appservice/commands.py", line 37, in _ex_handler
    raise ex
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/__init__.py", line 691, in _run_job
    result = cmd_copy(params)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/__init__.py", line 328, in __call__
    return self.handler(*args, **kwargs)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
    return op(**command_args)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/command_modules/appservice/custom.py", line 3003, in create_function
    update_app_settings(cmd, functionapp.resource_group, functionapp.name,
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/command_modules/appservice/custom.py", line 260, in update_app_settings
    temp = shell_safe_json_parse(s)
  File "/usr/lib64/az/lib/python3.6/site-packages/azure/cli/core/util.py", line 525, in shell_safe_json_parse
    parent_proc = get_parent_proc_name().lower()
AttributeError: 'NoneType' object has no attribute 'lower'
```

The error `AttributeError: 'NoneType' object has no attribute 'lower'` is because `get_parent_proc_name()` returns `None`:

https://github.com/Azure/azure-cli/blob/213fcd75ba256730d1dae2a65127274481ab4e8f/src/azure-cli-core/azure/cli/core/util.py#L1237-L1241

According to the debug log:

```
cli.azure.cli.core.util: cannot import name '_psutil_linux' from partially initialized module 'psutil' (most likely due to a circular import) (/usr/lib64/az/lib/python3.6/site-packages/psutil/__init__.py)
```

This is very likely to be caused by https://github.com/Azure/azure-cli/issues/18222.

Nevertheless, `shell_safe_json_parse` shouldn't fail just because `get_parent_proc_name` returns `None`.

## Change

Check return value of `get_parent_proc_name`, so that even if `get_parent_proc_name` returns `None`, `shell_safe_json_parse` won't fail.

