### PR TITLE
{ACS} KUBECONFIG env var is allowed to have several paths separated by colons

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2678,8 +2678,9 @@ def aks_get_credentials(cmd, client, resource_group_name, name, admin=False,
     # Check if KUBECONFIG environmental variable is set
     # If path is different than default then that means -f/--file is passed
     # in which case we ignore the KUBECONFIG variable
+    # KUBECONFIG can be colon separated. If we find that condition, use the first entry
     if "KUBECONFIG" in os.environ and path == os.path.join(os.path.expanduser('~'), '.kube', 'config'):
-        path = os.environ["KUBECONFIG"]
+        path = os.environ["KUBECONFIG"].split(":")[0]
 
     if not credentialResults:
         raise CLIError("No Kubernetes credentials found.")


### PR DESCRIPTION

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In my local environment, we leverage KUBECONFIG to specify a variety of configuration files. The KUBECONFIG env var is permitted to be colon separated [kubernetes.io reference material](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)

**Testing Guide**
<!--Example commands with explanations.-->
Definitely on Mac, and presumably on linux ( perhaps Win as well?) the current az cli doesn't comprehend when KUBECONFIG env var is set, and has a colon separated designation. This is the most simple remediation I could think of, no worries if this doesn't meet your expectations for the repo. 

I didn't see any tests related to checking on the kubeconfig file if it came out of the environment, or twiddling of the environment in the test suite.  So noting, I didn't modify the test suite.  

```shell
sh $ mkdir -p /tmp/.kube
sh $ export KUBECONFIG=$HOME/.kube/config:/tmp/.kube/config
sh $ az aks get-credentials ...
#
# Notice the lack of addition of entries to ~/.kube/config
# 
sh $ export KUBECONFIG=$HOME/.kube/config
sh $ az aks get-credentials ...
#
# Notice that now the entries have been added to ~/.kube/config
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
