### PR TITLE
{Packaging} Temporarily pin setuptools

### DIFF
--- a/scripts/release/pypi/build.sh
+++ b/scripts/release/pypi/build.sh
@@ -17,7 +17,7 @@ echo "Branch $branch"
 echo "Search setup files from `pwd`."
 python --version
 
-pip install -U pip setuptools wheel
+pip install -U pip setuptools==58.4.0 wheel
 pip list
 
 script_dir=`cd $(dirname $BASH_SOURCE[0]); pwd`


### PR DESCRIPTION
**Description**<!--Mandatory-->

Pin `setuptools` to `58.4.0`.

`setuptools` `58.5.2` introduced an _unexpected_ breaking change, making all custom `build_py` subclasses to fail:

https://github.com/Azure/azure-cli/blob/1cf3072bb2e3af3db4f9b3dffc575c7e2c46efc9/src/azure-cli/azure_cli_bdist_wheel.py#L10-L20

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1178162&view=logs&jobId=e725b3e9-648f-510f-a0a1-f18bdc151d12&j=e725b3e9-648f-510f-a0a1-f18bdc151d12&t=7dda8e6e-5520-5cbf-e881-69c151aecb23

<details>
<summary>Full call stack</summary>

```
2021-11-04T03:23:41.8710919Z Traceback (most recent call last):
2021-11-04T03:23:41.8711856Z   File "/home/vsts/work/1/s/src/azure-cli/setup.py", line 160, in <module>
2021-11-04T03:23:41.8712337Z     setup(
2021-11-04T03:23:41.8713101Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/setuptools/__init__.py", line 159, in setup
2021-11-04T03:23:41.8713849Z     return distutils.core.setup(**attrs)
2021-11-04T03:23:41.8714381Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/core.py", line 148, in setup
2021-11-04T03:23:42.0792338Z     dist.run_commands()
2021-11-04T03:23:42.0793141Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/dist.py", line 966, in run_commands
2021-11-04T03:23:42.1846501Z     self.run_command(cmd)
2021-11-04T03:23:42.1847638Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/dist.py", line 985, in run_command
2021-11-04T03:23:42.1848465Z     cmd_obj.run()
2021-11-04T03:23:42.1849964Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/wheel/bdist_wheel.py", line 335, in run
2021-11-04T03:23:42.1850889Z     self.run_command('install')
2021-11-04T03:23:42.1851397Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/cmd.py", line 313, in run_command
2021-11-04T03:23:42.2316182Z     self.distribution.run_command(command)
2021-11-04T03:23:42.2317514Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/dist.py", line 985, in run_command
2021-11-04T03:23:42.2320510Z     cmd_obj.run()
2021-11-04T03:23:42.2321832Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/setuptools/command/install.py", line 68, in run
2021-11-04T03:23:42.2322583Z     return orig.install.run(self)
2021-11-04T03:23:42.2323717Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/command/install.py", line 558, in run
2021-11-04T03:23:42.2335935Z     self.run_command(cmd_name)
2021-11-04T03:23:42.2336648Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/cmd.py", line 313, in run_command
2021-11-04T03:23:42.2337157Z     self.distribution.run_command(command)
2021-11-04T03:23:42.2337636Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/dist.py", line 985, in run_command
2021-11-04T03:23:42.2338089Z     cmd_obj.run()
2021-11-04T03:23:42.2349505Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/setuptools/command/install_egg_info.py", line 34, in run
2021-11-04T03:23:42.2350417Z     self.run_command('egg_info')
2021-11-04T03:23:42.2350922Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/cmd.py", line 313, in run_command
2021-11-04T03:23:42.2351403Z     self.distribution.run_command(command)
2021-11-04T03:23:42.2351893Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/dist.py", line 985, in run_command
2021-11-04T03:23:42.2357369Z     cmd_obj.run()
2021-11-04T03:23:42.2358817Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 299, in run
2021-11-04T03:23:42.2359947Z     self.find_sources()
2021-11-04T03:23:42.2361214Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 306, in find_sources
2021-11-04T03:23:42.2362230Z     mm.run()
2021-11-04T03:23:42.2363085Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 541, in run
2021-11-04T03:23:42.2364084Z     self.add_defaults()
2021-11-04T03:23:42.2364807Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 578, in add_defaults
2021-11-04T03:23:42.2365253Z     sdist.add_defaults(self)
2021-11-04T03:23:42.2365673Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/command/sdist.py", line 226, in add_defaults
2021-11-04T03:23:42.2366081Z     self._add_defaults_python()
2021-11-04T03:23:42.2366796Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/setuptools/command/sdist.py", line 113, in _add_defaults_python
2021-11-04T03:23:42.2367678Z     self._add_data_files(self._safe_data_files(build_py))
```

</details>

```
2021-11-04T03:23:42.2368540Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 621, in _safe_data_files
2021-11-04T03:23:42.2369747Z     return build_py.get_data_files_without_manifest()
2021-11-04T03:23:42.2370277Z   File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/distutils/cmd.py", line 103, in __getattr__
2021-11-04T03:23:42.2370751Z     raise AttributeError(attr)
2021-11-04T03:23:42.2374899Z AttributeError: get_data_files_without_manifest
```


This issue has been reported to `setuptools` at https://github.com/pypa/setuptools/issues/2849
