### PR TITLE
{Packaging} Adapt to latest setuptools

### DIFF
--- a/scripts/release/pypi/build.sh
+++ b/scripts/release/pypi/build.sh
@@ -17,7 +17,7 @@ echo "Branch $branch"
 echo "Search setup files from `pwd`."
 python --version
 
-pip install -U pip setuptools==58.4.0 wheel
+pip install -U pip setuptools wheel
 pip list
 
 script_dir=`cd $(dirname $BASH_SOURCE[0]); pwd`

--- a/src/azure-cli/azure_cli_bdist_wheel.py
+++ b/src/azure-cli/azure_cli_bdist_wheel.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from distutils.command.build_py import build_py
+from setuptools.command.build_py import build_py
 
 
 class azure_cli_build_py(build_py):

--- a/src/azure-cli/setup.cfg
+++ b/src/azure-cli/setup.cfg
@@ -1,2 +1,2 @@
 [build_py]
-extra-build-source-files=azure.cli,__main__,azure/cli/__main__.py
+extra_build_source_files=azure.cli,__main__,azure/cli/__main__.py


### PR DESCRIPTION
**Description**<!--Mandatory-->

https://github.com/Azure/azure-cli/pull/20194 pinned `setuptools` to temporarily workaround https://github.com/pypa/setuptools/issues/2849.

As `setuptools` has been fixed by https://github.com/pypa/setuptools/pull/2855, we can use its latest verision.

As indicated by 

https://docs.python.org/3/library/distutils.html

> distutils is deprecated

https://github.com/pypa/setuptools/pull/2855/files#diff-93769fd2dda9046fec77cc3efa634577aac30dd7dce9ef40c48783d1a54aef1fR624-R627

```
            "Custom 'build_py' does not implement "
            "'get_data_files_without_manifest'.\nPlease extend command classes"
            " from setuptools instead of distutils."
```

we make `azure_cli_build_py` inherit from the new `setuptools.command.build_py.build_py`.
