### PR TITLE
[Network] add wait for network subcommands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -5956,7 +5956,7 @@ short-summary: Place the CLI in a waiting state until a condition of the vnet ga
 examples:
   - name: Wait for vnet gateway nat rule to return as created.
     text: |
-        az network vnet-gateway nat-rule wait -g MyResourceGroup --gateway-name MyVnetGateway --name Nat --created
+        az network vnet-gateway nat-rule wait -g MyResourceGroup --name Nat --created
 """
 
 helps['network vnet-gateway nat-rule add'] = """

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -4720,7 +4720,7 @@ examples:
         az network custom-ip prefix create --location westus2 --name MyCustomIpPrefix --resource-group MyResourceGroup
 """
 
-helps['network custom-ip prefix create'] = """
+helps['network custom-ip prefix wait'] = """
 type: command
 short-summary: Place the CLI in a waiting state until a condition of the custom ip prefix is met.
 examples:

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -5956,7 +5956,7 @@ short-summary: Place the CLI in a waiting state until a condition of the vnet ga
 examples:
   - name: Wait for vnet gateway nat rule to return as created.
     text: |
-        az network vnet-gateway nat-rule wait -g MyResourceGroup -gateway-name MyVnetGateway --name Nat --created
+        az network vnet-gateway nat-rule wait -g MyResourceGroup --gateway-name MyVnetGateway --name Nat --created
 """
 
 helps['network vnet-gateway nat-rule add'] = """

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -5806,10 +5806,6 @@ short-summary: Manage packet capture on a virtual network gateway.
 helps['network vnet-gateway packet-capture wait'] = """
 type: command
 short-summary: Place the CLI in a waiting state until a condition of the vnet gateway packet capture is met.
-examples:
-  - name: Wait for vnet gateway packet capture to return as created.
-    text: |
-        az network vnet-gateway packet-capture wait -g MyResourceGroup -n MyVnetGateway --created
 """
 
 helps['network vnet-gateway packet-capture start'] = """
@@ -5873,10 +5869,6 @@ short-summary: Manage the VPN client connection ipsec-policy for P2S client conn
 helps['network vnet-gateway vpn-client ipsec-policy wait'] = """
 type: command
 short-summary: Place the CLI in a waiting state until a condition of the vnet gateway vpn client ipsec policy is met.
-examples:
-  - name: Wait for vnet gateway vpn client ipsec policy to return as created.
-    text: |
-        az network vnet-gateway vpn-client ipsec-policy wait -g MyResourceGroup -n MyVnetGateway --created
 """
 
 helps['network vnet-gateway vpn-client ipsec-policy show'] = """
@@ -5953,10 +5945,6 @@ short-summary: Manage nat rule in a virtual network gateway
 helps['network vnet-gateway nat-rule wait'] = """
 type: command
 short-summary: Place the CLI in a waiting state until a condition of the vnet gateway nat rule is met.
-examples:
-  - name: Wait for vnet gateway nat rule to return as created.
-    text: |
-        az network vnet-gateway nat-rule wait -g MyResourceGroup --name Nat --created
 """
 
 helps['network vnet-gateway nat-rule add'] = """
@@ -6168,10 +6156,6 @@ short-summary: Manage packet capture on a VPN connection.
 helps['network vpn-connection packet-capture wait'] = """
 type: command
 short-summary: Place the CLI in a waiting state until a condition of the vpn connection packet capture is met.
-examples:
-  - name: Wait for vpn connection packet capture to return as created.
-    text: |
-        az network vpn-connection packet-capture wait -g MyResourceGroup -n MyConnection --created
 """
 
 helps['network vpn-connection packet-capture start'] = """

--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -4720,6 +4720,15 @@ examples:
         az network custom-ip prefix create --location westus2 --name MyCustomIpPrefix --resource-group MyResourceGroup
 """
 
+helps['network custom-ip prefix create'] = """
+type: command
+short-summary: Place the CLI in a waiting state until a condition of the custom ip prefix is met.
+examples:
+  - name: Wait for custom ip prefix to return as created.
+    text: |
+        az network custom-ip prefix wait --name MyCustomIpPrefix --resource-group MyResourceGroup --created
+"""
+
 helps['network custom-ip prefix delete'] = """
 type: command
 short-summary: Delete a custom IP prefix resource.
@@ -5794,6 +5803,15 @@ type: group
 short-summary: Manage packet capture on a virtual network gateway.
 """
 
+helps['network vnet-gateway packet-capture wait'] = """
+type: command
+short-summary: Place the CLI in a waiting state until a condition of the vnet gateway packet capture is met.
+examples:
+  - name: Wait for vnet gateway packet capture to return as created.
+    text: |
+        az network vnet-gateway packet-capture wait -g MyResourceGroup -n MyVnetGateway --created
+"""
+
 helps['network vnet-gateway packet-capture start'] = """
 type: command
 short-summary: Start packet capture on a virtual network gateway.
@@ -5850,6 +5868,15 @@ examples:
 helps['network vnet-gateway vpn-client ipsec-policy'] = """
 type: group
 short-summary: Manage the VPN client connection ipsec-policy for P2S client connection of the virtual network gateway.
+"""
+
+helps['network vnet-gateway vpn-client ipsec-policy wait'] = """
+type: command
+short-summary: Place the CLI in a waiting state until a condition of the vnet gateway vpn client ipsec policy is met.
+examples:
+  - name: Wait for vnet gateway vpn client ipsec policy to return as created.
+    text: |
+        az network vnet-gateway vpn-client ipsec-policy wait -g MyResourceGroup -n MyVnetGateway --created
 """
 
 helps['network vnet-gateway vpn-client ipsec-policy show'] = """
@@ -5921,6 +5948,15 @@ examples:
 helps['network vnet-gateway nat-rule'] = """
 type: group
 short-summary: Manage nat rule in a virtual network gateway
+"""
+
+helps['network vnet-gateway nat-rule wait'] = """
+type: command
+short-summary: Place the CLI in a waiting state until a condition of the vnet gateway nat rule is met.
+examples:
+  - name: Wait for vnet gateway nat rule to return as created.
+    text: |
+        az network vnet-gateway nat-rule wait -g MyResourceGroup -gateway-name MyVnetGateway --name Nat --created
 """
 
 helps['network vnet-gateway nat-rule add'] = """
@@ -6127,6 +6163,15 @@ examples:
 helps['network vpn-connection packet-capture'] = """
 type: group
 short-summary: Manage packet capture on a VPN connection.
+"""
+
+helps['network vpn-connection packet-capture wait'] = """
+type: command
+short-summary: Place the CLI in a waiting state until a condition of the vpn connection packet capture is met.
+examples:
+  - name: Wait for vpn connection packet capture to return as created.
+    text: |
+        az network vpn-connection packet-capture wait -g MyResourceGroup -n MyConnection --created
 """
 
 helps['network vpn-connection packet-capture start'] = """

--- a/src/azure-cli/azure/cli/command_modules/network/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/commands.py
@@ -1220,6 +1220,7 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_custom_ip_prefixes')
         g.show_command('show')
         g.generic_update_command('update', setter_name='begin_create_or_update', custom_func_name='update_custom_ip_prefix', supports_no_wait=True)
+        g.wait_command('wait')
     # endRegion
 
     # region PublicIPAddresses
@@ -1370,6 +1371,7 @@ def load_command_table(self, _):
     with self.command_group('network vnet-gateway packet-capture', network_vgw_sdk, client_factory=cf_virtual_network_gateways, is_preview=True, min_api='2019-07-01') as g:
         g.custom_command('start', 'start_vnet_gateway_package_capture', supports_no_wait=True)
         g.custom_command('stop', 'stop_vnet_gateway_package_capture', supports_no_wait=True)
+        g.wait_command('wait')
 
     with self.command_group('network vnet-gateway vpn-client', network_vgw_sdk, client_factory=cf_virtual_network_gateways) as g:
         g.custom_command('generate', 'generate_vpn_client')
@@ -1379,6 +1381,7 @@ def load_command_table(self, _):
     with self.command_group('network vnet-gateway vpn-client ipsec-policy', network_vgw_sdk, client_factory=cf_virtual_network_gateways, is_preview=True, min_api='2018-02-01') as g:
         g.custom_command('set', 'set_vpn_client_ipsec_policy', supports_no_wait=True)
         g.show_command('show', 'begin_get_vpnclient_ipsec_parameters')
+        g.wait_command('wait')
 
     # with self.command_group
 
@@ -1404,6 +1407,7 @@ def load_command_table(self, _):
         g.custom_command('add', 'add_vnet_gateway_nat_rule', supports_no_wait=True)
         g.custom_show_command('list', 'show_vnet_gateway_nat_rule')
         g.custom_command('remove', 'remove_vnet_gateway_nat_rule', supports_no_wait=True)
+        g.wait_command('wait')
     # endregion
 
     # region VirtualNetworkGatewayConnections
@@ -1432,6 +1436,7 @@ def load_command_table(self, _):
     with self.command_group('network vpn-connection packet-capture', network_vpn_sdk, client_factory=cf_virtual_network_gateway_connections, is_preview=True, min_api='2019-07-01') as g:
         g.custom_command('start', 'start_vpn_conn_package_capture', supports_no_wait=True)
         g.custom_command('stop', 'stop_vpn_conn_package_capture', supports_no_wait=True)
+        g.wait_command('wait')
 
     # endregion
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Add wait command for `network custom-ip prefix`, `network vnet-gateway nat-rule`, `network vnet-gateway packet-capture`, `network vnet-gateway vpn-client ipsec-policy`, `network vpn-connection packet-capture`

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
