### PR TITLE
{Packaging} Set `system_site_packages: false` in Homebrew formula

### DIFF
--- a/scripts/release/homebrew/docker/formula_template.txt
+++ b/scripts/release/homebrew/docker/formula_template.txt
@@ -28,7 +28,7 @@ class AzureCli < Formula
 {{ resources }}
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, "python3", system_site_packages: false)
     venv.pip_install resources
 
     # Get the CLI components we'll install


### PR DESCRIPTION
## Description

Incorporate the change from 

- https://github.com/Homebrew/homebrew-core/pull/85719

Homebrew made a breaking change in 

- https://github.com/Homebrew/brew/pull/11611 

that the created virtual environment now has access to system `site_packages`. This causes conflicts with libraries installed to system `site-packages` (`/usr/local/lib/python3.9/site-packages`), mainly [ansible-collections/azure](https://github.com/ansible-collections/azure/blob/dev/requirements-azure.txt):

- https://github.com/Azure/azure-cli/issues/19027

This issue is reported to Homebrew at

- https://github.com/Homebrew/discussions/discussions/2009
- https://github.com/Homebrew/brew/issues/11885

Homebrew has now added a switch `system_site_packages`:

- https://github.com/Homebrew/brew/pull/12101

We need to set `system_site_packages: false` to avoid conflicts with libraries installed to system `site-packages`.

## Additional Context

This conflict has also been reported to [ansible-collections/azure](https://github.com/ansible-collections/azure/blob/dev/requirements-azure.txt) and got fixed already:

- https://github.com/ansible-collections/azure/issues/604
- https://github.com/ansible-collections/azure/pull/608