### PR TITLE
{Core} Drop `azure-common` from `azure-cli-core`

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -46,7 +46,6 @@ DEPENDENCIES = [
     'adal~=1.2.7',
     'argcomplete~=1.8',
     'azure-cli-telemetry==1.0.6.*',
-    'azure-common~=1.1',
     'azure-mgmt-core>=1.2.0,<1.3.0',     # the preview version of azure-mgmt-core is 1.3.0b1, it cannot fit azure-core >=1.14.0
     'cryptography>=3.2,<3.4',
     'humanfriendly>=4.7,<10.0',


### PR DESCRIPTION
**Description**<!--Mandatory-->

`azure-common` was introduced when vendoring `azure-mgmt-resource` Track 2 SDK (https://github.com/Azure/azure-cli/pull/15711). It should have been dropped by https://github.com/Azure/azure-cli/pull/18047 but was unintentionally overlooked.

[`azure-common`](https://github.com/Azure/azure-sdk-for-python/tree/azure-common_1.1.27/sdk/core/azure-common) is an interface to create SDK clients with Azure CLI credential. Azure CLI doesn't use it in any way. `azure-common` has now been deprecated.

Leaving it in `azure-cli-core` causes confusion and encourages incorrect usages: https://github.com/Azure/azure-cli/issues/19528
