### PR TITLE
{Auth} More detailed error message when MSAL returns multiple accounts 

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
@@ -43,7 +43,7 @@ class UserCredential(PublicClientApplication):
 
         accounts = self.get_accounts(username)
 
-        # MSAL should never return multiple accounts for the same username
+        # Usernames are usually unique. We are collecting corner cases to better understand its behavior.
         if len(accounts) > 1:
             raise CLIError(f"Found multiple accounts with the same username '{username}': {accounts}\n"
                            "Please report to us via Github: https://github.com/Azure/azure-cli/issues/20168")

--- a/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
@@ -43,16 +43,14 @@ class UserCredential(PublicClientApplication):
 
         accounts = self.get_accounts(username)
 
+        # MSAL should never return multiple account for the same username
+        assert len(accounts) <= 1, (f"Found multiple accounts with the same username '{username}': {accounts}\n"
+                                    "Please report to us via Github: https://github.com/Azure/azure-cli/issues/new")
+
         if not accounts:
             raise CLIError("User '{}' does not exist in MSAL token cache. Run `az login`.".format(username))
 
-        if len(accounts) > 1:
-            raise CLIError("Found multiple accounts with the same username '{}': {}\n"
-                           "Please report to us via Github: https://github.com/Azure/azure-cli/issues/new"
-                           .format(username, accounts))
-
-        account = accounts[0]
-        self._account = account
+        self._account = accounts[0]
 
     def get_token(self, *scopes, **kwargs):
         # scopes = ['https://pas.windows.net/CheckMyAccess/Linux/.default']

--- a/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
@@ -38,14 +38,18 @@ class UserCredential(PublicClientApplication):
         """
         super().__init__(client_id, **kwargs)
 
+        # Make sure username is specified, otherwise MSAL returns all accounts
+        assert username, "username must be specified, got {!r}".format(username)
+
         accounts = self.get_accounts(username)
 
         if not accounts:
-            raise CLIError("User {} does not exist in MSAL token cache. Run `az login`.".format(username))
+            raise CLIError("User '{}' does not exist in MSAL token cache. Run `az login`.".format(username))
 
         if len(accounts) > 1:
-            raise CLIError("Found multiple accounts with the same username. Please report to us via Github: "
-                           "https://github.com/Azure/azure-cli/issues/new")
+            raise CLIError("Found multiple accounts with the same username '{}': {}\n"
+                           "Please report to us via Github: https://github.com/Azure/azure-cli/issues/new"
+                           .format(username, accounts))
 
         account = accounts[0]
         self._account = account

--- a/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
@@ -43,7 +43,7 @@ class UserCredential(PublicClientApplication):
 
         accounts = self.get_accounts(username)
 
-        # MSAL should never return multiple account for the same username
+        # MSAL should never return multiple accounts for the same username
         if len(accounts) > 1:
             raise CLIError(f"Found multiple accounts with the same username '{username}': {accounts}\n"
                            "Please report to us via Github: https://github.com/Azure/azure-cli/issues/20168")

--- a/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
@@ -44,8 +44,9 @@ class UserCredential(PublicClientApplication):
         accounts = self.get_accounts(username)
 
         # MSAL should never return multiple account for the same username
-        assert len(accounts) <= 1, (f"Found multiple accounts with the same username '{username}': {accounts}\n"
-                                    "Please report to us via Github: https://github.com/Azure/azure-cli/issues/new")
+        if len(accounts) > 1:
+            raise CLIError(f"Found multiple accounts with the same username '{username}': {accounts}\n"
+                           "Please report to us via Github: https://github.com/Azure/azure-cli/issues/20168")
 
         if not accounts:
             raise CLIError("User '{}' does not exist in MSAL token cache. Run `az login`.".format(username))


### PR DESCRIPTION
**Description**<!--Mandatory-->

Previously we thought `msal.application.ClientApplication.get_accounts` can't return multiple accounts because MSAL groups them (https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/349). That's why we added a double check:

https://github.com/Azure/azure-cli/blob/bd081bb9a4449091bfcce50e2b51292d8a1591d8/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py#L46-L48

But now we do see this happening: https://github.com/Azure/azure-cli/issues/20172, https://github.com/Azure/azure-cli/issues/20168.

Even though the root cause is unknown, its better to expose more information in the error message.
