### PR TITLE
{AKS} Refactor a clean-up part of the create sub-command in acs module

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -1257,7 +1257,7 @@ class AKSCreateContext:
     # pylint: disable=unused-argument,too-many-statements
     def get_enable_managed_identity_service_principal_and_client_secret(
         self, **kwargs
-    ):
+    ) -> Tuple[bool, Union[str, None], Union[str, None]]:
         """Dynamically obtain the values of enable_managed_identity, service_principal and client_secret according to
         the context.
 
@@ -1276,7 +1276,6 @@ class AKSCreateContext:
 
         :return: A tuple of enable_managed_identity, service_principal and client_secret
         """
-
         # service_principal
         sp_parameter_name = "service_principal"
         sp_property_name_in_mc = "client_id"

--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -219,9 +219,7 @@ class AKSCreateContext:
         self.intermediates.pop(variable_name, None)
 
     # pylint: disable=unused-argument
-    def get_resource_group_name(
-        self, enable_validation: bool = False, **kwargs
-    ):
+    def get_resource_group_name(self, **kwargs):
         # Note: This parameter will not be decorated into the `mc` object.
         # read the original value passed by the command
         resource_group_name = self.raw_param.get("resource_group_name")
@@ -231,7 +229,7 @@ class AKSCreateContext:
         return resource_group_name
 
     # pylint: disable=unused-argument
-    def get_name(self, enable_validation: bool = False, **kwargs):
+    def get_name(self, **kwargs):
         # Note: This parameter will not be decorated into the `mc` object.
         # read the original value passed by the command
         name = self.raw_param.get("name")
@@ -329,7 +327,7 @@ class AKSCreateContext:
         return dns_name_prefix
 
     # pylint: disable=unused-argument
-    def get_location(self, enable_validation: bool = False, **kwargs):
+    def get_location(self, **kwargs):
         parameter_name = "location"
 
         # read the original value passed by the command
@@ -372,7 +370,7 @@ class AKSCreateContext:
         return location
 
     # pylint: disable=unused-argument
-    def get_kubernetes_version(self, enable_validation: bool = False, **kwargs):
+    def get_kubernetes_version(self, **kwargs):
         # read the original value passed by the command
         raw_value = self.raw_param.get("kubernetes_version")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -406,7 +404,7 @@ class AKSCreateContext:
         return no_ssh_key
 
     # pylint: disable=unused-argument
-    def get_vm_set_type(self, enable_validation: bool = False, **kwargs):
+    def get_vm_set_type(self, **kwargs):
         parameter_name = "vm_set_type"
 
         # read the original value passed by the command
@@ -565,7 +563,7 @@ class AKSCreateContext:
         return fqdn_subdomain
 
     # pylint: disable=unused-argument
-    def get_nodepool_name(self, enable_validation: bool = False, **kwargs):
+    def get_nodepool_name(self, **kwargs):
         parameter_name = "nodepool_name"
 
         # read the original value passed by the command
@@ -613,7 +611,7 @@ class AKSCreateContext:
         return nodepool_name
 
     # pylint: disable=unused-argument
-    def get_nodepool_tags(self, enable_validation: bool = False, **kwargs):
+    def get_nodepool_tags(self, **kwargs):
         # read the original value passed by the command
         raw_value = self.raw_param.get("nodepool_tags")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -636,7 +634,7 @@ class AKSCreateContext:
         return nodepool_tags
 
     # pylint: disable=unused-argument
-    def get_nodepool_labels(self, enable_validation: bool = False, **kwargs):
+    def get_nodepool_labels(self, **kwargs):
         # read the original value passed by the command
         raw_value = self.raw_param.get("nodepool_labels")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -697,7 +695,7 @@ class AKSCreateContext:
         return int(node_count)
 
     # pylint: disable=unused-argument
-    def get_node_vm_size(self, enable_validation: bool = False, **kwargs):
+    def get_node_vm_size(self, **kwargs):
         # read the original value passed by the command
         raw_value = self.raw_param.get("node_vm_size")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -720,7 +718,7 @@ class AKSCreateContext:
         return node_vm_size
 
     # pylint: disable=unused-argument
-    def get_vnet_subnet_id(self, enable_validation: bool = False, **kwargs):
+    def get_vnet_subnet_id(self, **kwargs):
         # read the original value passed by the command
         raw_value = self.raw_param.get("vnet_subnet_id")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -743,7 +741,7 @@ class AKSCreateContext:
         return vnet_subnet_id
 
     # pylint: disable=unused-argument
-    def get_ppg(self, enable_validation: bool = False, **kwargs):
+    def get_ppg(self, **kwargs):
         # read the original value passed by the command
         raw_value = self.raw_param.get("ppg")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -768,7 +766,7 @@ class AKSCreateContext:
         return ppg
 
     # pylint: disable=unused-argument
-    def get_zones(self, enable_validation: bool = False, **kwargs):
+    def get_zones(self, **kwargs):
         # read the original value passed by the command
         raw_value = self.raw_param.get("zones")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -791,9 +789,7 @@ class AKSCreateContext:
         return zones
 
     # pylint: disable=unused-argument
-    def get_enable_node_public_ip(
-        self, enable_validation: bool = False, **kwargs
-    ) -> bool:
+    def get_enable_node_public_ip(self, **kwargs) -> bool:
         # read the original value passed by the command
         raw_value = self.raw_param.get("enable_node_public_ip")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -818,9 +814,7 @@ class AKSCreateContext:
         return enable_node_public_ip
 
     # pylint: disable=unused-argument
-    def get_node_public_ip_prefix_id(
-        self, enable_validation: bool = False, **kwargs
-    ):
+    def get_node_public_ip_prefix_id(self, **kwargs):
         # read the original value passed by the command
         raw_value = self.raw_param.get("node_public_ip_prefix_id")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -845,9 +839,7 @@ class AKSCreateContext:
         return node_public_ip_prefix_id
 
     # pylint: disable=unused-argument
-    def get_enable_encryption_at_host(
-        self, enable_validation: bool = False, **kwargs
-    ) -> bool:
+    def get_enable_encryption_at_host(self, **kwargs) -> bool:
         # read the original value passed by the command
         raw_value = self.raw_param.get("enable_encryption_at_host")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -872,9 +864,7 @@ class AKSCreateContext:
         return enable_encryption_at_host
 
     # pylint: disable=unused-argument
-    def get_enable_ultra_ssd(
-        self, enable_validation: bool = False, **kwargs
-    ) -> bool:
+    def get_enable_ultra_ssd(self, **kwargs) -> bool:
         # read the original value passed by the command
         raw_value = self.raw_param.get("enable_ultra_ssd")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -897,9 +887,7 @@ class AKSCreateContext:
         return enable_ultra_ssd
 
     # pylint: disable=unused-argument
-    def get_max_pods(
-        self, enable_validation: bool = False, **kwargs
-    ) -> Union[int, None]:
+    def get_max_pods(self, **kwargs) -> Union[int, None]:
         # Note: int 0 is converted to None
         # read the original value passed by the command
         raw_value = self.raw_param.get("max_pods")
@@ -927,9 +915,7 @@ class AKSCreateContext:
         return max_pods
 
     # pylint: disable=unused-argument
-    def get_node_osdisk_size(
-        self, enable_validation: bool = False, **kwargs
-    ) -> Union[int, None]:
+    def get_node_osdisk_size(self, **kwargs) -> Union[int, None]:
         # Note: int 0 is converted to None
         # read the original value passed by the command
         raw_value = self.raw_param.get("node_osdisk_size")
@@ -958,7 +944,7 @@ class AKSCreateContext:
         return node_osdisk_size
 
     # pylint: disable=unused-argument
-    def get_node_osdisk_type(self, enable_validation: bool = False, **kwargs):
+    def get_node_osdisk_type(self, **kwargs):
         # read the original value passed by the command
         raw_value = self.raw_param.get("node_osdisk_type")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -1127,7 +1113,7 @@ class AKSCreateContext:
         return max_count
 
     # pylint: disable=unused-argument
-    def get_admin_username(self, enable_validation: bool = False, **kwargs):
+    def get_admin_username(self, **kwargs):
         # read the original value passed by the command
         raw_value = self.raw_param.get("admin_username")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -1146,9 +1132,7 @@ class AKSCreateContext:
         return admin_username
 
     # pylint: disable=unused-argument
-    def get_windows_admin_username_and_password(
-        self, enable_validation: bool = False, **kwargs
-    ):
+    def get_windows_admin_username_and_password(self, **kwargs):
         # windows_admin_username
         # read the original value passed by the command
         username_raw_value = self.raw_param.get("windows_admin_username")
@@ -1251,7 +1235,7 @@ class AKSCreateContext:
         return windows_admin_username, windows_admin_password
 
     # pylint: disable=unused-argument
-    def get_enable_ahub(self, enable_validation: bool = False, **kwargs):
+    def get_enable_ahub(self, **kwargs):
         # Note: This parameter will not be decorated into the `mc` object.
         # read the original value passed by the command
         enable_ahub = self.raw_param.get("enable_ahub")
@@ -1260,9 +1244,9 @@ class AKSCreateContext:
         # this parameter does not need validation
         return enable_ahub
 
-    # pylint: disable=unused-argument
+    # pylint: disable=unused-argument,too-many-statements
     def get_enable_managed_identity_service_principal_and_client_secret(
-        self, enable_validation: bool = False, **kwargs
+        self, **kwargs
     ):
         """Dynamically obtain the values of enable_managed_identity, service_principal and client_secret according to
         the context.

--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -5,7 +5,7 @@
 
 from knack.prompting import NoTTYException, prompt, prompt_pass
 from knack.log import get_logger
-from typing import Any, List, Dict, Union
+from typing import Any, List, Dict, Tuple, Union
 
 from azure.cli.core import AzCommandsLoader
 from azure.cli.core.azclierror import (
@@ -219,7 +219,7 @@ class AKSCreateContext:
         self.intermediates.pop(variable_name, None)
 
     # pylint: disable=unused-argument
-    def get_resource_group_name(self, **kwargs):
+    def get_resource_group_name(self, **kwargs) -> str:
         # Note: This parameter will not be decorated into the `mc` object.
         # read the original value passed by the command
         resource_group_name = self.raw_param.get("resource_group_name")
@@ -229,7 +229,7 @@ class AKSCreateContext:
         return resource_group_name
 
     # pylint: disable=unused-argument
-    def get_name(self, **kwargs):
+    def get_name(self, **kwargs) -> str:
         # Note: This parameter will not be decorated into the `mc` object.
         # read the original value passed by the command
         name = self.raw_param.get("name")
@@ -239,7 +239,9 @@ class AKSCreateContext:
         return name
 
     # pylint: disable=unused-argument
-    def get_ssh_key_value(self, enable_validation: bool = False, **kwargs):
+    def get_ssh_key_value(
+        self, enable_validation: bool = False, **kwargs
+    ) -> str:
         # read the original value passed by the command
         raw_value = self.raw_param.get("ssh_key_value")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -272,7 +274,9 @@ class AKSCreateContext:
         return ssh_key_value
 
     # pylint: disable=unused-argument
-    def get_dns_name_prefix(self, enable_validation: bool = False, **kwargs):
+    def get_dns_name_prefix(
+        self, enable_validation: bool = False, **kwargs
+    ) -> Union[str, None]:
         parameter_name = "dns_name_prefix"
 
         # read the original value passed by the command
@@ -327,7 +331,7 @@ class AKSCreateContext:
         return dns_name_prefix
 
     # pylint: disable=unused-argument
-    def get_location(self, **kwargs):
+    def get_location(self, **kwargs) -> str:
         parameter_name = "location"
 
         # read the original value passed by the command
@@ -370,7 +374,7 @@ class AKSCreateContext:
         return location
 
     # pylint: disable=unused-argument
-    def get_kubernetes_version(self, **kwargs):
+    def get_kubernetes_version(self, **kwargs) -> str:
         # read the original value passed by the command
         raw_value = self.raw_param.get("kubernetes_version")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -389,7 +393,7 @@ class AKSCreateContext:
         return kubernetes_version
 
     # pylint: disable=unused-argument
-    def get_no_ssh_key(self, enable_validation: bool = False, **kwargs):
+    def get_no_ssh_key(self, enable_validation: bool = False, **kwargs) -> bool:
         # Note: This parameter will not be decorated into the `mc` object.
         # read the original value passed by the command
         no_ssh_key = self.raw_param.get("no_ssh_key")
@@ -404,7 +408,7 @@ class AKSCreateContext:
         return no_ssh_key
 
     # pylint: disable=unused-argument
-    def get_vm_set_type(self, **kwargs):
+    def get_vm_set_type(self, **kwargs) -> str:
         parameter_name = "vm_set_type"
 
         # read the original value passed by the command
@@ -432,10 +436,9 @@ class AKSCreateContext:
         else:
             vm_set_type = raw_value
 
-        dynamic_completion = False
-        # check whether the parameter meet the conditions of dynamic completion
-        if not vm_set_type:
-            dynamic_completion = True
+        # the value verified by the validator may have case problems, and the
+        # "_set_vm_set_type" function will adjust it
+        dynamic_completion = True
         # disable dynamic completion if the value is read from `mc`
         dynamic_completion = dynamic_completion and not read_from_mc
         if dynamic_completion:
@@ -452,7 +455,9 @@ class AKSCreateContext:
         return vm_set_type
 
     # pylint: disable=unused-argument
-    def get_load_balancer_sku(self, enable_validation: bool = False, **kwargs):
+    def get_load_balancer_sku(
+        self, enable_validation: bool = False, **kwargs
+    ) -> str:
         parameter_name = "load_balancer_sku"
 
         # read the original value passed by the command
@@ -507,6 +512,7 @@ class AKSCreateContext:
     def get_api_server_authorized_ip_ranges(
         self, enable_validation: bool = False, **kwargs
     ):
+        # TODO: need update, raw input should be str, output should be List[str]
         parameter_name = "api_server_authorized_ip_ranges"
 
         # read the original value passed by the command
@@ -538,7 +544,9 @@ class AKSCreateContext:
         return api_server_authorized_ip_ranges
 
     # pylint: disable=unused-argument
-    def get_fqdn_subdomain(self, enable_validation: bool = False, **kwargs):
+    def get_fqdn_subdomain(
+        self, enable_validation: bool = False, **kwargs
+    ) -> Union[str, None]:
         # read the original value passed by the command
         raw_value = self.raw_param.get("fqdn_subdomain")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -563,7 +571,7 @@ class AKSCreateContext:
         return fqdn_subdomain
 
     # pylint: disable=unused-argument
-    def get_nodepool_name(self, **kwargs):
+    def get_nodepool_name(self, **kwargs) -> str:
         parameter_name = "nodepool_name"
 
         # read the original value passed by the command
@@ -611,7 +619,7 @@ class AKSCreateContext:
         return nodepool_name
 
     # pylint: disable=unused-argument
-    def get_nodepool_tags(self, **kwargs):
+    def get_nodepool_tags(self, **kwargs) -> Union[Dict, None]:
         # read the original value passed by the command
         raw_value = self.raw_param.get("nodepool_tags")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -634,7 +642,7 @@ class AKSCreateContext:
         return nodepool_tags
 
     # pylint: disable=unused-argument
-    def get_nodepool_labels(self, **kwargs):
+    def get_nodepool_labels(self, **kwargs) -> Union[Dict, None]:
         # read the original value passed by the command
         raw_value = self.raw_param.get("nodepool_labels")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -695,7 +703,7 @@ class AKSCreateContext:
         return int(node_count)
 
     # pylint: disable=unused-argument
-    def get_node_vm_size(self, **kwargs):
+    def get_node_vm_size(self, **kwargs) -> str:
         # read the original value passed by the command
         raw_value = self.raw_param.get("node_vm_size")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -718,7 +726,7 @@ class AKSCreateContext:
         return node_vm_size
 
     # pylint: disable=unused-argument
-    def get_vnet_subnet_id(self, **kwargs):
+    def get_vnet_subnet_id(self, **kwargs) -> Union[str, None]:
         # read the original value passed by the command
         raw_value = self.raw_param.get("vnet_subnet_id")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -741,7 +749,7 @@ class AKSCreateContext:
         return vnet_subnet_id
 
     # pylint: disable=unused-argument
-    def get_ppg(self, **kwargs):
+    def get_ppg(self, **kwargs) -> Union[str, None]:
         # read the original value passed by the command
         raw_value = self.raw_param.get("ppg")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -766,7 +774,7 @@ class AKSCreateContext:
         return ppg
 
     # pylint: disable=unused-argument
-    def get_zones(self, **kwargs):
+    def get_zones(self, **kwargs) -> Union[List[str], None]:
         # read the original value passed by the command
         raw_value = self.raw_param.get("zones")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -814,7 +822,7 @@ class AKSCreateContext:
         return enable_node_public_ip
 
     # pylint: disable=unused-argument
-    def get_node_public_ip_prefix_id(self, **kwargs):
+    def get_node_public_ip_prefix_id(self, **kwargs) -> Union[str, None]:
         # read the original value passed by the command
         raw_value = self.raw_param.get("node_public_ip_prefix_id")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -944,7 +952,7 @@ class AKSCreateContext:
         return node_osdisk_size
 
     # pylint: disable=unused-argument
-    def get_node_osdisk_type(self, **kwargs):
+    def get_node_osdisk_type(self, **kwargs) -> Union[str, None]:
         # read the original value passed by the command
         raw_value = self.raw_param.get("node_osdisk_type")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -1113,7 +1121,7 @@ class AKSCreateContext:
         return max_count
 
     # pylint: disable=unused-argument
-    def get_admin_username(self, **kwargs):
+    def get_admin_username(self, **kwargs) -> str:
         # read the original value passed by the command
         raw_value = self.raw_param.get("admin_username")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -1132,7 +1140,9 @@ class AKSCreateContext:
         return admin_username
 
     # pylint: disable=unused-argument
-    def get_windows_admin_username_and_password(self, **kwargs):
+    def get_windows_admin_username_and_password(
+        self, **kwargs
+    ) -> Tuple[Union[str, None], Union[str, None]]:
         # windows_admin_username
         # read the original value passed by the command
         username_raw_value = self.raw_param.get("windows_admin_username")
@@ -1235,7 +1245,7 @@ class AKSCreateContext:
         return windows_admin_username, windows_admin_password
 
     # pylint: disable=unused-argument
-    def get_enable_ahub(self, **kwargs):
+    def get_enable_ahub(self, **kwargs) -> bool:
         # Note: This parameter will not be decorated into the `mc` object.
         # read the original value passed by the command
         enable_ahub = self.raw_param.get("enable_ahub")

--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -220,7 +220,14 @@ class AKSCreateContext:
 
     # pylint: disable=unused-argument
     def get_resource_group_name(self, **kwargs) -> str:
-        # Note: This parameter will not be decorated into the `mc` object.
+        """Obtain the value of resource_group_name.
+
+        Note: resource_group_name will not be decorated into the `mc` object.
+
+        The value of this parameter should be provided by user explicitly.
+
+        :return: string
+        """
         # read the original value passed by the command
         resource_group_name = self.raw_param.get("resource_group_name")
 
@@ -230,7 +237,14 @@ class AKSCreateContext:
 
     # pylint: disable=unused-argument
     def get_name(self, **kwargs) -> str:
-        # Note: This parameter will not be decorated into the `mc` object.
+        """Obtain the value of name.
+
+        Note: name will not be decorated into the `mc` object.
+
+        The value of this parameter should be provided by user explicitly.
+
+        :return: string
+        """
         # read the original value passed by the command
         name = self.raw_param.get("name")
 
@@ -242,6 +256,21 @@ class AKSCreateContext:
     def get_ssh_key_value(
         self, enable_validation: bool = False, **kwargs
     ) -> str:
+        """Obtain the value of ssh_key_value.
+
+        If the user does not specify this parameter, the validator function "validate_ssh_key" checks the default file
+        location "~/.ssh/id_rsa.pub", if the file exists, read its content and return; otherise, create a key pair at
+        "~/.ssh/id_rsa.pub" and return the public key.
+        If the user provides a string-like input, the validator function "validate_ssh_key" checks whether it is a file
+        path, if so, read its content and return; if it is a valid public key, return it; otherwise, create a key pair
+        there and return the public key.
+
+        This function supports the option of enable_validation. When enabled, it will call "_validate_ssh_key" to
+        verify the validity of ssh_key_value. If parameter no_ssh_key is set to True, verification will be skipped;
+        otherwise, a CLIError will be raised when the value of ssh_key_value is invalid.
+
+        :return: string
+        """
         # read the original value passed by the command
         raw_value = self.raw_param.get("ssh_key_value")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -277,15 +306,22 @@ class AKSCreateContext:
     def get_dns_name_prefix(
         self, enable_validation: bool = False, **kwargs
     ) -> Union[str, None]:
+        """Dynamically obtain the value of ssh_key_value according to the context.
+
+        When both dns_name_prefix and fqdn_subdomain are not assigned, dynamic completion will be triggerd. Function
+        "_get_default_dns_prefix" will be called to create a default dns_name_prefix composed of name(cluster),
+        resource_group_name, and subscription_id.
+
+        This function supports the option of enable_validation. When enabled, it will check if both dns_name_prefix and
+        fqdn_subdomain are assigend, if so, throw the MutuallyExclusiveArgumentError.
+        This function supports the option of read_only. When enabled, it will skip dynamic completion and validation.
+
+        :return: string
+        """
         parameter_name = "dns_name_prefix"
 
         # read the original value passed by the command
         raw_value = self.raw_param.get(parameter_name)
-        # Try to read from intermediates, the intermediate only exists when the parameter value has been
-        # dynamically completed but has not been decorated into the `mc` object.
-        # Note: The intermediate value should be cleared immediately after it is decorated into the
-        # `mc` object.
-        intermediate = self.get_intermediate(parameter_name, None)
         # try to read the property value corresponding to the parameter from the `mc` object
         value_obtained_from_mc = None
         if self.mc:
@@ -295,13 +331,13 @@ class AKSCreateContext:
         read_from_mc = False
         if value_obtained_from_mc is not None:
             dns_name_prefix = value_obtained_from_mc
-            # clean up intermediate if `mc` has been decorated
-            self.remove_intermediate(parameter_name)
             read_from_mc = True
-        elif intermediate is not None:
-            dns_name_prefix = intermediate
         else:
             dns_name_prefix = raw_value
+
+        # skip dynamic completion & validation if option read_only is specified
+        if kwargs.get("read_only"):
+            return dns_name_prefix
 
         dynamic_completion = False
         # check whether the parameter meet the conditions of dynamic completion
@@ -332,12 +368,18 @@ class AKSCreateContext:
 
     # pylint: disable=unused-argument
     def get_location(self, **kwargs) -> str:
+        """Dynamically obtain the value of location according to the context.
+
+        When location is not assigned, dynamic completion will be triggerd. Function "_get_rg_location" will be called
+        to get the location of the provided resource group, which internally used ResourceManagementClient to send
+        the request.
+
+        :return: string
+        """
         parameter_name = "location"
 
         # read the original value passed by the command
         raw_value = self.raw_param.get(parameter_name)
-        # try to read from intermediates
-        intermediate = self.get_intermediate(parameter_name, None)
         # try to read the property value corresponding to the parameter from the `mc` object
         value_obtained_from_mc = None
         if self.mc:
@@ -347,11 +389,7 @@ class AKSCreateContext:
         read_from_mc = False
         if value_obtained_from_mc is not None:
             location = value_obtained_from_mc
-            # clean up intermediate if `mc` has been decorated
-            self.remove_intermediate(parameter_name)
             read_from_mc = True
-        elif intermediate is not None:
-            location = intermediate
         else:
             location = raw_value
 
@@ -365,16 +403,16 @@ class AKSCreateContext:
             location = _get_rg_location(
                 self.cmd.cli_ctx, self.get_resource_group_name()
             )
-            # add to intermediate
-            self.set_intermediate(
-                parameter_name, location, overwrite_exists=True
-            )
 
         # this parameter does not need validation
         return location
 
     # pylint: disable=unused-argument
     def get_kubernetes_version(self, **kwargs) -> str:
+        """Obtain the value of kubernetes_version.
+
+        :return: string
+        """
         # read the original value passed by the command
         raw_value = self.raw_param.get("kubernetes_version")
         # try to read the property value corresponding to the parameter from the `mc` object
@@ -394,7 +432,18 @@ class AKSCreateContext:
 
     # pylint: disable=unused-argument
     def get_no_ssh_key(self, enable_validation: bool = False, **kwargs) -> bool:
-        # Note: This parameter will not be decorated into the `mc` object.
+        """Obtain the value of name.
+
+        Note: no_ssh_key will not be decorated into the `mc` object.
+
+        This function supports the option of enable_validation. When enabled, it will check if both dns_name_prefix and
+        fqdn_subdomain are assigend, if so, throw the MutuallyExclusiveArgumentError.
+        This function supports the option of enable_validation. When enabled, it will call "_validate_ssh_key" to
+        verify the validity of ssh_key_value. If parameter no_ssh_key is set to True, verification will be skipped;
+        otherwise, a CLIError will be raised when the value of ssh_key_value is invalid.
+
+        :return: bool
+        """
         # read the original value passed by the command
         no_ssh_key = self.raw_param.get("no_ssh_key")
 
@@ -409,12 +458,20 @@ class AKSCreateContext:
 
     # pylint: disable=unused-argument
     def get_vm_set_type(self, **kwargs) -> str:
+        """Dynamically obtain the value of vm_set_type according to the context.
+
+        Dynamic completion will be triggerd by default. Function "_set_vm_set_type" will be called and the
+        corresponding vm set type will be returned according to the value of kubernetes_version. It will also
+        normalize the value as server validation is case-sensitive.
+
+        This function supports the option of read_only. When enabled, it will skip dynamic completion and validation.
+
+        :return: string
+        """
         parameter_name = "vm_set_type"
 
         # read the original value passed by the command
         raw_value = self.raw_param.get(parameter_name)
-        # try to read from intermediates
-        intermediate = self.get_intermediate(parameter_name, None)
         # try to read the property value corresponding to the parameter from the `mc` object
         value_obtained_from_mc = None
         if self.mc and self.mc.agent_pool_profiles:
@@ -428,13 +485,13 @@ class AKSCreateContext:
         read_from_mc = False
         if value_obtained_from_mc is not None:
             vm_set_type = value_obtained_from_mc
-            # clean up intermediate if `mc` has been decorated
-            self.remove_intermediate(parameter_name)
             read_from_mc = True
-        elif intermediate is not None:
-            vm_set_type = intermediate
         else:
             vm_set_type = raw_value
+
+        # skip dynamic completion & validation if option read_only is specified
+        if kwargs.get("read_only"):
+            return vm_set_type
 
         # the value verified by the validator may have case problems, and the
         # "_set_vm_set_type" function will adjust it
@@ -446,10 +503,6 @@ class AKSCreateContext:
                 vm_set_type=vm_set_type,
                 kubernetes_version=self.get_kubernetes_version(),
             )
-            # add to intermediate
-            self.set_intermediate(
-                parameter_name, vm_set_type, overwrite_exists=True
-            )
 
         # this parameter does not need validation
         return vm_set_type
@@ -458,12 +511,22 @@ class AKSCreateContext:
     def get_load_balancer_sku(
         self, enable_validation: bool = False, **kwargs
     ) -> str:
+        """Dynamically obtain the value of load_balancer_sku according to the context.
+
+        When load_balancer_sku is not assigned, dynamic completion will be triggerd. Function "set_load_balancer_sku"
+        will be called and the corresponding load balancer sku will be returned according to the value of
+        kubernetes_version.
+
+        This function supports the option of enable_validation. When enabled, it will check if load_balancer_sku equals
+        to "basic" when api_server_authorized_ip_ranges is assigned, if so, throw the MutuallyExclusiveArgumentError.
+        This function supports the option of read_only. When enabled, it will skip dynamic completion and validation.
+
+        :return: string
+        """
         parameter_name = "load_balancer_sku"
 
         # read the original value passed by the command
         raw_value = self.raw_param.get(parameter_name)
-        # try to read from intermediates
-        intermediate = self.get_intermediate(parameter_name, None)
         # try to read the property value corresponding to the parameter from the `mc` object
         value_obtained_from_mc = None
         if self.mc and self.mc.network_profile:
@@ -473,13 +536,13 @@ class AKSCreateContext:
         read_from_mc = False
         if value_obtained_from_mc is not None:
             load_balancer_sku = value_obtained_from_mc
-            # clean up intermediate if `mc` has been decorated
-            self.remove_intermediate(parameter_name)
             read_from_mc = True
-        elif intermediate is not None:
-            load_balancer_sku = intermediate
         else:
             load_balancer_sku = raw_value
+
+        # skip dynamic completion & validation if option read_only is specified
+        if kwargs.get("read_only"):
+            return load_balancer_sku
 
         dynamic_completion = False
         # check whether the parameter meet the conditions of dynamic completion
@@ -491,10 +554,6 @@ class AKSCreateContext:
             load_balancer_sku = set_load_balancer_sku(
                 sku=load_balancer_sku,
                 kubernetes_version=self.get_kubernetes_version(),
-            )
-            # add to intermediate
-            self.set_intermediate(
-                parameter_name, load_balancer_sku, overwrite_exists=True
             )
 
         # validation

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -939,7 +939,7 @@ class AKSCreateContextTestCase(unittest.TestCase):
         ctx_2 = AKSCreateContext(self.cmd, {"enable_ahub": True})
         self.assertEqual(ctx_2.get_enable_ahub(), True)
 
-    def test_get_enable_managed_identity_service_principal_and_client_secret(
+    def test_get_service_principal_and_client_secret(
         self,
     ):
         # default
@@ -952,8 +952,8 @@ class AKSCreateContextTestCase(unittest.TestCase):
             },
         )
         self.assertEqual(
-            ctx_1.get_enable_managed_identity_service_principal_and_client_secret(),
-            (True, None, None),
+            ctx_1.get_service_principal_and_client_secret(),
+            (None, None),
         )
 
         # dynamic completion
@@ -970,9 +970,6 @@ class AKSCreateContextTestCase(unittest.TestCase):
         ctx_2.set_intermediate(
             "subscription_id", "1234-5678", overwrite_exists=True
         )
-        self.assertEqual(
-            ctx_2.get_intermediate("enable_managed_identity"), None
-        )
         with patch(
             "azure.cli.command_modules.acs.decorator._get_rg_location",
             return_value="test_location",
@@ -981,12 +978,9 @@ class AKSCreateContextTestCase(unittest.TestCase):
             return_value=None,
         ):
             self.assertEqual(
-                ctx_2.get_enable_managed_identity_service_principal_and_client_secret(),
-                (False, "test_service_principal", "test_client_secret"),
+                ctx_2.get_service_principal_and_client_secret(),
+                ("test_service_principal", "test_client_secret"),
             )
-        self.assertEqual(
-            ctx_2.get_intermediate("enable_managed_identity"), False
-        )
 
         # dynamic completion
         ctx_3 = AKSCreateContext(
@@ -1013,8 +1007,8 @@ class AKSCreateContextTestCase(unittest.TestCase):
             return_value=("test_service_principal", "test_aad_session_key"),
         ):
             self.assertEqual(
-                ctx_3.get_enable_managed_identity_service_principal_and_client_secret(),
-                (True, "test_service_principal", "test_client_secret"),
+                ctx_3.get_service_principal_and_client_secret(),
+                ("test_service_principal", "test_client_secret"),
             )
         service_principal_profile = (
             self.models.ManagedClusterServicePrincipalProfile(
@@ -1028,8 +1022,8 @@ class AKSCreateContextTestCase(unittest.TestCase):
         )
         ctx_3.attach_mc(mc)
         self.assertEqual(
-            ctx_3.get_enable_managed_identity_service_principal_and_client_secret(),
-            (False, "test_mc_service_principal", "test_mc_client_secret"),
+            ctx_3.get_service_principal_and_client_secret(),
+            ("test_mc_service_principal", "test_mc_client_secret"),
         )
 
         # dynamic completion
@@ -1054,7 +1048,7 @@ class AKSCreateContextTestCase(unittest.TestCase):
             return_value=None,
         ):
             with self.assertRaises(CLIError):
-                ctx_4.get_enable_managed_identity_service_principal_and_client_secret()
+                ctx_4.get_service_principal_and_client_secret()
 
 
 class AKSCreateDecoratorTestCase(unittest.TestCase):
@@ -1291,12 +1285,6 @@ class AKSCreateDecoratorTestCase(unittest.TestCase):
             location="test_location", windows_profile=windows_profile_2
         )
         self.assertEqual(dec_mc_2, ground_truth_mc_2)
-        self.assertEqual(
-            dec_2.context.get_intermediate("windows_admin_username"), None
-        )
-        self.assertEqual(
-            dec_2.context.get_intermediate("windows_admin_password"), None
-        )
 
     def test_set_up_service_principal_profile(self):
         # default value in `aks_create`

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 import importlib
-from re import T
 from knack import CLI
 from knack.util import CLIError
 import tempfile

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import importlib
+from re import T
 from knack import CLI
 from knack.util import CLIError
 import tempfile
@@ -233,10 +234,10 @@ class AKSCreateContextTestCase(unittest.TestCase):
         public_key = "{} {}".format(key.get_name(), key.get_base64())
 
         # default
-        ctx_1 = AKSCreateContext(
-            self.cmd, {"ssh_key_value": "test_ssh_key_value"}
+        ctx_1 = AKSCreateContext(self.cmd, {"ssh_key_value": public_key})
+        self.assertEqual(
+            ctx_1.get_ssh_key_value(enable_validation=True), public_key
         )
-        self.assertEqual(ctx_1.get_ssh_key_value(), "test_ssh_key_value")
         ssh_config = self.models.ContainerServiceSshConfiguration(
             public_keys=[
                 self.models.ContainerServiceSshPublicKey(
@@ -253,43 +254,24 @@ class AKSCreateContextTestCase(unittest.TestCase):
         ctx_1.attach_mc(mc)
         self.assertEqual(ctx_1.get_ssh_key_value(), "test_mc_ssh_key_value")
 
-        # valid key
-        ctx_2 = AKSCreateContext(
-            self.cmd, {"ssh_key_value": public_key, "no_ssh_key": False}
-        )
-        self.assertEqual(
-            ctx_2.get_ssh_key_value(enable_validation=True), public_key
-        )
-
         # invalid key with validation
-        ctx_3 = AKSCreateContext(
+        ctx_2 = AKSCreateContext(
             self.cmd, {"ssh_key_value": "fake-key", "no_ssh_key": False}
         )
         with self.assertRaises(CLIError):
-            ctx_3.get_ssh_key_value(enable_validation=True)
+            ctx_2.get_ssh_key_value(enable_validation=True)
 
         # invalid key & valid parameter with validation
-        ctx_4 = AKSCreateContext(
+        ctx_3 = AKSCreateContext(
             self.cmd, {"ssh_key_value": "fake-key", "no_ssh_key": True}
         )
         self.assertEqual(
-            ctx_4.get_ssh_key_value(enable_validation=True), "fake-key"
+            ctx_3.get_ssh_key_value(enable_validation=True), "fake-key"
         )
 
     def test_get_dns_name_prefix(self):
-        # default
+        # default & dynamic completion
         ctx_1 = AKSCreateContext(
-            self.cmd, {"dns_name_prefix": "test_dns_name_prefix"}
-        )
-        self.assertEqual(ctx_1.get_dns_name_prefix(), "test_dns_name_prefix")
-        mc = self.models.ManagedCluster(
-            location="test_location", dns_prefix="test_mc_dns_name_prefix"
-        )
-        ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_dns_name_prefix(), "test_mc_dns_name_prefix")
-
-        # dynamic completion
-        ctx_2 = AKSCreateContext(
             self.cmd,
             {
                 "dns_name_prefix": None,
@@ -298,23 +280,23 @@ class AKSCreateContextTestCase(unittest.TestCase):
                 "resource_group_name": "test_rg_name",
             },
         )
-        ctx_2.set_intermediate("subscription_id", "1234-5678")
+        ctx_1.set_intermediate("subscription_id", "1234-5678")
         self.assertEqual(
-            ctx_2.get_dns_name_prefix(), "testname-testrgname-1234-5"
+            ctx_1.get_dns_name_prefix(), "testname-testrgname-1234-5"
         )
         self.assertEqual(
-            ctx_2.get_intermediate("dns_name_prefix"),
+            ctx_1.get_intermediate("dns_name_prefix"),
             "testname-testrgname-1234-5",
         )
         mc = self.models.ManagedCluster(
             location="test_location", dns_prefix="test_mc_dns_name_prefix"
         )
-        ctx_2.attach_mc(mc)
-        self.assertEqual(ctx_2.get_dns_name_prefix(), "test_mc_dns_name_prefix")
-        self.assertEqual(ctx_2.get_intermediate("dns_name_prefix"), None)
+        ctx_1.attach_mc(mc)
+        self.assertEqual(ctx_1.get_dns_name_prefix(), "test_mc_dns_name_prefix")
+        self.assertEqual(ctx_1.get_intermediate("dns_name_prefix"), None)
 
         # invalid parameter with validation
-        ctx_3 = AKSCreateContext(
+        ctx_2 = AKSCreateContext(
             self.cmd,
             {
                 "dns_name_prefix": "test_dns_name_prefix",
@@ -322,35 +304,26 @@ class AKSCreateContextTestCase(unittest.TestCase):
             },
         )
         with self.assertRaises(MutuallyExclusiveArgumentError):
-            ctx_3.get_dns_name_prefix(enable_validation=True)
+            ctx_2.get_dns_name_prefix(enable_validation=True)
 
     def test_get_location(self):
-        # default
-        ctx_1 = AKSCreateContext(self.cmd, {"location": "test_location"})
-        self.assertEqual(ctx_1.get_location(), "test_location")
-        mc = self.models.ManagedCluster(location="test_mc_location")
-        ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_location(), "test_mc_location")
-
-        # dynamic completion
+        # default & dynamic completion
+        ctx_1 = AKSCreateContext(self.cmd, {"location": None})
         with patch(
             "azure.cli.command_modules.acs.decorator._get_rg_location",
             return_value="test_location",
         ):
-            ctx_2 = AKSCreateContext(
-                self.cmd,
-                {"location": None, "resource_group_name": "test_rg_name"},
-            )
-            self.assertEqual(ctx_2.get_location(), "test_location")
+            self.assertEqual(ctx_1.get_location(), "test_location")
+        self.assertEqual(ctx_1.get_intermediate("location"), "test_location")
+        mc = self.models.ManagedCluster(location="test_mc_location")
+        ctx_1.attach_mc(mc)
+        self.assertEqual(ctx_1.get_location(), "test_mc_location")
+        self.assertEqual(ctx_1.get_intermediate("location"), None)
 
     def test_get_kubernetes_version(self):
         # default
-        ctx_1 = AKSCreateContext(
-            self.cmd, {"kubernetes_version": "test_kubernetes_version"}
-        )
-        self.assertEqual(
-            ctx_1.get_kubernetes_version(), "test_kubernetes_version"
-        )
+        ctx_1 = AKSCreateContext(self.cmd, {"kubernetes_version": ""})
+        self.assertEqual(ctx_1.get_kubernetes_version(), "")
         mc = self.models.ManagedCluster(
             location="test_location",
             kubernetes_version="test_mc_kubernetes_version",
@@ -362,20 +335,27 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_no_ssh_key(self):
         # default
-        ctx_1 = AKSCreateContext(self.cmd, {"no_ssh_key": True})
-        self.assertEqual(ctx_1.get_no_ssh_key(), True)
+        ctx_1 = AKSCreateContext(self.cmd, {"no_ssh_key": False})
+        self.assertEqual(ctx_1.get_no_ssh_key(), False)
 
-        # invalid parameter with validation
+        # invalid key & valid parameter with validation
         ctx_2 = AKSCreateContext(
-            self.cmd, {"ssh_key_value": "fake-key", "no_ssh_key": False}
+            self.cmd, {"ssh_key_value": "fake-key", "no_ssh_key": True}
         )
-        with self.assertRaises(CLIError):
-            ctx_2.get_no_ssh_key(enable_validation=True)
+        self.assertEqual(
+            ctx_2.get_ssh_key_value(enable_validation=True), "fake-key"
+        )
 
     def test_get_vm_set_type(self):
-        # default
-        ctx_1 = AKSCreateContext(self.cmd, {"vm_set_type": "test_vm_set_type"})
-        self.assertEqual(ctx_1.get_vm_set_type(), "test_vm_set_type")
+        # default & dynamic completion
+        ctx_1 = AKSCreateContext(
+            self.cmd, {"vm_set_type": None, "kubernetes_version": ""}
+        )
+        self.assertEqual(ctx_1.get_vm_set_type(), "VirtualMachineScaleSets")
+        self.assertEqual(
+            ctx_1.get_intermediate("vm_set_type"),
+            "VirtualMachineScaleSets",
+        )
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_ap_name", type="test_mc_vm_set_type"
         )
@@ -384,16 +364,17 @@ class AKSCreateContextTestCase(unittest.TestCase):
         )
         ctx_1.attach_mc(mc)
         self.assertEqual(ctx_1.get_vm_set_type(), "test_mc_vm_set_type")
+        self.assertEqual(ctx_1.get_intermediate("vm_set_type"), None)
 
-        # dynamic completion
+        # custom value & dynamic completion
         ctx_2 = AKSCreateContext(
             self.cmd,
-            {"vm_set_type": None, "kubernetes_version": None},
+            {"vm_set_type": "availabilityset", "kubernetes_version": ""},
         )
-        self.assertEqual(ctx_2.get_vm_set_type(), "VirtualMachineScaleSets")
+        self.assertEqual(ctx_2.get_vm_set_type(), "AvailabilitySet")
         self.assertEqual(
             ctx_2.get_intermediate("vm_set_type"),
-            "VirtualMachineScaleSets",
+            "AvailabilitySet",
         )
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_ap_name", type="test_mc_vm_set_type"
@@ -406,13 +387,12 @@ class AKSCreateContextTestCase(unittest.TestCase):
         self.assertEqual(ctx_2.get_intermediate("vm_set_type"), None)
 
     def test_get_load_balancer_sku(self):
-        # default
+        # default & dynamic completion
         ctx_1 = AKSCreateContext(
-            self.cmd, {"load_balancer_sku": "test_load_balancer_sku"}
+            self.cmd,
+            {"load_balancer_sku": None, "kubernetes_version": ""},
         )
-        self.assertEqual(
-            ctx_1.get_load_balancer_sku(), "test_load_balancer_sku"
-        )
+        self.assertEqual(ctx_1.get_load_balancer_sku(), "standard")
         network_profile = self.models.ContainerServiceNetworkProfile(
             load_balancer_sku="test_mc_load_balancer_sku"
         )
@@ -424,15 +404,15 @@ class AKSCreateContextTestCase(unittest.TestCase):
             ctx_1.get_load_balancer_sku(), "test_mc_load_balancer_sku"
         )
 
-        # dynamic completion
+        # custom value & dynamic completion
         ctx_2 = AKSCreateContext(
             self.cmd,
-            {"load_balancer_sku": None, "kubernetes_version": None},
+            {"load_balancer_sku": None, "kubernetes_version": "1.12.0"},
         )
-        self.assertEqual(ctx_2.get_load_balancer_sku(), "standard")
+        self.assertEqual(ctx_2.get_load_balancer_sku(), "basic")
         self.assertEqual(
             ctx_2.get_intermediate("load_balancer_sku"),
-            "standard",
+            "basic",
         )
         network_profile = self.models.ContainerServiceNetworkProfile(
             load_balancer_sku="test_mc_load_balancer_sku"
@@ -458,6 +438,7 @@ class AKSCreateContextTestCase(unittest.TestCase):
             ctx_3.get_load_balancer_sku(enable_validation=True)
 
     def test_get_api_server_authorized_ip_ranges(self):
+        # TODO: need update, raw input should be str, output should be List[str]
         # default
         ctx_1 = AKSCreateContext(
             self.cmd,
@@ -499,10 +480,8 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_fqdn_subdomain(self):
         # default
-        ctx_1 = AKSCreateContext(
-            self.cmd, {"fqdn_subdomain": "test_fqdn_subdomain"}
-        )
-        self.assertEqual(ctx_1.get_fqdn_subdomain(), "test_fqdn_subdomain")
+        ctx_1 = AKSCreateContext(self.cmd, {"fqdn_subdomain": None})
+        self.assertEqual(ctx_1.get_fqdn_subdomain(), None)
         mc = self.models.ManagedCluster(
             location="test_location", fqdn_subdomain="test_mc_fqdn_subdomain"
         )
@@ -524,10 +503,8 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_nodepool_name(self):
         # default
-        ctx_1 = AKSCreateContext(
-            self.cmd, {"nodepool_name": "test_nodepool_name"}
-        )
-        self.assertEqual(ctx_1.get_nodepool_name(), "test_nodepool_name")
+        ctx_1 = AKSCreateContext(self.cmd, {"nodepool_name": "nodepool1"})
+        self.assertEqual(ctx_1.get_nodepool_name(), "nodepool1")
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_mc_nodepool_name"
         )
@@ -570,27 +547,21 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_nodepool_tags(self):
         # default
-        ctx_1 = AKSCreateContext(
-            self.cmd, {"nodepool_tags": {"key1": "value1"}}
-        )
-        self.assertEqual(ctx_1.get_nodepool_tags(), {"key1": "value1"})
+        ctx_1 = AKSCreateContext(self.cmd, {"nodepool_tags": None})
+        self.assertEqual(ctx_1.get_nodepool_tags(), None)
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
-            name="test_nodepool_name", tags={"key1": "value1", "key2": "value2"}
+            name="test_nodepool_name", tags={}
         )
         mc = self.models.ManagedCluster(
             location="test_location", agent_pool_profiles=[agent_pool_profile]
         )
         ctx_1.attach_mc(mc)
-        self.assertEqual(
-            ctx_1.get_nodepool_tags(), {"key1": "value1", "key2": "value2"}
-        )
+        self.assertEqual(ctx_1.get_nodepool_tags(), {})
 
     def test_get_nodepool_labels(self):
         # default
-        ctx_1 = AKSCreateContext(
-            self.cmd, {"nodepool_labels": {"key1": "value1"}}
-        )
-        self.assertEqual(ctx_1.get_nodepool_labels(), {"key1": "value1"})
+        ctx_1 = AKSCreateContext(self.cmd, {"nodepool_labels": None})
+        self.assertEqual(ctx_1.get_nodepool_labels(), None)
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_nodepool_name",
             node_labels={"key1": "value1", "key2": "value2"},
@@ -605,8 +576,8 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_node_count(self):
         # default
-        ctx_1 = AKSCreateContext(self.cmd, {"node_count": 10})
-        self.assertEqual(ctx_1.get_node_count(), 10)
+        ctx_1 = AKSCreateContext(self.cmd, {"node_count": 3})
+        self.assertEqual(ctx_1.get_node_count(), 3)
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_nodepool_name", count=20
         )
@@ -630,8 +601,8 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_node_vm_size(self):
         # default
-        ctx_1 = AKSCreateContext(self.cmd, {"node_vm_size": "Standard_ABCD"})
-        self.assertEqual(ctx_1.get_node_vm_size(), "Standard_ABCD")
+        ctx_1 = AKSCreateContext(self.cmd, {"node_vm_size": "Standard_DS2_v2"})
+        self.assertEqual(ctx_1.get_node_vm_size(), "Standard_DS2_v2")
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_nodepool_name", vm_size="Standard_ABCD_v2"
         )
@@ -643,10 +614,8 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_vnet_subnet_id(self):
         # default
-        ctx_1 = AKSCreateContext(
-            self.cmd, {"vnet_subnet_id": "test_vnet_subnet_id"}
-        )
-        self.assertEqual(ctx_1.get_vnet_subnet_id(), "test_vnet_subnet_id")
+        ctx_1 = AKSCreateContext(self.cmd, {"vnet_subnet_id": None})
+        self.assertEqual(ctx_1.get_vnet_subnet_id(), None)
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_nodepool_name", vnet_subnet_id="test_mc_vnet_subnet_id"
         )
@@ -658,8 +627,8 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_ppg(self):
         # default
-        ctx_1 = AKSCreateContext(self.cmd, {"ppg": "test_ppg"})
-        self.assertEqual(ctx_1.get_ppg(), "test_ppg")
+        ctx_1 = AKSCreateContext(self.cmd, {"ppg": None})
+        self.assertEqual(ctx_1.get_ppg(), None)
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_nodepool_name",
             proximity_placement_group_id="test_mc_ppg",
@@ -672,10 +641,8 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_zones(self):
         # default
-        ctx_1 = AKSCreateContext(
-            self.cmd, {"zones": ["test_zones1", "test_zones2"]}
-        )
-        self.assertEqual(ctx_1.get_zones(), ["test_zones1", "test_zones2"])
+        ctx_1 = AKSCreateContext(self.cmd, {"zones": None})
+        self.assertEqual(ctx_1.get_zones(), None)
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_nodepool_name",
             availability_zones=["test_mc_zones1", "test_mc_zones2"],
@@ -690,26 +657,26 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_enable_node_public_ip(self):
         # default
-        ctx_1 = AKSCreateContext(self.cmd, {"enable_node_public_ip": True})
-        self.assertEqual(ctx_1.get_enable_node_public_ip(), True)
+        ctx_1 = AKSCreateContext(self.cmd, {"enable_node_public_ip": False})
+        self.assertEqual(ctx_1.get_enable_node_public_ip(), False)
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
-            name="test_nodepool_name", enable_node_public_ip=False
+            name="test_nodepool_name", enable_node_public_ip=True
         )
         mc = self.models.ManagedCluster(
             location="test_location", agent_pool_profiles=[agent_pool_profile]
         )
         ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_enable_node_public_ip(), False)
+        self.assertEqual(ctx_1.get_enable_node_public_ip(), True)
 
     def test_get_node_public_ip_prefix_id(self):
         # default
         ctx_1 = AKSCreateContext(
             self.cmd,
-            {"node_public_ip_prefix_id": "test_node_public_ip_prefix_id"},
+            {"node_public_ip_prefix_id": None},
         )
         self.assertEqual(
             ctx_1.get_node_public_ip_prefix_id(),
-            "test_node_public_ip_prefix_id",
+            None,
         )
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_nodepool_name",
@@ -726,29 +693,29 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_enable_encryption_at_host(self):
         # default
-        ctx_1 = AKSCreateContext(self.cmd, {"enable_encryption_at_host": True})
-        self.assertEqual(ctx_1.get_enable_encryption_at_host(), True)
+        ctx_1 = AKSCreateContext(self.cmd, {"enable_encryption_at_host": False})
+        self.assertEqual(ctx_1.get_enable_encryption_at_host(), False)
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
-            name="test_nodepool_name", enable_encryption_at_host=False
+            name="test_nodepool_name", enable_encryption_at_host=True
         )
         mc = self.models.ManagedCluster(
             location="test_location", agent_pool_profiles=[agent_pool_profile]
         )
         ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_enable_encryption_at_host(), False)
+        self.assertEqual(ctx_1.get_enable_encryption_at_host(), True)
 
     def test_enable_ultra_ssd(self):
         # default
-        ctx_1 = AKSCreateContext(self.cmd, {"enable_ultra_ssd": True})
-        self.assertEqual(ctx_1.get_enable_ultra_ssd(), True)
+        ctx_1 = AKSCreateContext(self.cmd, {"enable_ultra_ssd": False})
+        self.assertEqual(ctx_1.get_enable_ultra_ssd(), False)
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
-            name="test_nodepool_name", enable_ultra_ssd=False
+            name="test_nodepool_name", enable_ultra_ssd=True
         )
         mc = self.models.ManagedCluster(
             location="test_location", agent_pool_profiles=[agent_pool_profile]
         )
         ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_enable_ultra_ssd(), False)
+        self.assertEqual(ctx_1.get_enable_ultra_ssd(), True)
 
     def test_get_max_pods(self):
         # default
@@ -778,10 +745,8 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_node_osdisk_type(self):
         # default
-        ctx_1 = AKSCreateContext(
-            self.cmd, {"node_osdisk_type": "test_node_osdisk_type"}
-        )
-        self.assertEqual(ctx_1.get_node_osdisk_type(), "test_node_osdisk_type")
+        ctx_1 = AKSCreateContext(self.cmd, {"node_osdisk_type": None})
+        self.assertEqual(ctx_1.get_node_osdisk_type(), None)
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_nodepool_name", os_disk_type="test_mc_node_osdisk_type"
         )
@@ -795,16 +760,16 @@ class AKSCreateContextTestCase(unittest.TestCase):
 
     def test_get_enable_cluster_autoscaler(self):
         # default
-        ctx_1 = AKSCreateContext(self.cmd, {"enable_cluster_autoscaler": True})
-        self.assertEqual(ctx_1.get_enable_cluster_autoscaler(), True)
+        ctx_1 = AKSCreateContext(self.cmd, {"enable_cluster_autoscaler": False})
+        self.assertEqual(ctx_1.get_enable_cluster_autoscaler(), False)
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
-            name="test_nodepool_name", enable_auto_scaling=False
+            name="test_nodepool_name", enable_auto_scaling=True
         )
         mc = self.models.ManagedCluster(
             location="test_location", agent_pool_profiles=[agent_pool_profile]
         )
         ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_enable_cluster_autoscaler(), False)
+        self.assertEqual(ctx_1.get_enable_cluster_autoscaler(), True)
 
         # invalid parameter with validation
         ctx_2 = AKSCreateContext(

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -284,16 +284,11 @@ class AKSCreateContextTestCase(unittest.TestCase):
         self.assertEqual(
             ctx_1.get_dns_name_prefix(), "testname-testrgname-1234-5"
         )
-        self.assertEqual(
-            ctx_1.get_intermediate("dns_name_prefix"),
-            "testname-testrgname-1234-5",
-        )
         mc = self.models.ManagedCluster(
             location="test_location", dns_prefix="test_mc_dns_name_prefix"
         )
         ctx_1.attach_mc(mc)
         self.assertEqual(ctx_1.get_dns_name_prefix(), "test_mc_dns_name_prefix")
-        self.assertEqual(ctx_1.get_intermediate("dns_name_prefix"), None)
 
         # invalid parameter with validation
         ctx_2 = AKSCreateContext(
@@ -314,11 +309,9 @@ class AKSCreateContextTestCase(unittest.TestCase):
             return_value="test_location",
         ):
             self.assertEqual(ctx_1.get_location(), "test_location")
-        self.assertEqual(ctx_1.get_intermediate("location"), "test_location")
         mc = self.models.ManagedCluster(location="test_mc_location")
         ctx_1.attach_mc(mc)
         self.assertEqual(ctx_1.get_location(), "test_mc_location")
-        self.assertEqual(ctx_1.get_intermediate("location"), None)
 
     def test_get_kubernetes_version(self):
         # default
@@ -352,10 +345,6 @@ class AKSCreateContextTestCase(unittest.TestCase):
             self.cmd, {"vm_set_type": None, "kubernetes_version": ""}
         )
         self.assertEqual(ctx_1.get_vm_set_type(), "VirtualMachineScaleSets")
-        self.assertEqual(
-            ctx_1.get_intermediate("vm_set_type"),
-            "VirtualMachineScaleSets",
-        )
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_ap_name", type="test_mc_vm_set_type"
         )
@@ -364,7 +353,6 @@ class AKSCreateContextTestCase(unittest.TestCase):
         )
         ctx_1.attach_mc(mc)
         self.assertEqual(ctx_1.get_vm_set_type(), "test_mc_vm_set_type")
-        self.assertEqual(ctx_1.get_intermediate("vm_set_type"), None)
 
         # custom value & dynamic completion
         ctx_2 = AKSCreateContext(
@@ -372,10 +360,6 @@ class AKSCreateContextTestCase(unittest.TestCase):
             {"vm_set_type": "availabilityset", "kubernetes_version": ""},
         )
         self.assertEqual(ctx_2.get_vm_set_type(), "AvailabilitySet")
-        self.assertEqual(
-            ctx_2.get_intermediate("vm_set_type"),
-            "AvailabilitySet",
-        )
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_ap_name", type="test_mc_vm_set_type"
         )
@@ -384,7 +368,6 @@ class AKSCreateContextTestCase(unittest.TestCase):
         )
         ctx_2.attach_mc(mc)
         self.assertEqual(ctx_2.get_vm_set_type(), "test_mc_vm_set_type")
-        self.assertEqual(ctx_2.get_intermediate("vm_set_type"), None)
 
     def test_get_load_balancer_sku(self):
         # default & dynamic completion
@@ -410,10 +393,6 @@ class AKSCreateContextTestCase(unittest.TestCase):
             {"load_balancer_sku": None, "kubernetes_version": "1.12.0"},
         )
         self.assertEqual(ctx_2.get_load_balancer_sku(), "basic")
-        self.assertEqual(
-            ctx_2.get_intermediate("load_balancer_sku"),
-            "basic",
-        )
         network_profile = self.models.ContainerServiceNetworkProfile(
             load_balancer_sku="test_mc_load_balancer_sku"
         )
@@ -424,7 +403,6 @@ class AKSCreateContextTestCase(unittest.TestCase):
         self.assertEqual(
             ctx_2.get_load_balancer_sku(), "test_mc_load_balancer_sku"
         )
-        self.assertEqual(ctx_2.get_intermediate("load_balancer_sku"), None)
 
         # invalid parameter with validation
         ctx_3 = AKSCreateContext(
@@ -521,10 +499,6 @@ class AKSCreateContextTestCase(unittest.TestCase):
         self.assertEqual(
             ctx_2.get_nodepool_name(enable_trim=True), "test_nodepoo"
         )
-        self.assertEqual(
-            ctx_2.get_intermediate("nodepool_name"),
-            "test_nodepoo",
-        )
         agent_pool_profile = self.models.ManagedClusterAgentPoolProfile(
             name="test_nodepool_name"
         )
@@ -535,15 +509,10 @@ class AKSCreateContextTestCase(unittest.TestCase):
         self.assertEqual(
             ctx_2.get_nodepool_name(enable_trim=True), "test_nodepool_name"
         )
-        self.assertEqual(ctx_2.get_intermediate("nodepool_name"), None)
 
         # dynamic completion
         ctx_3 = AKSCreateContext(self.cmd, {"nodepool_name": None})
         self.assertEqual(ctx_3.get_nodepool_name(enable_trim=True), "nodepool1")
-        self.assertEqual(
-            ctx_3.get_intermediate("nodepool_name"),
-            "nodepool1",
-        )
 
     def test_get_nodepool_tags(self):
         # default
@@ -917,10 +886,6 @@ class AKSCreateContextTestCase(unittest.TestCase):
                 ctx_2.get_windows_admin_username_and_password(),
                 ("test_win_admin_name", "test_win_admin_pd"),
             )
-        self.assertEqual(
-            ctx_2.get_intermediate("windows_admin_username"),
-            "test_win_admin_name",
-        )
         windows_profile = self.models.ManagedClusterWindowsProfile(
             # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="fake secrets in unit test")]
             admin_username="test_mc_win_admin_name",
@@ -951,10 +916,6 @@ class AKSCreateContextTestCase(unittest.TestCase):
                 ctx_3.get_windows_admin_username_and_password(),
                 ("test_win_admin_name", "test_win_admin_pd"),
             )
-        self.assertEqual(
-            ctx_3.get_intermediate("windows_admin_password"),
-            "test_win_admin_pd",
-        )
         windows_profile = self.models.ManagedClusterWindowsProfile(
             # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="fake secrets in unit test")]
             admin_username="test_mc_win_admin_name",


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

* Adjust the input of the default test case in the unit tests to the default value corresponding to the parameter in function aks_create.
* Add docstring for all getter functions.
* Break down get_enable_managed_identity_service_principal_and_client_secret into get_service_principal_and_client_secret  and get_enable_managed_identity.
* Remove all parameter intermediates and introduce an additional "read_only" option to bypass dynamic completion and validation to avoid circulation function calls.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
