### PR TITLE
[Profile] `az logout`, `az account clear`: Remove ADAL token cache file `accessTokens.json`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import os
+
 from knack.log import get_logger
 from knack.prompting import prompt_pass, NoTTYException
 from knack.util import CLIError
@@ -97,6 +99,8 @@ def set_active_subscription(cmd, subscription):
 
 def account_clear(cmd):
     """Clear all stored subscriptions. To clear individual, use 'logout'"""
+    _remove_adal_token_cache()
+
     if in_cloud_console():
         logger.warning(_CLOUD_CONSOLE_LOGOUT_WARNING)
     profile = Profile(cli_ctx=cmd.cli_ctx)
@@ -160,6 +164,8 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
 
 def logout(cmd, username=None):
     """Log out to remove access to Azure subscriptions"""
+    _remove_adal_token_cache()
+
     if in_cloud_console():
         logger.warning(_CLOUD_CONSOLE_LOGOUT_WARNING)
 
@@ -204,3 +210,18 @@ def check_cli(cmd):
         print('CLI self-test completed: OK')
     else:
         raise CLIError(exceptions)
+
+
+def _remove_adal_token_cache():
+    """Remove ADAL token cache file ~/.azure/accessTokens.json, as it is no longer needed by MSAL-based Azure CLI.
+    """
+    from azure.cli.core._environment import get_config_dir
+    adal_token_cache = os.path.join(get_config_dir(), 'accessTokens.json')
+    try:
+        os.remove(adal_token_cache)
+        logger.warning("ADAL token cache '%s' has been deleted. `az login` no longer generates this file. "
+                       "For more details, see https://docs.microsoft.com/cli/azure/msal-based-azure-cli",
+                       adal_token_cache)
+        return True  # Deleted
+    except FileNotFoundError:
+        return False  # Not exist

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -219,9 +219,6 @@ def _remove_adal_token_cache():
     adal_token_cache = os.path.join(get_config_dir(), 'accessTokens.json')
     try:
         os.remove(adal_token_cache)
-        logger.warning("ADAL token cache '%s' has been deleted. `az login` no longer generates this file. "
-                       "For more details, see https://docs.microsoft.com/cli/azure/msal-based-azure-cli",
-                       adal_token_cache)
         return True  # Deleted
     except FileNotFoundError:
         return False  # Not exist

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -159,6 +159,7 @@ class ProfileCommandTest(unittest.TestCase):
         logout(cmd, username='user2')
         remove_adal_token_cache_mock.assert_called_once()
         profile_instance.get_current_account_user.assert_not_called()
+        profile_instance.logout.assert_called_with('user2')
 
     @mock.patch('azure.cli.command_modules.profile.custom._remove_adal_token_cache', autospec=True)
     @mock.patch('azure.cli.command_modules.profile.custom.Profile', autospec=True)

--- a/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/tests/latest/test_profile_custom.py
@@ -2,11 +2,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-
+import os
 import unittest
 from unittest import mock
 
-from azure.cli.command_modules.profile.custom import list_subscriptions, get_access_token, login
+from azure.cli.command_modules.profile.custom import (
+    list_subscriptions, get_access_token, login, logout, account_clear, _remove_adal_token_cache)
+
 from azure.cli.core.mock import DummyCli
 from knack.util import CLIError
 
@@ -134,3 +136,51 @@ class ProfileCommandTest(unittest.TestCase):
         namespace.tenant = "non-existing-tenant.onmicrosoft.com"
         with self.assertRaisesRegex(CLIError, 'Failed to resolve tenant'):
             validate_tenant(cmd, namespace)
+
+    @mock.patch('azure.cli.command_modules.profile.custom._remove_adal_token_cache', autospec=True)
+    @mock.patch('azure.cli.command_modules.profile.custom.Profile', autospec=True)
+    def test_logout(self, profile_mock, remove_adal_token_cache_mock):
+        cmd = mock.MagicMock()
+
+        profile_instance = mock.MagicMock()
+        profile_instance.get_current_account_user.return_value = "user1"
+        profile_mock.return_value = profile_instance
+
+        # Log out without username
+        logout(cmd)
+        remove_adal_token_cache_mock.assert_called_once()
+        profile_instance.get_current_account_user.assert_called_once()
+
+        # Reset mock for next test
+        remove_adal_token_cache_mock.reset_mock()
+        profile_instance.get_current_account_user.reset_mock()
+
+        # Log out with username
+        logout(cmd, username='user2')
+        remove_adal_token_cache_mock.assert_called_once()
+        profile_instance.get_current_account_user.assert_not_called()
+
+    @mock.patch('azure.cli.command_modules.profile.custom._remove_adal_token_cache', autospec=True)
+    @mock.patch('azure.cli.command_modules.profile.custom.Profile', autospec=True)
+    def test_account_clear(self, profile_mock, remove_adal_token_cache_mock):
+        cmd = mock.MagicMock()
+
+        profile_instance = mock.MagicMock()
+        profile_mock.return_value = profile_instance
+
+        account_clear(cmd)
+
+        remove_adal_token_cache_mock.assert_called_once()
+        profile_instance.logout_all.assert_called_once()
+
+    def test_remove_adal_token_cache(self):
+        # If accessTokens.json doesn't exist
+        assert not _remove_adal_token_cache()
+
+        # If accessTokens.json exists
+        from azure.cli.core._environment import get_config_dir
+        adal_token_cache = os.path.join(get_config_dir(), 'accessTokens.json')
+        with open(adal_token_cache, 'w') as f:
+            f.write("test_token_cache")
+        assert _remove_adal_token_cache()
+        assert not os.path.exists(adal_token_cache)


### PR DESCRIPTION
**Description**<!--Mandatory-->

After MSAL migration, we don’t actively delete ADAL token cache file `accessTokens.json` because we don’t want automations which rely on this file to be broken.

If `az logout` or `az account clear` is run explicitly, `accessTokens.json` will be deleted.
