### PR TITLE
[Rest] BREAKING CHANGE: `az rest`: Remove `resourceGroup`, `x509ThumbprintHex` transforms

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/transform.py
+++ b/src/azure-cli-core/azure/cli/core/commands/transform.py
@@ -15,6 +15,11 @@ def register_global_transforms(cli_ctx):
     cli_ctx.register_event(events.EVENT_INVOKER_TRANSFORM_RESULT, _x509_from_base64_to_hex_transform)
 
 
+def unregister_global_transforms(cli_ctx):
+    cli_ctx.unregister_event(events.EVENT_INVOKER_TRANSFORM_RESULT, _resource_group_transform)
+    cli_ctx.unregister_event(events.EVENT_INVOKER_TRANSFORM_RESULT, _x509_from_base64_to_hex_transform)
+
+
 def _parse_id(strid):
     parsed = {}
     parts = re.split('/', strid)

--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -15,6 +15,10 @@ UPGRADE_MSG = 'Not able to upgrade automatically. Instructions can be found at h
 
 def rest_call(cmd, url, method=None, headers=None, uri_parameters=None,
               body=None, skip_authorization_header=False, resource=None, output_file=None):
+    from azure.cli.core.commands.transform import unregister_global_transforms
+    # No transform should be performed on `az rest`.
+    unregister_global_transforms(cmd.cli_ctx)
+
     from azure.cli.core.util import send_raw_request
     r = send_raw_request(cmd.cli_ctx, method, url, headers, uri_parameters, body,
                          skip_authorization_header, resource, output_file)


### PR DESCRIPTION
## Description

- Fix #16286

The logic to add `resourceGroup` properties to the output JSON was added as early as #66.

While it helps (to some extent) in normal ARM commands, it causes trouble in `az rest` as the `GET` result can't be `PUT` back. 

```
$ vnet=$(az rest -m GET -u /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/my-test/providers/Microsoft.Network/virtualNetworks/vnettest?api-version=2021-02-01)

$ echo "$vnet"
{
  "etag": "W/\"6edecdf3-4fb4-4b9e-a3a0-bcf184d6caf7\"",
  "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/my-test/providers/Microsoft.Network/virtualNetworks/vnettest",
  "location": "centralus",
  "name": "vnettest",
  "properties": {
    "addressSpace": {
      "addressPrefixes": [
        "10.1.0.0/16"
      ]
    },
    "enableDdosProtection": false,
    "provisioningState": "Failed",
    "resourceGuid": "069414bc-bd93-47a1-976e-2e51578a2c72",
    "subnets": [
      {
        "etag": "W/\"6edecdf3-4fb4-4b9e-a3a0-bcf184d6caf7\"",
        "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/my-test/providers/Microsoft.Network/virtualNetworks/vnettest/subnets/default",
        "name": "default",
        "properties": {
          "addressPrefix": "10.1.0.0/24",
          "delegations": [],
          "privateEndpointNetworkPolicies": "Disabled",
          "privateLinkServiceNetworkPolicies": "Disabled",
          "provisioningState": "Failed"
        },
>>      "resourceGroup": "my-test",
        "type": "Microsoft.Network/virtualNetworks/subnets"
      }
    ],
    "virtualNetworkPeerings": []
  },
>>"resourceGroup": "my-test",
  "type": "Microsoft.Network/virtualNetworks"
}

$ az rest -m PUT -u /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/my-test/providers/Microsoft.Network/virtualNetworks/vnettest?api-version=2021-02-01 --body "$vnet"
Bad Request({
  "error": {
    "code": "InvalidRequestFormat",
    "message": "Cannot parse the request.",
    "details": [
      {
        "code": "InvalidJson",
        "message": "Could not find member 'resourceGroup' on object of type 'Subnet'. Path 'properties.subnets[0].resourceGroup', line 27, position 24."
      },
      {
        "code": "InvalidJson",
        "message": "Could not find member 'resourceGroup' on object of type 'VirtualNetwork'. Path 'resourceGroup', line 33, position 18."
      }
    ]
  }
})
```

## Change

Remove `resourceGroup`, `x509ThumbprintHex` transforms so that `az rest` preserves the original server response.