### PR TITLE
{Core} Make `can_launch_browser` return `False` for Docker container on WSL 2

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -161,46 +161,51 @@ class TestUtils(unittest.TestCase):
         else:
             webbrowser_open_mock.assert_called_once_with('http://foo', 2)
 
+    @mock.patch('shutil.which', autospec=True)
     @mock.patch('azure.cli.core.util._get_platform_info', autospec=True)
     @mock.patch('webbrowser.get', autospec=True)
-    def test_can_launch_browser(self, webbrowser_get_mock, get_platform_mock):
-        # WSL is always fine
-        get_platform_mock.return_value = ('linux', '4.4.0-17134-microsoft')
-        result = can_launch_browser()
-        self.assertTrue(result)
+    def test_can_launch_browser(self, webbrowser_get_mock, get_platform_mock, which_mock):
+        import webbrowser
 
-        # windows is always fine
+        # Windows is always fine
         get_platform_mock.return_value = ('windows', '10')
-        result = can_launch_browser()
-        self.assertTrue(result)
+        assert can_launch_browser()
 
-        # osx is always fine
+        # MacOS is always fine
         get_platform_mock.return_value = ('darwin', '10')
-        result = can_launch_browser()
-        self.assertTrue(result)
+        assert can_launch_browser()
 
-        # now tests linux
-        with mock.patch('os.environ', autospec=True) as env_mock:
-            # when no GUI, return false
-            get_platform_mock.return_value = ('linux', '4.15.0-1014-azure')
-            env_mock.get.return_value = None
-            result = can_launch_browser()
-            self.assertFalse(result)
+        # Real linux with browser
+        get_platform_mock.return_value = ('linux', '4.15.0-1014-azure')
+        browser_mock = mock.MagicMock()
+        browser_mock.name = 'www-browser'
+        webbrowser_get_mock.return_value = browser_mock
+        assert can_launch_browser()
 
-            # when there is gui, and browser is a good one, return True
-            browser_mock = mock.MagicMock()
-            browser_mock.name = 'goodone'
-            env_mock.get.return_value = 'foo'
-            result = can_launch_browser()
-            self.assertTrue(result)
+        # Real linux without browser
+        get_platform_mock.return_value = ('linux', '4.15.0-1014-azure')
+        webbrowser_get_mock.side_effect = webbrowser.Error
+        assert not can_launch_browser()
 
-            # when there is gui, but the browser is text mode, return False
-            browser_mock = mock.MagicMock()
-            browser_mock.name = 'www-browser'
-            webbrowser_get_mock.return_value = browser_mock
-            env_mock.get.return_value = 'foo'
-            result = can_launch_browser()
-            self.assertFalse(result)
+        # WSL Linux with www-browser
+        get_platform_mock.return_value = ('linux', '5.10.16.3-microsoft-standard-WSL2')
+        browser_mock = mock.MagicMock()
+        browser_mock.name = 'www-browser'
+        webbrowser_get_mock.return_value = browser_mock
+        assert can_launch_browser()
+
+        # WSL Linux without www-browser, but with powershell.exe
+        get_platform_mock.return_value = ('linux', '5.10.16.3-microsoft-standard-WSL2')
+        webbrowser_get_mock.side_effect = webbrowser.Error
+        which_mock.return_value = True
+        assert can_launch_browser()
+
+        # Docker container on WSL 2 can't launch browser
+        get_platform_mock.return_value = ('linux', '5.10.16.3-microsoft-standard-WSL2')
+        import webbrowser
+        webbrowser_get_mock.side_effect = webbrowser.Error
+        which_mock.return_value = False
+        assert not can_launch_browser()
 
     def test_configured_default_setter(self):
         config = mock.MagicMock()


### PR DESCRIPTION
## Description

A workaround for https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/421

Currently in MSAL-based CLI, running `az login` in docker will hang, as **MSAL doesn't throw an exception when it fails to open a web browser**.

On the other hand, in ADAL-based CLI, if CLI fails to open a web browser, it throws `RuntimeError` and falls back to device code flow:

https://github.com/Azure/azure-cli/blob/14cc787d0f58bc649d402b486fdecc5625eee9ac/src/azure-cli-core/azure/cli/core/_profile.py#L199-L205

## Change

This PR makes `can_launch_browser` support Docker container on WSL 2 so that CLI detects if it can launch a browser first before calling `acquire_token_interactive`, so that it won't call `acquire_token_interactive` and hang. 

If no browser is available, use device code instead.
