### PR TITLE
[App Service] Fix #18468: `az staticwebapp appsettings`: Make set functional

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2447,28 +2447,28 @@ helps['staticwebapp hostname delete'] = """
 
 helps['staticwebapp appsettings'] = """
     type: group
-    short-summary: Manage app settings of Functions of the static app.
+    short-summary: Manage app settings the static app.
 """
 
 helps['staticwebapp appsettings list'] = """
     type: command
-    short-summary: List function app settings of the static app. A function must first be deployed to use this method.
+    short-summary: List app settings of the static app.
     examples:
-    - name: List function app settings of the static app.
+    - name: List app settings of the static app.
       text: az staticwebapp appsettings list -n MyStaticAppName
 """
 
 helps['staticwebapp appsettings set'] = """
     type: command
-    short-summary: Set (replace) function app settings of the static app.
+    short-summary: Add to or change the app settings of the static app.
     examples:
-    - name: Set (replace) function app settings of the static app.
+    - name: Add to or change the app settings of the static app.
       text: az staticwebapp appsettings set -n MyStaticAppName --setting-names key1=val1 key2=val2
 """
 
 helps['staticwebapp appsettings delete'] = """
     type: command
-    short-summary: Delete function app settings with given keys of the static app.
+    short-summary: Delete app settings with given keys of the static app.
     examples:
     - name: Delete given app settings of the static app.
       text: az staticwebapp appsettings delete -n MyStaticAppName --setting-names key1 key2

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -456,9 +456,9 @@ def load_command_table(self, _):
         g.custom_show_command('show', 'show_identity')
 
     with self.command_group('staticwebapp appsettings', custom_command_type=staticsite_sdk) as g:
-        g.custom_command('list', 'list_staticsite_function_app_settings')
-        g.custom_command('set', 'set_staticsite_function_app_settings')
-        g.custom_command('delete', 'delete_staticsite_function_app_settings')
+        g.custom_command('list', 'list_staticsite_app_settings')
+        g.custom_command('set', 'set_staticsite_app_settings')
+        g.custom_command('delete', 'delete_staticsite_app_settings')
 
     with self.command_group('staticwebapp users', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsite_users')

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -8,8 +8,8 @@ from unittest import mock
 from azure.cli.command_modules.appservice.static_sites import \
     list_staticsites, show_staticsite, delete_staticsite, create_staticsites, CLIError, disconnect_staticsite, \
     reconnect_staticsite, list_staticsite_environments, show_staticsite_environment, list_staticsite_domains, \
-    set_staticsite_domain, delete_staticsite_domain, list_staticsite_functions, list_staticsite_function_app_settings, \
-    set_staticsite_function_app_settings, delete_staticsite_function_app_settings, list_staticsite_users, \
+    set_staticsite_domain, delete_staticsite_domain, list_staticsite_functions, list_staticsite_app_settings, \
+    set_staticsite_app_settings, delete_staticsite_app_settings, list_staticsite_users, \
     invite_staticsite_users, update_staticsite_users, update_staticsite, list_staticsite_secrets, \
     reset_staticsite_api_key, delete_staticsite_environment, link_user_function, unlink_user_function, get_user_function, \
     assign_identity, remove_identity, show_identity
@@ -311,75 +311,75 @@ class TestStaticAppCommands(unittest.TestCase):
         self.staticapp_client.list_static_site_build_functions.assert_called_once_with(
             self.rg1, self.name1, self.environment1)
 
-    def test_list_staticsite_function_app_settings_with_resourcegroup(self):
-        list_staticsite_function_app_settings(self.mock_cmd, self.name1, self.rg1)
+    def test_list_staticsite_app_settings_with_resourcegroup(self):
+        list_staticsite_app_settings(self.mock_cmd, self.name1, self.rg1)
 
-        self.staticapp_client.list_static_site_function_app_settings.assert_called_once_with(
+        self.staticapp_client.list_static_site_app_settings.assert_called_once_with(
             self.rg1, self.name1)
 
-    def test_list_staticsite_function_app_settings_without_resourcegroup(self):
+    def test_list_staticsite_app_settings_without_resourcegroup(self):
         self.staticapp_client.list.return_value = [self.app1, self.app2]
 
-        list_staticsite_function_app_settings(self.mock_cmd, self.name1)
+        list_staticsite_app_settings(self.mock_cmd, self.name1)
 
-        self.staticapp_client.list_static_site_function_app_settings.assert_called_once_with(
+        self.staticapp_client.list_static_site_app_settings.assert_called_once_with(
             self.rg1, self.name1)
 
-    def test_set_staticsite_function_app_settings_with_resourcegroup(self):
+    def test_set_staticsite_app_settings_with_resourcegroup(self):
+        from azure.mgmt.web.models import StringDictionary
+
         app_settings1_input = ['key1=val1', 'key2=val2==', 'key3=val3=']
-        app_settings1_dict = {'key1': 'val1', 'key2': 'val2==', 'key3': 'val3='}
 
-        set_staticsite_function_app_settings(self.mock_cmd, self.name1, app_settings1_input, self.rg1)
+        self.staticapp_client.list_static_site_app_settings.return_value = StringDictionary(properties={})
 
-        self.staticapp_client.create_or_update_static_site_function_app_settings.assert_called_once_with(
-            self.rg1, self.name1, app_settings=app_settings1_dict)
+        set_staticsite_app_settings(self.mock_cmd, self.name1, app_settings1_input, self.rg1)
 
-    def test_set_staticsite_function_app_settings_without_resourcegroup(self):
+        self.staticapp_client.create_or_update_static_site_app_settings.assert_called_once()
+
+    def test_set_staticsite_app_settings_without_resourcegroup(self):
+        from azure.mgmt.web.models import StringDictionary
+
         app_settings1_input = ['key1=val1', 'key2=val2==', 'key3=val3=']
-        app_settings1_dict = {'key1': 'val1', 'key2': 'val2==', 'key3': 'val3='}
         self.staticapp_client.list.return_value = [self.app1, self.app2]
 
-        set_staticsite_function_app_settings(self.mock_cmd, self.name1, app_settings1_input)
+        self.staticapp_client.list_static_site_app_settings.return_value = StringDictionary(properties={})
 
-        self.staticapp_client.create_or_update_static_site_function_app_settings.assert_called_once_with(
-            self.rg1, self.name1, app_settings=app_settings1_dict)
+        set_staticsite_app_settings(self.mock_cmd, self.name1, app_settings1_input)
 
-    def test_delete_staticsite_function_app_settings_with_resourcegroup(self):
+        self.staticapp_client.create_or_update_static_site_app_settings.assert_called_once()
+
+    def test_delete_staticsite_app_settings_with_resourcegroup(self):
         # setup
         current_app_settings = {'key1': 'val1', 'key2': 'val2'}
         app_settings_keys_to_delete = ['key1']
-        updated_app_settings = {'key2': 'val2'}
 
         class AppSettings:
             properties = current_app_settings
 
-        self.staticapp_client.list_static_site_function_app_settings.return_value = AppSettings
+        self.staticapp_client.list_static_site_app_settings.return_value = AppSettings
 
         # action
-        delete_staticsite_function_app_settings(self.mock_cmd, self.name1, app_settings_keys_to_delete, self.rg1)
+        delete_staticsite_app_settings(self.mock_cmd, self.name1, app_settings_keys_to_delete, self.rg1)
 
         # validate
-        self.staticapp_client.create_or_update_static_site_function_app_settings.assert_called_once_with(
-            self.rg1, self.name1, app_settings=updated_app_settings)
+        self.staticapp_client.create_or_update_static_site_app_settings.assert_called_once()
 
-    def test_delete_staticsite_function_app_settings_without_resourcegroup(self):
+    def test_delete_staticsite_app_settings_without_resourcegroup(self):
         # setup
         current_app_settings = {'key1': 'val1', 'key2': 'val2'}
         app_settings_keys_to_delete = ['key1']
-        updated_app_settings = {'key2': 'val2'}
 
         class AppSettings:
             properties = current_app_settings
 
-        self.staticapp_client.list_static_site_function_app_settings.return_value = AppSettings
+        self.staticapp_client.list_static_site_app_settings.return_value = AppSettings
         self.staticapp_client.list.return_value = [self.app1, self.app2]
 
         # action
-        delete_staticsite_function_app_settings(self.mock_cmd, self.name1, app_settings_keys_to_delete)
+        delete_staticsite_app_settings(self.mock_cmd, self.name1, app_settings_keys_to_delete)
 
         # validate
-        self.staticapp_client.create_or_update_static_site_function_app_settings.assert_called_once_with(
-            self.rg1, self.name1, app_settings=updated_app_settings)
+        self.staticapp_client.create_or_update_static_site_app_settings.assert_called_once()
 
     def test_list_staticsite_users_with_resourcegroup(self):
         authentication_provider = 'GitHub'


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Switches the `az staticwebapp appsettings set/list/delete` commands to use the new SWA app settings SDK methods instead of the function app settings APIs
Also fixes the issue described in https://github.com/Azure/azure-cli/issues/18468 where `az staticwebapp appsettings set` was not functional

**Testing Guide**
<!--Example commands with explanations.-->
`azdev test TestStaticAppCommands`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
[App Service] `az staticwebapp appsettings set`: Make set functional (#18468)
[App Service] `az staticwebapp appsettings`: Switch to the new SWA app settings SDK methods

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
