### PR TITLE
[App Service] `az webapp up`: Add support for deploying to an App Service Environment

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -618,7 +618,7 @@ def load_arguments(self, _):
                    help="Configure default logging required to enable viewing log stream immediately after launching the webapp",
                    default=False, action='store_true')
         c.argument('html', help="Ignore app detection and deploy as an html app", default=False, action='store_true')
-        c.argument('ase', options_list=['--ase'], help='name of the (pre-existing) app service environment to deploy to')
+        c.argument('app_service_environment', options_list=['--app-service-environment', '-e'], help='name of the (pre-existing) App Service Environment to deploy to. Requires an Isolated V2 sku [I1v2, I2v2, I3v2]')
 
     with self.argument_context('webapp ssh') as c:
         c.argument('port', options_list=['--port', '-p'],

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -618,6 +618,7 @@ def load_arguments(self, _):
                    help="Configure default logging required to enable viewing log stream immediately after launching the webapp",
                    default=False, action='store_true')
         c.argument('html', help="Ignore app detection and deploy as an html app", default=False, action='store_true')
+        c.argument('ase', options_list=['--ase'], help='name of the (pre-existing) app service environment to deploy to')
 
     with self.argument_context('webapp ssh') as c:
         c.argument('port', options_list=['--port', '-p'],

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3701,7 +3701,7 @@ def get_history_triggered_webjob(cmd, resource_group_name, name, webjob_name, sl
 
 
 def webapp_up(cmd, name=None, resource_group_name=None, plan=None, location=None, sku=None,  # pylint: disable=too-many-statements,too-many-branches
-              os_type=None, runtime=None, dryrun=False, logs=False, launch_browser=False, html=False):
+              os_type=None, runtime=None, dryrun=False, logs=False, launch_browser=False, html=False, ase=None):
     if not name:
         name = generate_default_app_name(cmd)
 
@@ -3828,7 +3828,7 @@ def webapp_up(cmd, name=None, resource_group_name=None, plan=None, location=None
     # updated we update those
     try:
         create_app_service_plan(cmd, rg_name, plan, _is_linux, hyper_v=False, per_site_scaling=False, sku=sku,
-                                number_of_workers=1 if _is_linux else None, location=loc)
+                                number_of_workers=1 if _is_linux else None, location=loc, app_service_environment=ase)
     except Exception as ex:  # pylint: disable=broad-except
         if ex.response.status_code == 409:  # catch 409 conflict when trying to create existing ASP in diff location
             try:

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3701,7 +3701,8 @@ def get_history_triggered_webjob(cmd, resource_group_name, name, webjob_name, sl
 
 
 def webapp_up(cmd, name=None, resource_group_name=None, plan=None, location=None, sku=None,  # pylint: disable=too-many-statements,too-many-branches
-              os_type=None, runtime=None, dryrun=False, logs=False, launch_browser=False, html=False, ase=None):
+              os_type=None, runtime=None, dryrun=False, logs=False, launch_browser=False, html=False,
+              app_service_environment=None):
     if not name:
         name = generate_default_app_name(cmd)
 
@@ -3828,7 +3829,8 @@ def webapp_up(cmd, name=None, resource_group_name=None, plan=None, location=None
     # updated we update those
     try:
         create_app_service_plan(cmd, rg_name, plan, _is_linux, hyper_v=False, per_site_scaling=False, sku=sku,
-                                number_of_workers=1 if _is_linux else None, location=loc, app_service_environment=ase)
+                                number_of_workers=1 if _is_linux else None, location=loc,
+                                app_service_environment=app_service_environment)
     except Exception as ex:  # pylint: disable=broad-except
         if ex.response.status_code == 409:  # catch 409 conflict when trying to create existing ASP in diff location
             try:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Allows the user to deploy to a (pre-existing) App Service Environment with `az webapp up` through a `--app-service-environment`/`-e` parameter 

**Testing Guide**
<!--Example commands with explanations.-->
```
# Note the SKU needs to be an IsolatedV2 plan to deploy to an ASE
az webapp up --name <name> -g <group> --app-service-environment <ase_name> --sku I1V2 --plan <plan_name>
```


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
