### PR TITLE
[Keyvault] `az keyvault delete --hsm-name`: Add warning when deleting managed HSM

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -213,6 +213,8 @@ def delete_vault_or_hsm(cmd, client, resource_group_name=None, vault_name=None, 
 
     assert hsm_name
     hsm_client = get_client_factory(ResourceType.MGMT_KEYVAULT, Clients.managed_hsms)(cmd.cli_ctx, None)
+    logger.warning('This command will soft delete the resource, and you will still be billed until it is purged. '
+                   'For more information, go to https://aka.ms/doc/KeyVaultMHSMSoftDelete')
     return sdk_no_wait(
         no_wait, hsm_client.begin_delete,
         resource_group_name=resource_group_name,


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Customers are not aware that deleted managed HSM still incur billing before getting purged, either manually or at the end of the retention period. Add a warning when deleting managed HSM. 

**Testing Guide**
<!--Example commands with explanations.-->
Create a managed HSM
`az keyvault create -g {resource-group-name} --hsm-name {hsm-name} --administrators {oid-of-the-administrator}`
Delete a managed HSM, should see a warning. 
`az keyvault delete --hsm-name {hsm-name}`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
