### PR TITLE
{Azure Maps} az maps: Remove Mobility Reference

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/maps/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/maps/custom.py
@@ -31,8 +31,7 @@ def maps_account_create(client,
             '\nQueries are not linked to any customer or end-user when shared with TomTom ' \
             'and cannot be used to identify individuals.' \
             '\nMicrosoft is currently in the process of adding TomTom to the Online Services Subcontractor List. ' \
-            '\nNote that the Mobility and Weather Services which include integration with ' \
-            'Moovit and AccuWeather are currently in PREVIEW ' \
+            '\nNote that Weather Services integrates with AccuWeather and is currently in PREVIEW ' \
             '(see https://azure.microsoft.com/support/legal/preview-supplemental-terms/). '
     hint = 'Please select.'
     client_denied_terms = 'You must agree to the License and Privacy Statement to create an account.'


### PR DESCRIPTION
**Description**<!--Mandatory-->
Azure Maps no longer has a Mobility service. Updating output text to reflect this removal.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
