### PR TITLE
{Packaging} Allow installation on Python 3.10

### DIFF
--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -127,7 +127,7 @@ pyOpenSSL==19.0.0
 pyreadline==2.1
 python-dateutil==2.8.0
 pytz==2019.1
-pywin32==300
+pywin32==302
 requests-oauthlib==1.2.0
 requests[socks]==2.25.1
 scp==0.13.2


### PR DESCRIPTION
**Description**<!--Mandatory-->

A quick fix for https://github.com/Azure/azure-cli/issues/19857.

As Python 3.10 is now the **default** version when downloading Python (https://www.python.org/downloads/), we need to make Azure CLI compatible with Python 3.10. Otherwise, the beta installation with `pip` as documented in https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-beta will fail with:

```
ERROR: Could not find a version that satisfies the requirement pywin32==300 (from versions: 302)
ERROR: No matching distribution found for pywin32==300
```

⚠ There are actually much more tasks to do before Python 3.10 is fully supported. Given the inherent complexity of supporting new Python versions, **this is only a quick fix to allow Azure CLI to be installed on Python 3.10**. No tests or linter checks are introduced so far.
