### PR TITLE
[Profile] Deprecate `--sdk-auth`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -73,7 +73,9 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.ignore('_subscription')  # hide the global subscription parameter
 
         with self.argument_context('account show') as c:
-            c.argument('show_auth_for_sdk', options_list=['--sdk-auth'], action='store_true', help='Output result to a file compatible with Azure SDK auth. Only applicable when authenticating with a Service Principal.')
+            c.argument('show_auth_for_sdk', options_list=['--sdk-auth'], action='store_true',
+                       deprecate_info=c.deprecate(target='--sdk-auth', expiration='3.0.0'),
+                       help='Output result to a file compatible with Azure SDK auth. Only applicable when authenticating with a Service Principal.')
 
         with self.argument_context('account get-access-token') as c:
             c.argument('resource_type', get_enum_type(cloud_resource_types), options_list=['--resource-type'], arg_group='', help='Type of well-known resource.')

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -90,7 +90,9 @@ def load_arguments(self, _):
                    help='Skip creating the default assignment, which allows the service principal to access resources under the current subscription. '
                         'When specified, --scopes will be ignored. You may use `az role assignment create` to create '
                         'role assignments for this service principal later.')
-        c.argument('show_auth_for_sdk', options_list='--sdk-auth', help='output result in compatible with Azure SDK auth file', arg_type=get_three_state_flag())
+        c.argument('show_auth_for_sdk', options_list='--sdk-auth',
+                   deprecate_info=c.deprecate(target='--sdk-auth', expiration='3.0.0'),
+                   help='output result in compatible with Azure SDK auth file', arg_type=get_three_state_flag())
 
     with self.argument_context('ad sp owner list') as c:
         c.argument('identifier', options_list=['--id'], help='service principal name, or object id or the service principal')


### PR DESCRIPTION
**Description**<!--Mandatory-->

Rework https://github.com/Azure/azure-cli/pull/17362

Because consumers of the JSON output - Azure SDKs has deprecated the usage of `get_client_from_json_dict` (https://github.com/Azure/azure-sdk-for-python/issues/15075), Azure CLI should deprecate `--sdk-auth` as well.

It will be totally removed after MSAL migration (https://github.com/Azure/azure-cli/issues/18944).

Reference email: _Deprecate generating JSON auth file in Azure CLI_

**History Notes**
[Profile] `az account show`: Deprecate `--sdk-auth`
[Role] `az ad sp create-for-rbac`: Deprecate `--sdk-auth`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
