### PR TITLE
[App Service] `az staticwebapp environment delete`: Add command to support deleting static app environment

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2414,6 +2414,14 @@ helps['staticwebapp environment show'] = """
       text: az staticwebapp environment show -n MyStaticAppName
 """
 
+helps['staticwebapp environment delete'] = """
+    type: command
+    short-summary: Delete the static app production environment or the specified environment.
+    examples:
+    - name: Delete a static app environment.
+      text: az staticwebapp environment delete -n MyStaticAppName
+"""
+
 helps['staticwebapp environment functions'] = """
     type: command
     short-summary: Show information about functions.

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -442,7 +442,7 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_staticsite_environments')
         g.custom_show_command('show', 'show_staticsite_environment')
         g.custom_command('functions', 'list_staticsite_functions')
-        g.custom_command('delete', 'delete_staticsite_environment')
+        g.custom_command('delete', 'delete_staticsite_environment', confirmation=True)
 
     with self.command_group('staticwebapp hostname', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsite_domains')

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -442,6 +442,7 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_staticsite_environments')
         g.custom_show_command('show', 'show_staticsite_environment')
         g.custom_command('functions', 'list_staticsite_functions')
+        g.custom_command('delete', 'delete_staticsite_environment')
 
     with self.command_group('staticwebapp hostname', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsite_domains')

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -59,6 +59,15 @@ def list_staticsite_environments(cmd, name, resource_group_name=None):
     return client.get_static_site_builds(resource_group_name, name)
 
 
+def delete_staticsite_environment(cmd, name, environment_name='default', resource_group_name=None, no_wait=False):
+    client = _get_staticsites_client_factory(cmd.cli_ctx)
+    if not resource_group_name:
+        resource_group_name = _get_resource_group_name_of_staticsite(client, name)
+
+    return sdk_no_wait(no_wait, client.delete_static_site_build,
+                       resource_group_name, name, environment_name)
+
+
 def show_staticsite_environment(cmd, name, environment_name='default', resource_group_name=None):
     client = _get_staticsites_client_factory(cmd.cli_ctx)
     if not resource_group_name:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -10,7 +10,8 @@ from azure.cli.command_modules.appservice.static_sites import \
     reconnect_staticsite, list_staticsite_environments, show_staticsite_environment, list_staticsite_domains, \
     set_staticsite_domain, delete_staticsite_domain, list_staticsite_functions, list_staticsite_function_app_settings, \
     set_staticsite_function_app_settings, delete_staticsite_function_app_settings, list_staticsite_users, \
-    invite_staticsite_users, update_staticsite_users, update_staticsite, list_staticsite_secrets, reset_staticsite_api_key
+    invite_staticsite_users, update_staticsite_users, update_staticsite, list_staticsite_secrets, \
+    reset_staticsite_api_key, delete_staticsite_environment
 
 
 class TestStaticAppCommands(unittest.TestCase):
@@ -266,6 +267,18 @@ class TestStaticAppCommands(unittest.TestCase):
 
         self.staticapp_client.delete_static_site_custom_domain.assert_called_once_with(
             resource_group_name=self.rg1, name=self.name1, domain_name=self.hostname1)
+
+    def test_delete_staticsite_environment_with_resourcegroup(self):
+        delete_staticsite_environment(self.mock_cmd, self.name1, self.environment1, self.rg1)
+
+        self.staticapp_client.delete_static_site_build.assert_called_once_with(self.rg1, self.name1, self.environment1)
+
+    def test_delete_staticsite_environment_without_resourcegroup(self):
+        self.staticapp_client.list.return_value = [self.app1, self.app2]
+
+        delete_staticsite_environment(self.mock_cmd, self.name1, self.environment1)
+
+        self.staticapp_client.delete_static_site_build.assert_called_once_with(self.rg1, self.name1, self.environment1)
 
     def test_list_staticsite_functions_with_resourcegroup(self):
         list_staticsite_functions(self.mock_cmd, self.name1, self.rg1, self.environment1)


### PR DESCRIPTION
**Description**<!--Mandatory-->

Add command to delete azure static webapp environment.

Related issue: #19514

**Testing Guide**

Example:
```
az staticwebapp environment delete --name swa-name --env environment-name
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
