### PR TITLE
[ARM] `az ts create`: Simplify overwrite confirmation message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1931,7 +1931,7 @@ def create_template_spec(cmd, resource_group_name, name, template_file=None, loc
         exists = False
         if no_prompt is False:
             try:  # Check if child template spec already exists.
-                existing_ts = rcf.template_spec_versions.get(resource_group_name=resource_group_name, template_spec_name=name, template_spec_version=version)
+                rcf.template_spec_versions.get(resource_group_name=resource_group_name, template_spec_name=name, template_spec_version=version)
                 from knack.prompting import prompt_y_n
                 confirmation = prompt_y_n("This will override template spec {} version {}. Proceed?".format(name, version))
                 if not confirmation:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Current template spec create overwrite confirmation message is overwhelming and needs to be simplified.
![image](https://user-images.githubusercontent.com/26332174/136221137-b85e51bb-5058-400d-bfcc-155715e1ce91.png)


**Testing Guide**
<!--Example commands with explanations.-->

1. Create template spec version 

```
az ts create -g {ResourceGroup}  --name {TemplateSpecName} -l {Location} --version {TemplateSpecVersion}
--template-file {TemplateFileLocation}
```

2. Update the template spec version template file using create command

```
az ts create -g {ResourceGroup}  --name {TemplateSpecName} -l {Location} --version {TemplateSpecVersion}
--template-file {TemplateFileLocation}
```

confirmation prompt should now be: 

`" This will override template spec {TemplateSpecName} version {TemplateSpecVersion} Proceed? (y/n): "`

![image](https://user-images.githubusercontent.com/26332174/136221701-74979314-f5d9-420d-b4f4-c21d7a9d424c.png)



**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
