### PR TITLE
{Style} Fix `test_format_styled_text_legacy_powershell` on Windows

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_style.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_style.py
@@ -64,6 +64,12 @@ class TestStyle(unittest.TestCase):
             (Style.ACTION, "Blue: Commands, parameters, and system inputs")
         ]
 
+        # Try to delete _is_legacy_powershell cache
+        try:
+            delattr(format_styled_text, '_is_legacy_powershell')
+        except AttributeError:
+            pass
+
         # When theme is 'none', no need to call is_modern_terminal and get_parent_proc_name
         formatted = format_styled_text(styled_text, theme='none')
         is_modern_terminal_mock.assert_not_called()


### PR DESCRIPTION
## Description

On Windows, as `pytest` doesn't have a `--forked` option, tests are run in the same process. Due to the cache of `_is_legacy_powershell`, tests can affect each other and result in failure:

```
> azdev test core --series --no-exitfirst

self = <azure.cli.core.tests.test_style.TestStyle testMethod=test_format_styled_text_legacy_powershell>, is_modern_terminal_mock = <MagicMock name='is_modern_terminal' id='2191729711376'>
get_parent_proc_name_mock = <MagicMock name='get_parent_proc_name' id='2191712241600'>

    @mock.patch('azure.cli.core.util.get_parent_proc_name', return_value='powershell.exe')
    @mock.patch('azure.cli.core.style.is_modern_terminal', return_value=False)
    def test_format_styled_text_legacy_powershell(self, is_modern_terminal_mock, get_parent_proc_name_mock):
        """Verify bright/dark blue is replaced with the default color in legacy powershell.exe terminal."""
        styled_text = [
            (Style.ACTION, "Blue: Commands, parameters, and system inputs")
        ]

        # When theme is 'none', no need to call is_modern_terminal and get_parent_proc_name
        formatted = format_styled_text(styled_text, theme='none')
        is_modern_terminal_mock.assert_not_called()
        get_parent_proc_name_mock.assert_not_called()
        assert formatted == """Blue: Commands, parameters, and system inputs"""

        excepted = """\x1b[0mBlue: Commands, parameters, and system inputs\x1b[0m"""
        formatted = format_styled_text(styled_text, theme='dark')
>       assert formatted == excepted
E       AssertionError: assert '\x1b[94mBlue...inputs\x1b[0m' == '\x1b[0mBlue:...inputs\x1b[0m'
E         - Blue: Commands, parameters, and system inputs
E         ?   ^
E         + Blue: Commands, parameters, and system inputs
E         ?   ^^
```

## Change

This PR clears the cache of `_is_legacy_powershell` before testing `format_styled_text` to avoid noise from other tests.
