### PR TITLE
{Packaging} Loosen `cryptography` dependency

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -47,7 +47,7 @@ DEPENDENCIES = [
     'argcomplete~=1.8',
     'azure-cli-telemetry==1.0.6.*',
     'azure-mgmt-core>=1.2.0,<1.3.0',     # the preview version of azure-mgmt-core is 1.3.0b1, it cannot fit azure-core >=1.14.0
-    'cryptography~=3.0',
+    'cryptography',
     'humanfriendly>=4.7,<10.0',
     'jmespath',
     'knack~=0.8.2',

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -47,7 +47,7 @@ DEPENDENCIES = [
     'argcomplete~=1.8',
     'azure-cli-telemetry==1.0.6.*',
     'azure-mgmt-core>=1.2.0,<1.3.0',     # the preview version of azure-mgmt-core is 1.3.0b1, it cannot fit azure-core >=1.14.0
-    'cryptography>=3.2,<3.4',
+    'cryptography~=3.0',
     'humanfriendly>=4.7,<10.0',
     'jmespath',
     'knack~=0.8.2',


### PR DESCRIPTION
## Description

- Fix #19635

Reasons why we can loose the `cryptography` dependency now:

### For **upper bound**

https://github.com/Azure/azure-cli/pull/15687#discussion_r578898876 set an upper bound for `cryptography` due to https://github.com/pyca/cryptography/issues/5771.

By following https://cryptography.io/en/latest/installation/#alpine, I am now able to install `cryptography` 3.4.8 on Alpine Linux (https://github.com/Azure/azure-cli/issues/19591). There is no need to set upper bound now.

### For **lower bound**

Community packagers ask us not to bump the minimum dependency in `setup.py` as this causes trouble for platforms that doesn't support newer versions of `cryptography` (https://github.com/Azure/azure-cli/pull/15687#issuecomment-878819248). By loosing the dependency on `cryptography`, users or packagers themselves are now responsible for security vulnerabilities in older versions of `cryptography`.

As we still pin the version in `requirements.*.txt`, packages distributed by us still contain `cryptography` which is security-complaint.
