### PR TITLE
[ARM] Fix #19420: `az bicep install`: Fix the CERTIFICATE_VERIFY_FAILED for generating SSL

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -141,7 +141,8 @@ def is_bicep_file(file_path):
 
 def get_bicep_available_release_tags():
     try:
-        response = requests.get("https://aka.ms/BicepReleases")
+        ca_file = certifi.where()
+        response = requests.get("https://aka.ms/BicepReleases", verify=ca_file)
         return [release["tag_name"] for release in response.json()]
     except IOError as err:
         raise ClientRequestError(f"Error while attempting to retrieve available Bicep versions: {err}.")
@@ -149,7 +150,8 @@ def get_bicep_available_release_tags():
 
 def get_bicep_latest_release_tag():
     try:
-        response = requests.get("https://aka.ms/BicepLatestRelease")
+        ca_file = certifi.where()
+        response = requests.get("https://aka.ms/BicepLatestRelease", verify=ca_file)
         response.raise_for_status()
         return response.json()["tag_name"]
     except IOError as err:

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -9,6 +9,7 @@ import stat
 import platform
 import subprocess
 import json
+import certifi
 
 from json.decoder import JSONDecodeError
 from contextlib import suppress
@@ -106,8 +107,8 @@ def ensure_bicep_installation(release_tag=None, stdout=True):
                 print(f"Installing Bicep CLI {release_tag}...")
             else:
                 print("Installing Bicep CLI...")
-
-        request = urlopen(_get_bicep_download_url(system, release_tag))
+        ca_file = certifi.where()
+        request = urlopen(_get_bicep_download_url(system, release_tag), cafile=ca_file)
         with open(installation_path, "wb") as f:
             f.write(request.read())
 


### PR DESCRIPTION
**Description**
This pull request fixes issue #19420. 
The old code did not pass the path to the certificate file to request.get() and urlopen(), reulting in a SSL: CERTIFICATE_VERIFY_FAILED error.

**Testing Guide**
On a clean developer pc behind a corporate proxy with a certificate signed by a private root CA, type on a pwsh prompt:
az bicep install
Result:
bicep will be installed
(without the fix, there would be a certificate error)

On a clean regular developer pc, do the same, type
az bicep install
bicep will be installed, just as before the fix.

**History Notes**
[Bicep] az bicep install: works now behind a corporate proxy
