### PR TITLE
{Core} Fix: `open_page_in_browser` corrupts WSL shell

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -657,7 +657,8 @@ def open_page_in_browser(url):
         try:
             # https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe
             # Ampersand (&) should be quoted
-            return subprocess.Popen(['powershell.exe', '-NoProfile', '-Command', 'Start-Process "{}"'.format(url)])
+            return subprocess.Popen(
+                ['powershell.exe', '-NoProfile', '-Command', 'Start-Process "{}"'.format(url)]).wait()
         except OSError:  # WSL might be too old  # FileNotFoundError introduced in Python 3
             pass
     elif platform_name == 'darwin':


### PR DESCRIPTION
## Symptom

In WSL, when running `az feedback`, CLI calls `open_page_in_browser` to launch a web browser. The shell gets corrupted:

![image](https://user-images.githubusercontent.com/4003950/131283923-4696306d-5e6c-495f-b954-e9f2398c1a48.png)

Pressing <kbd>ENTER</kbd> doesn't make a line break, and any typed text is not echoed back.

## Cause

If `python` exits before the subprocess `powershell.exe` exits, this can corrupt the WSL shell (https://github.com/microsoft/WSL/issues/7367). 

## Change

Call `wait` on `subprocess.Popen` so that CLI blocks until `powershell.exe` exits.

## Additional information

This issue doesn't happen in `az login` even though `az login` also calls `open_page_in_browser`. This is because `az login` waits for the auth code after launching `powershell.exe`, giving `powershell.exe` enough time to exit.
