### PR TITLE
{AKS} Refine test for `aks create` in decorator pattern

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -295,6 +295,46 @@ class AKSModels:
         #     setattr(self, model_name, model_type)
 
 
+class AKSParamDict:
+    """Store the original parameters passed in by the command as an internal dictionary.
+
+    Only expose the "get" method externally for obtaining parameter values. At the same time records the usage of
+    parameters.
+    """
+    def __init__(self, param_dict):
+        if not isinstance(param_dict, dict):
+            raise CLIInternalError(
+                "Unexpected param_dict object with type '{}'.".format(
+                    type(param_dict)
+                )
+            )
+        self.__store = param_dict.copy()
+        self.__count = {}
+
+    @property
+    def __class__(self):
+        return dict
+
+    def __increase(self, key):
+        self.__count[key] = self.__count.get(key, 0) + 1
+
+    def get(self, key):
+        self.__increase(key)
+        return self.__store.get(key)
+
+    def __format_count(self):
+        untouched_keys = [x for x in self.__store.keys() if x not in self.__count.keys()]
+        for k in untouched_keys:
+            self.__count[k] = 0
+
+    def print_usage_statistics(self):
+        self.__format_count()
+        print("\nParameter usage statistics:")
+        for k, v in self.__count.items():
+            print(k, v)
+        print("Total: {}".format(len(self.__count.keys())))
+
+
 # pylint: disable=too-many-public-methods
 class AKSContext:
     """Implement getter functions for all parameters in aks_create and aks_update.


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

* Fix typo
* Use `inspect` to get the parameters of the entry function (`aks_create`) for testing

Unit Test Coverage

- "covered_lines": 1579,
- "num_statements": 1591,
- "percent_covered": 99.24575738529226,
- "missing_lines": 12,
- "excluded_lines": 0

Parameter usage statistics (default):

- location 1
- resource_group_name 2
- tags 1
- dns_name_prefix 1
- fqdn_subdomain 3
- name 1
- kubernetes_version 3
- disable_rbac 1
- node_osdisk_diskencryptionset_id 1
- disable_local_accounts 1
- node_count 1
- enable_cluster_autoscaler 1
- min_count 1
- max_count 1
- nodepool_name 1
- nodepool_tags 1
- nodepool_labels 1
- node_vm_size 1
- os_sku 1
- vnet_subnet_id 3
- ppg 1
- zones 1
- enable_node_public_ip 1
- node_public_ip_prefix_id 1
- enable_encryption_at_host 1
- enable_ultra_ssd 1
- max_pods 1
- vm_set_type 1
- node_osdisk_size 1
- node_osdisk_type 1
- ssh_key_value 1
- no_ssh_key 1
- admin_username 1
- windows_admin_username 1
- windows_admin_password 1
- service_principal 3
- client_secret 3
- enable_managed_identity 3
- skip_subnet_role_assignment 1
- attach_acr 1
- load_balancer_managed_outbound_ip_count 1
- load_balancer_outbound_ips 1
- load_balancer_outbound_ip_prefixes 1
- load_balancer_outbound_ports 1
- load_balancer_idle_timeout 1
- outbound_type 1
- load_balancer_sku 1
- network_plugin 2
- pod_cidr 2
- service_cidr 2
- dns_service_ip 2
- docker_bridge_address 2
- network_policy 2
- enable_addons 1
- workspace_resource_id 1
- aci_subnet_name 1
- enable_aad 3
- aad_client_app_id 3
- aad_server_app_id 3
- aad_server_app_secret 3
- enable_azure_rbac 1
- aad_tenant_id 1
- api_server_authorized_ip_ranges 1
- enable_private_cluster 2
- disable_public_fqdn 2
- enable_public_fqdn 1
- private_dns_zone 2
- assign_identity 1
- assign_kubelet_identity 2
- auto_upgrade_channel 1
- cluster_autoscaler_profile 1
- uptime_sla 1
- edge_zone 1
- enable_ahub 0
- enable_rbac 0
- generate_ssh_keys 0
- aad_admin_group_object_ids 0
- appgw_name 0
- appgw_subnet_cidr 0
- appgw_id 0
- appgw_subnet_id 0
- appgw_watch_namespace 0
- enable_sgxquotehelper 0
- no_wait 0
- yes 0
- aks_custom_headers 0

Total: 86

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
