### PR TITLE
{packaging} Update argcomplete to 1.12.3

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -43,7 +43,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'argcomplete~=1.8',
+    'argcomplete~=1.12',
     'azure-cli-telemetry==1.0.6.*',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.9
-argcomplete==1.11.1
+argcomplete==1.12.3
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==11.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.9
-argcomplete==1.11.1
+argcomplete==1.12.3
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==11.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.7.2
 applicationinsights==0.11.7
-argcomplete==1.11.1
+argcomplete==1.12.3
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==11.0.0


### PR DESCRIPTION
**Description**<!--Mandatory-->
Packaging azure-cli on Fedora requires patches since Fedora offers
argcomplete 1.12.3. Bump the version number to the latest argcomplete
release.

**Testing Guide**
Existing tests should continue working.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
