### PR TITLE
[Core] Support managed identity in App Service container

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/adal_authentication.py
@@ -15,6 +15,7 @@ logger = get_logger(__name__)
 
 class MSIAuthenticationWrapper(MSIAuthentication):
     # This method is exposed for Azure Core. Add *scopes, **kwargs to fit azure.core requirement
+    # pylint: disable=line-too-long
     def get_token(self, *scopes, **kwargs):  # pylint:disable=unused-argument
         logger.debug("MSIAuthenticationWrapper.get_token invoked by Track 2 SDK with scopes=%s", scopes)
 
@@ -27,7 +28,8 @@ class MSIAuthenticationWrapper(MSIAuthentication):
             # If available, use resource provided by SDK
             self.resource = resource
         self.set_token()
-        # Managed Identity token entry sample:
+        # VM managed identity endpoint 2018-02-01 token entry sample:
+        # curl "http://169.254.169.254:80/metadata/identity/oauth2/token?resource=https://management.core.windows.net/&api-version=2018-02-01" -H "Metadata: true"
         # {
         #     "access_token": "eyJ0eXAiOiJKV...",
         #     "client_id": "da95e381-d7ab-4fdc-8047-2457909c723b",
@@ -35,10 +37,20 @@ class MSIAuthenticationWrapper(MSIAuthentication):
         #     "expires_on": "1605238724",
         #     "ext_expires_in": "86399",
         #     "not_before": "1605152024",
-        #     "resource": "https://management.azure.com/",
+        #     "resource": "https://management.core.windows.net/",
         #     "token_type": "Bearer"
         # }
-        return AccessToken(self.token['access_token'], int(self.token['expires_on']))
+
+        # App Service managed identity endpoint 2017-09-01 token entry sample:
+        # curl "${MSI_ENDPOINT}?resource=https://management.core.windows.net/&api-version=2017-09-01" -H "secret: ${MSI_SECRET}"
+        # {
+        #     "access_token": "eyJ0eXAiOiJKV...",
+        #     "expires_on":"11/05/2021 15:18:31 +00:00",
+        #     "resource":"https://management.core.windows.net/",
+        #     "token_type":"Bearer",
+        #     "client_id":"df45d93a-de31-47ca-acef-081ca60d1a83"
+        # }
+        return AccessToken(self.token['access_token'], _normalize_expires_on(self.token['expires_on']))
 
     def set_token(self):
         import traceback
@@ -69,3 +81,20 @@ class MSIAuthenticationWrapper(MSIAuthentication):
     def signed_session(self, session=None):
         logger.debug("MSIAuthenticationWrapper.signed_session invoked by Track 1 SDK")
         super().signed_session(session)
+
+
+def _normalize_expires_on(expires_on):
+    """
+    The expires_on field returned by managed identity differs on Azure VM (epoch str) and App Service (datetime str).
+    Normalize to epoch int.
+    """
+    try:
+        # Treat as epoch string "1605238724"
+        expires_on_epoch_int = int(expires_on)
+    except ValueError:
+        import datetime
+        # Treat as datetime string "11/05/2021 15:18:31 +00:00"
+        expires_on_epoch_int = int(datetime.datetime.strptime(expires_on, '%m/%d/%Y %H:%M:%S %z').timestamp())
+
+    logger.debug("Normalize expires_on: %r -> %r", expires_on, expires_on_epoch_int)
+    return expires_on_epoch_int

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_adal_authentication.py
@@ -1,0 +1,22 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import os
+import re
+import unittest
+from unittest import mock
+
+from azure.cli.core.auth.adal_authentication import _normalize_expires_on
+from knack.util import CLIError
+
+
+class TestUtil(unittest.TestCase):
+    def test_normalize_expires_on(self):
+        assert _normalize_expires_on("11/05/2021 15:18:31 +00:00") == 1636125511
+        assert _normalize_expires_on('1636125511') == 1636125511
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/azure-cli-core/azure/cli/core/auth/tests/test_adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/tests/test_adal_authentication.py
@@ -3,13 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import os
-import re
 import unittest
-from unittest import mock
 
 from azure.cli.core.auth.adal_authentication import _normalize_expires_on
-from knack.util import CLIError
 
 
 class TestUtil(unittest.TestCase):


### PR DESCRIPTION
## Description

- Close https://github.com/Azure/azure-cli/issues/19480
- Close https://github.com/Azure/azure-cli/issues/20196
- Close https://github.com/Azure/azure-cli/issues/20186

For more details, see https://github.com/Azure/azure-cli/issues/19480#issuecomment-961197625

`msrestazure` still uses `2017-09-01` for [managed identity in App Service container](https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=powershell#rest-protocol-examples). The returned `expires_on` is a datetime string like `"11/05/2021 15:18:31 +00:00"`. This differs from `expires_on` returned by [managed identity on Azure VM](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token):

- epoch in str (VM managed identity endpoint 2018-02-01): `"1605238724"`
- datetime in Month/Day/Year str with timezone (App service managed identity endpoint 2017-09-01): `"11/05/2021 15:18:31 +00:00"`

As it is not possible to update `msrestazure` to use the latest `2019-08-01` managed identity endpoint, because `msrestazure` has been out of maintenance. Azure CLI needs to be able to handle such inconsistency in order to support managed identity in App Service container.

## Testing Guide

1. In Azure Portal, create an app service with "quickstart" docker image `mcr.microsoft.com/appsvc/staticsite:latest`
2. Configure system assigned identity for the app service
3. Follow the doc to SSH into the container: https://docs.microsoft.com/en-us/azure/app-service/configure-linux-open-ssh-session

```
az webapp create-remote-connection --subscription 0b1f6471-1bf0-4dda-aec3-cb9272f09590 --resource-group mytest1 -n myweb2

ssh root@127.0.0.1 -p 43147

apt install git
git clone https://github.com/jiasli/azure-cli --branch webapp-mi --depth 1
apt-get install python3-venv
python3 -m venv py
. py/bin/activate
pip install -U pip
pip install azdev
azdev setup -c
az login --identity --debug
```

