### PR TITLE
{AKS} Skip test_aks_nodepool_add_with_ossku

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -2389,6 +2389,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.cmd(
             'aks delete -g {resource_group} -n {name} --yes --no-wait', checks=[self.is_empty()])
 
+    @unittest.skip("Need generate ssh keys")
     @AllowLargeResponse()
     @AKSCustomResourceGroupPreparer(random_name_length=17, name_prefix='clitest', location='eastus')
     def test_aks_nodepool_add_with_ossku(self, resource_group, resource_group_location):


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

There is a CI pipeline failed to run due to the lack of generating ssh keys in the test `test_aks_create_with_ossku` and the absence of `~/.ssh` file in the CI pipeline.
Pipeline link: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1080310&view=logs&jobId=ad51cf76-b294-5bde-777e-be77cc5f3050&j=ad51cf76-b294-5bde-777e-be77cc5f3050&t=0e02ab23-4098-514d-f7b9-ab422251bbb2
Error:
> raise CLIError('An RSA key file or key value must be supplied to SSH Key Value. 'You can use --generate-ssh-keys to let CLI generate one for you')
  knack.util.CLIError: An RSA key file or key value must be supplied to SSH Key Value. You can use --generate-ssh-keys to let CLI generate one for you

So I skip this test at first

@hbeberman  Therefore, please add the logic of generating ssh keys to test `test_aks_create_with_ossku`, such as using `self.generate_ssh_keys()` or `--generate-ssh-keys`

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
