### PR TITLE
{Feedback} `az feedback`: Add distro name and version

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/feedback/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/feedback/custom.py
@@ -370,6 +370,13 @@ def _build_issue_info_tup(command_log_file=None):
     format_dict["cli_version"] = _get_az_version_summary()
     format_dict["python_info"] = "Python {}".format(platform.python_version())
     platform_info = "{} (Cloud Shell)".format(platform.platform()) if in_cloud_console() else platform.platform()
+
+    try:
+        import distro
+        platform_info = '{}, {}'.format(platform_info, distro.name(pretty=True))
+    except ImportError:
+        pass
+
     format_dict["platform"] = platform_info
     format_dict["auto_gen_comment"] = _AUTO_GEN_COMMENT
     from azure.cli.core._environment import _ENV_AZ_INSTALLER

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -99,6 +99,7 @@ chardet==3.0.4
 colorama==0.4.1
 ConfigArgParse==0.14.0
 cryptography==3.3.2
+distro==1.6.0
 fabric==2.4.0
 humanfriendly==9.1
 idna==2.8

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -150,6 +150,9 @@ DEPENDENCIES = [
     'xmltodict~=0.12'
 ]
 
+# On Linux, the distribution (Ubuntu, Debian, etc) and version are checked
+if sys.platform == 'linux':
+    DEPENDENCIES.append('distro')
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()


### PR DESCRIPTION
## Description

`platform.platform()` has some limitations:

- doesn't have the distribution information
- can be the same for different distributions (Ubuntu, Fedora, etc on docker):
  ```
  platform.platform()
  'Linux-5.10.16.3-microsoft-standard-WSL2-x86_64-with-glibc2.33'
  ```

To better help us identify packaging problem, the distribution name and version are also shown.

Note: Ubuntu doesn't follow the `PRETTY_NAME = NAME + VERSION` convention:

```
> docker run -it --rm ubuntu cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04.2 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.2 LTS"
VERSION_ID="20.04"
```

So on Ubuntu, the code name is missing from `distro.name(pretty=True)`:

```
# python3 -c "import distro; print(distro.name(pretty=True))"
Ubuntu 20.04.2 LTS
```

Debian does:

```
> docker run -it --rm debian cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
```

```
> docker run -it --rm python:3.9-bullseye /bin/bash
# pip install distro
# python -c "import distro; print(distro.name(pretty=True))"
Debian GNU/Linux 11 (bullseye)
```