### PR TITLE
[Backup] `az backup container register`: Fix refresh container bug

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -140,7 +140,7 @@ def load_arguments(self, _):
 
     with self.argument_context('backup container list') as c:
         c.argument('vault_name', vault_name_type, id_part=None)
-        c.argument('backup_management_type', backup_management_type)
+        c.argument('backup_management_type', arg_type=get_enum_type(allowed_backup_management_types + ["MAB"]), help=backup_management_type_help)
         c.argument('use_secondary_region', action='store_true', help='Use this flag to list containers in secondary region.')
 
     with self.argument_context('backup container unregister') as c:
@@ -403,7 +403,7 @@ def load_arguments(self, _):
         c.argument('operation', arg_type=get_enum_type(['Backup', 'ConfigureBackup', 'DeleteBackupData', 'DisableBackup', 'Restore']), help='User initiated operation.')
         c.argument('start_date', type=datetime_type, help='The start date of the range in UTC (d-m-Y).')
         c.argument('end_date', type=datetime_type, help='The end date of the range in UTC (d-m-Y).')
-        c.argument('backup_management_type', backup_management_type)
+        c.argument('backup_management_type', arg_type=get_enum_type(allowed_backup_management_types + ["MAB"]), help=backup_management_type_help)
         c.argument('use_secondary_region', action='store_true', help='Use this flag to show recoverypoints in secondary region.')
 
     with self.argument_context('backup job wait') as c:

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -1396,7 +1396,7 @@ def _track_register_operation(cli_ctx, result, vault_name, resource_group, conta
                                                                fabric_name, container_name,
                                                                operation_id, raw=True)
     while result.response.status_code == 202:
-        time.sleep(1)
+        time.sleep(5)
         result = protection_container_operation_results_client.get(vault_name, resource_group,
                                                                    fabric_name, container_name,
                                                                    operation_id, raw=True)
@@ -1408,7 +1408,7 @@ def _track_backup_operation(cli_ctx, resource_group, result, vault_name):
     operation_id = _get_operation_id_from_header(result.response.headers['Azure-AsyncOperation'])
     operation_status = backup_operation_statuses_client.get(vault_name, resource_group, operation_id)
     while operation_status.status == OperationStatusValues.in_progress.value:
-        time.sleep(1)
+        time.sleep(5)
         operation_status = backup_operation_statuses_client.get(vault_name, resource_group, operation_id)
     return operation_status
 
@@ -1430,7 +1430,7 @@ def _track_backup_crr_operation(cli_ctx, result, azure_region):
     operation_id = _get_operation_id_from_header(result.response.headers['Azure-AsyncOperation'])
     operation_status = crr_operation_statuses_client.get(azure_region, operation_id)
     while operation_status.status == OperationStatusValues.in_progress.value:
-        time.sleep(1)
+        time.sleep(5)
         operation_status = crr_operation_statuses_client.get(azure_region, operation_id)
     return operation_status
 
@@ -1442,7 +1442,7 @@ def _track_refresh_operation(cli_ctx, result, vault_name, resource_group):
     result = protection_container_refresh_operation_results_client.get(vault_name, resource_group,
                                                                        fabric_name, operation_id, raw=True)
     while result.response.status_code == 202:
-        time.sleep(1)
+        time.sleep(5)
         result = protection_container_refresh_operation_results_client.get(vault_name, resource_group,
                                                                            fabric_name, operation_id, raw=True)
 

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_help.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_help.py
@@ -159,7 +159,7 @@ def track_backup_operation(cli_ctx, resource_group, result, vault_name):
     operation_id = get_operation_id_from_header(result.response.headers['Azure-AsyncOperation'])
     operation_status = backup_operation_statuses_client.get(vault_name, resource_group, operation_id)
     while operation_status.status == OperationStatusValues.in_progress.value:
-        time.sleep(1)
+        time.sleep(5)
         operation_status = backup_operation_statuses_client.get(vault_name, resource_group, operation_id)
     return operation_status
 
@@ -172,7 +172,7 @@ def track_refresh_operation(cli_ctx, result, vault_name, resource_group):
                                                                        fabric_name, operation_id,
                                                                        raw=True)
     while result.response.status_code == 202:
-        time.sleep(1)
+        time.sleep(5)
         result = protection_container_refresh_operation_results_client.get(vault_name, resource_group,
                                                                            fabric_name, operation_id,
                                                                            raw=True)
@@ -186,7 +186,7 @@ def track_register_operation(cli_ctx, result, vault_name, resource_group, contai
                                                                fabric_name, container_name,
                                                                operation_id, raw=True)
     while result.response.status_code == 202:
-        time.sleep(1)
+        time.sleep(5)
         result = protection_container_operation_results_client.get(vault_name, resource_group,
                                                                    fabric_name, container_name,
                                                                    operation_id, raw=True)
@@ -200,7 +200,7 @@ def track_inquiry_operation(cli_ctx, result, vault_name, resource_group, contain
                                                                fabric_name, container_name,
                                                                operation_id, raw=True)
     while result.response.status_code == 202:
-        time.sleep(1)
+        time.sleep(5)
         result = protection_container_operation_results_client.get(vault_name, resource_group,
                                                                    fabric_name, container_name,
                                                                    operation_id, raw=True)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
@@ -109,8 +109,11 @@ def register_wl_container(cmd, client, vault_name, resource_group_name, workload
     container_name = _get_protectable_container_name(cmd, resource_group_name, vault_name, resource_id)
 
     if container_name is None or not cust_help.is_native_name(container_name):
+        filter_string = cust_help.get_filter_string({'backupManagementType': "AzureWorkload"})
         # refresh containers and try to get the protectable container object again
-        client.refresh(vault_name, resource_group_name, fabric_name)
+        refresh_result = client.refresh(vault_name, resource_group_name, fabric_name,
+                                        filter=filter_string, raw=True)
+        cust_help.track_refresh_operation(cmd.cli_ctx, refresh_result, vault_name, resource_group_name)
         container_name = _get_protectable_container_name(cmd, resource_group_name, vault_name, resource_id)
 
         if container_name is None or not cust_help.is_native_name(container_name):


### PR DESCRIPTION
**Description**<!--Mandatory-->

- Fixed the refresh protectable container API call that happens when the protectable container is not found on the first try in az backup container register command. CRI link - [Incident 259315847 : [ARR] [SAP],[DISCOVERY], | [KRKEMA] | [Unable to discovery SAP Hana DB from Azure VM "xub29041431h0" using Azure CLI via ADO pipeline. Getting error message: Container unavailable or already registered.]](https://portal.microsofticm.com/imp/v3/incidents/details/259315847/home)

- Added 'MAB' in the allowed values for backup management type in az backup job/container list command

- Increased the sleep delay while tracking operations to prevent frequent calls.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
