### PR TITLE
{Misc.} Remove usages of `six`

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -58,7 +58,6 @@ DEPENDENCIES = [
     'PyJWT>=2.1.0',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
     'requests[socks]~=2.25.1',
-    'six~=1.12',
     'urllib3[secure]>=1.26.5',
 ]
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -278,7 +278,7 @@ class ExecutionResult(object):
         return self.json_value
 
     def _in_process_execute(self, cli_ctx, command, expect_failure=False):
-        from six import StringIO
+        from io import StringIO
         from vcr.errors import CannotOverwriteExistingCassetteException
 
         if command.startswith('az '):

--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -22,7 +22,7 @@ def find_recording_dir(test_file):
 
 @contextmanager
 def force_progress_logging():
-    from six import StringIO
+    from io import StringIO
     import logging
     from knack.log import get_logger
     from .reverse_dependency import get_commands_loggers

--- a/src/azure-cli/azure/cli/command_modules/acr/helm.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/helm.py
@@ -5,7 +5,7 @@
 
 import os
 import platform
-from six.moves.urllib.request import urlopen  # pylint: disable=import-error
+from urllib.request import urlopen
 
 from knack.util import CLIError
 from knack.log import get_logger

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -29,8 +29,8 @@ import webbrowser
 import zipfile
 from distutils.version import StrictVersion
 from math import isnan
-from six.moves.urllib.request import urlopen  # pylint: disable=import-error
-from six.moves.urllib.error import URLError  # pylint: disable=import-error
+from urllib.request import urlopen
+from urllib.error import URLError
 
 # pylint: disable=import-error
 import yaml

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -21,7 +21,7 @@ import uuid
 from functools import reduce
 from nacl import encoding, public
 
-from six.moves.urllib.request import urlopen  # pylint: disable=import-error, ungrouped-imports
+from urllib.request import urlopen
 import OpenSSL.crypto
 from fabric import Connection
 

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -8,7 +8,7 @@ import json
 import re
 import os
 from datetime import datetime, timedelta, timezone
-from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
+from urllib.parse import urlparse
 # pylint: disable=too-many-lines
 from knack.log import get_logger
 
@@ -1305,7 +1305,7 @@ def _run_client_script_for_windows(client_scripts):
     file_name, password = _get_script_file_name_and_password(windows_script)
 
     # Create File
-    from six.moves.urllib.request import urlopen  # pylint: disable=import-error
+    from urllib.request import urlopen
     import shutil
     with urlopen(windows_script.url) as response, open(file_name, 'wb') as out_file:
         shutil.copyfileobj(response, out_file)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_help.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_help.py
@@ -8,7 +8,7 @@ import json
 import re
 import os
 from datetime import datetime, timedelta
-from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
+from urllib.parse import urlparse
 
 from knack.log import get_logger
 

--- a/src/azure-cli/azure/cli/command_modules/batch/_command_type.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_command_type.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 import re
-from six import string_types
 
 from knack.arguments import CLICommandArgument, IgnoreAction
 from knack.introspection import extract_full_summary_from_signature, extract_args_from_signature
@@ -431,7 +430,7 @@ class AzureBatchDataPlaneCommand:
     # pylint: disable=too-many-instance-attributes, too-few-public-methods, too-many-statements
     def __init__(self, operation, command_loader, client_factory=None, validator=None, **kwargs):
 
-        if not isinstance(operation, string_types):
+        if not isinstance(operation, str):
             raise ValueError("Operation must be a string. Got '{}'".format(operation))
 
         self._flatten = kwargs.pop('flatten', pformat.FLATTEN)  # Number of object levels to flatten

--- a/src/azure-cli/azure/cli/command_modules/batch/_exception_handler.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_exception_handler.py
@@ -25,6 +25,4 @@ def batch_exception_handler(ex):
     elif isinstance(ex, CloudError):
         raise CLIError(ex)
     else:
-        import sys
-        from six import reraise
-        reraise(*sys.exc_info())
+        raise ex

--- a/src/azure-cli/azure/cli/command_modules/batch/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_format.py
@@ -7,7 +7,7 @@ import json
 
 from collections import OrderedDict
 
-from six.moves.urllib.parse import unquote  # pylint: disable=import-error
+from urllib.parse import unquote
 
 HEAD_PROPERTIES = {  # Convert response headers to properties.
     'Last-Modified': 'lastModified',

--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -6,7 +6,7 @@
 import os
 import azure.batch.models
 from azure.cli.core.util import get_file_json
-from six.moves.urllib.parse import urlsplit  # pylint: disable=import-error
+from urllib.parse import urlsplit
 
 
 # TYPES VALIDATORS

--- a/src/azure-cli/azure/cli/command_modules/batch/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/custom.py
@@ -4,8 +4,8 @@
 # --------------------------------------------------------------------------------------------
 
 import base64
-from six.moves.urllib.parse import urlsplit  # pylint: disable=import-error
-from six.moves import configparser
+from urllib.parse import urlsplit
+import configparser
 
 from knack.log import get_logger
 

--- a/src/azure-cli/azure/cli/command_modules/batchai/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/batchai/custom.py
@@ -25,7 +25,7 @@ from knack.util import CLIError
 from msrest.serialization import Deserializer
 from msrestazure.azure_exceptions import CloudError
 from msrestazure.tools import is_valid_resource_id, parse_resource_id
-from six.moves import urllib_parse
+from urllib.parse import urlparse
 
 from azure.cli.core import keys
 from azure.cli.core.util import get_default_admin_username
@@ -185,7 +185,7 @@ def _get_account_name_from_azure_file_url(azure_file_url):
     """
     if not azure_file_url:
         raise CLIError('Azure File URL cannot absent or be empty')
-    o = urllib_parse.urlparse(azure_file_url)
+    o = urlparse(azure_file_url)
     try:
         account, _ = o.netloc.split('.', 1)
         return account

--- a/src/azure-cli/azure/cli/command_modules/billing/_exception_handler.py
+++ b/src/azure-cli/azure/cli/command_modules/billing/_exception_handler.py
@@ -11,6 +11,4 @@ def billing_exception_handler(ex):
     if isinstance(ex, ErrorResponse):
         message = ex.error.error.message
         raise CLIError(message)
-    import sys
-    from six import reraise
-    reraise(*sys.exc_info())
+    raise ex

--- a/src/azure-cli/azure/cli/command_modules/configure/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/_utils.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from six.moves import configparser  # pylint: disable=redefined-builtin
+import configparser
 
 
 def get_default_from_config(config, section, option, choice_list, fallback=1):

--- a/src/azure-cli/azure/cli/command_modules/consumption/_exception_handler.py
+++ b/src/azure-cli/azure/cli/command_modules/consumption/_exception_handler.py
@@ -11,6 +11,4 @@ def consumption_exception_handler(ex):
     if isinstance(ex, ErrorResponseException):
         message = ex.message
         raise CLIError(message)
-    import sys
-    from six import reraise
-    reraise(*sys.exc_info())
+    raise ex

--- a/src/azure-cli/azure/cli/command_modules/monitor/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/custom.py
@@ -107,7 +107,7 @@ def list_metrics(cmd, resource,
     from azure.mgmt.monitor.models import ResultType
     from datetime import datetime
     import dateutil.parser
-    from six.moves.urllib.parse import quote_plus
+    from urllib.parse import quote_plus
 
     if not start_time and not end_time:
         # if neither value provided, end_time is now

--- a/src/azure-cli/azure/cli/command_modules/netappfiles/_exception_handler.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/_exception_handler.py
@@ -15,7 +15,4 @@ def netappfiles_exception_handler(ex):
         message = ex
         raise CLIError(message)
 
-    import sys
-
-    from six import reraise
-    reraise(*sys.exc_info())
+    raise ex

--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -6,8 +6,6 @@
 # pylint: disable=line-too-long, too-many-lines
 from argcomplete.completers import FilesCompleter
 
-import six
-
 from knack.arguments import CLIArgumentType, ignore_type
 
 from azure.cli.core.commands.parameters import (get_location_type, get_resource_name_completion_list,
@@ -762,8 +760,7 @@ def load_arguments(self, _):
         c.extra('cmd')
 
     with self.argument_context('network express-route peering') as c:
-        # Using six.integer_types so we get int for Py3 and long for Py2
-        c.argument('peer_asn', help='Autonomous system number of the customer/connectivity provider.', type=six.integer_types[-1])
+        c.argument('peer_asn', help='Autonomous system number of the customer/connectivity provider.', type=int)
         c.argument('vlan_id', help='Identifier used to identify the customer.')
         c.argument('circuit_name', circuit_name_type)
         c.argument('peering_name', name_arg_type, id_part='child_name_1')

--- a/src/azure-cli/azure/cli/command_modules/network/zone_file/make_zone_file.py
+++ b/src/azure-cli/azure/cli/command_modules/network/zone_file/make_zone_file.py
@@ -47,7 +47,7 @@ def make_zone_file(json_obj):
     }
     """
     import azure.cli.command_modules.network.zone_file.record_processors as record_processors
-    from six import StringIO
+    from io import StringIO
 
     zone_file = StringIO()
 

--- a/src/azure-cli/azure/cli/command_modules/policyinsights/_exception_handler.py
+++ b/src/azure-cli/azure/cli/command_modules/policyinsights/_exception_handler.py
@@ -12,7 +12,4 @@ def policy_insights_exception_handler(ex):
     if isinstance(ex, QueryFailure):
         message = '({}) {}'.format(ex.error.error.code, ex.error.error.message)
         raise CLIError(message)
-    import sys
-    from six import reraise
-
-    reraise(*sys.exc_info())
+    raise ex

--- a/src/azure-cli/azure/cli/command_modules/rdbms/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/custom.py
@@ -12,7 +12,7 @@ from msrestazure.azure_exceptions import CloudError
 from msrestazure.tools import resource_id, is_valid_resource_id, parse_resource_id  # pylint: disable=import-error
 from knack.log import get_logger
 from knack.util import todict
-from six.moves.urllib.request import urlretrieve  # pylint: disable=import-error
+from urllib.request import urlretrieve
 from azure.core.exceptions import ResourceNotFoundError
 from azure.cli.core._profile import Profile
 from azure.cli.core.commands.client_factory import get_subscription_id

--- a/src/azure-cli/azure/cli/command_modules/reservations/_exception_handler.py
+++ b/src/azure-cli/azure/cli/command_modules/reservations/_exception_handler.py
@@ -11,6 +11,4 @@ def reservations_exception_handler(ex):
     if isinstance(ex, Error):
         message = ex.error.error.message
         raise CLIError(message)
-    import sys
-    from six import reraise
-    reraise(*sys.exc_info())
+    raise ex

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 import requests
 import semver
 
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 from knack.log import get_logger
 from azure.cli.core.api import get_config_dir
 from azure.cli.core.azclierror import (

--- a/src/azure-cli/azure/cli/command_modules/resource/_exception_handler.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_exception_handler.py
@@ -12,6 +12,4 @@ def managementgroups_exception_handler(ex):
         if ex.error.error:
             raise CLIError(ex.error.error)
         raise CLIError(ex.error)
-    import sys
-    from six import reraise
-    reraise(*sys.exc_info())
+    raise ex

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -17,8 +17,8 @@ import sys
 import uuid
 import base64
 
-from six.moves.urllib.request import urlopen  # pylint: disable=import-error
-from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
+from urllib.request import urlopen
+from urllib.parse import urlparse
 
 from msrestazure.tools import is_valid_resource_id, parse_resource_id
 
@@ -936,7 +936,7 @@ def _build_preflight_error_message(preflight_error):
 
 
 def _prepare_template_uri_with_query_string(template_uri, input_query_string):
-    from six.moves.urllib.parse import urlencode, parse_qs, urlsplit, urlunsplit  # pylint: disable=import-error
+    from urllib.parse import urlencode, parse_qs, urlsplit, urlunsplit
 
     try:
         scheme, netloc, path, query_string, fragment = urlsplit(template_uri)  # pylint: disable=unused-variable

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_resource_custom.py
@@ -7,8 +7,8 @@ import os
 import tempfile
 import unittest
 
-from six.moves.urllib.request import pathname2url  # pylint: disable=import-error
-from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
+from urllib.request import pathname2url
+from urllib.parse import urljoin
 
 from unittest import mock
 

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_resource_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2018_03_01/test_resource_validators.py
@@ -6,7 +6,7 @@
 import unittest
 import os.path
 from unittest import mock
-from six import StringIO
+from io import StringIO
 
 from knack.util import CLIError
 from azure.cli.command_modules.resource._validators import (

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_resource_custom.py
@@ -7,8 +7,8 @@ import os
 import tempfile
 import unittest
 
-from six.moves.urllib.request import pathname2url  # pylint: disable=import-error
-from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
+from urllib.request import pathname2url
+from urllib.parse import urljoin
 
 from unittest import mock
 

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_resource_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/hybrid_2019_03_01/test_resource_validators.py
@@ -6,7 +6,7 @@
 import unittest
 import os.path
 from unittest import mock
-from six import StringIO
+from io import StringIO
 
 from knack.util import CLIError
 from azure.cli.command_modules.resource._validators import (

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_custom.py
@@ -7,9 +7,8 @@ import os
 import tempfile
 import unittest
 
-from six.moves.urllib.request import pathname2url  # pylint: disable=import-error
-from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
-from six import assertRaisesRegex
+from urllib.request import pathname2url
+from urllib.parse import urljoin
 
 from unittest import mock
 
@@ -240,7 +239,7 @@ class TestCustom(unittest.TestCase):
         def prompt_function(x):
             from knack.prompting import NoTTYException
             raise NoTTYException
-        with assertRaisesRegex(self, CLIError, "Missing input parameters: missing"):
+        with self.assertRaisesRegex(CLIError, "Missing input parameters: missing"):
             _get_missing_parameters(parameters, template, prompt_function)
 
     def test_deployment_parameters(self):

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_validators.py
@@ -6,7 +6,7 @@
 import unittest
 import os.path
 from unittest import mock
-from six import StringIO
+from io import StringIO
 
 from knack.util import CLIError
 from azure.cli.command_modules.resource._validators import (

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -655,8 +655,6 @@ def _get_managed_db_resource_id(cli_ctx, resource_group_name, managed_instance_n
     '''
     Gets the Managed db resource id in this Azure environment.
     '''
-
-    # url parse package has different names in Python 2 and 3. 'six' package works cross-version.
     from azure.cli.core.commands.client_factory import get_subscription_id
     from msrestazure.tools import resource_id
 
@@ -699,8 +697,7 @@ def _get_managed_dropped_db_resource_id(
     Gets the Managed db resource id in this Azure environment.
     '''
 
-    # url parse package has different names in Python 2 and 3. 'six' package works cross-version.
-    from six.moves.urllib.parse import quote  # pylint: disable=import-error
+    from urllib.parse import quote
     from azure.cli.core.commands.client_factory import get_subscription_id
     from msrestazure.tools import resource_id
 
@@ -829,8 +826,7 @@ class DatabaseIdentity():  # pylint: disable=too-few-public-methods
         self.cli_ctx = cli_ctx
 
     def id(self):
-        # url parse package has different names in Python 2 and 3. 'six' package works cross-version.
-        from six.moves.urllib.parse import quote  # pylint: disable=import-error
+        from urllib.parse import quote
         from azure.cli.core.commands.client_factory import get_subscription_id
 
         return '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Sql/servers/{}/databases/{}'.format(
@@ -1655,8 +1651,7 @@ def _get_storage_account_name(storage_endpoint):
     Determines storage account name from endpoint url string.
     e.g. 'https://mystorage.blob.core.windows.net' -> 'mystorage'
     '''
-    # url parse package has different names in Python 2 and 3. 'six' package works cross-version.
-    from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
+    from urllib.parse import urlparse
 
     return urlparse(storage_endpoint).netloc.split('.')[0]
 
@@ -3912,8 +3907,7 @@ def server_dns_alias_set(
     '''
     Sets a server DNS alias.
     '''
-    # url parse package has different names in Python 2 and 3. 'six' package works cross-version.
-    from six.moves.urllib.parse import quote  # pylint: disable=import-error
+    from urllib.parse import quote
     from azure.cli.core.commands.client_factory import get_subscription_id
 
     # Build the old alias id
@@ -5135,7 +5129,7 @@ def failover_group_create(
     Creates a failover group.
     '''
 
-    from six.moves.urllib.parse import quote  # pylint: disable=import-error
+    from urllib.parse import quote
     from azure.cli.core.commands.client_factory import get_subscription_id
 
     # Build the partner server id

--- a/src/azure-cli/azure/cli/command_modules/storage/_exception_handler.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_exception_handler.py
@@ -14,6 +14,4 @@ def file_related_exception_handler(ex):
         raise FileOperationError(ex, recommendation='File is expected, not a directory.')
     if isinstance(ex, NotADirectoryError):
         raise FileOperationError(ex, recommendation='Directory is expected, not a file.')
-    import sys
-    from six import reraise
-    reraise(*sys.exc_info())
+    raise ex

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -26,7 +26,6 @@ from ._validators import (get_datetime_type, validate_metadata, get_permission_v
 
 def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statements, too-many-lines, too-many-branches
     from argcomplete.completers import FilesCompleter
-    from six import u as unicode_string
 
     from knack.arguments import ignore_type, CLIArgumentType
 
@@ -1615,7 +1614,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
     with self.argument_context('storage message') as c:
         c.argument('queue_name', queue_name_type)
         c.argument('message_id', options_list='--id')
-        c.argument('content', type=unicode_string, help='Message content, up to 64KB in size.')
+        c.argument('content', type=str, help='Message content, up to 64KB in size.')
 
     with self.argument_context('storage remove') as c:
         from .completers import file_path_completer

--- a/src/azure-cli/azure/cli/command_modules/storage/_params_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params_azure_stack.py
@@ -23,7 +23,6 @@ from ._validators import (get_datetime_type, validate_metadata, get_permission_v
 
 def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statements, too-many-lines
     from argcomplete.completers import FilesCompleter
-    from six import u as unicode_string
 
     from knack.arguments import ignore_type, CLIArgumentType
 
@@ -1062,7 +1061,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
     with self.argument_context('storage message') as c:
         c.argument('queue_name', queue_name_type)
         c.argument('message_id', options_list='--id')
-        c.argument('content', type=unicode_string, help='Message content, up to 64KB in size.')
+        c.argument('content', type=str, help='Message content, up to 64KB in size.')
 
     with self.argument_context('storage remove') as c:
         from .completers import file_path_completer

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -12,8 +12,8 @@ import datetime
 import sys
 import zipfile
 import stat
-from six.moves.urllib.parse import urlparse
-from six.moves.urllib.request import urlopen  # pylint: disable=import-error
+from urllib.parse import urlparse
+from urllib.request import urlopen
 from azure.cli.core._profile import Profile
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/storage/storage_url_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/storage_url_helpers.py
@@ -22,7 +22,7 @@ class StorageResourceIdentifier:
         self.snapshot = None
         self.sas_token = None
 
-        from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
+        from urllib.parse import urlparse
         url = urlparse(moniker)
 
         self._is_url = (url.scheme == 'http' or url.scheme == 'https')

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2018_03_01/test_storage_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2018_03_01/test_storage_validators.py
@@ -6,7 +6,7 @@
 import unittest
 from unittest import mock
 from argparse import Namespace
-from six import StringIO
+from io import StringIO
 
 from knack import CLI
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2019_03_01/test_storage_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2019_03_01/test_storage_validators.py
@@ -6,7 +6,7 @@
 import unittest
 from unittest import mock
 from argparse import Namespace
-from six import StringIO
+from io import StringIO
 
 from knack import CLI
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2020_09_01/test_storage_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2020_09_01/test_storage_validators.py
@@ -6,7 +6,7 @@
 import unittest
 from unittest import mock
 from argparse import Namespace
-from six import StringIO
+from io import StringIO
 
 from knack import CLI
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
@@ -6,7 +6,7 @@
 import unittest
 from unittest import mock
 from argparse import (Namespace, ArgumentError)
-from six import StringIO
+from io import StringIO
 
 from knack import CLI
 

--- a/src/azure-cli/azure/cli/command_modules/storage/track2_util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/track2_util.py
@@ -88,8 +88,7 @@ def url_quote(url):
 
 
 def encode_base64(data):
-    import six
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     encoded = base64.b64encode(data)
     return encoded.decode('utf-8')

--- a/src/azure-cli/azure/cli/command_modules/storage/url_quote_util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/url_quote_util.py
@@ -13,12 +13,12 @@ SAFE_CHARS = '/()$=\',~'
 
 
 def encode_for_url(url_component, safe=SAFE_CHARS):
-    from six.moves.urllib.parse import quote as url_quote  # pylint: disable=import-error
+    from urllib.parse import quote as url_quote
     return url_quote(url_component, safe)
 
 
 def encode_url_path(url, safe=SAFE_CHARS):
-    from six.moves.urllib.parse import urlparse, urlunparse  # pylint: disable=import-error
+    from urllib.parse import urlparse, urlunparse
     url_parts = urlparse(url)
     quoted_path = encode_for_url(url_parts.path, safe)
     return urlunparse(url_parts[:2] + (quoted_path,) + url_parts[3:])

--- a/src/azure-cli/azure/cli/command_modules/synapse/operations/sqlpool.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/operations/sqlpool.py
@@ -157,8 +157,7 @@ def sql_pool_show_connection_string(
 
 
 def _construct_database_resource_id(cli_ctx, resource_group_name, server_name, database_name):
-    # url parse package has different names in Python 2 and 3. 'six' package works cross-version.
-    from six.moves.urllib.parse import quote  # pylint: disable=import-error
+    from urllib.parse import quote
     from azure.cli.core.commands.client_factory import get_subscription_id
 
     return '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Sql/servers/{}/databases/{}'.format(

--- a/src/azure-cli/azure/cli/command_modules/synapse/operations/sqlpoolblobauditingpolicy.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/operations/sqlpoolblobauditingpolicy.py
@@ -369,8 +369,7 @@ def _get_storage_account_name(storage_endpoint):
     Determines storage account name from endpoint url string.
     e.g. 'https://mystorage.blob.core.windows.net' -> 'mystorage'
     """
-    # url parse package has different names in Python 2 and 3. 'six' package works cross-version.
-    from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
+    from urllib.parse import urlparse
 
     return urlparse(storage_endpoint).netloc.split('.')[0]
 

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -22,7 +22,7 @@ except ImportError:
     from urlparse import urlparse  # pylint: disable=import-error
 
 # the urlopen is imported for automation purpose
-from six.moves.urllib.request import urlopen  # noqa, pylint: disable=import-error,unused-import,ungrouped-imports
+from urllib.request import urlopen
 
 from knack.log import get_logger
 from knack.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_commands.py
@@ -13,8 +13,6 @@ import unittest
 from unittest import mock
 import uuid
 
-import six
-
 from knack.util import CLIError
 from azure_devtools.scenario_tests import AllowLargeResponse, record_only
 from azure.cli.core.profiles import ResourceType

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_commands.py
@@ -13,8 +13,6 @@ import unittest
 from unittest import mock
 import uuid
 
-import six
-
 from knack.util import CLIError
 from azure_devtools.scenario_tests import AllowLargeResponse, record_only
 from azure.cli.core.profiles import ResourceType

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_commands.py
@@ -13,8 +13,6 @@ import unittest
 from unittest import mock
 import uuid
 
-import six
-
 from knack.util import CLIError
 from azure_devtools.scenario_tests import AllowLargeResponse, record_only
 from azure.cli.core.profiles import ResourceType

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -116,12 +116,11 @@ DEPENDENCIES = [
     'azure-mgmt-relay~=0.1.0',
     'azure-mgmt-reservations==0.6.0',  # TODO: Use requirements.txt instead of '==' #9781
     'azure-mgmt-resource==19.0.0',
-    # 'azure-mgmt-reservations~=0.6.0',
     'azure-mgmt-search~=8.0',
     'azure-mgmt-security~=1.0.0',
     'azure-mgmt-servicebus~=6.0.0',
-    'azure-mgmt-servicefabric~=1.0.0',
     'azure-mgmt-servicefabricmanagedclusters~=1.0.0',
+    'azure-mgmt-servicefabric~=1.0.0',
     'azure-mgmt-signalr~=1.0.0b2',
     'azure-mgmt-sqlvirtualmachine~=1.0.0b1',
     'azure-mgmt-sql~=3.0.1',
@@ -133,8 +132,8 @@ DEPENDENCIES = [
     'azure-storage-common~=1.4',
     'azure-synapse-accesscontrol~=0.5.0',
     'azure-synapse-artifacts~=0.6.0',
-    'azure-synapse-spark~=0.2.0',
     'azure-synapse-managedprivateendpoints~=0.3.0',
+    'azure-synapse-spark~=0.2.0',
     'fabric~=2.4',
     'javaproperties==0.5.1',
     'jsondiff==1.2.0',
@@ -144,6 +143,7 @@ DEPENDENCIES = [
     'pytz==2019.1',
     'scp~=0.13.2',
     'semver==2.13.0',
+    'six>=1.10.0',  # six is still used by countless extensions
     'sshtunnel~=0.1.4',
     'websocket-client~=0.56.0',
     'xmltodict~=0.12'

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -29,7 +29,6 @@ DEPENDENCIES = [
     'requests',
     'pyyaml~=5.2',
     'knack',
-    'six>=1.10.0',
     'tabulate>=0.7.7',
     'colorama>=0.3.7'
 ]
@@ -59,7 +58,7 @@ setup(
         ]
     },
     install_requires=DEPENDENCIES,
-    extras_require={ 
+    extras_require={
         ":python_version<'3.0'": ['pylint==1.9.2'],
         ":python_version>='3.0'": ['pylint==2.0.0']
     }


### PR DESCRIPTION
**Description**<!--Mandatory-->

`six` was previously dropped from `azure-cli-core` (https://github.com/Azure/azure-cli/pull/17366). It should be dropped from `azure-cli` as well.

However, as there are countless extensions still using `six`, we still need to install it. This PR removes all usages of `six.
