### PR TITLE
{ServiceBus} Fix MU capacity to include 16 when updating namespace

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
@@ -32,7 +32,7 @@ def load_arguments_sb(self, _):
         c.argument('default_action', help='Default action for network rule set.')
         c.argument('tags', arg_type=tags_type)
         c.argument('sku', arg_type=get_enum_type(SkuName), help='Namespace SKU.')
-        c.argument('capacity', type=int, choices=[1, 2, 4, 8], help='Number of message units. This property is only applicable to namespaces of Premium SKU', validator=validate_premiumsku_capacity)
+        c.argument('capacity', type=int, choices=[1, 2, 4, 8, 16], help='Number of message units. This property is only applicable to namespaces of Premium SKU', validator=validate_premiumsku_capacity)
 
     with self.argument_context('servicebus namespace exists') as c:
         c.argument('name', arg_type=name_type, help='Namespace name. Name can contain only letters, numbers, and hyphens. The namespace must start with a letter, and it must end with a letter or number.')


### PR DESCRIPTION
Increase capacity to allow 16MU for Premium namespace of servicebus, inline with the portal.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
