### PR TITLE
{Packaging} Bump `azure-core` and `azure-mgmt-core`

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -46,7 +46,7 @@ DEPENDENCIES = [
     'adal~=1.2.7',
     'argcomplete~=1.8',
     'azure-cli-telemetry==1.0.6.*',
-    'azure-mgmt-core>=1.2.0,<1.3.0',     # the preview version of azure-mgmt-core is 1.3.0b1, it cannot fit azure-core >=1.14.0
+    'azure-mgmt-core>=1.2.0,<2',
     'cryptography',
     'humanfriendly>=4.7,<10.0',
     'jmespath',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -9,7 +9,7 @@ azure-cli-core==2.29.0
 azure-cli-telemetry==1.0.6
 azure-cli==2.29.0
 azure-common==1.1.22
-azure-core==1.13.0
+azure-core==1.19.0
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
 azure-functions-devops-build==0.0.22
@@ -35,7 +35,7 @@ azure-mgmt-consumption==2.0.0
 azure-mgmt-containerinstance==9.0.0
 azure-mgmt-containerregistry==8.1.0
 azure-mgmt-containerservice==16.1.0
-azure-mgmt-core==1.2.1
+azure-mgmt-core==1.3.0
 azure-mgmt-cosmosdb==6.4.0
 azure-mgmt-databoxedge==1.0.0
 azure-mgmt-datalake-analytics==0.2.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -9,7 +9,7 @@ azure-cli-core==2.29.0
 azure-cli-telemetry==1.0.6
 azure-cli==2.29.0
 azure-common==1.1.22
-azure-core==1.13.0
+azure-core==1.19.0
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
 azure-functions-devops-build==0.0.22
@@ -35,7 +35,7 @@ azure-mgmt-consumption==2.0.0
 azure-mgmt-containerinstance==9.0.0
 azure-mgmt-containerregistry==8.1.0
 azure-mgmt-containerservice==16.1.0
-azure-mgmt-core==1.2.1
+azure-mgmt-core==1.3.0
 azure-mgmt-cosmosdb==6.4.0
 azure-mgmt-databoxedge==1.0.0
 azure-mgmt-datalake-analytics==0.2.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -9,7 +9,7 @@ azure-cli-core==2.29.0
 azure-cli-telemetry==1.0.6
 azure-cli==2.29.0
 azure-common==1.1.22
-azure-core==1.13.0
+azure-core==1.19.0
 azure-cosmos==3.2.0
 azure-datalake-store==0.0.49
 azure-functions-devops-build==0.0.22
@@ -35,7 +35,7 @@ azure-mgmt-consumption==2.0.0
 azure-mgmt-containerinstance==9.0.0
 azure-mgmt-containerregistry==8.1.0
 azure-mgmt-containerservice==16.1.0
-azure-mgmt-core==1.2.1
+azure-mgmt-core==1.3.0
 azure-mgmt-cosmosdb==6.4.0
 azure-mgmt-databoxedge==1.0.0
 azure-mgmt-datalake-analytics==0.2.1


### PR DESCRIPTION
**Description**<!--Mandatory-->

#18087 pinned `azure-mgmt-core` to solve #18025.

`azure-core` and `azure-mgmt-core` with CAE support has been GA'ed:

- `azure-core`: https://pypi.org/project/azure-core/
- `azure-mgmt-core`: https://pypi.org/project/azure-mgmt-core/

We should bump it to the latest version so that extension developers can start using them:

> I'm developing an extension and I have an issue with a dependency restriction between `azure-cli-core` and `azure-mgmt-core`: `azure-cli-core` 2.28.1 depends on `azure-mgmt-core`<1.3.0 and >=1.2.0
> 
> but I need to use azure-mgmt-core 1.3.0 to have the following feature: [ARMChallengeAuthenticationPolicy supports bearer token authorization and CAE challenges](https://pypi.org/project/azure-mgmt-core/)

Reference: [original Teams post](https://teams.microsoft.com/l/message/19:31160a5ec7e24ba0b9d58a5e812c43dd@thread.tacv2/1633697071856?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=9a661795-1b01-4a5b-9dd5-be571422334c&parentMessageId=1633697071856&teamName=Azure%20CLIs%20partners&channelName=Azure%20CLI&createdTime=1633697071856)

