### PR TITLE
{Pylint} Fix `use-list-literal`

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -45,7 +45,6 @@ disable=
     consider-using-dict-items,
     consider-using-enumerate,
     redundant-u-string-prefix,
-    use-list-literal,
     raising-bad-type,
     unused-private-member,
     used-before-assignment

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -849,7 +849,7 @@ def _list_app(cli_ctx, resource_group_name=None):
 def _list_deleted_app(cli_ctx, resource_group_name=None, name=None, slot=None):
     client = web_client_factory(cli_ctx)
     locations = _get_deleted_apps_locations(cli_ctx)
-    result = list()
+    result = []
     for location in locations:
         result = result + list(client.deleted_web_apps.list_by_location(location))
     if resource_group_name:

--- a/src/azure-cli/azure/cli/command_modules/cdn/tests/latest/test_afd_security_policy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/cdn/tests/latest/test_afd_security_policy_scenarios.py
@@ -41,7 +41,7 @@ class CdnAfdSecurityPolicyScenarioTest(CdnAfdScenarioMixin, ScenarioTest):
 
         # Create a security policy
         security_policy_name = self.create_random_name(prefix='security', length=24)
-        domain_ids = list()
+        domain_ids = []
         domain_ids.append(f'/subscriptions/{self.get_subscription_id()}/resourcegroups/{resource_group}/providers/Microsoft.Cdn/profiles/{profile_name}/afdEndpoints/{endpoint1_name}')
         domain_ids.append(f'/subscriptions/{self.get_subscription_id()}/resourcegroups/{resource_group}/providers/Microsoft.Cdn/profiles/{profile_name}/afdEndpoints/{endpoint2_name}')
         waf_policy_id = f'/subscriptions/{self.get_subscription_id()}/resourcegroups/CliDevReservedGroup/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/SampleStandard'

--- a/src/azure-cli/azure/cli/command_modules/dla/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/dla/custom.py
@@ -67,7 +67,7 @@ def list_adla_jobs(client, account_name, top=500, name=None, submitter=None, sub
 def create_adla_account(cmd, client, resource_group_name, account_name, default_data_lake_store, location=None,
                         tags=None, max_degree_of_parallelism=30, max_job_count=3, query_store_retention=30, tier=None):
     from azure.mgmt.datalake.analytics.account.models import DataLakeAnalyticsAccount, DataLakeStoreAccountInfo
-    adls_list = list()
+    adls_list = []
     adls_list.append(DataLakeStoreAccountInfo(default_data_lake_store))
     location = location or _get_resource_group_location(cmd.cli_ctx, resource_group_name)
     create_params = DataLakeAnalyticsAccount(location,

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
@@ -76,7 +76,7 @@ class BaseScenarioTests(ScenarioTest):
         self.check(result, True)
 
     def _Create_PrivateZones(self, numOfZones=2):
-        createdZones = list()
+        createdZones = []
         for num in range(numOfZones):
             createdZones.append(self._Create_PrivateZone())
         createdZones.sort(key=lambda x: x['name'])
@@ -113,7 +113,7 @@ class BaseScenarioTests(ScenarioTest):
 
     def _Create_VirtualNetworkLinks(self, numOfLinks=2):
         self._Create_PrivateZone()
-        createdLinks = list()
+        createdLinks = []
         for num in range(numOfLinks):
             createdLinks.append(
                 self._Create_VirtualNetworkLink(createZone=False))

--- a/src/azure-cli/azure/cli/command_modules/security/actions.py
+++ b/src/azure-cli/azure/cli/command_modules/security/actions.py
@@ -50,7 +50,7 @@ class _AppendToDictionaryAction(argparse.Action):
         if key in items:
             items[key].append(value)
         else:
-            items[key] = list()
+            items[key] = []
             items[key].append(value)
         setattr(namespace, self.dest, items)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -1244,7 +1244,7 @@ def services_type(loader):
 
 def get_char_options_validator(types, property_name):
     def _validator(namespace):
-        service_types = set(getattr(namespace, property_name, list()))
+        service_types = set(getattr(namespace, property_name, []))
 
         if not service_types:
             raise ValueError('Missing options --{}.'.format(property_name.replace('_', '-')))

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
@@ -1030,7 +1030,7 @@ def services_type(loader):
 
 def get_char_options_validator(types, property_name):
     def _validator(namespace):
-        service_types = set(getattr(namespace, property_name, list()))
+        service_types = set(getattr(namespace, property_name, []))
 
         if not service_types:
             raise ValueError('Missing options --{}.'.format(property_name.replace('_', '-')))


### PR DESCRIPTION
**Description**<!--Mandatory-->

Part of https://github.com/Azure/azure-cli/pull/20192

Fix linter error `R1734`:

```
R1734: Consider using [] instead of list() (use-list-literal)
```

https://pylint.pycqa.org/en/latest/technical_reference/features.html#imports-checker-messages

> use-list-literal (R1734)
> Consider using [] instead of list() Emitted when using list() to create an empty list instead of the literal []. **The literal is faster as it avoids an additional function call.**

