### PR TITLE
{Configure} Remove relic code for `az configure` login

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/configure/_consts.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/_consts.py
@@ -16,13 +16,6 @@ OUTPUT_LIST = [
     {'name': 'none', 'desc': 'No output, except for errors and warnings.'}
 ]
 
-LOGIN_METHOD_LIST = [
-    'Device code authentication, we will provide a code you enter into a web page and log into',
-    "Username and password (MFA enforced accounts or MSA accounts such as live-id not supported)",
-    'Service Principal with secret',
-    'Skip this step (login is available with the \'az login\' command)'
-]
-
 MSG_INTRO = '\nWelcome to the Azure CLI! This command will guide you through logging in and ' \
             'setting some default values.\n'
 MSG_CLOSING = '\nYou\'re all set! Here are some commands to try:\n' \
@@ -40,7 +33,6 @@ MSG_HEADING_ENV_VARS = '\nEnvironment variables:'
 
 MSG_PROMPT_MANAGE_GLOBAL = '\nDo you wish to change your settings?'
 MSG_PROMPT_GLOBAL_OUTPUT = '\nWhat default output format would you like?'
-MSG_PROMPT_LOGIN = '\nHow would you like to log in to access your subscriptions?'
 MSG_PROMPT_TELEMETRY = '\nMicrosoft would like to collect anonymous Azure CLI usage data to ' \
                        'improve our CLI.  Participation is voluntary and when you choose to ' \
                        'participate, your device automatically sends information to Microsoft ' \


### PR DESCRIPTION
**Description**<!--Mandatory-->

Using `az configure` to log in has been dropped 4 years ago (#1989). These is some relic code that should be removed during MSAL migration (https://github.com/Azure/azure-cli/pull/19853) due to the refactoring on `find_subscriptions_on_login`.
