### PR TITLE
[App Service] `az staticwebapp browse`: Open static webapp in browser

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2386,7 +2386,7 @@ helps['staticwebapp delete'] = """
 
 helps['staticwebapp browse'] = """
     type: command
-    short-summary: Open a static web app in a browser.
+    short-summary: Open a static web app in a browser. Uses the first custom domain URL if one exists. Otherwise opens the auto-generated URL.
     examples:
     - name: Open a static web app in a browser.
       text: az staticwebapp browse -n MyStaticAppName -g MyRg

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2384,6 +2384,14 @@ helps['staticwebapp delete'] = """
       text: az staticwebapp delete -n MyStaticAppName -g MyRg
 """
 
+helps['staticwebapp browse'] = """
+    type: command
+    short-summary: Open a static web app in a browser.
+    examples:
+    - name: Open a static web app in a browser.
+      text: az staticwebapp browse -n MyStaticAppName -g MyRg
+"""
+
 helps['staticwebapp environment'] = """
     type: group
     short-summary: Manage environment of the static app.

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -439,6 +439,7 @@ def load_command_table(self, _):
         g.custom_command('disconnect', 'disconnect_staticsite', supports_no_wait=True)
         g.custom_command('reconnect', 'reconnect_staticsite', supports_no_wait=True)
         g.custom_command('update', 'update_staticsite', supports_no_wait=True)
+        g.custom_command('browse', 'view_in_browser')
 
     with self.command_group('staticwebapp environment', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsite_environments')

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
-from azure.cli.core.util import sdk_no_wait
+from azure.cli.core.util import sdk_no_wait, open_page_in_browser
 from knack.util import CLIError
 from knack.log import get_logger
 
@@ -376,3 +376,21 @@ def reset_staticsite_api_key(cmd, name, resource_group_name=None):
     return client.reset_static_site_api_key(resource_group_name=resource_group_name,
                                             name=name,
                                             reset_properties_envelope=reset_envelope)
+
+
+def _get_url(cmd, resource_group_name, name):
+    custom_domains = [d.domain_name for d in list(list_staticsite_domains(cmd, name, resource_group_name))]
+    site = show_staticsite(cmd, name, resource_group_name)
+    default_url = site.default_hostname
+
+    if not custom_domains or default_url in custom_domains:
+        url = default_url
+    else:
+        url = custom_domains[0]
+
+    return "https://{}".format(url)
+
+
+def view_in_browser(cmd, resource_group_name, name):
+    url = _get_url(cmd, resource_group_name, name)
+    open_page_in_browser(url)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Adds command `az staticwebapp browse`, which opens a static webapp in a browser. This is similar to the preexisting command `az webapp browse`.

Requested by https://github.com/Azure/azure-cli/issues/16473 

**Testing Guide**
<!--Example commands with explanations.-->
` az staticwebapp browse -g <group> -n <name>`


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
