### PR TITLE
{Storage} `az storage blob query`: Fix import error when `--input-format json`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -1793,7 +1793,7 @@ def validate_fs_directory_download_source_url(cmd, namespace):
 
 def validate_text_configuration(cmd, ns):
     DelimitedTextDialect = cmd.get_models('_models#DelimitedTextDialect', resource_type=ResourceType.DATA_STORAGE_BLOB)
-    DelimitedJSON = cmd.get_models('_models#DelimitedJSON', resource_type=ResourceType.DATA_STORAGE_BLOB)
+    DelimitedJsonDialect = cmd.get_models('_models#DelimitedJsonDialect', resource_type=ResourceType.DATA_STORAGE_BLOB)
     if ns.input_format == 'csv':
         ns.input_config = DelimitedTextDialect(
             delimiter=ns.in_column_separator,
@@ -1802,7 +1802,7 @@ def validate_text_configuration(cmd, ns):
             escapechar=ns.in_escape_char,
             has_header=ns.in_has_header)
     if ns.input_format == 'json':
-        ns.input_config = DelimitedJSON(delimiter=ns.in_line_separator)
+        ns.input_config = DelimitedJsonDialect(delimiter=ns.in_line_separator)
 
     if ns.output_format == 'csv':
         ns.output_config = DelimitedTextDialect(
@@ -1812,7 +1812,7 @@ def validate_text_configuration(cmd, ns):
             escapechar=ns.out_escape_char,
             has_header=ns.out_has_header)
     if ns.output_format == 'json':
-        ns.output_config = DelimitedJSON(delimiter=ns.out_line_separator)
+        ns.output_config = DelimitedJsonDialect(delimiter=ns.out_line_separator)
     del ns.input_format, ns.in_line_separator, ns.in_column_separator, ns.in_quote_char, ns.in_record_separator, \
         ns.in_escape_char, ns.in_has_header
     del ns.output_format, ns.out_line_separator, ns.out_column_separator, ns.out_quote_char, ns.out_record_separator, \

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/quick_query.json
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/quick_query.json
@@ -1,0 +1,21 @@
+{
+  "id": 1,
+  "name": "mouse",
+  "price": 12.5,
+  "tags": [
+    "wireless",
+    "accessory"
+  ],
+  "dimensions": {
+    "length": 3,
+    "width": 2,
+    "height": 2
+  },
+  "weight": 0.2,
+  "warehouses": [
+    {
+      "latitude": 41.8,
+      "longitude": -87.6
+    }
+  ]
+}

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_live_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_live_scenarios.py
@@ -103,19 +103,31 @@ class StorageBlobQueryTests(StorageScenarioMixin, LiveScenarioTest):
     def test_storage_blob_query_scenario(self, resource_group, storage_account):
         account_info = self.get_account_info(group=resource_group, name=storage_account)
         container = self.create_container(account_info)
-        blob = self.create_random_name(prefix='blob', length=12)
+        csv_blob = self.create_random_name(prefix='csvblob', length=12)
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         csv_file = os.path.join(curr_dir, 'quick_query.csv').replace('\\', '\\\\')
 
-        self.storage_cmd('storage blob upload -f "{}" -c {} -n {}', account_info, csv_file, container, blob)
+        # test csv input
+        self.storage_cmd('storage blob upload -f "{}" -c {} -n {}', account_info, csv_file, container, csv_blob)
         query_string = "SELECT _2 from BlobStorage"
         result = self.storage_cmd('storage blob query -c {} -n {} --query-expression "{}"',
-                                  account_info, container, blob, query_string).output
+                                  account_info, container, csv_blob, query_string).output
         self.assertIsNotNone(result)
 
+        # test csv output
         temp_dir = self.create_temp_dir()
         result_file = os.path.join(temp_dir, 'result.csv')
         self.assertFalse(os.path.exists(result_file))
         self.storage_cmd('storage blob query -c {} -n {} --query-expression "{}" --result-file "{}"',
-                         account_info, container, blob, query_string, result_file)
+                         account_info, container, csv_blob, query_string, result_file)
         self.assertTrue(os.path.exists(result_file))
+
+        json_blob = self.create_random_name(prefix='jsonblob', length=12)
+        json_file = os.path.join(curr_dir, 'quick_query.json').replace('\\', '\\\\')
+
+        # test json input
+        self.storage_cmd('storage blob upload -f "{}" -c {} -n {}', account_info, json_file, container, json_blob)
+        query_string = "SELECT latitude FROM BlobStorage[*].warehouses[*]"
+        result = self.storage_cmd('storage blob query -c {} -n {} --query-expression "{}" --input-format json',
+                                  account_info, container, json_blob, query_string).output
+        self.assertIsNotNone(result)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Previously, `az storage blob query` will fail with `--input-format json` like this:
```
> az storage blob query -c yscontainer -n test_blob_query.json  --query-expression "SELECT latitude FROM BlobStorage[*].warehouses[*]" --account-name yssa --input-format json --debug
......
cli.azure.cli.core.profiles._shared: Traceback (most recent call last):
  File "d:\workspace\azure-cli\src\azure-cli-core\azure\cli\core\profiles\_shared.py", line 579, in _get_attr
    op = getattr(op, part)
AttributeError: module 'azure.multiapi.storagev2.blob.v2020_04_08._models' has no attribute 'DelimitedJson'

cli.azure.cli.core.azclierror: 'NoneType' object is not callable

```
Here is to fix import error.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
