### PR TITLE
[Container] `az container create`: Fix the issue that `--subnet` or `--vnet` cannot be used with IP address type `Public` to allow `Private`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/container/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/container/_validators.py
@@ -78,7 +78,7 @@ def validate_subnet(ns):
     if not is_valid_resource_id(ns.subnet) and ((ns.vnet and not ns.subnet) or (ns.subnet and not ns.vnet)):
         raise CLIError('usage error: --vnet NAME --subnet NAME | --vnet ID --subnet NAME | --subnet ID')
 
-    if (ns.subnet or ns.vnet) and ns.ip_address:
+    if (ns.subnet or ns.vnet) and ns.ip_address == "Public":
         raise MutuallyExclusiveArgumentError('Can not use "--subnet" or "--vnet" with IP address type "Public".')
     if (ns.subnet or ns.vnet) and ns.dns_name_label:
         raise MutuallyExclusiveArgumentError('Can not use "--subnet" or "--vnet" with "--dns-name-label".')

--- a/src/azure-cli/azure/cli/command_modules/container/tests/latest/recordings/test_container_create_with_vnet.yaml
+++ b/src/azure-cli/azure/cli/command_modules/container/tests/latest/recordings/test_container_create_with_vnet.yaml
@@ -13,12 +13,12 @@ interactions:
       ParameterSetName:
       - -g -n --image --vnet
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-azure-mgmt-resource/19.0.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-azure-mgmt-resource/19.0.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-10-14T21:09:33Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-10-25T21:18:08Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:09:36 GMT
+      - Mon, 25 Oct 2021 21:18:10 GMT
       expires:
       - '-1'
       pragma:
@@ -55,12 +55,12 @@ interactions:
       ParameterSetName:
       - -g -n --image --subnet
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-azure-mgmt-resource/19.0.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-azure-mgmt-resource/19.0.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-10-14T21:09:33Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-10-25T21:18:08Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -69,7 +69,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:09:36 GMT
+      - Mon, 25 Oct 2021 21:18:10 GMT
       expires:
       - '-1'
       pragma:
@@ -95,14 +95,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-azure-mgmt-resource/19.0.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-azure-mgmt-resource/19.0.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-10-14T21:09:33Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2021-10-25T21:18:08Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -111,7 +111,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:09:37 GMT
+      - Mon, 25 Oct 2021 21:18:10 GMT
       expires:
       - '-1'
       pragma:
@@ -137,9 +137,9 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003/subnets/subnet000004?api-version=2018-08-01
   response:
@@ -155,7 +155,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:09:38 GMT
+      - Mon, 25 Oct 2021 21:18:12 GMT
       expires:
       - '-1'
       pragma:
@@ -181,9 +181,9 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003?api-version=2018-08-01
   response:
@@ -199,7 +199,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:09:38 GMT
+      - Mon, 25 Oct 2021 21:18:12 GMT
       expires:
       - '-1'
       pragma:
@@ -230,18 +230,18 @@ interactions:
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003?api-version=2018-08-01
   response:
     body:
       string: "{\r\n  \"name\": \"vent000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003\",\r\n
-        \ \"etag\": \"W/\\\"a83deb41-04ae-47ad-bced-168efcd55635\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"15b62086-d795-496e-9b03-3529f53cdf89\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\":
-        \"d1668bea-33ae-4b3e-bb7c-f3aebcdb2942\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        \"bec4dd24-7f7f-4a2e-8439-f02926d87001\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
         [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [],\r\n
         \   \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\": false\r\n
         \ }\r\n}"
@@ -249,7 +249,7 @@ interactions:
       azure-asyncnotification:
       - Enabled
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8c2faca1-ba31-4e31-ad97-76250a498337?api-version=2018-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/460593cb-0a6d-43ac-9471-7151216218ac?api-version=2018-08-01
       cache-control:
       - no-cache
       content-length:
@@ -257,7 +257,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:09:41 GMT
+      - Mon, 25 Oct 2021 21:18:14 GMT
       expires:
       - '-1'
       pragma:
@@ -270,7 +270,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - bc79128e-88e4-43fc-b0e2-01bba302ed4d
+      - 45f74a00-6136-4c4e-ae9d-40deaf689ebc
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -295,19 +295,19 @@ interactions:
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003/subnets/subnet000004?api-version=2018-08-01
   response:
     body:
       string: "{\r\n  \"name\": \"subnet000004\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003/subnets/subnet000004\",\r\n
-        \ \"etag\": \"W/\\\"171fd65d-210a-4e3e-94b4-5c0bb5525a62\\\"\",\r\n  \"properties\":
+        \ \"etag\": \"W/\\\"98de6aa0-f8c9-46d0-85e9-ad496f4243b2\\\"\",\r\n  \"properties\":
         {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
         \   \"delegations\": [\r\n      {\r\n        \"name\": \"Microsoft.ContainerInstance/containerGroups\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003/subnets/subnet000004/delegations/Microsoft.ContainerInstance/containerGroups\",\r\n
-        \       \"etag\": \"W/\\\"171fd65d-210a-4e3e-94b4-5c0bb5525a62\\\"\",\r\n
+        \       \"etag\": \"W/\\\"98de6aa0-f8c9-46d0-85e9-ad496f4243b2\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"serviceName\": \"Microsoft.ContainerInstance/containerGroups\",\r\n
         \         \"actions\": [\r\n            \"Microsoft.Network/virtualNetworks/subnets/action\"\r\n
@@ -315,7 +315,7 @@ interactions:
         \     }\r\n    ]\r\n  },\r\n  \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/23c836cc-a3cd-4fce-a00e-1d03078f3ad6?api-version=2018-08-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/126cd772-ed5d-4a4d-aa2d-da93d285c6c0?api-version=2018-08-01
       cache-control:
       - no-cache
       content-length:
@@ -323,7 +323,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:09:41 GMT
+      - Mon, 25 Oct 2021 21:18:14 GMT
       expires:
       - '-1'
       pragma:
@@ -336,7 +336,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - cc5408a5-a9a7-4f70-8d78-5bb23bde8142
+      - c97705cf-93f4-4e3a-9d29-cf2b275cede0
       x-ms-ratelimit-remaining-subscription-writes:
       - '1198'
     status:
@@ -354,30 +354,30 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8c2faca1-ba31-4e31-ad97-76250a498337?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/460593cb-0a6d-43ac-9471-7151216218ac?api-version=2018-08-01
   response:
     body:
       string: "{\r\n  \"status\": \"Canceled\",\r\n  \"error\": {\r\n    \"code\":
         \"Canceled\",\r\n    \"message\": \"Operation was canceled.\",\r\n    \"details\":
         [\r\n      {\r\n        \"code\": \"CanceledAndSupersededDueToAnotherOperation\",\r\n
-        \       \"message\": \"Operation PutVirtualNetworkOperation (8c2faca1-ba31-4e31-ad97-76250a498337)
-        was canceled and superseded by operation PutSubnetOperation (23c836cc-a3cd-4fce-a00e-1d03078f3ad6).\"\r\n
+        \       \"message\": \"Operation PutVirtualNetworkOperation (460593cb-0a6d-43ac-9471-7151216218ac)
+        was canceled and superseded by operation PutSubnetOperation (126cd772-ed5d-4a4d-aa2d-da93d285c6c0).\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     headers:
       cache-control:
       - no-cache
       canceled-by-azure-asyncoperation:
-      - https://management.azure.com/subscriptions/da28f5e5-aa45-46fe-90c8-053ca49ab4b5/providers/Microsoft.Network/locations/westus/operations/23c836cc-a3cd-4fce-a00e-1d03078f3ad6?api-version=2018-08-01
+      - https://management.azure.com/subscriptions/da28f5e5-aa45-46fe-90c8-053ca49ab4b5/providers/Microsoft.Network/locations/westus/operations/126cd772-ed5d-4a4d-aa2d-da93d285c6c0?api-version=2018-08-01
       content-length:
       - '420'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:09:45 GMT
+      - Mon, 25 Oct 2021 21:18:17 GMT
       expires:
       - '-1'
       pragma:
@@ -394,7 +394,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - a61d1096-97c2-4609-8e50-0777c636d010
+      - 893a4f7f-8b36-478f-89c6-f69cf0febfa0
     status:
       code: 200
       message: OK
@@ -410,11 +410,11 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/23c836cc-a3cd-4fce-a00e-1d03078f3ad6?api-version=2018-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/126cd772-ed5d-4a4d-aa2d-da93d285c6c0?api-version=2018-08-01
   response:
     body:
       string: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -426,7 +426,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:09:45 GMT
+      - Mon, 25 Oct 2021 21:18:17 GMT
       expires:
       - '-1'
       pragma:
@@ -443,7 +443,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - dc4132b0-854f-4784-bec8-0b92c4eb8d67
+      - c5b7b3ca-4799-478c-9210-1a3f4666c3f8
     status:
       code: 200
       message: OK
@@ -459,19 +459,19 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-azure-mgmt-network/19.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003/subnets/subnet000004?api-version=2018-08-01
   response:
     body:
       string: "{\r\n  \"name\": \"subnet000004\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003/subnets/subnet000004\",\r\n
-        \ \"etag\": \"W/\\\"96144e7a-d6cf-43db-9fc0-3f69d7bb555f\\\"\",\r\n  \"properties\":
+        \ \"etag\": \"W/\\\"5ed97908-5dba-448d-b327-56745b188f1d\\\"\",\r\n  \"properties\":
         {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
         \   \"delegations\": [\r\n      {\r\n        \"name\": \"Microsoft.ContainerInstance/containerGroups\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003/subnets/subnet000004/delegations/Microsoft.ContainerInstance/containerGroups\",\r\n
-        \       \"etag\": \"W/\\\"96144e7a-d6cf-43db-9fc0-3f69d7bb555f\\\"\",\r\n
+        \       \"etag\": \"W/\\\"5ed97908-5dba-448d-b327-56745b188f1d\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"serviceName\": \"Microsoft.ContainerInstance/containerGroups\",\r\n
         \         \"actions\": [\r\n            \"Microsoft.Network/virtualNetworks/subnets/action\"\r\n
@@ -485,9 +485,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:09:45 GMT
+      - Mon, 25 Oct 2021 21:18:17 GMT
       etag:
-      - W/"96144e7a-d6cf-43db-9fc0-3f69d7bb555f"
+      - W/"5ed97908-5dba-448d-b327-56745b188f1d"
       expires:
       - '-1'
       pragma:
@@ -504,7 +504,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 75fffa33-aa16-4210-b79e-64c7b5bd4869
+      - 68969b82-d0e8-4bf5-8bff-c7fd88568ffb
     status:
       code: 200
       message: OK
@@ -528,9 +528,9 @@ interactions:
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-mgmt-containerinstance/9.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-mgmt-containerinstance/9.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002?api-version=2021-09-01
   response:
@@ -538,7 +538,7 @@ interactions:
       string: '{"properties":{"sku":"Standard","provisioningState":"Pending","containers":[{"name":"clicontainer000002","properties":{"image":"nginx","ports":[{"protocol":"TCP","port":80}],"environmentVariables":[],"resources":{"requests":{"memoryInGB":1.5,"cpu":1.0}}}}],"initContainers":[],"restartPolicy":"Always","osType":"Linux","instanceView":{"events":[],"state":"Pending"},"subnetIds":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003/subnets/subnet000004"}]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002","name":"clicontainer000002","type":"Microsoft.ContainerInstance/containerGroups","location":"westus","tags":{}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/ae73dd01-25ba-43be-9a5f-c1636ccd1d3d?api-version=2018-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/503663ba-96d7-4abb-a78a-27a4de50f123?api-version=2018-06-01
       cache-control:
       - no-cache
       content-length:
@@ -546,7 +546,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:09:48 GMT
+      - Mon, 25 Oct 2021 21:18:23 GMT
       expires:
       - '-1'
       pragma:
@@ -556,9 +556,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests-pt1h:
-      - '420'
+      - '476'
       x-ms-ratelimit-remaining-subscription-resource-requests-pt5m:
-      - '194'
+      - '199'
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -576,14 +576,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-mgmt-containerinstance/9.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-mgmt-containerinstance/9.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/ae73dd01-25ba-43be-9a5f-c1636ccd1d3d?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/503663ba-96d7-4abb-a78a-27a4de50f123?api-version=2018-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002","status":"Pending","startTime":"2021-10-14T21:09:48.7874434Z","properties":{"events":[]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002","status":"Pending","startTime":"2021-10-25T21:18:23.0092034Z","properties":{"events":[]}}'
     headers:
       cache-control:
       - no-cache
@@ -592,7 +592,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:10:18 GMT
+      - Mon, 25 Oct 2021 21:18:53 GMT
       expires:
       - '-1'
       pragma:
@@ -620,14 +620,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-mgmt-containerinstance/9.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-mgmt-containerinstance/9.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/ae73dd01-25ba-43be-9a5f-c1636ccd1d3d?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/503663ba-96d7-4abb-a78a-27a4de50f123?api-version=2018-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002","status":"Pending","startTime":"2021-10-14T21:09:48.7874434Z","properties":{"events":[]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002","status":"Pending","startTime":"2021-10-25T21:18:23.0092034Z","properties":{"events":[]}}'
     headers:
       cache-control:
       - no-cache
@@ -636,7 +636,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:10:48 GMT
+      - Mon, 25 Oct 2021 21:19:23 GMT
       expires:
       - '-1'
       pragma:
@@ -664,26 +664,23 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-mgmt-containerinstance/9.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-mgmt-containerinstance/9.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/ae73dd01-25ba-43be-9a5f-c1636ccd1d3d?api-version=2018-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/503663ba-96d7-4abb-a78a-27a4de50f123?api-version=2018-06-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002","status":"Succeeded","startTime":"2021-10-14T21:09:48.7874434Z","properties":{"events":[{"count":2,"firstTimestamp":"2021-10-14T21:10:14Z","lastTimestamp":"2021-10-14T21:10:29Z","name":"Pulling","message":"pulling
-        image \"nginx@sha256:7250923ba3543110040462388756ef099331822c6172a050b12c7a38361ea46f\"","type":"Normal"},{"count":2,"firstTimestamp":"2021-10-14T21:10:24Z","lastTimestamp":"2021-10-14T21:10:29Z","name":"Pulled","message":"Successfully
-        pulled image \"nginx@sha256:7250923ba3543110040462388756ef099331822c6172a050b12c7a38361ea46f\"","type":"Normal"},{"count":1,"firstTimestamp":"2021-10-14T21:10:51Z","lastTimestamp":"2021-10-14T21:10:51Z","name":"Started","message":"Started
-        container","type":"Normal"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002","status":"Pending","startTime":"2021-10-25T21:18:23.0092034Z","properties":{"events":[]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '941'
+      - '311'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:11:18 GMT
+      - Mon, 25 Oct 2021 21:19:53 GMT
       expires:
       - '-1'
       pragma:
@@ -711,26 +708,67 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -n --image --vnet --subnet
+      - -g -n --image --vnet --subnet --ip-address
       User-Agent:
-      - AZURECLI/2.29.0 azsdk-python-mgmt-containerinstance/9.1.0 Python/3.8.8 (Windows-10-10.0.19041-SP0)
+      - AZURECLI/2.29.1 azsdk-python-mgmt-containerinstance/9.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerInstance/locations/westus/operations/503663ba-96d7-4abb-a78a-27a4de50f123?api-version=2018-06-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002","status":"Succeeded","startTime":"2021-10-25T21:18:23.0092034Z","properties":{"events":[]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '313'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 25 Oct 2021 21:20:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - container create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --image --vnet --subnet --ip-address
+      User-Agent:
+      - AZURECLI/2.29.1 azsdk-python-mgmt-containerinstance/9.1.0 Python/3.8.8 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002?api-version=2021-09-01
   response:
     body:
-      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000002","properties":{"image":"nginx","ports":[{"protocol":"TCP","port":80}],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2021-10-14T21:10:51.512Z","detailStatus":""},"events":[{"count":2,"firstTimestamp":"2021-10-14T21:10:14Z","lastTimestamp":"2021-10-14T21:10:29Z","name":"Pulling","message":"pulling
-        image \"nginx@sha256:7250923ba3543110040462388756ef099331822c6172a050b12c7a38361ea46f\"","type":"Normal"},{"count":2,"firstTimestamp":"2021-10-14T21:10:24Z","lastTimestamp":"2021-10-14T21:10:29Z","name":"Pulled","message":"Successfully
-        pulled image \"nginx@sha256:7250923ba3543110040462388756ef099331822c6172a050b12c7a38361ea46f\"","type":"Normal"},{"count":1,"firstTimestamp":"2021-10-14T21:10:51Z","lastTimestamp":"2021-10-14T21:10:51Z","name":"Started","message":"Started
-        container","type":"Normal"}]},"resources":{"requests":{"memoryInGB":1.5,"cpu":1.0}}}}],"initContainers":[],"restartPolicy":"Always","ipAddress":{"ports":[{"protocol":"TCP","port":80}],"ip":"10.0.0.4","type":"Private"},"osType":"Linux","instanceView":{"events":[],"state":"Running"},"subnetIds":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003/subnets/subnet000004"}]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002","name":"clicontainer000002","type":"Microsoft.ContainerInstance/containerGroups","location":"westus","tags":{}}'
+      string: '{"properties":{"sku":"Standard","provisioningState":"Succeeded","containers":[{"name":"clicontainer000002","properties":{"image":"nginx","ports":[{"protocol":"TCP","port":80}],"environmentVariables":[],"instanceView":{"restartCount":0,"currentState":{"state":"Running","startTime":"2021-10-25T21:20:05.052Z","detailStatus":""}},"resources":{"requests":{"memoryInGB":1.5,"cpu":1.0}}}}],"initContainers":[],"restartPolicy":"Always","ipAddress":{"ports":[{"protocol":"TCP","port":80}],"ip":"10.0.0.4","type":"Private"},"osType":"Linux","instanceView":{"events":[],"state":"Running"},"subnetIds":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/vent000003/subnets/subnet000004"}]},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ContainerInstance/containerGroups/clicontainer000002","name":"clicontainer000002","type":"Microsoft.ContainerInstance/containerGroups","location":"westus","tags":{}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1801'
+      - '1161'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 14 Oct 2021 21:11:18 GMT
+      - Mon, 25 Oct 2021 21:20:23 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/container/tests/latest/test_container_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/container/tests/latest/test_container_commands.py
@@ -302,12 +302,14 @@ class AzureContainerInstanceScenarioTest(ScenarioTest):
         container_group_name = self.create_random_name('clicontainer', 16)
         vnet_name = self.create_random_name('vent', 16)
         subnet_name = self.create_random_name('subnet', 16)
+        ip_address_type = "Private"
 
         self.kwargs.update({
             'container_group_name': container_group_name,
             'resource_group_location': resource_group_location,
             'vnet_name': vnet_name,
-            'subnet_name': subnet_name
+            'subnet_name': subnet_name,
+            'ip_addresss': ip_address_type
         })
 
         # Vnet name with no subnet
@@ -319,7 +321,7 @@ class AzureContainerInstanceScenarioTest(ScenarioTest):
             self.cmd('container create -g {rg} -n {container_group_name} --image nginx '
                      '--subnet {subnet_name} ')
 
-        self.cmd('container create -g {rg} -n {container_group_name} --image nginx --vnet {vnet_name} --subnet {subnet_name}',
+        self.cmd('container create -g {rg} -n {container_group_name} --image nginx --vnet {vnet_name} --subnet {subnet_name} --ip-address {ip_addresss}',
             checks=[self.exists('subnetIds[0].id')])
 
 


### PR DESCRIPTION
`**Description**<!--Mandatory-->`
Bug did not allow using "--subnet" or "--vnet" with "--ip-address Private", the restriction should only be for "--ip-address Public"

**Testing Guide**
`az container create --name appcontainer --resource-group josephporter-cli-tests --image mcr.microsoft.com/azuredocs/aci-helloworld --vnet aci-vnet --vnet-address-prefix 10.0.0.0/16 --subnet aci-subnet --subnet-address-prefix 10.0.0.0/24 --ip-address Private`

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
