### PR TITLE
[Packaging] Add Ubuntu 21.04 Hirsute Hippo support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -740,6 +740,9 @@ jobs:
       Groovy:
         deb_system: ubuntu
         distro: groovy
+      Hirsute:
+        deb_system: ubuntu
+        distro: hirsute
       Jessie:
         deb_system: debian
         distro: jessie


### PR DESCRIPTION
## Description

Fix #19313, #18703, #18493, #19235, #18714, #18420, #18356, #17713, #16875, #18542

### Old Azure CLI `hirsute` from Ubuntu universe repo is installed

If a user manually add Azure CLI software repository from Microsoft Linux repo following https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions, `/etc/apt/sources.list.d/azure-cli.list` will contain 

```
deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ hirsute main
```

As https://packages.microsoft.com/repos/azure-cli/dists/ doesn't have `hirsure`, `apt update` will fail

```
E: The repository 'https://packages.microsoft.com/repos/azure-cli hirsute Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
```

Then when `apt install azure-cli` is run, Azure CLI from Ubuntu universe repo (https://packages.ubuntu.com/hirsute/azure-cli) will be installed. 

⚠ The Azure CLI from Ubuntu universe repo is not maintained by Microsoft.

```
# apt show azure-cli
Package: azure-cli
Version: 2.18.0-1
Priority: optional
Section: universe/python
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Debian Python Team <team+python@tracker.debian.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 15.4 kB
Depends: python3:any, python3-azure-cli (>= 2.18.0-1)
Homepage: https://github.com/Azure/azure-cli
Download-Size: 2608 B
APT-Sources: http://archive.ubuntu.com/ubuntu hirsute/universe amd64 Packages
Description: Azure Command-Line Interface (CLI)
```

This Azure CLI from Ubuntu universe repo is very old and contains bugs.

### Official Azure CLI `focal` from Microsoft Linux repo doesn't work on `hirsute`

Besides, even if the user installs with https://aka.ms/InstallAzureCLIDeb which automatically falls back to `focal` (https://github.com/Azure/azure-cli/issues/19313#issuecomment-906129968), the `focal` package doesn't work correctly on `hirsute` (https://github.com/Azure/azure-cli/issues/18703).

## Change

This PR builds a `deb` packaging for `hirstute`.
