### PR TITLE
[App Service] `az appservice` : Fix AttributeError during user error handling

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -816,8 +816,9 @@ def _show_app(cmd, resource_group_name, name, cmd_app_type, slot=None):
     app_type = _kind_to_app_type(app.kind) if app else None
     if app_type != cmd_app_type:
         raise ResourceNotFoundError(
-            "Unable to find {} '{}', in RG '{}'".format(cmd_app_type.value, name, resource_group_name),
-            "Use 'az {} show' to show {}s".format(app_type.value, app_type.value))
+            "Unable to find {app_type} '{name}', in resource group '{resource_group}'".format(
+                app_type=cmd_app_type, name=name, resource_group=resource_group_name),
+            "Use 'az {app_type} show' to show {app_type}s".format(app_type=app_type))
     app.site_config = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get_configuration', slot)
     _rename_server_farm_props(app)
     _fill_ftp_publishing_url(cmd, app, resource_group_name, name, slot)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Upon deploying a Function App through the CLI, when the user specifies incorrect parameters, instead of printing a helpful error message the CLI triggers a stack trace because of an AttributeError. This pull request fixes this error.

**Testing Guide**

Deploy a new Function App as shown below.

```
$ az functionapp deployment source config-zip -g myresourcegroup -n myfunctionapp --src sourcecode.zip --build-remote true                                                                                                                   
Getting scm site credentials for zip deployment
The command failed with an unexpected error. Here is the traceback:
'str' object has no attribute 'value'
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/knack/cli.py", line 231, in invoke
    cmd_result = self.invocation.execute(args)
  File "/usr/lib/python3.8/site-packages/azure/cli/core/commands/__init__.py", line 657, in execute
    raise ex
  File "/usr/lib/python3.8/site-packages/azure/cli/core/commands/__init__.py", line 720, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/usr/lib/python3.8/site-packages/azure/cli/core/commands/__init__.py", line 691, in _run_job
    result = cmd_copy(params)
  File "/usr/lib/python3.8/site-packages/azure/cli/core/commands/__init__.py", line 328, in __call__
    return self.handler(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
    return op(**command_args)
  File "/usr/lib/python3.8/site-packages/azure/cli/command_modules/appservice/custom.py", line 405, in enable_zip_deploy_functionapp
    return enable_zip_deploy(cmd, resource_group_name, name, src, timeout, slot)
  File "/usr/lib/python3.8/site-packages/azure/cli/command_modules/appservice/custom.py", line 417, in enable_zip_deploy
    scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
  File "/usr/lib/python3.8/site-packages/azure/cli/command_modules/appservice/custom.py", line 1948, in _get_scm_url
    webapp = show_webapp(cmd, resource_group_name, name, slot=slot)
  File "/usr/lib/python3.8/site-packages/azure/cli/command_modules/appservice/custom.py", line 607, in show_webapp
    return _show_app(cmd, resource_group_name, name, "webapp", slot)
  File "/usr/lib/python3.8/site-packages/azure/cli/command_modules/appservice/custom.py", line 737, in _show_app
    "Use 'az {} show' to show {}s".format(app_type, app_type.value))
AttributeError: 'str' object has no attribute 'value'
To open an issue, please run: 'az feedback'
```

Instead of printing a helpful error message, the traceback shows no indication of the user's error. After applying this pull request, the user-friendly error message is correctly printed (see below).

```
$ az functionapp deployment source config-zip -g myresourcegroup -n myfunctionapp --src sourcecode.zip --build-remote true                                                                                                                   
Getting scm site credentials for zip deployment
Unable to find webapp 'myfunctionapp', in RG 'myresourcegroup'
Use 'az functionapp show' to show functionapps
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
