### PR TITLE
{testsdk} Bump `azure-cli-testsdk` to 0.3.0

### DIFF
--- a/src/azure-cli-testsdk/HISTORY.rst
+++ b/src/azure-cli-testsdk/HISTORY.rst
@@ -3,7 +3,11 @@
 Release History
 ===============
 
-* Add resource group name prefix validator in resource group preparer
+0.3.0
++++++
+* Patch authentication for MSAL-based ``azure-cli-core`` (#19853)
+* Drop support for ADAL-based ``azure-cli-core`` (#19853)
+* Add resource group name prefix validator in resource group preparer (#10800)
 
 0.2.4
 +++++

--- a/src/azure-cli-testsdk/setup.py
+++ b/src/azure-cli-testsdk/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = "0.2.4"
+VERSION = "0.3.0"
 
 CLASSIFIERS = [
     'Development Status :: 3 - Alpha',


### PR DESCRIPTION
**Description**<!--Mandatory-->

Even though we don't release `azure-cli-testsdk` on PyPI, it's better to bump its version to 0.3.0, as breaking change is introduced during https://github.com/Azure/azure-cli/pull/19853. 
