### PR TITLE
{Packaging} Drop `azure-storage-common`

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -87,7 +87,6 @@ azure-mgmt-trafficmanager==0.51.0
 azure-multiapi-storage==0.6.2
 azure-mgmt-web==2.0.0
 azure-nspkg==3.0.2
-azure-storage-common==1.4.2
 azure-synapse-accesscontrol==0.5.0
 azure-synapse-artifacts==0.6.0
 azure-synapse-spark==0.2.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -87,7 +87,6 @@ azure-mgmt-trafficmanager==0.51.0
 azure-mgmt-web==2.0.0
 azure-multiapi-storage==0.6.2
 azure-nspkg==3.0.2
-azure-storage-common==1.4.2
 azure-synapse-accesscontrol==0.5.0
 azure-synapse-artifacts==0.6.0
 azure-synapse-spark==0.2.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -87,7 +87,6 @@ azure-mgmt-trafficmanager==0.51.0
 azure-mgmt-web==2.0.0
 azure-multiapi-storage==0.6.2
 azure-nspkg==3.0.2
-azure-storage-common==1.4.2
 azure-synapse-accesscontrol==0.5.0
 azure-synapse-artifacts==0.6.0
 azure-synapse-spark==0.2.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -130,7 +130,6 @@ DEPENDENCIES = [
     'azure-mgmt-trafficmanager~=0.51.0',
     'azure-mgmt-web~=2.0.0',
     'azure-multiapi-storage~=0.6.2',
-    'azure-storage-common~=1.4',
     'azure-synapse-accesscontrol~=0.5.0',
     'azure-synapse-artifacts~=0.6.0',
     'azure-synapse-spark~=0.2.0',


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Storage module only depends on `azure-mgmt-storage` and `azure-multiapi-storage`. We don't need `azure-storage-common` any more.

**Testing Guide**
<!--Example commands with explanations.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
