### PR TITLE
{Packaging} Bump `requests` and `urllib3` and loosen dependencies in `setup.py`

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -57,8 +57,7 @@ DEPENDENCIES = [
     'pkginfo>=1.5.0.1',
     'PyJWT>=2.1.0',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
-    'requests[socks]~=2.25.1',
-    'urllib3[secure]>=1.26.5'
+    'requests[socks]'
 ]
 
 # dependencies for specific OSes

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -127,13 +127,13 @@ PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0
-requests[socks]==2.25.1
+requests[socks]==2.26.0
 scp==0.13.2
 semver==2.13.0
 six==1.14.0
 sshtunnel==0.1.5
 tabulate==0.8.9
-urllib3==1.26.5
+urllib3==1.26.7
 vsts==0.1.25
 wcwidth==0.1.7
 websocket-client==0.56.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -128,13 +128,13 @@ PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0
-requests[socks]==2.25.1
+requests[socks]==2.26.0
 scp==0.13.2
 semver==2.13.0
 six==1.14.0
 sshtunnel==0.1.5
 tabulate==0.8.9
-urllib3==1.26.5
+urllib3==1.26.7
 vsts==0.1.25
 wcwidth==0.1.7
 websocket-client==0.56.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -128,13 +128,13 @@ pyreadline==2.1
 python-dateutil==2.8.0
 pywin32==302
 requests-oauthlib==1.2.0
-requests[socks]==2.25.1
+requests[socks]==2.26.0
 scp==0.13.2
 semver==2.13.0
 six==1.14.0
 sshtunnel==0.1.5
 tabulate==0.8.9
-urllib3==1.26.5
+urllib3==1.26.7
 vsts==0.1.25
 wcwidth==0.1.7
 websocket-client==0.56.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -148,6 +148,7 @@ DEPENDENCIES = [
     'semver==2.13.0',
     'six>=1.10.0',  # six is still used by countless extensions
     'sshtunnel~=0.1.4',
+    'urllib3[secure]',
     'websocket-client~=0.56.0',
     'xmltodict~=0.12'
 ]


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix #18499, #19682

Bump `requests` and `urllib3` and loosen dependencies in `setup.py`.

Being too strict on versions can frequently leads to endless backtracking in latest `pip` (#18324, #18518) . 

Now we don't want to be too specific on versions. Instead, the user should be responsible for security vulnerabilities in older versions of dependencies, same as https://github.com/Azure/azure-cli/pull/19639.

