### PR TITLE
{AKS} Add unit tests for keyvault addon

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -3481,6 +3481,7 @@ class AKSContext:
 
         return self._get_enable_private_cluster(enable_validation=True)
 
+    # pylint: disable=unused-argument
     def _get_disable_public_fqdn(self, enable_validation: bool = False, **kwargs) -> bool:
         """Internal function to obtain the value of disable_public_fqdn.
 
@@ -3593,6 +3594,7 @@ class AKSContext:
         """
         return self._get_enable_public_fqdn(enable_validation=True)
 
+    # pylint: disable=unused-argument
     def _get_private_dns_zone(self, enable_validation: bool = False, **kwargs) -> Union[str, None]:
         """Internal function to obtain the value of private_dns_zone.
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -346,15 +346,21 @@ class AKSContextTestCase(unittest.TestCase):
 
         # fail on min_count > max_count
         with self.assertRaises(InvalidArgumentValueError):
-            ctx.validate_counts_in_autoscaler(5, True, 3, 1, DecoratorMode.CREATE)
+            ctx.validate_counts_in_autoscaler(
+                5, True, 3, 1, DecoratorMode.CREATE
+            )
 
         # fail on node_count < min_count in create mode
         with self.assertRaises(InvalidArgumentValueError):
-            ctx.validate_counts_in_autoscaler(5, True, 7, 10, DecoratorMode.CREATE)
+            ctx.validate_counts_in_autoscaler(
+                5, True, 7, 10, DecoratorMode.CREATE
+            )
 
         # skip node_count check in update mode
         ctx.validate_counts_in_autoscaler(5, True, 7, 10, DecoratorMode.UPDATE)
-        ctx.validate_counts_in_autoscaler(None, True, 7, 10, DecoratorMode.UPDATE)
+        ctx.validate_counts_in_autoscaler(
+            None, True, 7, 10, DecoratorMode.UPDATE
+        )
 
         # fail on enable_cluster_autoscaler not specified
         with self.assertRaises(RequiredArgumentMissingError):


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

* Add unit tests for keyvault addon

Unit Test Coverage

From

- "covered_lines": 1566,
- "num_statements": 1602,
- "percent_covered": 97.75280898876404,
- "missing_lines": 36,
- "excluded_lines": 0

To

- "covered_lines": 1590,
- "num_statements": 1602,
- "percent_covered": 99.25093632958801,
- "missing_lines": 12,
- "excluded_lines": 0


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
