### PR TITLE
[Packaging] Add Debian 11 Bullseye support 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -749,6 +749,9 @@ jobs:
       Buster:
         deb_system: debian
         distro: buster
+      Bullseye:
+        deb_system: debian
+        distro: bullseye
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build Artifacts'


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix #19326, #18654, and possibly #18895, #18804, #18798, #16783

Debian releases and their life cycle can be found at

- https://www.debian.org/releases/
- https://wiki.debian.org/DebianReleases

Similar to https://github.com/Azure/azure-cli/pull/19367, we need to support Debian 11 Bullseye, otherwise the buggy unofficial Azure CLI from https://packages.debian.org/bullseye/azure-cli will be installed.
