### PR TITLE
{Packaging} Bump PyGithub

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -122,7 +122,7 @@ pbr==5.3.1
 portalocker==1.7.1
 psutil==5.8.0
 pycparser==2.19
-PyGithub==1.38
+PyGithub==1.55
 PyJWT==2.1.0
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -123,7 +123,7 @@ pbr==5.3.1
 portalocker==1.7.1
 psutil==5.8.0
 pycparser==2.19
-PyGithub==1.38
+PyGithub==1.55
 PyJWT==2.1.0
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -121,7 +121,7 @@ pbr==5.3.1
 portalocker==1.7.1
 psutil==5.8.0
 pycparser==2.19
-PyGithub==1.38
+PyGithub==1.55
 PyJWT==2.1.0
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix https://github.com/Homebrew/homebrew-core/pull/86758#issuecomment-937386829

The old PyGithub 1.33 fails to install with the latest `setuptools`:

https://github.com/Homebrew/homebrew-core/runs/3822014268?check_suite_focus=true#step:7:477

```
error in PyGithub setup command: use_2to3 is invalid.
```

This can also be reproduced locally:

```
> pip install PyGithub==1.38 --force-reinstall --no-cache
Collecting PyGithub==1.38
  Downloading PyGithub-1.38.tar.gz (2.6 MB)
     |████████████████████████████████| 2.6 MB 939 kB/s
  Preparing metadata (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: 'D:\cli\py310\Scripts\python.exe' -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\jiasli\\AppData\\Local\\Temp\\pip-install-ucdnpr32\\pygithub_0d915833b57340d9ba94217798ac9ac0\\setup.py'"'"'; __file__='"'"'C:\\Users\\jiasli\\AppData\\Local\\Temp\\pip-install-ucdnpr32\\pygithub_0d915833b57340d9ba94217798ac9ac0\\setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base 'C:\Users\jiasli\AppData\Local\Temp\pip-pip-egg-info-ldrl09zy'
       cwd: C:\Users\jiasli\AppData\Local\Temp\pip-install-ucdnpr32\pygithub_0d915833b57340d9ba94217798ac9ac0\
  Complete output (1 lines):
  error in PyGithub setup command: use_2to3 is invalid.
```

This issue is similar to https://github.com/Azure/azure-cli/issues/19468 (fixed by https://github.com/Azure/azure-cli/pull/19495)