### PR TITLE
[App Service]: Fix #16470: `az staticwebapp secrets`: Add commands to manage deployment secrets

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2511,6 +2511,27 @@ helps['staticwebapp users update'] = """
       text: az staticwebapp users update -n MyStaticAppName --user-details JohnDoe --role Contributor
 """
 
+helps['staticwebapp secrets'] = """
+    type: group
+    short-summary: Manage deployment token for the static app
+"""
+
+helps['staticwebapp secrets list'] = """
+    type: command
+    short-summary: List the deployment token for the static app.
+    examples:
+    - name: List deployment token
+      text: az staticwebapp secrets list --name MyStaticAppName
+"""
+
+helps['staticwebapp secrets reset-api-key'] = """
+    type: command
+    short-summary: Reset the deployment token for the static app.
+    examples:
+    - name: Reset deployment token
+      text: az staticwebapp secrets reset-api-key --name MyStaticAppName
+"""
+
 helps['webapp deploy'] = """
     type: command
     short-summary: Deploys a provided artifact to Azure Web Apps.

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -19,7 +19,7 @@ from ._completers import get_hostname_completion_list
 from ._constants import FUNCTIONS_VERSIONS, FUNCTIONS_STACKS_API_JSON_PATHS, FUNCTIONS_STACKS_API_KEYS
 from ._validators import (validate_timeout_value, validate_site_create, validate_asp_create,
                           validate_add_vnet, validate_front_end_scale_factor, validate_ase_create, validate_ip_address,
-                          validate_service_tag)
+                          validate_service_tag, validate_public_cloud)
 
 AUTH_TYPES = {
     'AllowAnonymous': 'na',
@@ -970,7 +970,7 @@ def load_arguments(self, _):
     with self.argument_context('appservice domain show-terms') as c:
         c.argument('hostname', options_list=['--hostname', '-n'], help='Name of the custom domain')
 
-    with self.argument_context('staticwebapp') as c:
+    with self.argument_context('staticwebapp', validator=validate_public_cloud) as c:
         c.argument('name', options_list=['--name', '-n'], metavar='NAME', help="Name of the static site")
         c.argument('source', options_list=['--source', '-s'], help="URL for the repository of the static site.")
         c.argument('token', options_list=['--token', '-t'],

--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -244,3 +244,9 @@ def _validate_service_tag_existence(cmd, namespace):
         if rule.ip_address and rule.ip_address.lower() == input_tag_value.lower():
             raise ArgumentUsageError('Service Tag: ' + namespace.service_tag + ' already exists. '
                                      'Cannot add duplicate Service Tag values.')
+
+
+def validate_public_cloud(cmd):
+    from azure.cli.core.cloud import AZURE_PUBLIC_CLOUD
+    if cmd.cli_ctx.cloud.name != AZURE_PUBLIC_CLOUD.name:
+        raise CLIError('This command is not yet supported on soveriegn clouds.')

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -429,7 +429,7 @@ def load_command_table(self, _):
         g.custom_command('create', 'create_domain')
         g.custom_command('show-terms', 'show_domain_purchase_terms')
 
-    with self.command_group('staticwebapp', custom_command_type=staticsite_sdk, is_preview=True) as g:
+    with self.command_group('staticwebapp', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsites')
         g.custom_show_command('show', 'show_staticsite')
         g.custom_command('create', 'create_staticsites', supports_no_wait=True)
@@ -438,26 +438,26 @@ def load_command_table(self, _):
         g.custom_command('reconnect', 'reconnect_staticsite', supports_no_wait=True)
         g.custom_command('update', 'update_staticsite', supports_no_wait=True)
 
-    with self.command_group('staticwebapp environment', custom_command_type=staticsite_sdk, is_preview=True) as g:
+    with self.command_group('staticwebapp environment', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsite_environments')
         g.custom_show_command('show', 'show_staticsite_environment')
         g.custom_command('functions', 'list_staticsite_functions')
 
-    with self.command_group('staticwebapp hostname', custom_command_type=staticsite_sdk, is_preview=True) as g:
+    with self.command_group('staticwebapp hostname', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsite_domains')
         g.custom_command('set', 'set_staticsite_domain', supports_no_wait=True)
         g.custom_command('delete', 'delete_staticsite_domain', supports_no_wait=True, confirmation=True)
 
-    with self.command_group('staticwebapp appsettings', custom_command_type=staticsite_sdk, is_preview=True) as g:
+    with self.command_group('staticwebapp appsettings', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsite_function_app_settings')
         g.custom_command('set', 'set_staticsite_function_app_settings')
         g.custom_command('delete', 'delete_staticsite_function_app_settings')
 
-    with self.command_group('staticwebapp users', custom_command_type=staticsite_sdk, is_preview=True) as g:
+    with self.command_group('staticwebapp users', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsite_users')
         g.custom_command('invite', 'invite_staticsite_users')
         g.custom_command('update', 'update_staticsite_users')
 
-    with self.command_group('staticwebapp secrets', custom_command_type=staticsite_sdk, is_preview=True) as g:
+    with self.command_group('staticwebapp secrets', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsite_secrets')
         g.custom_command('reset-api-key', 'reset_staticsite_api_key', supports_no_wait=True)

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -457,3 +457,7 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_staticsite_users')
         g.custom_command('invite', 'invite_staticsite_users')
         g.custom_command('update', 'update_staticsite_users')
+
+    with self.command_group('staticwebapp secrets', custom_command_type=staticsite_sdk, is_preview=True) as g:
+        g.custom_command('list', 'list_staticsite_secrets')
+        g.custom_command('reset-api-key', 'reset_staticsite_api_key', supports_no_wait=True)

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -347,6 +347,7 @@ def _find_user_id_and_authentication_provider(client, resource_group_name, name,
 
     return user_id, authentication_provider
 
+
 def list_staticsite_secrets(cmd, name, resource_group_name=None, no_wait=False):
     client = _get_staticsites_client_factory(cmd.cli_ctx)
     if not resource_group_name:

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -346,3 +346,24 @@ def _find_user_id_and_authentication_provider(client, resource_group_name, name,
         raise CLIError("user details and authentication provider was not found.")
 
     return user_id, authentication_provider
+
+def list_staticsite_secrets(cmd, name, resource_group_name=None, no_wait=False):
+    client = _get_staticsites_client_factory(cmd.cli_ctx)
+    if not resource_group_name:
+        resource_group_name = _get_resource_group_name_of_staticsite(client, name)
+
+    return sdk_no_wait(no_wait, client.list_static_site_secrets,
+                       resource_group_name=resource_group_name, name=name)
+
+
+def reset_staticsite_api_key(cmd, name, resource_group_name=None, no_wait=False):
+    client = _get_staticsites_client_factory(cmd.cli_ctx)
+    if not resource_group_name:
+        resource_group_name = _get_resource_group_name_of_staticsite(client, name)
+
+    existing_staticsite = show_staticsite(cmd, name, resource_group_name)
+    ResetPropertiesEnvelope = cmd.get_models('StaticSiteResetPropertiesARMResource')
+    reset_envelope = ResetPropertiesEnvelope(repository_token=existing_staticsite.repository_token)
+    return sdk_no_wait(no_wait, client.reset_static_site_api_key,
+                       resource_group_name=resource_group_name, name=name,
+                       reset_properties_envelope=reset_envelope)

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -348,16 +348,15 @@ def _find_user_id_and_authentication_provider(client, resource_group_name, name,
     return user_id, authentication_provider
 
 
-def list_staticsite_secrets(cmd, name, resource_group_name=None, no_wait=False):
+def list_staticsite_secrets(cmd, name, resource_group_name=None):
     client = _get_staticsites_client_factory(cmd.cli_ctx)
     if not resource_group_name:
         resource_group_name = _get_resource_group_name_of_staticsite(client, name)
 
-    return sdk_no_wait(no_wait, client.list_static_site_secrets,
-                       resource_group_name=resource_group_name, name=name)
+    return client.list_static_site_secrets(resource_group_name=resource_group_name, name=name)
 
 
-def reset_staticsite_api_key(cmd, name, resource_group_name=None, no_wait=False):
+def reset_staticsite_api_key(cmd, name, resource_group_name=None):
     client = _get_staticsites_client_factory(cmd.cli_ctx)
     if not resource_group_name:
         resource_group_name = _get_resource_group_name_of_staticsite(client, name)
@@ -365,6 +364,6 @@ def reset_staticsite_api_key(cmd, name, resource_group_name=None, no_wait=False)
     existing_staticsite = show_staticsite(cmd, name, resource_group_name)
     ResetPropertiesEnvelope = cmd.get_models('StaticSiteResetPropertiesARMResource')
     reset_envelope = ResetPropertiesEnvelope(repository_token=existing_staticsite.repository_token)
-    return sdk_no_wait(no_wait, client.reset_static_site_api_key,
-                       resource_group_name=resource_group_name, name=name,
-                       reset_properties_envelope=reset_envelope)
+    return client.reset_static_site_api_key(resource_group_name=resource_group_name,
+                                            name=name,
+                                            reset_properties_envelope=reset_envelope)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -526,7 +526,7 @@ class TestStaticAppCommands(unittest.TestCase):
         self.staticapp_client.reset_static_site_api_key.assert_called_once()
 
         from ast import literal_eval
-        reset_envelope = literal_eval(self.staticapp_client.reset_static_site_api_key.call_args.kwargs["reset_properties_envelope"].__str__())
+        reset_envelope = literal_eval(self.staticapp_client.reset_static_site_api_key.call_args[1]["reset_properties_envelope"].__str__())
         self.assertEqual(reset_envelope["repository_token"], self.token1)     
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -10,7 +10,7 @@ from azure.cli.command_modules.appservice.static_sites import \
     reconnect_staticsite, list_staticsite_environments, show_staticsite_environment, list_staticsite_domains, \
     set_staticsite_domain, delete_staticsite_domain, list_staticsite_functions, list_staticsite_function_app_settings, \
     set_staticsite_function_app_settings, delete_staticsite_function_app_settings, list_staticsite_users, \
-    invite_staticsite_users, update_staticsite_users, update_staticsite
+    invite_staticsite_users, update_staticsite_users, update_staticsite, list_staticsite_secrets, reset_staticsite_api_key
 
 
 class TestStaticAppCommands(unittest.TestCase):
@@ -502,6 +502,32 @@ class TestStaticAppCommands(unittest.TestCase):
         with self.assertRaises(CLIError):
             update_staticsite_users(self.mock_cmd, self.name1, roles, authentication_provider=authentication_provider,
                                     resource_group_name=self.rg1)
+
+    def test_list_staticsite_secrets(self):
+        from azure.mgmt.web.models import StringDictionary
+        self.staticapp_client.list_static_site_secrets.return_value = StringDictionary(properties={"apiKey": "key"})
+
+        secret = list_staticsite_secrets(self.mock_cmd, self.name1, self.rg1)
+
+        self.staticapp_client.list_static_site_secrets.assert_called_once_with(resource_group_name=self.rg1, name=self.name1)
+        from ast import literal_eval
+        self.assertEqual(literal_eval(secret.__str__())["properties"]["apiKey"], "key")
+    
+    def test_reset_staticsite_api_key(self):
+        from azure.mgmt.web.models import StringDictionary, StaticSiteResetPropertiesARMResource
+        self.staticapp_client.get_static_site.return_value = self.app1
+        self.staticapp_client.reset_static_site_api_key.return_value = StringDictionary(properties={"apiKey": "new_key"})
+        self.mock_cmd.get_models.return_value = StaticSiteResetPropertiesARMResource
+
+        secret = reset_staticsite_api_key(self.mock_cmd, self.name1, self.rg1)
+
+        self.staticapp_client.get_static_site.assert_called_once_with(self.rg1, self.name1)
+        self.mock_cmd.get_models.assert_called_once_with('StaticSiteResetPropertiesARMResource')
+        self.staticapp_client.reset_static_site_api_key.assert_called_once()
+
+        from ast import literal_eval
+        reset_envelope = literal_eval(self.staticapp_client.reset_static_site_api_key.call_args.kwargs["reset_properties_envelope"].__str__())
+        self.assertEqual(reset_envelope["repository_token"], self.token1)     
 
 
 def _set_up_client_mock(self):


### PR DESCRIPTION
**Description**
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fix #16470: add commands to manage deployment secrets


**Testing Guide**

`az staticwebapp secrets list -n {name} -g {resource_group}` to list deployment secrets.

`az staticwebapp secrets reset-api-key -n {name} -g {resource_group}` to reset api key.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
