### PR TITLE
{CI} Check the return code of `git log`

### DIFF
--- a/scripts/release/generate_history_notes.py
+++ b/scripts/release/generate_history_notes.py
@@ -147,8 +147,11 @@ def get_commits():
                            stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT)
     stdout, _ = out.communicate()
+    output = stdout.decode()
+    if out.returncode != 0:
+        raise Exception(output)
     dev_commits = []
-    for line in stdout.decode('utf-8').splitlines():
+    for line in output.splitlines():
         words = line.strip('"').split(None, 1)
         sha = words[0]
         subject = words[1]


### PR DESCRIPTION
**Description**<!--Mandatory-->

The return code of `git log` should be checked before continuing the script.

If `git log` fails with 

```
Exception: fatal: ambiguous argument 'azure-cli-2.28.2..upstream/dev': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

the script went wrong with a very vague error:

```
2021-10-08T02:27:55.4352815Z Get PRs for 3 commits.
2021-10-08T02:27:55.4353351Z 'git <command> [<revision>...] -- [<file>...]'
2021-10-08T02:27:55.4353727Z Traceback (most recent call last):
2021-10-08T02:27:55.4354420Z   File "/home/vsts/work/r1/a/azure-cli/scripts/release/generate_history_notes.py", line 256, in <module>
2021-10-08T02:27:55.4354857Z     generate_history_notes()
2021-10-08T02:27:55.4355654Z   File "/home/vsts/work/r1/a/azure-cli/scripts/release/generate_history_notes.py", line 67, in generate_history_notes
2021-10-08T02:27:55.4356298Z     prs = get_prs_for_commit(commit['sha'])
2021-10-08T02:27:55.4356989Z   File "/home/vsts/work/r1/a/azure-cli/scripts/release/generate_history_notes.py", line 165, in get_prs_for_commit
2021-10-08T02:27:55.4357472Z     raise Exception("Request to {} failed with {}".format(
2021-10-08T02:27:55.4358163Z Exception: Request to https://api.github.com/repos/azure/azure-cli/commits/'git/pulls failed with 422
2021-10-08T02:27:55.4557192Z ##[error]Script failed with error: Error: The process '/bin/bash' failed with exit code 1
```

because each line in the error message is parsed as a commit, which is of course not. In this case, `'git` is treated as a commit ID.
