### PR TITLE
{Core} Fix `--only-show-errors` on root parser

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -35,7 +35,7 @@ from knack.deprecation import ImplicitDeprecated, resolve_deprecate_info
 from knack.invocation import CommandInvoker
 from knack.preview import ImplicitPreviewItem, PreviewItem, resolve_preview_info
 from knack.experimental import ImplicitExperimentalItem, ExperimentalItem, resolve_experimental_info
-from knack.log import get_logger
+from knack.log import get_logger, CLILogging
 from knack.util import CLIError, CommandResultItem, todict
 from knack.events import EVENT_INVOKER_TRANSFORM_RESULT
 from knack.validators import DefaultStr
@@ -562,7 +562,8 @@ class AzCliCommandInvoker(CommandInvoker):
         self.cli_ctx.raise_event(EVENT_INVOKER_CMD_TBL_LOADED, cmd_tbl=self.commands_loader.command_table,
                                  parser=self.parser)
 
-        arg_check = [a for a in args if a not in ['--debug', '--verbose']]
+        arg_check = [a for a in args if a not in
+                     (CLILogging.DEBUG_FLAG, CLILogging.VERBOSE_FLAG, CLILogging.ONLY_SHOW_ERRORS_FLAG)]
         if not arg_check:
             self.parser.enable_autocomplete()
             subparser = self.parser.subparsers[tuple()]


### PR DESCRIPTION
**Description**<!--Mandatory-->

Using `--only-show-errors` on root parser fails:

```
> az --only-show-errors
the following arguments are required: _command_package

Examples from AI knowledge base:
https://aka.ms/cli_ref
Read more about the command in reference docs
```

This PR fixes `--only-show-errors` on root parser, same as https://github.com/microsoft/knack/pull/253.

This issue was found while investigating https://github.com/Azure/azure-cli/issues/20269.