### PR TITLE
{Pylint} Fix `consider-using-from-import`

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -37,7 +37,6 @@ disable=
     wrong-import-order,
     consider-using-f-string,
     unspecified-encoding,
-    consider-using-from-import,
     use-maxsplit-arg,
     arguments-renamed,
     consider-using-in,

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -107,7 +107,7 @@ class AzCli(CLI):
         self.data['headers']['x-ms-client-request-id'] = str(uuid.uuid1())
 
     def get_progress_controller(self, det=False, spinner=None):
-        import azure.cli.core.commands.progress as progress
+        from azure.cli.core.commands import progress
         if not self.progress_controller:
             self.progress_controller = progress.ProgressHook()
 
@@ -279,7 +279,7 @@ class MainCommandsLoader(CLICommandsLoader):
                 except Exception as ex:  # pylint: disable=broad-except
                     # Changing this error message requires updating CI script that checks for failed
                     # module loading.
-                    import azure.cli.core.telemetry as telemetry
+                    from azure.cli.core import telemetry
                     logger.error("Error loading command module '%s': %s", mod, ex)
                     telemetry.set_exception(exception=ex, fault_type='module-load-error-' + mod,
                                             summary='Error loading module: {}'.format(mod))

--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -5,7 +5,7 @@
 
 import sys
 
-import azure.cli.core.telemetry as telemetry
+from azure.cli.core import telemetry
 from knack.util import CLIError
 from knack.log import get_logger
 

--- a/src/azure-cli-core/azure/cli/core/command_recommender.py
+++ b/src/azure-cli-core/azure/cli/core/command_recommender.py
@@ -5,7 +5,7 @@
 
 from enum import Enum
 
-import azure.cli.core.telemetry as telemetry
+from azure.cli.core import telemetry
 from knack.log import get_logger
 
 

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -26,7 +26,7 @@ from azure.cli.core.extension import get_extension
 from azure.cli.core.util import (
     get_command_type_kwarg, read_file_content, get_arg_list, poller_classes)
 from azure.cli.core.local_context import LocalContextAction
-import azure.cli.core.telemetry as telemetry
+from azure.cli.core import telemetry
 from azure.cli.core.commands.progress import IndeterminateProgressBar
 
 from knack.arguments import CLICommandArgument

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -115,7 +115,7 @@ def handle_template_based_exception(ex):
 
 
 def handle_long_running_operation_exception(ex):
-    import azure.cli.core.telemetry as telemetry
+    from azure.cli.core import telemetry
 
     telemetry.set_exception(
         ex,

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import azure.cli.core._debug as _debug
+from azure.cli.core import _debug
 from azure.cli.core.auth.util import resource_to_scopes
 from azure.cli.core.extension import EXTENSIONS_MOD_PREFIX
 from azure.cli.core.profiles import ResourceType, CustomResourceType, get_api_version, get_sdk

--- a/src/azure-cli-core/azure/cli/core/commands/transform.py
+++ b/src/azure-cli-core/azure/cli/core/commands/transform.py
@@ -7,7 +7,7 @@ import re
 
 from azure.cli.core.util import b64_to_hex
 
-import knack.events as events
+from knack import events
 
 
 def register_global_transforms(cli_ctx):

--- a/src/azure-cli-core/azure/cli/core/extension/dynamic_install.py
+++ b/src/azure-cli-core/azure/cli/core/extension/dynamic_install.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import azure.cli.core.telemetry as telemetry
+from azure.cli.core import telemetry
 from azure.cli.core.commands import AzCliCommandInvoker
 from azure.cli.core.azclierror import CommandNotFoundError
 from knack.log import get_logger

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -8,7 +8,7 @@ import difflib
 import argparse
 import argcomplete
 
-import azure.cli.core.telemetry as telemetry
+from azure.cli.core import telemetry
 from azure.cli.core.extension import get_extension
 from azure.cli.core.commands import ExtensionCommandSource
 from azure.cli.core.commands import AzCliCommandInvoker

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -15,7 +15,7 @@ import uuid
 from collections import defaultdict
 from functools import wraps
 from knack.util import CLIError
-import azure.cli.core.decorators as decorators
+from azure.cli.core import decorators
 
 PRODUCT_NAME = 'azurecli'
 TELEMETRY_VERSION = '0.0.1.4'

--- a/src/azure-cli-core/azure/cli/core/tests/test_telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_telemetry.py
@@ -42,7 +42,7 @@ class TestCoreTelemetry(unittest.TestCase):
 
     def test_cloud_forbid_telemetry(self):
         from unittest import mock
-        import azure.cli.core.telemetry as telemetry
+        from azure.cli.core import telemetry
         from azure.cli.core.mock import DummyCli
         from knack.completion import ARGCOMPLETE_ENV_NAME
 

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -60,7 +60,7 @@ def handle_exception(ex):  # pylint: disable=too-many-locals, too-many-statement
     from azure.common import AzureException
     from azure.core.exceptions import AzureError
     from requests.exceptions import SSLError, HTTPError
-    import azure.cli.core.azclierror as azclierror
+    from azure.cli.core import azclierror
     import traceback
 
     logger.debug("azure.cli.core.util.handle_exception is called with an exception:")
@@ -185,8 +185,8 @@ def extract_http_operation_error(ex):
 
 
 def get_error_type_by_azure_error(ex):
-    import azure.core.exceptions as exceptions
-    import azure.cli.core.azclierror as azclierror
+    from azure.core import exceptions
+    from azure.cli.core import azclierror
 
     if isinstance(ex, exceptions.HttpResponseError):
         status_code = str(ex.status_code)
@@ -205,7 +205,7 @@ def get_error_type_by_azure_error(ex):
 
 # pylint: disable=too-many-return-statements
 def get_error_type_by_status_code(status_code):
-    import azure.cli.core.azclierror as azclierror
+    from azure.cli.core import azclierror
 
     if status_code == '400':
         return azclierror.BadRequestError

--- a/src/azure-cli/azure/cli/__main__.py
+++ b/src/azure-cli/azure/cli/__main__.py
@@ -11,7 +11,7 @@ start_time = timeit.default_timer()
 import sys
 import uuid
 
-import azure.cli.core.telemetry as telemetry
+from azure.cli.core import telemetry
 from azure.cli.core import get_default_cli
 from knack.completion import ARGCOMPLETE_ENV_NAME
 from knack.log import get_logger

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -18,7 +18,7 @@ from azure.cli.core.profiles import ResourceType
 from azure.cli.core.commands.validators import validate_tag
 from azure.cli.core.util import CLIError
 from azure.cli.core.azclierror import InvalidArgumentValueError
-import azure.cli.core.keys as keys
+from azure.cli.core import keys
 
 
 logger = get_logger(__name__)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
@@ -3,11 +3,11 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import azure.cli.command_modules.backup.custom as custom
-import azure.cli.command_modules.backup.custom_afs as custom_afs
-import azure.cli.command_modules.backup.custom_help as custom_help
+from azure.cli.command_modules.backup import custom
+from azure.cli.command_modules.backup import custom_afs
+from azure.cli.command_modules.backup import custom_help
 import azure.cli.command_modules.backup.custom_common as common
-import azure.cli.command_modules.backup.custom_wl as custom_wl
+from azure.cli.command_modules.backup import custom_wl
 from azure.cli.command_modules.backup._client_factory import protection_policies_cf, backup_protected_items_cf, \
     backup_protection_containers_cf, backup_protectable_items_cf
 from azure.cli.core.azclierror import ValidationError, RequiredArgumentMissingError, InvalidArgumentValueError, \

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_common.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 
-import azure.cli.command_modules.backup.custom_help as custom_help
+from azure.cli.command_modules.backup import custom_help
 from azure.cli.command_modules.backup._client_factory import backup_protected_items_cf, \
     protection_containers_cf, protected_items_cf, backup_protected_items_crr_cf, recovery_points_crr_cf
 from azure.cli.core.util import CLIError

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
@@ -31,7 +31,7 @@ from azure.cli.command_modules.backup._client_factory import backup_workload_ite
 
 import azure.cli.command_modules.backup.custom_help as cust_help
 import azure.cli.command_modules.backup.custom_common as common
-import azure.cli.command_modules.backup.custom as custom
+from azure.cli.command_modules.backup import custom
 from azure.cli.core.azclierror import InvalidArgumentValueError, RequiredArgumentMissingError, ValidationError, \
     ResourceNotFoundError, ArgumentUsageError, MutuallyExclusiveArgumentError
 

--- a/src/azure-cli/azure/cli/command_modules/batchai/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/batchai/custom.py
@@ -32,7 +32,7 @@ from azure.cli.core.util import get_default_admin_username
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.profiles import ResourceType, get_sdk
 from azure.core.exceptions import ResourceNotFoundError
-import azure.mgmt.batchai.models as models
+from azure.mgmt.batchai import models
 
 # Environment variables for specifying azure storage account and key. We want the user to make explicit
 # decision about which storage account to use instead of using his default account specified via AZURE_STORAGE_ACCOUNT

--- a/src/azure-cli/azure/cli/command_modules/config/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/config/custom.py
@@ -8,7 +8,7 @@ from knack.util import CLIError
 
 from azure.cli.core.util import ScopedConfig
 
-import azure.cli.core.telemetry as telemetry
+from azure.cli.core import telemetry
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli/azure/cli/command_modules/util/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/util/custom.py
@@ -38,7 +38,7 @@ def upgrade_version(cmd, update_all=None, yes=None):  # pylint: disable=too-many
     import platform
     import sys
     import subprocess
-    import azure.cli.core.telemetry as telemetry
+    from azure.cli.core import telemetry
     from azure.cli.core import __version__ as local_version
     from azure.cli.core._environment import _ENV_AZ_INSTALLER
     from azure.cli.core.extension import get_extensions, WheelExtension

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -22,7 +22,7 @@ from azure.cli.core.util import (hash_string, DISALLOWED_USER_NAMES, get_default
 from azure.cli.command_modules.vm._vm_utils import (
     check_existence, get_target_network_api, get_storage_blob_uri, list_sku_info)
 from azure.cli.command_modules.vm._template_builder import StorageProfile
-import azure.cli.core.keys as keys
+from azure.cli.core import keys
 from azure.core.exceptions import ResourceNotFoundError
 
 from ._client_factory import _compute_client_factory


### PR DESCRIPTION
**Description**<!--Mandatory-->

Part of https://github.com/Azure/azure-cli/pull/20192

Fix linter error `R0402`:

```
R0402: Use 'from azure.cli.core import telemetry' instead (consider-using-from-import)
```

https://pylint.pycqa.org/en/latest/technical_reference/features.html#imports-checker-messages

> consider-using-from-import (R0402)
> Use 'from %s import %s' instead Emitted when a submodule of a package is imported and aliased with the same name. E.g., instead of `import concurrent.futures as futures` use `from concurrent import futures`

