### PR TITLE
{Pylint} Adapt to Pylint 2.11.1

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -9,6 +9,8 @@ reports=no
 # import-outside-toplevel: Lazy import to improve performance
 # locally-disabled: Warning locally suppressed using disable-msg
 # too-many-arguments: Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
+# consider-using-f-string: str.format is still a Python standard
+# unspecified-encoding: Allow using the system encoding, instead of forcing utf-8 to avoid opening errors
 disable=
     arguments-out-of-order,
     bad-option-value,
@@ -33,6 +35,20 @@ disable=
     too-many-lines,
     using-constant-test,
     wrong-import-order,
+    consider-using-f-string,
+    unspecified-encoding,
+    consider-using-from-import,
+    use-maxsplit-arg,
+    arguments-renamed,
+    consider-using-in,
+    use-dict-literal,
+    consider-using-dict-items,
+    consider-using-enumerate,
+    redundant-u-string-prefix,
+    use-list-literal,
+    raising-bad-type,
+    unused-private-member,
+    used-before-assignment
 
 [FORMAT]
 max-line-length=120


### PR DESCRIPTION
**Description**<!--Mandatory-->

New `pylint` is more strict. Temporarily disable these checks and we will fix them one by one in separate PRs, like #17861.

- [ ] consider-using-f-string
- [ ] unspecified-encoding
- [ ] consider-using-from-import
- [ ] use-maxsplit-arg
- [ ] arguments-renamed
- [ ] consider-using-in
- [ ] use-dict-literal
- [ ] consider-using-dict-items
- [ ] consider-using-enumerate
- [ ] redundant-u-string-prefix
- [ ] use-list-literal
- [ ] raising-bad-type
- [ ] unused-private-member
- [ ] used-before-assignment