### PR TITLE
[Network] Fix #20289: `az network bastion create` invalid validator when `--scale-units` is None

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -744,7 +744,7 @@ def validate_private_dns_zone(cmd, namespace):
 def validate_scale_unit_ranges(namespace):
     unit_num = namespace.scale_units
     err_msg = "The number of --scale-units should in range [2, 50]."
-    if unit_num < 2 or unit_num > 50:
+    if unit_num and (unit_num < 2 or unit_num > 50):
         raise InvalidArgumentValueError(err_msg)
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -744,7 +744,7 @@ def validate_private_dns_zone(cmd, namespace):
 def validate_scale_unit_ranges(namespace):
     unit_num = namespace.scale_units
     err_msg = "The number of --scale-units should in range [2, 50]."
-    if unit_num != None and (unit_num < 2 or unit_num > 50):
+    if unit_num is not None and (unit_num < 2 or unit_num > 50):
         raise InvalidArgumentValueError(err_msg)
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_validators.py
@@ -744,7 +744,7 @@ def validate_private_dns_zone(cmd, namespace):
 def validate_scale_unit_ranges(namespace):
     unit_num = namespace.scale_units
     err_msg = "The number of --scale-units should in range [2, 50]."
-    if unit_num and (unit_num < 2 or unit_num > 50):
+    if unit_num != None and (unit_num < 2 or unit_num > 50):
         raise InvalidArgumentValueError(err_msg)
 
 


### PR DESCRIPTION
> Closed https://github.com/Azure/azure-cli/issues/20289

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix invalid validator when `--scale-units` is None.

**Testing Guide**
<!--Example commands with explanations.-->
```
$ az network bastion create --location {} --name {} --public-ip-address {} --resource-group {} --vnet-name {}
```
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
