### PR TITLE
{Packaging} Drop pytz

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -126,7 +126,6 @@ PyJWT==2.1.0
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0
-pytz==2019.1
 requests-oauthlib==1.2.0
 requests[socks]==2.25.1
 scp==0.13.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -127,7 +127,6 @@ PyJWT==2.1.0
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0
-pytz==2019.1
 requests-oauthlib==1.2.0
 requests[socks]==2.25.1
 scp==0.13.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -126,7 +126,6 @@ PyNaCl==1.4.0
 pyOpenSSL==19.0.0
 pyreadline==2.1
 python-dateutil==2.8.0
-pytz==2019.1
 pywin32==302
 requests-oauthlib==1.2.0
 requests[socks]==2.25.1

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -142,7 +142,6 @@ DEPENDENCIES = [
     'packaging~=20.9',
     'PyGithub~=1.38',
     'PyNaCl~=1.4.0',
-    'pytz==2019.1',
     'scp~=0.13.2',
     'semver==2.13.0',
     'six>=1.10.0',  # six is still used by countless extensions


### PR DESCRIPTION
Derived from https://github.com/Azure/azure-cli/pull/19963

`pytz` was first introduced by 5afb8bd9536d5789a12647d090dc1cfe11dec6a2 related to `keyvault` module, but the reason for it is unknown.

By searching the whole project, we found no place where `pytz` is referenced: https://github.com/Azure/azure-cli/search?q=pytz

Therefore, `pytz` should be dropped from the dependencies. 