### PR TITLE
[App Service] Fix #11818: `az webapp ssh`, `az webapp create-remote-connection`, `az webapp log download`, `az webapp log tail`: Add proxy support

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -18,6 +18,7 @@ import ssl
 import sys
 import uuid
 from functools import reduce
+import invoke
 from nacl import encoding, public
 
 import OpenSSL.crypto
@@ -4439,7 +4440,11 @@ def _start_ssh_session(hostname, port, username, password):
             logger.warning('.')
             time.sleep(1)
     try:
-        c.run('cat /etc/motd', pty=True)
+        try:
+            c.run('cat /etc/motd', pty=True)
+        except invoke.exceptions.UnexpectedExit:
+            # Don't crash over a non-existing /etc/motd.
+            pass
         c.run('source /etc/profile; exec $SHELL -l', pty=True)
     except Exception as ex:  # pylint: disable=broad-except
         logger.info(ex)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -59,7 +59,9 @@ from .utils import (_normalize_sku,
                     _get_location_from_resource_group,
                     _list_app,
                     _rename_server_farm_props,
-                    _get_location_from_webapp, _normalize_location)
+                    _get_location_from_webapp,
+                    _normalize_location,
+                    get_pool_manager)
 from ._create_util import (zip_contents_from_dir, get_runtime_version_details, create_resource_group, get_app_details,
                            check_resource_group_exists, set_location, get_site_availability, get_profile_username,
                            get_plan_to_use, get_lang_from_content, get_rg_to_use, get_sku_to_use,
@@ -2400,7 +2402,6 @@ def _get_site_credential(cli_ctx, resource_group_name, name, slot=None):
 
 
 def _get_log(url, user_name, password, log_file=None):
-    import certifi
     import urllib3
     try:
         import urllib3.contrib.pyopenssl
@@ -2408,7 +2409,7 @@ def _get_log(url, user_name, password, log_file=None):
     except ImportError:
         pass
 
-    http = urllib3.PoolManager(cert_reqs='CERT_REQUIRED', ca_certs=certifi.where())
+    http = get_pool_manager(url)
     headers = urllib3.util.make_headers(basic_auth='{0}:{1}'.format(user_name, password))
     r = http.request(
         'GET',

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands.py
@@ -12,11 +12,15 @@ import tempfile
 from azure_devtools.scenario_tests.utilities import create_random_name
 import requests
 import datetime
+import urllib3
+from knack.util import CLIError
+import certifi
 
 from azure_devtools.scenario_tests import AllowLargeResponse, record_only
 from azure.cli.testsdk import (ScenarioTest, LocalContextScenarioTest, LiveScenarioTest, ResourceGroupPreparer,
                                StorageAccountPreparer, KeyVaultPreparer, JMESPathCheck, live_only)
 from azure.cli.testsdk.checkers import JMESPathCheckNotExists
+from azure.cli.command_modules.appservice.utils import get_pool_manager
 
 from azure.cli.core.azclierror import ResourceNotFoundError
 
@@ -2112,6 +2116,81 @@ class DomainScenarioTest(ScenarioTest):
         ).assert_with_checks([
             JMESPathCheck('agreement_keys', "['DNRA', 'DNPA']")
         ])
+
+
+class TunnelProxyTest(unittest.TestCase):
+    def setUp(self):
+        # Clean pre-existing proxy env vars
+        for env_var in [
+            'NO_PROXY',
+            'no_proxy',
+            'HTTPS_PROXY',
+            'https_proxy',
+            'AZURE_CLI_DISABLE_CONNECTION_VERIFICATION',
+            'REQUESTS_CA_BUNDLE',
+        ]:
+            if env_var in os.environ:
+                del os.environ[env_var]
+        os.environ['HTTPS_PROXY'] = 'http://myproxy.local:8888'
+
+    def test_with_proxy(self):
+        http = get_pool_manager('https://scm.azurewebsites.net')
+
+        self.assertEqual(http.proxy.netloc, 'myproxy.local:8888')
+        with self.assertRaises(KeyError):
+            http.proxy_headers['proxy-authorization']
+        self.assertEqual(http.connection_pool_kw['cert_reqs'], 'CERT_REQUIRED')
+        self.assertIsInstance(http, urllib3.ProxyManager)
+
+    def test_without_proxy(self):
+        del os.environ['HTTPS_PROXY']
+        http = get_pool_manager('https://scm.azurewebsites.net')
+
+        self.assertIsNone(http.proxy)
+        self.assertIsInstance(http, urllib3.PoolManager)
+        self.assertNotIsInstance(http, urllib3.ProxyManager)
+
+    def test_no_proxy(self):
+        os.environ['NO_PROXY'] = 'azurewebsites.net'
+        http = get_pool_manager('https://scm.azurewebsites.net')
+
+        self.assertIsNone(http.proxy)
+        self.assertIsInstance(http, urllib3.PoolManager)
+        self.assertNotIsInstance(http, urllib3.ProxyManager)
+
+    def test_proxy_auth(self):
+        os.environ['HTTPS_PROXY'] = 'http://test_user:secret_p@ss@myproxy.local:8888'
+        http = get_pool_manager('https://scm.azurewebsites.net')
+
+        self.assertEqual(
+            http.proxy_headers['proxy-authorization'],
+            'Basic dGVzdF91c2VyOnNlY3JldF9wQHNz',
+        )
+
+    def test_proxy_custom_ca_bundle(self):
+        with tempfile.TemporaryFile() as file:
+            file = tempfile.NamedTemporaryFile(suffix='-ca-certificates.crt')
+            os.environ['REQUESTS_CA_BUNDLE'] = file.name
+            http = get_pool_manager('https://scm.azurewebsites.net')
+
+        self.assertEqual(http.connection_pool_kw['ca_certs'], file.name)
+
+    def test_proxy_custom_ca_bundle_incorrect(self):
+        with tempfile.TemporaryDirectory() as empty_folder:
+            os.environ['REQUESTS_CA_BUNDLE'] = f'{empty_folder}/ca-certificates.crt'
+
+            self.assertRaises(CLIError, get_pool_manager, 'https://scm.azurewebsites.net')
+
+    def test_proxy_default_ca_bundle(self):
+        http = get_pool_manager('https://scm.azurewebsites.net')
+
+        self.assertEqual(http.connection_pool_kw['ca_certs'], certifi.where())
+
+    def test_proxy_unsafe_ssl(self):
+        os.environ['AZURE_CLI_DISABLE_CONNECTION_VERIFICATION'] = '1'
+        http = get_pool_manager('https://scm.azurewebsites.net')
+
+        self.assertEqual(http.connection_pool_kw['cert_reqs'], 'CERT_NONE')
 
 
 if __name__ == '__main__':

--- a/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
@@ -100,8 +100,15 @@ class TunnelServer:
 
         if 'https' in proxies and bypass_proxy is False:
             proxy = urllib.parse.urlparse(proxies['https'])
+
+            if proxy.username and proxy.password:
+                proxy_headers = urllib3.util.make_headers(proxy_basic_auth='{0}:{1}'.format(proxy.username, proxy.password))
+                logger.debug('Setting proxy-authorization header for basic auth')
+            else:
+                proxy_headers = None
+
             logger.info('Using proxy for app service tunnel connection')
-            http = urllib3.ProxyManager(proxy.geturl())
+            http = urllib3.ProxyManager(proxy.geturl(), proxy_headers=proxy_headers)
         else:
             http = urllib3.PoolManager()
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/utils.py
@@ -147,7 +147,7 @@ def get_pool_manager(url):
     proxies = urllib.request.getproxies()
     bypass_proxy = urllib.request.proxy_bypass(urllib.parse.urlparse(url).hostname)
 
-    if 'https' in proxies and bypass_proxy is False:
+    if 'https' in proxies and not bypass_proxy:
         proxy = urllib.parse.urlparse(proxies['https'])
 
         if proxy.username and proxy.password:

--- a/src/azure-cli/azure/cli/command_modules/appservice/utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/utils.py
@@ -4,15 +4,23 @@
 # --------------------------------------------------------------------------------------------
 
 import time
+import os
+import urllib
+import urllib3
+import certifi
+
 from knack.util import CLIError
 from knack.log import get_logger
 
 from azure.cli.core.azclierror import (RequiredArgumentMissingError)
 from azure.cli.core.commands.parameters import get_subscription_locations
+from azure.cli.core.util import should_disable_connection_verify
 
 from ._client_factory import web_client_factory
 
 logger = get_logger(__name__)
+
+REQUESTS_CA_BUNDLE = "REQUESTS_CA_BUNDLE"
 
 
 def str2bool(v):
@@ -133,3 +141,36 @@ def _normalize_location(cmd, location):
         if loc.display_name.lower() == location or loc.name.lower() == location:
             return loc.name
     return location
+
+
+def get_pool_manager(url):
+    proxies = urllib.request.getproxies()
+    bypass_proxy = urllib.request.proxy_bypass(urllib.parse.urlparse(url).hostname)
+
+    if 'https' in proxies and bypass_proxy is False:
+        proxy = urllib.parse.urlparse(proxies['https'])
+
+        if proxy.username and proxy.password:
+            proxy_headers = urllib3.util.make_headers(proxy_basic_auth='{0}:{1}'.format(proxy.username, proxy.password))
+            logger.debug('Setting proxy-authorization header for basic auth')
+        else:
+            proxy_headers = None
+
+        logger.info('Using proxy for app service tunnel connection')
+        http = urllib3.ProxyManager(proxy.geturl(), proxy_headers=proxy_headers)
+    else:
+        http = urllib3.PoolManager()
+
+    if should_disable_connection_verify():
+        http.connection_pool_kw['cert_reqs'] = 'CERT_NONE'
+    else:
+        http.connection_pool_kw['cert_reqs'] = 'CERT_REQUIRED'
+        if REQUESTS_CA_BUNDLE in os.environ:
+            ca_bundle_file = os.environ[REQUESTS_CA_BUNDLE]
+            logger.debug("Using CA bundle file at '%s'.", ca_bundle_file)
+            if not os.path.isfile(ca_bundle_file):
+                raise CLIError('REQUESTS_CA_BUNDLE environment variable is specified with an invalid file path')
+        else:
+            ca_bundle_file = certifi.where()
+        http.connection_pool_kw['ca_certs'] = ca_bundle_file
+    return http


### PR DESCRIPTION
**Description**
Add proxy support for `az webapp ssh`, `create-remote-connection`, `log download` and `log tail`. Setting the proxy works like elsewhere in azure cli, as documented here: https://docs.microsoft.com/en-us/cli/azure/use-cli-effectively#work-behind-a-proxy .

This fixes the issue in https://github.com/Azure/azure-cli/issues/11818 (which was seemingly closed by accident).

**Testing Guide**
```bash
export HTTPS_PROXY=http://PROXY_HOST:PROXY_PORT
az webapp create-remote-connection --subscription MYSUBSCRIPTION --resource-group MYRESOURCEGROUP --name MYAPPSERVICE -p 39629
ssh root@localhost -p 39629
```

**History Notes**
[App Service] `az webapp ssh`: Add proxy support
[App Service] `az webapp create-remote-connection`: Add proxy support
[App Service] `az webapp log download/tail`: Add proxy support


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
