### PR TITLE
[App Configuration]Fix dependencies for multiple installations

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -138,3 +138,5 @@ wcwidth==0.1.7
 websocket-client==0.56.0
 wrapt==1.11.2
 xmltodict==0.12.0
+jsondiff==1.2.0
+javaproperties==0.5.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -139,3 +139,5 @@ wcwidth==0.1.7
 websocket-client==0.56.0
 wrapt==1.11.2
 xmltodict==0.12.0
+jsondiff==1.2.0
+javaproperties==0.5.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -138,3 +138,5 @@ vsts==0.1.25
 wcwidth==0.1.7
 websocket-client==0.56.0
 xmltodict==0.12.0
+jsondiff==1.2.0
+javaproperties==0.5.1

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -137,8 +137,8 @@ DEPENDENCIES = [
     'azure-synapse-spark~=0.2.0',
     'azure-synapse-managedprivateendpoints~=0.3.0',
     'fabric~=2.4',
-    'javaproperties==0.5.1',
-    'jsondiff==1.2.0',
+    'javaproperties~=0.5.1',
+    'jsondiff~=1.2.0',
     'packaging~=20.9',
     'PyGithub~=1.38',
     'PyNaCl~=1.4.0',
@@ -147,7 +147,8 @@ DEPENDENCIES = [
     'semver==2.13.0',
     'sshtunnel~=0.1.4',
     'websocket-client~=0.56.0',
-    'xmltodict~=0.12'
+    'xmltodict~=0.12',
+    'chardet~=3.0.4'
 ]
 
 # On Linux, the distribution (Ubuntu, Debian, etc) and version are checked


### PR DESCRIPTION
**Description**<!--Mandatory-->
AppConfig command module introduces three dependencies. ```chardet```, ```jsondiff``` and ```javaproperties```. Regardless of installation methods, all three should be downloaded during CLI install. 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
