### PR TITLE
{CI} Move verify_debian_in_docker.sh to upstream repo

### DIFF
--- a/scripts/release/debian/verify_debian_in_docker.sh
+++ b/scripts/release/debian/verify_debian_in_docker.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# This script should be run in a docker to verify installing deb package from the apt repository.
+
+apt update -y
+apt install curl -y
+counter=4
+
+while [ $counter -gt 0 ]
+do
+    curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+    ACTUAL_VERSION=$(az version | sed -n 's|"azure-cli": "\(.*\)",|\1|p' | sed 's|[[:space:]]||g')
+    echo "actual version:${ACTUAL_VERSION}"
+    echo "expected version:${CLI_VERSION}"
+
+    if [ "$ACTUAL_VERSION" != "$CLI_VERSION" ]; then
+        if [ ! -z "$ACTUAL_VERSION" ]; then
+            echo "Latest package is not in the repo."
+            exit 1
+        fi
+        echo "wait 5m"
+        sleep 300
+        counter=$(( $counter - 1 ))
+    else
+        echo "Latest package is verified."
+        exit 0
+    fi
+done
+echo "Timeout!"
+exit 1


### PR DESCRIPTION
**Description**<!--Mandatory-->

CI task [Verify Debian Package](https://dev.azure.com/azure-sdk/internal/_releaseDefinition?definitionId=79&_a=definition-tasks&environmentId=193) relies on 

- https://raw.githubusercontent.com/fengzhou-msft/azure-cli/release_scripts/scripts/release/debian/verify_debian_in_docker.sh
- i.e. https://github.com/fengzhou-msft/azure-cli/blob/release_scripts/scripts/release/debian/verify_debian_in_docker.sh

This PR moves this script to upstream repo.
