### PR TITLE
{RDBMS}: Fix file read issue to retain double quotes in Properties File

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -13,9 +13,9 @@ from knack.log import get_logger
 from knack.util import CLIError
 from azure.cli.core.azclierror import MutuallyExclusiveArgumentError
 from azure.cli.core.commands.client_factory import get_subscription_id
-from azure.cli.core.util import send_raw_request, get_file_json, shell_safe_json_parse
+from azure.cli.core.util import send_raw_request
 from azure.cli.core.util import user_confirmation
-from azure.cli.core.azclierror import ClientRequestError, RequiredArgumentMissingError
+from azure.cli.core.azclierror import ClientRequestError, RequiredArgumentMissingError, FileOperationError
 from azure.mgmt.rdbms.mysql_flexibleservers.operations._servers_operations import ServersOperations as MySqlServersOperations
 from ._flexible_server_util import run_subprocess, run_subprocess_get_output, fill_action_template, get_git_root_dir, \
     GITHUB_ACTION_PATH
@@ -86,10 +86,10 @@ def migration_create_func(cmd, client, resource_group_name, server_name, propert
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
     properties_filepath = os.path.join(os.path.abspath(os.getcwd()), properties)
-    if os.path.exists(properties_filepath):
-        json_data = get_file_json(properties_filepath)
-    else:
-        json_data = shell_safe_json_parse(properties_filepath)
+    if not os.path.exists(properties_filepath):
+        raise FileOperationError("Properties file does not exist in the given location")
+    with open(properties_filepath, "r") as f:
+        json_data = f.read()
     if migration_name is None:
         # Convert a UUID to a string of hex digits in standard form
         migration_name = str(uuid.uuid4())


### PR DESCRIPTION
**Description**<!--Mandatory-->
1. In Create migration command, changed the way to read the json file in order to retain double quotes in the json structure. Current code in dev branch is breaking the create migration command.
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
