### PR TITLE
{Profile} `az account list`: Make help message more specific about clouds

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -69,7 +69,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.ignore('_subscription')
 
         with self.argument_context('account list') as c:
-            c.argument('all', help="List all subscriptions, rather than just 'Enabled' ones", action='store_true')
+            c.argument('all', help="List all subscriptions from all clouds, rather than just 'Enabled' ones", action='store_true')
             c.argument('refresh', help="retrieve up-to-date subscriptions from server", action='store_true')
             c.ignore('_subscription')  # hide the global subscription parameter
 

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -43,7 +43,9 @@ long-summary: To clear the current subscription, use 'az logout'.
 
 helps['account list'] = """
 type: command
-short-summary: Get a list of subscriptions for the logged in account.
+short-summary: >-
+    Get a list of subscriptions for the logged in account. By default, only 'Enabled' subscriptions from the current
+    cloud is shown.
 """
 
 helps['account list-locations'] = """


### PR DESCRIPTION
**Description**<!--Mandatory-->

While testing sovereign clouds for MSAL-based CLI, I found the help message of `az account list` vague about clouds.

Refine it to be more specific:

```
> az account list -h

Command
    az account list : Get a list of subscriptions for the logged in account. By default, only
    'Enabled' subscriptions from the current cloud is shown.

Arguments
    --all                           : List all subscriptions from all clouds, rather than just
                                      'Enabled' ones.
```
