### PR TITLE
{ServiceConnector} Fix issue when users use `-o table` as default output

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_addon_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_addon_factory.py
@@ -183,7 +183,7 @@ class AddonBase:
         '''Retrive the location of source resource group
         '''
         rg = self._retrive_source_rg()
-        output = run_cli_cmd('az group show -n {}'.format(rg))
+        output = run_cli_cmd('az group show -n {} -o json'.format(rg))
         return output.get('location')
 
     def _get_source_type(self):

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_transformers.py
@@ -34,7 +34,7 @@ def transform_linker_properties(result):
     result = todict(result)
     resource_id = result.get('id')
     try:
-        output = run_cli_cmd('az webapp connection list-configuration --id {}'.format(resource_id))
+        output = run_cli_cmd('az webapp connection list-configuration --id {} -o json'.format(resource_id))
         result['configurations'] = output.get('configurations')
     except CLIInternalError:
         pass

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_validators.py
@@ -118,7 +118,7 @@ def get_client_type(cmd, namespace):
 
         client_type = None
         try:
-            output = run_cli_cmd('az webapp show --id {}'.format(source_id))
+            output = run_cli_cmd('az webapp show --id {} -o json'.format(source_id))
             prop = output.get('siteConfig').get('linuxFxVersion', None) or\
                 output.get('siteConfig').get('windowsFxVersion', None)
             # use 'linuxFxVersion' and 'windowsFxVersion' property to decide
@@ -140,9 +140,9 @@ def get_client_type(cmd, namespace):
         client_type = None
         try:
             segments = parse_resource_id(source_id)
-            output = run_cli_cmd('az spring-cloud app show '
-                                 '-g {} -s {} -n {}'.format(segments.get('resource_group'), segments.get('name'),
-                                                            segments.get('child_name_1')))
+            output = run_cli_cmd('az spring-cloud app show -g {} -s {} -n {}'
+                                 ' -o json'.format(segments.get('resource_group'), segments.get('name'),
+                                                   segments.get('child_name_1')))
             prop_val = output.get('properties')\
                              .get('activeDeployment')\
                              .get('properties')\


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR fixes the issue when users use `-o table` as default output.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
