### PR TITLE
{AKS} Fix `test_aks_create_default_setting`, `test_aks_create_default_setting_msi`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -3191,7 +3191,7 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.cmd('aks get-credentials -g {resource_group} -n {name} -f -')
 
         # get-credentials without directory in path
-        temp_path = self.create_random_name('kubeconfig', 24) + '.tmp'
+        temp_path = self.create_random_name('kubeconfig_msi', 24) + '.tmp'
         self.kwargs.update({'file': temp_path})
         try:
             self.cmd(


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix #19957, #19841

`test_aks_create_default_setting` and `test_aks_create_default_setting_msi` share the same `kubeconfig000003.tmp` file

https://github.com/Azure/azure-cli/blob/968aa4c9ec54d77b19696db8b2b6b75d4842c505/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py#L853

https://github.com/Azure/azure-cli/blob/968aa4c9ec54d77b19696db8b2b6b75d4842c505/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py#L3194

Causing failure when they are run in parralel:

```
>           os.remove(temp_path)
E           FileNotFoundError: [Errno 2] No such file or directory: 'kubeconfig000003.tmp'

/opt/az/lib/python3.6/site-packages/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py:860: FileNotFoundError
```