### PR TITLE
{CI} Use Python 3.10 as the default and disable Python 3.9 tests

### DIFF
--- a/azure-pipelines-full-tests.yml
+++ b/azure-pipelines-full-tests.yml
@@ -24,8 +24,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -46,8 +46,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -68,8 +68,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -90,8 +90,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,9 +120,9 @@ jobs:
 
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3'
+    displayName: 'Use Python 3.10'
     inputs:
-      versionSpec: 3.9
+      versionSpec: 3.10
 
   - task: BatchScript@1
     inputs:
@@ -137,9 +137,9 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.9'
+    displayName: 'Use Python 3.10'
     inputs:
-      versionSpec: 3.9
+      versionSpec: 3.10
   - template: .azure-pipelines/templates/azdev_setup.yml
   - bash: |
       set -ev
@@ -306,9 +306,9 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.9'
+    displayName: 'Use Python 3.10'
     inputs:
-      versionSpec: 3.9
+      versionSpec: 3.10
 
 
   - script: |
@@ -375,10 +375,10 @@ jobs:
          --rm -v $PYPI_FILES:/mnt/pypi python:3.8 \
          /bin/bash -c "ls /mnt/pypi && pip install -f /mnt/pypi -q azure-cli==$CLI_VERSION.* && az self-test && az --version && sleep 5"
 
-       echo "== Testing pip install on Python 3.9 =="
-       docker run \
-         --rm -v $PYPI_FILES:/mnt/pypi python:3.9 \
-         /bin/bash -c "ls /mnt/pypi && pip install -f /mnt/pypi -q azure-cli==$CLI_VERSION.* && az self-test && az --version && sleep 5"
+       # echo "== Testing pip install on Python 3.9 =="
+       # docker run \
+       #   --rm -v $PYPI_FILES:/mnt/pypi python:3.9 \
+       #   /bin/bash -c "ls /mnt/pypi && pip install -f /mnt/pypi -q azure-cli==$CLI_VERSION.* && az self-test && az --version && sleep 5"
 
        echo "== Testing pip install on Python 3.10 =="
        docker run \
@@ -398,8 +398,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -419,8 +419,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -443,8 +443,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -468,8 +468,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -489,8 +489,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -510,8 +510,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -531,8 +531,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -595,7 +595,7 @@ jobs:
                   -e CLI_VERSION=$CLI_VERSION \
                   -e HOMEBREW_UPSTREAM_URL=$HOMEBREW_UPSTREAM_URL \
                   --name azurecli \
-                  python:3.9 \
+                  python:3.10 \
                   /mnt/scripts/run.sh
 
        # clean up
@@ -843,9 +843,9 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.9'
+    displayName: 'Use Python 3.10'
     inputs:
-      versionSpec: 3.9
+      versionSpec: 3.10
   - template: .azure-pipelines/templates/azdev_setup.yml
   - bash: |
       set -ev
@@ -859,9 +859,9 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.9'
+    displayName: 'Use Python 3.10'
     inputs:
-      versionSpec: 3.9
+      versionSpec: 3.10
   - template: .azure-pipelines/templates/azdev_setup.yml
   - bash: |
       set -ev
@@ -878,8 +878,10 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
+      Python310:
+        python.version: '3.10'
   pool:
     vmImage: 'ubuntu-20.04'
   steps:
@@ -907,9 +909,9 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.9'
+    displayName: 'Use Python 3.10'
     inputs:
-      versionSpec: 3.9
+      versionSpec: 3.10
   - template: .azure-pipelines/templates/azdev_setup.yml
   - bash: |
       set -ev
@@ -927,9 +929,9 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
     - task: UsePythonVersion@0
-      displayName: 'Use Python 3.9'
+      displayName: 'Use Python 3.10'
       inputs:
-        versionSpec: 3.9
+        versionSpec: 3.10
     - bash: pip install --upgrade pip wheel
       displayName: "Install pip and wheel"
     - bash: ./scripts/ci/test_ref_doc.sh


### PR DESCRIPTION
## Description

Python 3.9.8 introduced an unexpected breaking change (https://github.com/python/cpython/pull/28420) that breaks Azure CLI:

- https://github.com/Azure/azure-cli/issues/20269

According to https://bugs.python.org/issue45235, this change will be reverted on 3.9 and withdrawn from future releases for other version like 3.7, 3.8, 3.10.

Azure Pipeline now only has Python 3.9.8, but not old versions like 3.9.7:

- https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/use-python-version
- https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#python
    > #### Python
    > - ...
    > - 3.9.8
    > - 3.10.0

Even if Python releases 3.9.9 which reverts this change, it will take Azure Pipeline weeks to take that version.

To unblock our development and PRs from being merged, we have to use Python 3.10 as the default (thanks to the timely support for Python 3.10 (https://github.com/Azure/azure-cli/issues/19857))  and disable Python 3.9 tests.
