### PR TITLE
{Packaging} Update pytz to 2021.3

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -127,7 +127,7 @@ PyJWT==2.1.0
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0
-pytz==2019.1
+pytz==2021.3
 requests-oauthlib==1.2.0
 requests[socks]==2.25.1
 scp==0.13.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -128,7 +128,7 @@ PyJWT==2.1.0
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0
-pytz==2019.1
+pytz==2021.3
 requests-oauthlib==1.2.0
 requests[socks]==2.25.1
 scp==0.13.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -127,7 +127,7 @@ PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 pyreadline==2.1
 python-dateutil==2.8.0
-pytz==2019.1
+pytz==2021.3
 pywin32==302
 requests-oauthlib==1.2.0
 requests[socks]==2.25.1

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -143,7 +143,7 @@ DEPENDENCIES = [
     'packaging~=20.9',
     'PyGithub~=1.38',
     'PyNaCl~=1.4.0',
-    'pytz==2019.1',
+    'pytz==2021.3',
     'scp~=0.13.2',
     'semver==2.13.0',
     'six>=1.10.0',  # six is still used by countless extensions


### PR DESCRIPTION
**Description**

The pytz version in azure-cli is pinned to an old version from 2019. The
2021.3 version contains lots of time zone updates and still works with
Python 2.x versions.

**Testing Guide**

Existing tests can be used.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
