### PR TITLE
{monitor} `monitor diagnostic-settings subscription create`: JSON should not have a trailing comma after last element

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/monitor/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/_help.py
@@ -894,35 +894,35 @@ examples:
         --logs '[
            {
              "category": "Security",
-             "enabled": true,
+             "enabled": true
            },
            {
              "category": "Administrative",
-             "enabled": true,
+             "enabled": true
            },
            {
              "category": "ServiceHealth",
-             "enabled": true,
+             "enabled": true
            },
            {
              "category": "Alert",
-             "enabled": true,
+             "enabled": true
            },
            {
              "category": "Recommendation",
-             "enabled": true,
+             "enabled": true
            },
            {
              "category": "Policy",
-             "enabled": true,
+             "enabled": true
            },
            {
              "category": "Autoscale",
-             "enabled": true,
+             "enabled": true
            },
            {
              "category": "ResourceHealth",
-             "enabled": true,
+             "enabled": true
            }
            ]'
 """


### PR DESCRIPTION
The `logs` parameter to the create subscription sample contains JSON where the last property in each of the objects has a trailing comma. Removing them.

**Description**<!--Mandatory-->
Cosmetic change 

**Testing Guide**
n/a

**History Notes**
n/a

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).

Since this is a cosmetic change to the command parameters the above checks do not apply