### PR TITLE
{Misc.} Change deprecated `assertRaisesRegexp` to `assertRaisesRegex`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -932,7 +932,7 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(aux_tokens[0].token, MOCK_ACCESS_TOKEN)
 
         # test input aux_tenants and aux_subscriptions
-        with self.assertRaisesRegexp(CLIError,
+        with self.assertRaisesRegex(CLIError,
                                      "Please specify only one of aux_subscriptions and aux_tenants, not both"):
             cred, subscription_id, _ = profile.get_login_credentials(subscription_id=test_subscription_id1,
                                                                      aux_subscriptions=[test_subscription_id2],
@@ -1135,7 +1135,7 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(tenant_id, test_tenant_id)
 
         # verify tenant shouldn't be specified for MSI account
-        with self.assertRaisesRegexp(CLIError, "MSI"):
+        with self.assertRaisesRegex(CLIError, "MSI"):
             cred, subscription_id, _ = profile.get_raw_token(resource='http://test_resource', tenant=self.tenant_id)
 
     @mock.patch('azure.cli.core._profile.in_cloud_console', autospec=True)
@@ -1168,7 +1168,7 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(tenant_id, test_tenant_id)
 
         # verify tenant shouldn't be specified for Cloud Shell account
-        with self.assertRaisesRegexp(CLIError, 'Cloud Shell'):
+        with self.assertRaisesRegex(CLIError, 'Cloud Shell'):
             cred, subscription_id, _ = profile.get_raw_token(resource='http://test_resource', tenant=self.tenant_id)
 
     @mock.patch('azure.cli.core.auth.identity.Identity.logout_user')

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_account_filter_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_account_filter_scenarios.py
@@ -73,7 +73,7 @@ class AmsAccountFilterTests(ScenarioTest):
         self.kwargs.update({
             'nonexits_filter_name': nonexits_filter_name
         })
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az ams account-filter show -a {amsname} -g {rg} -n {nonexits_filter_name}')
 
     @ResourceGroupPreparer()

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_asset_filter_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_asset_filter_scenarios.py
@@ -137,7 +137,7 @@ class AmsAssetFilterTests(ScenarioTest):
         self.kwargs.update({
             'nonexits_asset_filter_name': nonexits_asset_filter_name
         })
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az ams asset-filter show -a {amsname} --asset-name {asset_name} -g {rg} -n {nonexits_asset_filter_name}')
 
     @ResourceGroupPreparer()

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_asset_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_asset_scenarios.py
@@ -72,7 +72,7 @@ class AmsAssetTests(ScenarioTest):
             'nonexits_asset_name': nonexits_asset_name
         })
 
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az ams asset show -a {amsname} -g {rg} -n {nonexits_asset_name}')
 
         list = self.cmd('az ams asset list -a {amsname} -g {rg}').get_output_in_json()

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_job_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_job_scenarios.py
@@ -75,7 +75,7 @@ class AmsJobTests(ScenarioTest):
         self.kwargs.update({
             'nonexits_job_name': nonexits_job_name
         })
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az ams job show -a {amsname} -n{nonexits_job_name} -g {rg} -t {transformName}')
 
         list = self.cmd('az ams job list -a {amsname} -g {rg} -t {transformName}').get_output_in_json()

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_live_event_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_live_event_scenarios.py
@@ -424,7 +424,7 @@ class AmsLiveEventTests(ScenarioTest):
         self.kwargs.update({
             'nonexits_live_event_name': nonexits_live_event_name
         })
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az ams live-event show -a {amsname} -n {nonexits_live_event_name} -g {rg}')
 
         self.cmd('az ams live-event delete -a {amsname} -n {liveEventName} -g {rg}')

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_live_output_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_live_output_scenarios.py
@@ -136,7 +136,7 @@ class AmsLiveOutputTests(ScenarioTest):
         self.kwargs.update({
             'nonexits_live_output_name': nonexits_live_output_name
         })
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az ams live-output show -a {amsname} -n {liveOutputName} -g {rg} --live-event-name {nonexits_live_output_name}')
 
     @ResourceGroupPreparer()

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_streaming_endpoint_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_streaming_endpoint_scenarios.py
@@ -256,7 +256,7 @@ class AmsStreamingEndpointsTests(ScenarioTest):
         self.kwargs.update({
             'nonexits_streaming_endpoint_name': nonexits_streaming_endpoint_name
         })
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az ams streaming-endpoint show -g {rg} -a {amsname} -n {nonexits_streaming_endpoint_name}')
 
         self.cmd('az ams streaming-endpoint delete -g {rg} -a {amsname} -n {streamingEndpointName}')

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_streaming_locator_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_streaming_locator_scenarios.py
@@ -66,7 +66,7 @@ class AmsStreamingLocatorTests(ScenarioTest):
         self.kwargs.update({
             'nonexits_streaming_locator_name': nonexits_streaming_locator_name
         })
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az ams streaming-locator show -a {amsname} -n {nonexits_streaming_locator_name} -g {rg}')
 
         list = self.cmd('az ams streaming-locator list -a {amsname} -g {rg}').get_output_in_json()

--- a/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_transform_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_transform_scenarios.py
@@ -50,7 +50,7 @@ class AmsTransformTests(ScenarioTest):
         self.kwargs.update({
             'nonexits_transform_name': nonexits_transform_name
         })
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az ams transform show -a {amsname} -n {nonexits_transform_name} -g {rg}')
 
         self.cmd('az ams transform update --description mydesc -a {amsname} -n {transformName} -g {rg}', checks=[

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_commands.py
@@ -874,14 +874,14 @@ class AppConfigImportExportNamingConventionScenarioTest(ScenarioTest):
         self.kwargs.update({
             'imported_file_path': import_multiple_feature_sections_path
         })
-        with self.assertRaisesRegexp(CLIError, 'Unable to proceed because file contains multiple sections corresponding to "Feature Management".'):
+        with self.assertRaisesRegex(CLIError, 'Unable to proceed because file contains multiple sections corresponding to "Feature Management".'):
             self.cmd('appconfig kv import -n {config_store_name} -s {import_source} --path "{imported_file_path}" --format {imported_format} --label {label} -y')
 
         # Error if imported file has "enabled for" in wrong format
         self.kwargs.update({
             'imported_file_path': import_wrong_enabledfor_format_path
         })
-        with self.assertRaisesRegexp(CLIError, 'definition or have a true/false value.'):
+        with self.assertRaisesRegex(CLIError, 'definition or have a true/false value.'):
             self.cmd('appconfig kv import -n {config_store_name} -s {import_source} --path "{imported_file_path}" --format {imported_format} --label {label} -y')
 
         # Import/Export yaml file
@@ -1074,7 +1074,7 @@ class AppConfigToAppConfigImportExportScenarioTest(ScenarioTest):
         self.kwargs.update({
             'label': dest_label
         })
-        with self.assertRaisesRegexp(CLIError, "Import failed! Please provide only one of these arguments: '--label' or '--preserve-labels'."):
+        with self.assertRaisesRegex(CLIError, "Import failed! Please provide only one of these arguments: '--label' or '--preserve-labels'."):
             self.cmd('appconfig kv import --connection-string {dest_connection_string} -s {import_source} --src-connection-string {src_connection_string} --src-label {src_label} --label {label} --preserve-labels -y')
 
         # Export tests from src config store to dest config store
@@ -1125,7 +1125,7 @@ class AppConfigToAppConfigImportExportScenarioTest(ScenarioTest):
         self.kwargs.update({
             'label': dest_label
         })
-        with self.assertRaisesRegexp(CLIError, "Export failed! Please provide only one of these arguments: '--dest-label' or '--preserve-labels'."):
+        with self.assertRaisesRegex(CLIError, "Export failed! Please provide only one of these arguments: '--dest-label' or '--preserve-labels'."):
             self.cmd('appconfig kv export --connection-string {src_connection_string} -d {import_source} --dest-connection-string {dest_connection_string} --label {src_label} --dest-label {label} --preserve-labels -y')
 
 
@@ -1352,19 +1352,19 @@ class AppConfigJsonContentTypeScenarioTest(ScenarioTest):
             'value': entry_value,
             'content_type': json_content_type_01
         })
-        with self.assertRaisesRegexp(CLIError, "is not a valid JSON object, which conflicts with the content type."):
+        with self.assertRaisesRegex(CLIError, "is not a valid JSON object, which conflicts with the content type."):
             self.cmd('appconfig kv set --connection-string {src_connection_string} --key {key} --value {value} --content-type {content_type} -y')
 
         self.kwargs.update({
             'value': '[abc,def]'
         })
-        with self.assertRaisesRegexp(CLIError, "is not a valid JSON object, which conflicts with the content type."):
+        with self.assertRaisesRegex(CLIError, "is not a valid JSON object, which conflicts with the content type."):
             self.cmd('appconfig kv set --connection-string {src_connection_string} --key {key} --value {value} --content-type {content_type} -y')
 
         self.kwargs.update({
             'value': 'True'
         })
-        with self.assertRaisesRegexp(CLIError, "is not a valid JSON object, which conflicts with the content type."):
+        with self.assertRaisesRegex(CLIError, "is not a valid JSON object, which conflicts with the content type."):
             self.cmd('appconfig kv set --connection-string {src_connection_string} --key {key} --value {value} --content-type {content_type} -y')
 
         # Create a non-JSON key-value and update its content type in subsequent command
@@ -1375,7 +1375,7 @@ class AppConfigJsonContentTypeScenarioTest(ScenarioTest):
                  checks=[self.check('key', entry_key),
                          self.check('value', entry_value)])
 
-        with self.assertRaisesRegexp(CLIError, "Set the value again in valid JSON format."):
+        with self.assertRaisesRegex(CLIError, "Set the value again in valid JSON format."):
             self.cmd('appconfig kv set --connection-string {src_connection_string} --key {key} --content-type {content_type} -y')
 
         """
@@ -1538,7 +1538,7 @@ class AppConfigJsonContentTypeScenarioTest(ScenarioTest):
             'imported_file_path': imported_file_path,
             'exported_file_path': exported_yaml_file_path
         })
-        with self.assertRaisesRegexp(CLIError, "Please provide JSON file format to match your content type."):
+        with self.assertRaisesRegex(CLIError, "Please provide JSON file format to match your content type."):
             self.cmd('appconfig kv import --connection-string {src_connection_string} -s {import_source} --path "{imported_file_path}" --format {imported_format} --separator {separator} --content-type {content_type} -y')
 
         self.cmd(
@@ -1770,7 +1770,7 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
             'feature': comma_pattern
         })
 
-        with self.assertRaisesRegexp(CLIError, "Comma separated feature names are not supported"):
+        with self.assertRaisesRegex(CLIError, "Comma separated feature names are not supported"):
             self.cmd('appconfig feature list -n {config_store_name} --feature {feature}')
 
         # Invalid Pattern - contains invalid *
@@ -1779,7 +1779,7 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
             'feature': invalid_pattern
         })
 
-        with self.assertRaisesRegexp(CLIError, "Bad Request"):
+        with self.assertRaisesRegex(CLIError, "Bad Request"):
             self.cmd('appconfig feature list -n {config_store_name} --feature {feature}')
 
         # Invalid Pattern - starts with *
@@ -1788,7 +1788,7 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
             'feature': invalid_pattern
         })
 
-        with self.assertRaisesRegexp(CLIError, "Bad Request"):
+        with self.assertRaisesRegex(CLIError, "Bad Request"):
             self.cmd('appconfig feature list -n {config_store_name} --feature {feature}')
 
         # Invalid Pattern - contains multiple **
@@ -1797,7 +1797,7 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
             'feature': invalid_pattern
         })
 
-        with self.assertRaisesRegexp(CLIError, "Bad Request"):
+        with self.assertRaisesRegex(CLIError, "Bad Request"):
             self.cmd('appconfig feature list -n {config_store_name} --feature {feature}')
 
         # Delete Beta (label v2) feature flag using connection-string
@@ -1944,11 +1944,11 @@ class AppConfigFeatureScenarioTest(ScenarioTest):
             'key': invalid_key
         })
 
-        with self.assertRaisesRegexp(CLIError, "Feature flag key must start with the reserved prefix"):
+        with self.assertRaisesRegex(CLIError, "Feature flag key must start with the reserved prefix"):
             self.cmd('appconfig feature set -n {config_store_name} --key {key}')
 
         # Missing key and feature
-        with self.assertRaisesRegexp(CLIError, "Please provide either `--key` or `--feature` value."):
+        with self.assertRaisesRegex(CLIError, "Please provide either `--key` or `--feature` value."):
             self.cmd('appconfig feature delete -n {config_store_name}')
 
 
@@ -2082,7 +2082,7 @@ class AppConfigFeatureFilterScenarioTest(ScenarioTest):
                          self.check('state', conditional_state)])
 
         # Delete Filter without index should throw error when duplicates exist
-        with self.assertRaisesRegexp(CLIError, "contains multiple instances of filter"):
+        with self.assertRaisesRegex(CLIError, "contains multiple instances of filter"):
             self.cmd('appconfig feature filter delete -n {config_store_name} --feature {feature} --label {label} --filter-name {filter_name} -y')
 
         # Delete Filter with index succeeds when correct index is provided
@@ -2109,7 +2109,7 @@ class AppConfigFeatureFilterScenarioTest(ScenarioTest):
             'filter_name': invalid_filter_name,
             'filter_parameters': invalid_filter_params
         })
-        with self.assertRaisesRegexp(CLIError, "Filter parameter value must be a JSON escaped string"):
+        with self.assertRaisesRegex(CLIError, "Filter parameter value must be a JSON escaped string"):
             self.cmd('appconfig feature filter add -n {config_store_name} --feature {feature} --label {label} --filter-name {filter_name} --filter-parameters {filter_parameters} -y')
 
         # Error on adding duplicate filter parameters
@@ -2117,7 +2117,7 @@ class AppConfigFeatureFilterScenarioTest(ScenarioTest):
         self.kwargs.update({
             'filter_parameters': invalid_filter_params
         })
-        with self.assertRaisesRegexp(CLIError, 'Filter parameter name "Name1" cannot be duplicated.'):
+        with self.assertRaisesRegex(CLIError, 'Filter parameter name "Name1" cannot be duplicated.'):
             self.cmd('appconfig feature filter add -n {config_store_name} --feature {feature} --label {label} --filter-name {filter_name} --filter-parameters {filter_parameters} -y')
 
         # Error on filter parameter with empty name
@@ -2125,7 +2125,7 @@ class AppConfigFeatureFilterScenarioTest(ScenarioTest):
         self.kwargs.update({
             'filter_parameters': invalid_filter_params
         })
-        with self.assertRaisesRegexp(CLIError, 'Parameter name cannot be empty.'):
+        with self.assertRaisesRegex(CLIError, 'Parameter name cannot be empty.'):
             self.cmd('appconfig feature filter add -n {config_store_name} --feature {feature} --label {label} --filter-name {filter_name} --filter-parameters {filter_parameters} -y')
 
         # Test more inputs for filter param value
@@ -2199,19 +2199,19 @@ class AppConfigKeyValidationScenarioTest(ScenarioTest):
             'key': "Col%%or",
             'value': "Red"
         })
-        with self.assertRaisesRegexp(CLIError, "Key is invalid. Key cannot be a '.' or '..', or contain the '%' character."):
+        with self.assertRaisesRegex(CLIError, "Key is invalid. Key cannot be a '.' or '..', or contain the '%' character."):
             self.cmd('appconfig kv set --connection-string {connection_string} --key {key} --value {value} -y')
 
         self.kwargs.update({
             'key': ""
         })
-        with self.assertRaisesRegexp(CLIError, "Key cannot be empty."):
+        with self.assertRaisesRegex(CLIError, "Key cannot be empty."):
             self.cmd('appconfig kv set --connection-string {connection_string} --key "{key}" --value {value} -y')
 
         self.kwargs.update({
             'key': "."
         })
-        with self.assertRaisesRegexp(CLIError, "Key is invalid. Key cannot be a '.' or '..', or contain the '%' character."):
+        with self.assertRaisesRegex(CLIError, "Key is invalid. Key cannot be a '.' or '..', or contain the '%' character."):
             self.cmd('appconfig kv set --connection-string {connection_string} --key {key} --value {value} -y')
 
         # validate key for KeyVault ref
@@ -2219,20 +2219,20 @@ class AppConfigKeyValidationScenarioTest(ScenarioTest):
             'key': "%KeyVault",
             'secret_identifier': "https://fake.vault.azure.net/secrets/fakesecret"
         })
-        with self.assertRaisesRegexp(CLIError, "Key is invalid. Key cannot be a '.' or '..', or contain the '%' character."):
+        with self.assertRaisesRegex(CLIError, "Key is invalid. Key cannot be a '.' or '..', or contain the '%' character."):
             self.cmd('appconfig kv set-keyvault --connection-string {connection_string} --key {key} --secret-identifier {secret_identifier} -y')
 
         # validate feature name
         self.kwargs.update({
             'feature': 'Beta%'
         })
-        with self.assertRaisesRegexp(CLIError, "Feature name cannot contain the '%' character."):
+        with self.assertRaisesRegex(CLIError, "Feature name cannot contain the '%' character."):
             self.cmd('appconfig feature set --connection-string {connection_string} --feature {feature} -y')
 
         self.kwargs.update({
             'feature': ''
         })
-        with self.assertRaisesRegexp(CLIError, "Feature name cannot be empty."):
+        with self.assertRaisesRegex(CLIError, "Feature name cannot be empty."):
             self.cmd('appconfig feature set --connection-string {connection_string} --feature "{feature}" -y')
 
         # validate keys and features during file import

--- a/src/azure-cli/azure/cli/command_modules/batchai/tests/latest/test_batchai_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/batchai/tests/latest/test_batchai_custom.py
@@ -113,7 +113,7 @@ class TestBatchAICustom(unittest.TestCase):
 
     def test_batchai_update_cluster_user_account_settings_using_command_line_when_key_is_wrong(self):
         params = ClusterCreateParameters(vm_size=None, user_account_settings=None)
-        with self.assertRaisesRegexp(CLIError, 'Incorrect ssh public key value'):
+        with self.assertRaisesRegex(CLIError, 'Incorrect ssh public key value'):
             _update_user_account_settings(params, 'user', 'my key', None)
 
     @patch('getpass.getuser')
@@ -184,7 +184,7 @@ class TestBatchAICustom(unittest.TestCase):
 
     def test_batchai_update_fileserver_user_account_settings_using_command_line_when_key_is_wrong(self):
         params = FileServerCreateParameters(vm_size=None, data_disks=None, ssh_configuration=None)
-        with self.assertRaisesRegexp(CLIError, 'Incorrect ssh public key value'):
+        with self.assertRaisesRegex(CLIError, 'Incorrect ssh public key value'):
             _update_user_account_settings(params, 'user', 'my key', None)
 
     @patch('getpass.getuser')
@@ -406,7 +406,7 @@ class TestBatchAICustom(unittest.TestCase):
                 )
             ]
         )
-        with self.assertRaisesRegexp(CLIError, 'Cannot find "account1" storage account'):
+        with self.assertRaisesRegex(CLIError, 'Cannot find "account1" storage account'):
             _patch_mount_volumes(DummyCli(), mount_volumes)
 
     @patch('azure.cli.command_modules.batchai.custom._get_storage_management_client')
@@ -425,7 +425,7 @@ class TestBatchAICustom(unittest.TestCase):
                 )
             ]
         )
-        with self.assertRaisesRegexp(CLIError, 'Please configure Azure Storage account name'):
+        with self.assertRaisesRegex(CLIError, 'Please configure Azure Storage account name'):
             _patch_mount_volumes(DummyCli(), mount_volumes)
 
     @patch('azure.cli.command_modules.batchai.custom._get_storage_management_client')
@@ -459,7 +459,7 @@ class TestBatchAICustom(unittest.TestCase):
                 )
             ]
         )
-        with self.assertRaisesRegexp(CLIError, 'Azure File URL cannot absent or be empty'):
+        with self.assertRaisesRegex(CLIError, 'Azure File URL cannot absent or be empty'):
             _patch_mount_volumes(DummyCli(), mount_volumes)
 
     def test_batchai_patch_mount_volumes_ill_formed_azure_file_url(self):
@@ -474,11 +474,11 @@ class TestBatchAICustom(unittest.TestCase):
                 )
             ]
         )
-        with self.assertRaisesRegexp(CLIError, 'Ill-formed Azure File URL'):
+        with self.assertRaisesRegex(CLIError, 'Ill-formed Azure File URL'):
             _patch_mount_volumes(DummyCli(), mount_volumes)
 
     def test_batchai_add_nfs_to_mount_volumes_no_relative_mount_path(self):
-        with self.assertRaisesRegexp(CLIError, 'File server relative mount path cannot be empty'):
+        with self.assertRaisesRegex(CLIError, 'File server relative mount path cannot be empty'):
             _add_nfs_to_mount_volumes(MountVolumes(), 'id', '')
 
     def test_batchai_add_nfs_to_empty_mount_volumes(self):
@@ -502,11 +502,11 @@ class TestBatchAICustom(unittest.TestCase):
             self.assertEqual('rw', mount_volumes.file_servers[i].mount_options)
 
     def test_batchai_add_azure_file_share_to_mount_volumes_no_account_info(self):
-        with self.assertRaisesRegexp(CLIError, 'Please configure Azure Storage account name'):
+        with self.assertRaisesRegex(CLIError, 'Please configure Azure Storage account name'):
             _add_azure_file_share_to_mount_volumes(DummyCli(), MountVolumes(), 'share', 'relative_path')
 
     def test_batchai_add_azure_file_share_to_mount_volumes_no_relative_mount_path(self):
-        with self.assertRaisesRegexp(CLIError, 'Azure File share relative mount path cannot be empty'):
+        with self.assertRaisesRegex(CLIError, 'Azure File share relative mount path cannot be empty'):
             _add_azure_file_share_to_mount_volumes(DummyCli(), MountVolumes(), 'share', '')
 
     @patch('azure.cli.command_modules.batchai.custom._get_storage_management_client')
@@ -580,11 +580,11 @@ class TestBatchAICustom(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_batchai_add_azure_container_mount_volumes_no_account(self):
-        with self.assertRaisesRegexp(CLIError, 'Please configure Azure Storage account name'):
+        with self.assertRaisesRegex(CLIError, 'Please configure Azure Storage account name'):
             _add_azure_container_to_mount_volumes(DummyCli(), MountVolumes(), 'container', 'relative_path')
 
     def test_batchai_add_azure_container_mount_volumes_no_relative_path(self):
-        with self.assertRaisesRegexp(CLIError, 'Azure Storage Container relative mount path cannot be empty'):
+        with self.assertRaisesRegex(CLIError, 'Azure Storage Container relative mount path cannot be empty'):
             _add_azure_container_to_mount_volumes(DummyCli(), MountVolumes(), 'container', '')
 
     def test_batchai_add_azure_container_to_absent_mount_volumes(self):
@@ -704,22 +704,22 @@ class TestBatchAICustom(unittest.TestCase):
         self.assertEqual(params, result)
 
         # Wrong image.
-        with self.assertRaisesRegexp(CLIError, 'Unsupported image alias'):
+        with self.assertRaisesRegex(CLIError, 'Unsupported image alias'):
             _update_nodes_information(params, 'unsupported', None, None, '', None, None, None)
 
         # No VM size.
         params.vm_size = None
-        with self.assertRaisesRegexp(CLIError, 'Please provide VM size'):
+        with self.assertRaisesRegex(CLIError, 'Please provide VM size'):
             _update_nodes_information(params, 'unsupported', None, None, '', None, None, None)
 
         # No scale settings.
         params.vm_size = 'Standard_NC6'
         params.scale_settings = None
-        with self.assertRaisesRegexp(CLIError, 'Please provide scale setting for the cluster'):
+        with self.assertRaisesRegex(CLIError, 'Please provide scale setting for the cluster'):
             _update_nodes_information(params, None, None, None, '', None, None, None)
 
         # Error if only min is specified
-        with self.assertRaisesRegexp(CLIError, 'You need to either provide both min and max node'):
+        with self.assertRaisesRegex(CLIError, 'You need to either provide both min and max node'):
             _update_nodes_information(params, 'UbuntuLTS', None, 'Standard_NC6', '', 2, 2, None)
 
     def test_get_image_or_die_supported_aliases(self):
@@ -731,7 +731,7 @@ class TestBatchAICustom(unittest.TestCase):
             _get_image_reference('ubuntudsvm', None))
 
     def test_get_image_or_die_unsupported_alias(self):
-        with self.assertRaisesRegexp(CLIError, 'Unsupported image alias "ubuntu", supported aliases are'):
+        with self.assertRaisesRegex(CLIError, 'Unsupported image alias "ubuntu", supported aliases are'):
             _get_image_reference('ubuntu', None)
 
     def test_get_image_or_die_with_valid_spec(self):
@@ -743,15 +743,15 @@ class TestBatchAICustom(unittest.TestCase):
             _get_image_reference('Canonical:UbuntuServer:16.04-LTS:latest', None))
 
     def test_get_image_or_die_with_invalid_spec(self):
-        with self.assertRaisesRegexp(CLIError, "--image must have format"):
+        with self.assertRaisesRegex(CLIError, "--image must have format"):
             _get_image_reference('Canonical:UbuntuServer:16.04-LTS', None)
-        with self.assertRaisesRegexp(CLIError, "--image must have format"):
+        with self.assertRaisesRegex(CLIError, "--image must have format"):
             _get_image_reference('Canonical:UbuntuServer:16.04-LTS:latest:', None)
-        with self.assertRaisesRegexp(CLIError, "Image publisher must be provided in --image argument"):
+        with self.assertRaisesRegex(CLIError, "Image publisher must be provided in --image argument"):
             _get_image_reference(':UbuntuServer:16.04-LTS:latest', None)
-        with self.assertRaisesRegexp(CLIError, "Image offer must be provided in --image argument"):
+        with self.assertRaisesRegex(CLIError, "Image offer must be provided in --image argument"):
             _get_image_reference('Canonical::16.04-LTS:latest', None)
-        with self.assertRaisesRegexp(CLIError, "Image sku must be provided in --image argument"):
+        with self.assertRaisesRegex(CLIError, "Image sku must be provided in --image argument"):
             _get_image_reference('Canonical:Offer::latest', None)
 
     def test_get_image_or_die_with_custom_image_without_version(self):
@@ -783,11 +783,11 @@ class TestBatchAICustom(unittest.TestCase):
         )
 
     def test_get_image_or_die_with_invalid_custom_image(self):
-        with self.assertRaisesRegexp(CLIError, 'Ill-formed custom image resource id'):
+        with self.assertRaisesRegex(CLIError, 'Ill-formed custom image resource id'):
             _get_image_reference('ubuntults', 'bla-bla')
 
     def test_get_image_or_die_with_custom_image_but_without_image(self):
-        with self.assertRaisesRegexp(CLIError, 'You need to specify --image argument'):
+        with self.assertRaisesRegex(CLIError, 'You need to specify --image argument'):
             _get_image_reference(
                 None, '/subscriptions/00/resourceGroups/gr/providers/Microsoft.Compute/images/img')
 
@@ -801,7 +801,7 @@ class TestBatchAICustom(unittest.TestCase):
             'mockrg', 'mockws', None)
 
     def test_validate_subnet_wrong_resource_id(self):
-        with self.assertRaisesRegexp(CLIError, 'Ill-formed subnet resource id'):
+        with self.assertRaisesRegex(CLIError, 'Ill-formed subnet resource id'):
             _ensure_subnet_is_valid(None, 'bla-bla', 'mockrg', 'mockws', 'mocknfs')
 
     def test_validate_subnet_no_conflicts(self):
@@ -821,7 +821,7 @@ class TestBatchAICustom(unittest.TestCase):
             return_value=FileServer(
                 subnet=ResourceId(id='conflict')
             ))
-        with self.assertRaisesRegexp(CLIError, 'Cluster and mounted NFS must be in the same subnet'):
+        with self.assertRaisesRegex(CLIError, 'Cluster and mounted NFS must be in the same subnet'):
             _ensure_subnet_is_valid(
                 mock_client,
                 '/subscriptions/000/resourceGroups/gr/providers/Microsoft.Network/virtualNetworks/vn/subnets/subnet',
@@ -847,7 +847,7 @@ class TestBatchAICustom(unittest.TestCase):
         self.assertEqual(_list_node_setup_files_for_cluster(DummyCli(), Cluster(), '.', 60), [])
 
     def test_list_setup_task_files_for_cluster_when_output_not_on_mounts_root(self):
-        with self.assertRaisesRegexp(CLIError, 'List files is supported only for clusters with startup task'):
+        with self.assertRaisesRegex(CLIError, 'List files is supported only for clusters with startup task'):
             cluster = Cluster(
                 node_setup=NodeSetup(
                     setup_task=SetupTask(
@@ -856,7 +856,7 @@ class TestBatchAICustom(unittest.TestCase):
             _list_node_setup_files_for_cluster(DummyCli(), cluster, '.', 60)
 
     def test_list_setup_task_files_for_cluster_when_cluster_doesnt_support_suffix(self):
-        with self.assertRaisesRegexp(CLIError, 'List files is not supported for this cluster'):
+        with self.assertRaisesRegex(CLIError, 'List files is not supported for this cluster'):
             cluster = Cluster(
                 node_setup=NodeSetup(
                     setup_task=SetupTask(
@@ -865,7 +865,7 @@ class TestBatchAICustom(unittest.TestCase):
             _list_node_setup_files_for_cluster(DummyCli(), cluster, '.', 60)
 
     def test_list_setup_task_files_for_cluster_when_cluster_has_not_mount_volumes(self):
-        with self.assertRaisesRegexp(CLIError, 'List files is supported only for clusters with startup task'):
+        with self.assertRaisesRegex(CLIError, 'List files is supported only for clusters with startup task'):
             cluster = Cluster(
                 node_setup=NodeSetup(
                     setup_task=SetupTask(
@@ -875,7 +875,7 @@ class TestBatchAICustom(unittest.TestCase):
             _list_node_setup_files_for_cluster(DummyCli(), cluster, '.', 60)
 
     def test_list_setup_task_files_for_cluster_when_output_not_on_afs_or_bfs(self):
-        with self.assertRaisesRegexp(CLIError, 'List files is supported only for clusters with startup task'):
+        with self.assertRaisesRegex(CLIError, 'List files is supported only for clusters with startup task'):
             cluster = Cluster(
                 vm_size=None,
                 user_account_settings=None,
@@ -953,7 +953,7 @@ class TestBatchAICustom(unittest.TestCase):
         self.assertTrue(len(names) > 90)
 
     def test_setup_task_no_output(self):
-        with self.assertRaisesRegexp(CLIError, '--setup-task requires providing of --setup-task-output'):
+        with self.assertRaisesRegex(CLIError, '--setup-task requires providing of --setup-task-output'):
             _add_setup_task('echo hi', None, ClusterCreateParameters(vm_size=None, user_account_settings=None))
 
     def test_setup_task_added_to_cluster_without_node_setup(self):

--- a/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
+++ b/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py
@@ -72,5 +72,5 @@ class SubscriptionSuppressionTest(ScenarioTest):
         self.cmd('az cloud list')
 
         # this should fail with an "unrecognized argument" error
-        with self.assertRaisesRegexp(SystemExit, '2'):
+        with self.assertRaisesRegex(SystemExit, '2'):
             self.cmd('az cloud list --subscription foo')

--- a/src/azure-cli/azure/cli/command_modules/container/tests/latest/test_container_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/container/tests/latest/test_container_commands.py
@@ -313,11 +313,11 @@ class AzureContainerInstanceScenarioTest(ScenarioTest):
         })
 
         # Vnet name with no subnet
-        with self.assertRaisesRegexp(CLIError, "usage error: --vnet NAME --subnet NAME | --vnet ID --subnet NAME | --subnet ID"):
+        with self.assertRaisesRegex(CLIError, "usage error: --vnet NAME --subnet NAME | --vnet ID --subnet NAME | --subnet ID"):
             self.cmd('container create -g {rg} -n {container_group_name} --image nginx --vnet {vnet_name}')
 
         # Subnet name with no vnet name
-        with self.assertRaisesRegexp(CLIError, "usage error: --vnet NAME --subnet NAME | --vnet ID --subnet NAME | --subnet ID"):
+        with self.assertRaisesRegex(CLIError, "usage error: --vnet NAME --subnet NAME | --vnet ID --subnet NAME | --subnet ID"):
             self.cmd('container create -g {rg} -n {container_group_name} --image nginx '
                      '--subnet {subnet_name} ')
 

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/test_cosmosdb_commands.py
@@ -328,7 +328,7 @@ class CosmosDBTests(ScenarioTest):
 
         self.cmd('az cosmosdb create -n {acc} -g {rg} --enable-virtual-network')
 
-        with self.assertRaisesRegexp(CLIError, "usage error: --subnet ID | --subnet NAME --vnet-name NAME"):
+        with self.assertRaisesRegex(CLIError, "usage error: --subnet ID | --subnet NAME --vnet-name NAME"):
             self.cmd('az cosmosdb network-rule add -n {acc} -g {rg} --subnet {vnet}')
 
         vnet_rule = self.cmd('az cosmosdb network-rule add -n {acc} -g {rg} --virtual-network {vnet} --subnet {sub} --ignore-missing-vnet-service-endpoint').get_output_in_json()

--- a/src/azure-cli/azure/cli/command_modules/deploymentmanager/tests/latest/test_deploymentmanager_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/deploymentmanager/tests/latest/test_deploymentmanager_scenario.py
@@ -156,7 +156,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager service-topology delete -g {rg} -n {st_name}')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager service-topology show -n {st_name} -g {rg}')
 
         self.kwargs = {
@@ -167,7 +167,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager service-topology delete -g {rg} -n {st_name}')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager service-topology show -n {st_name} -g {rg}')
 
     def services_validations(
@@ -237,11 +237,11 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager service delete -g {rg} --service-topology-name {st_name} -n {s_name}')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager service show -g {rg} --service-topology-name {st_name} -n {s_name}')
 
         self.cmd('deploymentmanager service delete -g {rg} --service-topology-name {st_name} -n {s2_name}')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager service show -g {rg} --service-topology-name {st_name} -n {s2_name}')
 
     def service_units_validations(
@@ -334,7 +334,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager service-unit delete -g {rg} --service-topology-name {st_name} --service-name {s_name} -n {su_name}')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager service-unit show -g {rg} --service-topology-name {st_name} --service-name {s_name} -n {su_name}')
 
         self.kwargs = {
@@ -345,7 +345,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager service-unit delete -g {rg} --service-topology-name {st_name} --service-name {s_name} -n {su_name}')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager service-unit show -g {rg} --service-topology-name {st_name} --service-name {s_name} -n {su_name}')
 
     def steps_validations(
@@ -407,7 +407,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager step delete -g {rg} -n {step_name}')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager step show -g {rg} -n {step_name}')
 
     def healthcheck_step_validations(
@@ -486,7 +486,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager step delete -g {rg} -n {step_name}')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager step show -g {rg} -n {step_name}')
 
         self.kwargs = {
@@ -495,7 +495,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
 
         self.cmd('deploymentmanager step delete -g {rg} -n {step2_name}')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager step show -g {rg} -n {step2_name}')
 
     def rollouts_validations(
@@ -601,9 +601,9 @@ class DeploymentManagerTests(ScenarioTest):
         self.cmd('deploymentmanager rollout delete -g {rg} -n {failed_rollout_name}')
         self.cmd('deploymentmanager rollout delete -g {rg} -n {rollout_name}')
 
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager rollout show -g {rg} -n {failed_rollout_name}')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager rollout show -g {rg} -n {rollout_name}')
 
     def set_managed_identity(self, subscription_id, resource_group_name):
@@ -806,7 +806,7 @@ class DeploymentManagerTests(ScenarioTest):
         }
         self.cmd('deploymentmanager artifact-source delete -n {name} -g {rg} --yes')
 
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('deploymentmanager artifact-source show -n {name} -g {rg}')
 
     def upload_blob(self, storage_account_info, storage_container_name, file_path, file_name):

--- a/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/tests/latest/test_keyvault_commands.py
@@ -373,7 +373,7 @@ class KeyVaultMgmtScenarioTest(ScenarioTest):
         ]).get_output_in_json()
 
         from azure.cli.core.azclierror import InvalidArgumentValueError
-        with self.assertRaisesRegexp(InvalidArgumentValueError, 'already exist'):
+        with self.assertRaisesRegex(InvalidArgumentValueError, 'already exist'):
             self.cmd('keyvault create -g {rg} -n {kv} -l {loc}')
         self.kwargs['policy_id'] = keyvault['properties']['accessPolicies'][0]['objectId']
         self.cmd('keyvault show -n {kv}', checks=[

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_activity_log_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_activity_log_scenario.py
@@ -15,5 +15,5 @@ class TestActivityLogScenarios(ScenarioTest):
     @StorageAccountPreparer()
     def test_activity_log_list_scenario(self, resource_group):
         from azure.core.exceptions import HttpResponseError
-        with self.assertRaisesRegexp(HttpResponseError, 'start time cannot be more than 90 days in the past'):
+        with self.assertRaisesRegex(HttpResponseError, 'start time cannot be more than 90 days in the past'):
             self.cmd('monitor activity-log list --start-time 2018-01-01T00:00:00Z --end-time 2999-01-01T00:00:00Z')

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_autoscale.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_autoscale.py
@@ -99,7 +99,7 @@ class TestMonitorAutoscaleScenario(ScenarioTest):
 
         # verify order is stable
         list_1 = self.cmd('monitor autoscale rule list -g {rg} --autoscale-name {vmss}').get_output_in_json()
-        with self.assertRaisesRegexp(CLIError, 'Please double check the name of the autoscale profile.'):
+        with self.assertRaisesRegex(CLIError, 'Please double check the name of the autoscale profile.'):
             self.cmd('monitor autoscale rule list -g {rg} --autoscale-name {vmss} --profile-name falseprofile')
 
         list_2 = self.cmd('monitor autoscale rule list -g {rg} --autoscale-name {vmss}').get_output_in_json()

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_log_analytics_cluster.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_log_analytics_cluster.py
@@ -49,7 +49,7 @@ class TestClusterScenarios(ScenarioTest):
 
         self.cmd("monitor log-analytics cluster delete -g {rg1} -n {new_cluster_name} -y", checks=[])
 
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('monitor log-analytics cluster show -g {rg1} -n {new_cluster_name}')
 
     @record_only()

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_log_analytics_workspace.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_log_analytics_workspace.py
@@ -310,7 +310,7 @@ class TestLogProfileScenarios(ScenarioTest):
 
         self.cmd("monitor log-analytics workspace delete -g {rg} -n {name} --force -y")
 
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('monitor log-analytics workspace show -g {rg} -n {name}')
 
     @ResourceGroupPreparer(name_prefix='cli_test_monitor_workspace_saved_search', location='eastus')
@@ -374,7 +374,7 @@ class TestLogProfileScenarios(ScenarioTest):
             ])
 
         self.cmd('monitor log-analytics workspace saved-search delete -g {rg} --workspace-name {workspace_name} -n {saved_search_name} -y')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('monitor log-analytics workspace saved-search show -g {rg} --workspace-name {workspace_name} -n {saved_search_name}')
 
     @ResourceGroupPreparer(name_prefix='cli_test_monitor_workspace_data_export', location='eastus')
@@ -417,22 +417,22 @@ class TestLogProfileScenarios(ScenarioTest):
                  ])
 
         from azure.core.exceptions import HttpResponseError
-        with self.assertRaisesRegexp(HttpResponseError, 'Table SecurityEvent Heartbeat does not exist in the workspace'):
+        with self.assertRaisesRegex(HttpResponseError, 'Table SecurityEvent Heartbeat does not exist in the workspace'):
             self.cmd('monitor log-analytics workspace data-export create -g {rg} --workspace-name {workspace_name} -n {data_export_name_2} '
                      '--destination {sa_id_1} --enable -t "SecurityEvent Heartbeat"',
                      checks=[
                      ])
-        with self.assertRaisesRegexp(HttpResponseError, 'you can create 10 export rules to 10 different destinations'):
+        with self.assertRaisesRegex(HttpResponseError, 'you can create 10 export rules to 10 different destinations'):
             self.cmd('monitor log-analytics workspace data-export create -g {rg} --workspace-name {workspace_name} -n {data_export_name_2} '
                      '--destination {sa_id_1} --enable -t {table_name}',
                      checks=[
                      ])
-        with self.assertRaisesRegexp(HttpResponseError, 'Table ABC does not exist in the workspace'):
+        with self.assertRaisesRegex(HttpResponseError, 'Table ABC does not exist in the workspace'):
             self.cmd('monitor log-analytics workspace data-export create -g {rg} --workspace-name {workspace_name} -n {data_export_name_2} '
                      '--destination {sa_id_1} --enable -t ABC',
                      checks=[
                      ])
-        with self.assertRaisesRegexp(HttpResponseError, 'you can create 10 export rules to 10 different destinations'):
+        with self.assertRaisesRegex(HttpResponseError, 'you can create 10 export rules to 10 different destinations'):
             self.cmd('monitor log-analytics workspace data-export create -g {rg} --workspace-name {workspace_name} -n {data_export_name_2} '
                      '--destination {sa_id_1} --enable -t AppPerformanceCounters',
                      checks=[
@@ -469,5 +469,5 @@ class TestLogProfileScenarios(ScenarioTest):
             ])
 
         self.cmd('monitor log-analytics workspace data-export delete -g {rg} --workspace-name {workspace_name} -n {data_export_name} -y')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('monitor log-analytics workspace data-export show -g {rg} --workspace-name {workspace_name} -n {data_export_name}')

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_metric_alert_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_metric_alert_scenarios.py
@@ -106,13 +106,13 @@ class MonitorTests(ScenarioTest):
         })
 
         from azure.core.exceptions import HttpResponseError
-        with self.assertRaisesRegexp(HttpResponseError, "Couldn't find a metric named MS-ERRORCODE-SU001"):
+        with self.assertRaisesRegex(HttpResponseError, "Couldn't find a metric named MS-ERRORCODE-SU001"):
             self.cmd('monitor metrics alert create -n {alert_name} -g {rg}'
                      ' --scopes {storage_account_id}'
                      ' --region {storage_location}'
                      ' --condition "count account.MS-ERRORCODE-SU001 > 4" --description "Cloud_lumico"')
 
-        with self.assertRaisesRegexp(HttpResponseError, "Couldn't find a metric named MS-ERRORCODE|,-SU001"):
+        with self.assertRaisesRegex(HttpResponseError, "Couldn't find a metric named MS-ERRORCODE|,-SU001"):
             self.cmd('monitor metrics alert create -n {alert_name} -g {rg}'
                      ' --scopes {storage_account_id}'
                      ' --region {storage_location}'

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_private_link_scope.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_private_link_scope.py
@@ -129,5 +129,5 @@ class TestMonitorPrivateLinkScope(ScenarioTest):
             self.check('length(@)', 1)
         ])
         self.cmd('monitor private-link-scope delete -n {scope} -g {rg} -y')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('monitor private-link-scope show -n {scope} -g {rg}')

--- a/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_unittest.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/tests/latest/test_monitor_unittest.py
@@ -143,11 +143,11 @@ class MonitorMetricAlertActionTest(unittest.TestCase):
         self.check_condition(ns, 'Average', 'ns', 'foo/bar_doo', 'GreaterThan', '90', None)
 
         ns = self._build_namespace()
-        with self.assertRaisesRegexp(CLIError, 'usage error: --condition'):
+        with self.assertRaisesRegex(CLIError, 'usage error: --condition'):
             self.call_condition(ns, 'avg blah"what > 90')
 
         ns = self._build_namespace()
-        with self.assertRaisesRegexp(CLIError, 'usage error: --condition'):
+        with self.assertRaisesRegex(CLIError, 'usage error: --condition'):
             self.call_condition(ns, 'avg Wra!!ga * woo')
 
         ns = self._build_namespace()

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_dns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_dns_commands.py
@@ -67,15 +67,15 @@ class DnsZoneImportTest(ScenarioTest):
             self.skipTest('This test should run on Linux platform')
 
         from azure.cli.core.azclierror import FileOperationError
-        with self.assertRaisesRegexp(FileOperationError, 'No such file: ') as e:
+        with self.assertRaisesRegex(FileOperationError, 'No such file: ') as e:
             self._test_zone('404zone.com', 'non_existing_zone_description_file.txt')
             self.assertEqual(e.errno, 1)
 
-        with self.assertRaisesRegexp(FileOperationError, 'Is a directory: ') as e:
+        with self.assertRaisesRegex(FileOperationError, 'Is a directory: ') as e:
             self._test_zone('404zone.com', '')
             self.assertEqual(e.errno, 1)
 
-        with self.assertRaisesRegexp(FileOperationError, 'Permission denied: ') as e:
+        with self.assertRaisesRegex(FileOperationError, 'Permission denied: ') as e:
             self._test_zone('404zone.com', '/root/')
             self.assertEqual(e.errno, 1)
 
@@ -87,12 +87,12 @@ class DnsZoneImportTest(ScenarioTest):
             self.skipTest('This test should run on Windows platform')
 
         from azure.cli.core.azclierror import FileOperationError
-        with self.assertRaisesRegexp(FileOperationError, 'No such file: ') as e:
+        with self.assertRaisesRegex(FileOperationError, 'No such file: ') as e:
             self._test_zone('404zone.com', 'non_existing_zone_description_file.txt')
             self.assertEqual(e.errno, 1)
 
         # Difference with Linux platform while reading a directory
-        with self.assertRaisesRegexp(FileOperationError, 'Permission denied:') as e:
+        with self.assertRaisesRegex(FileOperationError, 'Permission denied:') as e:
             self._test_zone('404zone.com', '.')
             self.assertEqual(e.errno, 1)
 

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_network_commands.py
@@ -389,7 +389,7 @@ class NetworkPublicIpWithSku(ScenarioTest):
         ])
 
         from azure.core.exceptions import HttpResponseError
-        with self.assertRaisesRegexp(HttpResponseError, 'Global publicIP addresses are only supported for standard SKU public IP addresses'):
+        with self.assertRaisesRegex(HttpResponseError, 'Global publicIP addresses are only supported for standard SKU public IP addresses'):
             self.cmd('network public-ip create -g {rg} -l {location} -n {ip4} --tier {global_tier}')
 
 
@@ -472,7 +472,7 @@ class NetworkPublicIpPrefix(ScenarioTest):
         ])
 
         # Check with unsupported IP address version: IPv5
-        with self.assertRaisesRegexp(SystemExit, '2'):
+        with self.assertRaisesRegex(SystemExit, '2'):
             self.cmd('network public-ip prefix create -g {rg} -n {prefix_name_ipv6} --length 127 --version IPv5')
 
     @ResourceGroupPreparer(name_prefix='cli_test_network_public_ip_prefix_zone', location='eastus2')
@@ -1398,7 +1398,7 @@ class NetworkAppGatewaySubresourceScenarioTest(ScenarioTest):
         self.cmd(
             'network application-gateway url-path-map rule create -g {rg} --gateway-name {ag} -n {rulename2} --path-map-name {name} '
             '--paths /mypath122/* --address-pool {pool} --http-settings {settings}')
-        with self.assertRaisesRegexp(CLIError, "Cannot reference a BackendAddressPool when Redirect Configuration is specified."):
+        with self.assertRaisesRegex(CLIError, "Cannot reference a BackendAddressPool when Redirect Configuration is specified."):
             self.cmd(
                 'network application-gateway url-path-map rule create -g {rg} --gateway-name {ag} -n {rulename2} --path-map-name {name} '
                 '--paths /mypath122/* --address-pool {pool} --http-settings {settings} --redirect-config {redirect_config}')
@@ -2187,7 +2187,7 @@ class NetworkExpressRouteScenarioTest(ScenarioTest):
         # Expecting no results as we just deleted the only express route in the resource group
         self.cmd('network express-route list --resource-group {rg}', checks=self.is_empty())
 
-        with self.assertRaisesRegexp(CLIError, 'Please provide a complete resource ID'):
+        with self.assertRaisesRegex(CLIError, 'Please provide a complete resource ID'):
             self.cmd('network express-route gateway connection show --ids /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myrg/providers/Microsoft.Network/expressRouteGateways/aaa')
 
     @unittest.skip('Test is wrong, please fix. rg not found')
@@ -2359,7 +2359,7 @@ class NetworkExpressRouteGlobalReachScenarioTest(ScenarioTest):
         self.cmd('network express-route peering create -g {rg} --circuit-name {er2} --peering-type AzurePrivatePeering --peer-asn 10002 --vlan-id 102 --primary-peer-subnet 104.0.0.0/30 --secondary-peer-subnet 105.0.0.0/30')
 
         # These commands won't succeed because circuit creation requires a manual step from the service.
-        with self.assertRaisesRegexp(HttpResponseError, 'is Not Provisioned'):
+        with self.assertRaisesRegex(HttpResponseError, 'is Not Provisioned'):
             self.cmd('network express-route peering connection create -g {rg} --circuit-name {er1} --peering-name AzurePrivatePeering -n {conn12} --peer-circuit {er2} --address-prefix 104.0.0.0/29')
         self.cmd('network express-route peering connection show -g {rg} --circuit-name {er1} --peering-name AzurePrivatePeering -n {conn12}')
         self.cmd('network express-route peering connection list -g {rg} --circuit-name {er1} --peering-name AzurePrivatePeering')
@@ -2383,7 +2383,7 @@ class NetworkExpressRouteGlobalReachScenarioTest(ScenarioTest):
         self.cmd('network express-route peering create -g {rg} --circuit-name {er2} --peering-type AzurePrivatePeering --peer-asn 10002 --vlan-id 102 --primary-peer-subnet 104.0.0.0/30 --secondary-peer-subnet 105.0.0.0/30')
 
         # cannot create it, so this test will fail due to resource is not found.
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('network express-route peering peer-connection show -g {rg} --circuit-name {er1} --peering-name AzurePrivatePeering -n {peconn12}')
         self.cmd('network express-route peering peer-connection list -g {rg} --circuit-name {er1} --peering-name AzurePrivatePeering')
 
@@ -2404,11 +2404,11 @@ class NetworkExpressRouteGlobalReachScenarioTest(ScenarioTest):
         self.cmd('network express-route peering create -g {rg} --circuit-name {er2} --peering-type AzurePrivatePeering --peer-asn 10002 --vlan-id 102 --primary-peer-subnet 104.0.0.0/30 --secondary-peer-subnet 105.0.0.0/30')
 
         # These commands won't succeed because circuit creation requires a manual step from the service.
-        with self.assertRaisesRegexp(HttpResponseError, 'is Not Provisioned'):
+        with self.assertRaisesRegex(HttpResponseError, 'is Not Provisioned'):
             self.cmd('network express-route peering connection create -g {rg} --circuit-name {er1} --peering-name AzurePrivatePeering -n {conn12} --peer-circuit {er2} --address-prefix 104.0.0.0/29')
-        with self.assertRaisesRegexp(HttpResponseError, 'ParentResourceIsInFailedState'):
+        with self.assertRaisesRegex(HttpResponseError, 'ParentResourceIsInFailedState'):
             self.cmd('network express-route peering connection ipv6-config set -g {rg} --circuit-name {er1} --peering-name AzurePrivatePeering -n {conn12} --address-prefix .../125')
-        with self.assertRaisesRegexp(HttpResponseError, 'ParentResourceIsInFailedState'):
+        with self.assertRaisesRegex(HttpResponseError, 'ParentResourceIsInFailedState'):
             self.cmd('network express-route peering connection ipv6-config remove -g {rg} --circuit-name {er1} --peering-name AzurePrivatePeering -n {conn12}')
         self.cmd('network express-route peering connection delete -g {rg} --circuit-name {er1} --peering-name AzurePrivatePeering -n {conn12}')
 
@@ -3159,7 +3159,7 @@ class NetworkNicAppGatewayScenarioTest(ScenarioTest):
         self.cmd('network lb address-pool create -g {rg} --lb-name {lb} -n {bap}')
         self.cmd('network nic create -g {rg} -n {nic} --subnet {subnet2} --vnet-name {vnet} --gateway-name {ag} --app-gateway-address-pools {pool1}',
                  checks=self.check('length(NewNIC.ipConfigurations[0].applicationGatewayBackendAddressPools)', 1))
-        with self.assertRaisesRegexp(HttpResponseError, 'not supported for secondary IpConfigurations'):
+        with self.assertRaisesRegex(HttpResponseError, 'not supported for secondary IpConfigurations'):
             self.cmd('network nic ip-config create -g {rg} --nic-name {nic} -n {config2} --subnet {subnet2} --vnet-name {vnet} --gateway-name {ag} --app-gateway-address-pools {pool2}')
         self.cmd('network nic ip-config update -g {rg} --nic-name {nic} -n {config1} --gateway-name {ag} --app-gateway-address-pools {pool1} {pool2}',
                  checks=self.check('length(applicationGatewayBackendAddressPools)', 2))
@@ -3606,14 +3606,14 @@ class NetworkVNetCachingScenarioTest(ScenarioTest):
         self.cmd('network vnet create -g {rg} -n {vnet} --address-prefix 10.0.0.0/16 --defer')
         self.cmd('network vnet subnet create -g {rg} --vnet-name {vnet} -n subnet1 --address-prefix 10.0.0.0/24 --defer')
         self.cmd('network vnet subnet create -g {rg} --vnet-name {vnet} -n subnet2 --address-prefix 10.0.1.0/24 --defer')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             # ensure vnet has not been created
             self.cmd('network vnet show -g {rg} -n {vnet}')
         self.cmd('cache show -g {rg} -n {vnet} -t VirtualNetwork')
         self.cmd('network vnet subnet create -g {rg} --vnet-name {vnet} -n subnet3 --address-prefix 10.0.2.0/24')
         self.cmd('network vnet show -g {rg} -n {vnet}',
                  checks=self.check('length(subnets)', 3))
-        with self.assertRaisesRegexp(CLIError, 'Not found in cache'):
+        with self.assertRaisesRegex(CLIError, 'Not found in cache'):
             self.cmd('cache show -g {rg} -n {vnet} -t VirtualNetwork')
 
         # test that generic update works with caching
@@ -4319,7 +4319,7 @@ class NetworkActiveActiveVnetScenarioTest(ScenarioTest):  # pylint: disable=too-
         output = self.cmd('network vpn-connection packet-capture start -g {rg} -n {conn12}').output.strip()
         self.assertTrue('Successful' in output, 'Expected Successful in output.\nActual: {}'.format(output))
         # currently we cannot create traffic by cli command. So it will return an error when stop.
-        with self.assertRaisesRegexp(HttpResponseError, 'The response did not contain any data'):
+        with self.assertRaisesRegex(HttpResponseError, 'The response did not contain any data'):
             self.cmd('network vpn-connection packet-capture stop -g {rg} -n {conn12} --sas-url {sas_url}')
 
 
@@ -4361,7 +4361,7 @@ class NetworkVpnGatewayScenarioTest(ScenarioTest):
             'vnet2_id': '/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{vnet2}'.format(**self.kwargs)
         })
 
-        with self.assertRaisesRegexp(CLIError, 'vpn_gateway_generation should not be provided if gateway_type is not Vpn.'):
+        with self.assertRaisesRegex(CLIError, 'vpn_gateway_generation should not be provided if gateway_type is not Vpn.'):
             self.cmd(
                 'network vnet-gateway create -g {rg} -n {gw1} --vnet {vnet1_id} --public-ip-address {ip1} --gateway-type ExpressRoute --vpn-gateway-generation Generation1')
 
@@ -4529,7 +4529,7 @@ class NetworkVpnGatewayScenarioTest(ScenarioTest):
         output = self.cmd('network vnet-gateway packet-capture start -g {rg} -n {gw1}').output.strip()
         self.assertTrue('Successful' in output, 'Expected Successful in output.\nActual: {}'.format(output))
         # currently we cannot create traffic by cli command. So it will return an error when stop.
-        with self.assertRaisesRegexp(HttpResponseError, 'The response did not contain any data'):
+        with self.assertRaisesRegex(HttpResponseError, 'The response did not contain any data'):
             self.cmd('network vnet-gateway packet-capture stop -g {rg} -n {gw1} --sas-url {sas_url}')
 
 
@@ -4874,7 +4874,7 @@ class NetworkProfileScenarioTest(ScenarioTest):
         # no e2e scenario without create. Testing path to service only.
         self.cmd('network profile list')
         self.cmd('network profile list -g {rg}')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('network profile show -g {rg} -n dummy')
         self.cmd('network profile delete -g {rg} -n dummy -y')
 

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_nw_flow_log.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_nw_flow_log.py
@@ -98,7 +98,7 @@ class NWFlowLogScenarioTest(ScenarioTest):
 
         self.cmd('network watcher flow-log delete --location {location} --name {flow_log}')
 
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('network watcher flow-log show --location {location} --name {flow_log}')
 
     @ResourceGroupPreparer(name_prefix='test_nw_flow_log_', location='westus')

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
@@ -608,7 +608,7 @@ class NetworkPrivateLinkPrivateLinkScopeScenarioTest(ScenarioTest):
             self.check('length(@)', 1)
         ])
         self.cmd('monitor private-link-scope delete -n {scope} -g {rg} -y')
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('monitor private-link-scope show -n {scope} -g {rg}')
 
 
@@ -699,11 +699,11 @@ class NetworkPrivateLinkRDBMSScenarioTest(ScenarioTest):
                      self.check('properties.provisioningState', 'Ready')
                  ])
 
-        with self.assertRaisesRegexp(CLIError, expectedError):
+        with self.assertRaisesRegex(CLIError, expectedError):
             self.cmd('network private-endpoint-connection approve --resource-name {} -g {} --name {} --description "{}" --type {}'
                      .format(server, resource_group, server_pec_name, approval_description, rp_type))
 
-        with self.assertRaisesRegexp(CLIError, expectedError):
+        with self.assertRaisesRegex(CLIError, expectedError):
             self.cmd('network private-endpoint-connection reject --resource-name {} -g {} --name {} --description "{}" --type {}'
                      .format(server, resource_group, server_pec_name, rejection_description, rp_type))
 
@@ -748,7 +748,7 @@ class NetworkPrivateLinkRDBMSScenarioTest(ScenarioTest):
                      self.check('properties.provisioningState', 'Ready')
                  ])
 
-        with self.assertRaisesRegexp(CLIError, expectedError):
+        with self.assertRaisesRegex(CLIError, expectedError):
             self.cmd('network private-endpoint-connection reject --resource-name {} -g {} --name {} --description "{}" --type {}'
                      .format(server, resource_group, server_pec_name, rejection_description, rp_type))
 
@@ -793,7 +793,7 @@ class NetworkPrivateLinkRDBMSScenarioTest(ScenarioTest):
                      self.check('properties.provisioningState', 'Ready')
                  ])
 
-        with self.assertRaisesRegexp(CLIError, expectedError):
+        with self.assertRaisesRegex(CLIError, expectedError):
             self.cmd('network private-endpoint-connection approve --resource-name {} -g {} --name {} --description "{}" --type {}'
                      .format(server, resource_group, server_pec_name, approval_description, rp_type))
 

--- a/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/tests/latest/test_privatedns_commands.py
@@ -376,7 +376,7 @@ class PrivateDnsZonesTests(BaseScenarioTests):
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
     def test_PutZone_ZoneExistsIfNoneMatchFailure_ExpectError(self, resource_group):
         self._Create_PrivateZone()
-        with self.assertRaisesRegexp(HttpResponseError, 'PreconditionFailed'):
+        with self.assertRaisesRegex(HttpResponseError, 'PreconditionFailed'):
             self.cmd('az network private-dns zone create -g {rg} -n {zone}')
 
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
@@ -392,7 +392,7 @@ class PrivateDnsZonesTests(BaseScenarioTests):
     def test_PatchZone_ZoneExistsIfMatchFailure_ExpectError(self, resource_group):
         self._Create_PrivateZone()
         self.kwargs['etag'] = self.create_guid()
-        with self.assertRaisesRegexp(HttpResponseError, 'etag mismatch'):
+        with self.assertRaisesRegex(HttpResponseError, 'etag mismatch'):
             self.cmd('az network private-dns zone update -g {rg} -n {zone} --if-match {etag}')
 
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
@@ -439,7 +439,7 @@ class PrivateDnsZonesTests(BaseScenarioTests):
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
     def test_PatchZone_ZoneNotExists_ExpectError(self, resource_group):
         GeneratePrivateZoneName(self)
-        with self.assertRaisesRegexp(ResourceNotFoundError, 'ResourceNotFound'):
+        with self.assertRaisesRegex(ResourceNotFoundError, 'ResourceNotFound'):
             self.cmd('az network private-dns zone update -g {rg} -n {zone}')
 
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
@@ -462,7 +462,7 @@ class PrivateDnsZonesTests(BaseScenarioTests):
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
     def test_GetZone_ZoneNotExists_ExpectError(self, resource_group):
         GeneratePrivateZoneName(self)
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az network private-dns zone show -g {rg} -n {zone}')
 
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
@@ -511,7 +511,7 @@ class PrivateDnsLinksTests(BaseScenarioTests):
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
     def test_PutLink_LinkExistsIfNoneMatchFailure_ExpectError(self, resource_group):
         self._Create_VirtualNetworkLink()
-        with self.assertRaisesRegexp(HttpResponseError, 'PreconditionFailed'):
+        with self.assertRaisesRegex(HttpResponseError, 'PreconditionFailed'):
             self.cmd('az network private-dns link vnet create -g {rg} -n {link} -z {zone} -v {vnet} -e {registrationEnabled}')
 
     @live_only()    # live only until https://github.com/Azure/azure-python-devtools/pull/58 fixed
@@ -531,21 +531,21 @@ class PrivateDnsLinksTests(BaseScenarioTests):
         self._Create_VirtualNetworkLink()
         self.kwargs['etag'] = self.create_guid()
         cmd = "az network private-dns link vnet update -g {rg} -n {link} -z {zone} --if-match '{etag}'"
-        with self.assertRaisesRegexp(HttpResponseError, 'etag mismatch'):
+        with self.assertRaisesRegex(HttpResponseError, 'etag mismatch'):
             self.cmd(cmd)
 
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
     def test_PatchLink_ZoneNotExists_ExpectError(self, resource_group):
         GeneratePrivateZoneName(self)
         GenerateVirtualNetworkLinkName(self)
-        with self.assertRaisesRegexp(ResourceNotFoundError, 'ResourceNotFound'):
+        with self.assertRaisesRegex(ResourceNotFoundError, 'ResourceNotFound'):
             self.cmd('az network private-dns link vnet update -g {rg} -n {link} -z {zone}')
 
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
     def test_PatchLink_LinkNotExists_ExpectError(self, resource_group):
         self._Create_PrivateZone()
         GenerateVirtualNetworkLinkName(self)
-        with self.assertRaisesRegexp(ResourceNotFoundError, 'ResourceNotFound'):
+        with self.assertRaisesRegex(ResourceNotFoundError, 'ResourceNotFound'):
             self.cmd('az network private-dns link vnet update -g {rg} -n {link} -z {zone}')
 
     @live_only()    # live only until https://github.com/Azure/azure-python-devtools/pull/58 fixed
@@ -627,14 +627,14 @@ class PrivateDnsLinksTests(BaseScenarioTests):
     def test_GetLink_ZoneNotExists_ExpectError(self, resource_group):
         GeneratePrivateZoneName(self)
         GenerateVirtualNetworkLinkName(self)
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az network private-dns link vnet show -g {rg} -n {link} -z {zone}')
 
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
     def test_GetLink_LinkNotExists_ExpectError(self, resource_group):
         self._Create_PrivateZone()
         GenerateVirtualNetworkLinkName(self)
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az network private-dns link vnet show -g {rg} -n {link} -z {zone}')
 
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
@@ -685,14 +685,14 @@ class PrivateDnsRecordSetsTests(BaseScenarioTests):
     def test_PutRecordSet_ZoneNotExists_ExpectError(self, resource_group):
         GeneratePrivateZoneName(self)
         GenerateRecordSetName(self)
-        with self.assertRaisesRegexp(ResourceNotFoundError, 'ResourceNotFound'):
+        with self.assertRaisesRegex(ResourceNotFoundError, 'ResourceNotFound'):
             self.cmd('az network private-dns record-set a create -g {rg} -n {recordset} -z {zone}')
 
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
     def test_PutRecordSet_IfNoneMatchFailure_ExpectError(self, resource_group):
         zone = self._Create_PrivateZone()
         self._Create_RecordSet('a', zone['name'])
-        with self.assertRaisesRegexp(HttpResponseError, 'PreconditionFailed'):
+        with self.assertRaisesRegex(HttpResponseError, 'PreconditionFailed'):
             self.cmd('az network private-dns record-set {recordType} create -g {rg} -n {recordset} -z {zone}')
 
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
@@ -706,7 +706,7 @@ class PrivateDnsRecordSetsTests(BaseScenarioTests):
         zone = self._Create_PrivateZone()
         recordset = self._Create_RecordSet('a', zone['name'])
         etag = self.create_guid()
-        with self.assertRaisesRegexp(HttpResponseError, 'PreconditionFailed'):
+        with self.assertRaisesRegex(HttpResponseError, 'PreconditionFailed'):
             self._Update_RecordSet(recordset['name'], 'a', zone['name'], etag)
 
     @ResourceGroupPreparer(name_prefix='clitest_privatedns')
@@ -969,15 +969,15 @@ class PrivateDnsZoneImportTest(ScenarioTest):
             self.skipTest('This test should run on Linux platform')
 
         from azure.cli.core.azclierror import FileOperationError
-        with self.assertRaisesRegexp(FileOperationError, 'No such file: ') as e:
+        with self.assertRaisesRegex(FileOperationError, 'No such file: ') as e:
             self._test_PrivateDnsZone('404zone.com', 'non_existing_zone_description_file.txt')
             self.assertEqual(e.errno, 1)
 
-        with self.assertRaisesRegexp(FileOperationError, 'Is a directory: ') as e:
+        with self.assertRaisesRegex(FileOperationError, 'Is a directory: ') as e:
             self._test_PrivateDnsZone('404zone.com', '')
             self.assertEqual(e.errno, 1)
 
-        with self.assertRaisesRegexp(FileOperationError, 'Permission denied: ') as e:
+        with self.assertRaisesRegex(FileOperationError, 'Permission denied: ') as e:
             self._test_PrivateDnsZone('404zone.com', '/root/')
             self.assertEqual(e.errno, 1)
 
@@ -988,12 +988,12 @@ class PrivateDnsZoneImportTest(ScenarioTest):
             self.skipTest('This test should run on Windows platform')
 
         from azure.cli.core.azclierror import FileOperationError
-        with self.assertRaisesRegexp(FileOperationError, 'No such file: ') as e:
+        with self.assertRaisesRegex(FileOperationError, 'No such file: ') as e:
             self._test_PrivateDnsZone('404zone.com', 'non_existing_zone_description_file.txt')
             self.assertEqual(e.errno, 1)
 
         # Difference with Linux platform while reading a directory
-        with self.assertRaisesRegexp(FileOperationError, 'Permission denied:') as e:
+        with self.assertRaisesRegex(FileOperationError, 'Permission denied:') as e:
             self._test_PrivateDnsZone('404zone.com', '.')
             self.assertEqual(e.errno, 1)
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_commands.py
@@ -682,11 +682,11 @@ class ProxyResourcesMgmtScenarioTest(ScenarioTest):
                      self.check('provisioningState', 'Ready')
                  ])
 
-        with self.assertRaisesRegexp(HttpResponseError, expectedError):
+        with self.assertRaisesRegex(HttpResponseError, expectedError):
             self.cmd('{} server private-endpoint-connection approve --server-name {} -g {} --name {} --description "{}"'
                      .format(database_engine, server, resource_group, server_pec_name, approval_description))
 
-        with self.assertRaisesRegexp(HttpResponseError, expectedError):
+        with self.assertRaisesRegex(HttpResponseError, expectedError):
             self.cmd('{} server private-endpoint-connection reject --server-name {} -g {} --name {} --description "{}"'
                      .format(database_engine, server, resource_group, server_pec_name, rejection_description))
 
@@ -737,7 +737,7 @@ class ProxyResourcesMgmtScenarioTest(ScenarioTest):
                      self.check('provisioningState', 'Ready')
                  ])
 
-        with self.assertRaisesRegexp(HttpResponseError, expectedError):
+        with self.assertRaisesRegex(HttpResponseError, expectedError):
             self.cmd('{} server private-endpoint-connection reject --server-name {} -g {} --name {} --description "{}"'
                      .format(database_engine, server, resource_group, server_pec_name, rejection_description))
 
@@ -787,7 +787,7 @@ class ProxyResourcesMgmtScenarioTest(ScenarioTest):
                      self.check('provisioningState', 'Ready')
                  ])
 
-        with self.assertRaisesRegexp(HttpResponseError, expectedError):
+        with self.assertRaisesRegex(HttpResponseError, expectedError):
             self.cmd('{} server private-endpoint-connection approve --server-name {} -g {} --name {} --description "{}"'
                      .format(database_engine, server, resource_group, server_pec_name, approval_description))
 

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -3678,7 +3678,7 @@ class ResourceGroupLocalContextScenarioTest(LocalContextScenarioTest):
             self.check('name', self.kwargs['group1']),
             self.check('location', self.kwargs['location'])
         ])
-        with self.assertRaisesRegexp(SystemExit, '2'):
+        with self.assertRaisesRegex(SystemExit, '2'):
             self.cmd('group delete')
         self.cmd('group delete -n {group1} -y')
         self.cmd('group create -n {group2}', checks=[

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -341,7 +341,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTest):
                 self.cmd('role assignment delete --assignee {upn} --role reader')
 
                 # test role assignment on empty scope
-                with self.assertRaisesRegexp(CLIError, "Cannot find user or service principal in graph database for 'fake'."):
+                with self.assertRaisesRegex(CLIError, "Cannot find user or service principal in graph database for 'fake'."):
                     self.cmd('role assignment create --assignee fake --role contributor')
             finally:
                 self.cmd('ad user delete --upn-or-object-id {upn}')

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/test_sf_application.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/test_sf_application.py
@@ -19,7 +19,7 @@ class ServiceFabricApplicationTests(ScenarioTest):
         self.cmd('az sf application-type delete -g {rg} -c {cluster_name} --application-type-name {app_type_name}')
 
         # SystemExit 3 'not found'
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az sf application-type show -g {rg} -c {cluster_name} --application-type-name {app_type_name}')
 
     def _app_type_version_test(self):
@@ -33,7 +33,7 @@ class ServiceFabricApplicationTests(ScenarioTest):
         self.cmd('az sf application-type version delete -g {rg} -c {cluster_name} --application-type-name {app_type_name} --version {v1}')
 
         # SystemExit 3 'not found'
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az sf application-type version show -g {rg} -c {cluster_name} --application-type-name {app_type_name} --version {v1}')
 
     def _app_service_test(self):
@@ -84,7 +84,7 @@ class ServiceFabricApplicationTests(ScenarioTest):
         self.cmd('az sf application-type delete -g {rg} -c {cluster_name} --application-type-name {app_type_name}')
 
         # SystemExit 3 'not found'
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az sf application show -g {rg} -c {cluster_name} --application-name {app_name}')
 
     @ResourceGroupPreparer()

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/test_sf_managed_application.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/test_sf_managed_application.py
@@ -55,7 +55,7 @@ class ServiceFabricManagedApplicationTests(ScenarioTest):
         self.cmd('az sf managed-application-type delete -g {rg} -c {cluster_name} --application-type-name {app_type_name}')
 
         # SystemExit 3 'not found'
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az sf managed-application-type show -g {rg} -c {cluster_name} --application-type-name {app_type_name}')
 
     @ResourceGroupPreparer()
@@ -82,7 +82,7 @@ class ServiceFabricManagedApplicationTests(ScenarioTest):
         _wait_for_managed_cluster_state_ready(self, self.kwargs)
 
         # 'not found'
-        with self.assertRaisesRegexp(Exception, r'\(NotFound\).+not found.'):
+        with self.assertRaisesRegex(Exception, r'\(NotFound\).+not found.'):
             self.cmd('az sf managed-application-type version list -g {rg} -c {cluster_name} --application-type-name {app_type_name}')
         # Create
         app_type_version = self.cmd('az sf managed-application-type version create -g {rg} -c {cluster_name} '

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/test_sf_managed_cluster.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/test_sf_managed_cluster.py
@@ -32,7 +32,7 @@ class ServiceFabricManagedClustersTests(ScenarioTest):
                  checks=[self.check('provisioningState', 'Succeeded')])
 
         # 'InvalidParameter - Cluster must have at least one active primary node type'
-        with self.assertRaisesRegexp(HttpResponseError, 'Cluster must have at least one active primary node type'):
+        with self.assertRaisesRegex(HttpResponseError, 'Cluster must have at least one active primary node type'):
             self.cmd('az sf managed-node-type delete -g {rg} -c {cluster_name} -n pnt')
 
         self.cmd('az sf managed-cluster show -g {rg} -c {cluster_name}',
@@ -41,7 +41,7 @@ class ServiceFabricManagedClustersTests(ScenarioTest):
         self.cmd('az sf managed-cluster delete -g {rg} -c {cluster_name}')
 
         # SystemExit 3 'not found'
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az sf managed-cluster show -g {rg} -c {cluster_name}')
 
     @ResourceGroupPreparer()
@@ -96,7 +96,7 @@ class ServiceFabricManagedClustersTests(ScenarioTest):
         self.cmd('az sf managed-node-type delete -g {rg} -c {cluster_name} -n snt')
 
         # SystemExit 3 'not found'
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az sf managed-node-type show -g {rg} -c {cluster_name} -n snt')
 
         self.cmd('az sf managed-node-type list -g {rg} -c {cluster_name}',
@@ -105,7 +105,7 @@ class ServiceFabricManagedClustersTests(ScenarioTest):
         self.cmd('az sf managed-cluster delete -g {rg} -c {cluster_name}')
 
         # SystemExit 3 'not found'
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az sf managed-cluster show -g {rg} -c {cluster_name}')
 
     @ResourceGroupPreparer()
@@ -171,7 +171,7 @@ class ServiceFabricManagedClustersTests(ScenarioTest):
         self.cmd('az sf managed-cluster delete -g {rg} -c {cluster_name}')
 
         # SystemExit 3 'not found'
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('az sf managed-cluster show -g {rg} -c {cluster_name}')
 
 

--- a/src/azure-cli/azure/cli/command_modules/sqlvm/tests/latest/test_sqlvm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sqlvm/tests/latest/test_sqlvm_commands.py
@@ -131,7 +131,7 @@ class SqlVmScenarioTest(ScenarioTest):
                        .format(storage_account, resource_group)).get_output_in_json()
 
         # Assert customer cannot create a SQL vm with no agent and do not provide offer and sku
-        with self.assertRaisesRegexp(CLIError, "usage error: --sql-mgmt-type NoAgent --image-sku NAME --image-offer NAME"):
+        with self.assertRaisesRegex(CLIError, "usage error: --sql-mgmt-type NoAgent --image-sku NAME --image-offer NAME"):
             self.cmd('sql vm create -n {} -g {} -l {} --license-type {} --sql-mgmt-type {}'
                      .format(sqlvm, resource_group, loc, 'PAYG', 'NoAgent'))
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2019_03_01/test_storage_blob_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2019_03_01/test_storage_blob_scenarios.py
@@ -361,7 +361,7 @@ class StorageBlobUploadTests(StorageScenarioMixin, ScenarioTest):
 
         # test 403
         from azure.common import AzureException
-        with self.assertRaisesRegexp(AzureException, "Authentication failure"):
+        with self.assertRaisesRegex(AzureException, "Authentication failure"):
             self.cmd('storage blob show --account-name {} --account-key="YQ==" -c foo -n bar.txt '.format(storage_account))
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2020_09_01/test_storage_blob_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/hybrid_2020_09_01/test_storage_blob_scenarios.py
@@ -361,7 +361,7 @@ class StorageBlobUploadTests(StorageScenarioMixin, ScenarioTest):
 
     #     # test 403
     #     from azure.common import AzureException
-    #     with self.assertRaisesRegexp(AzureException, "Authentication failure"):
+    #     with self.assertRaisesRegex(AzureException, "Authentication failure"):
     #         self.cmd('storage blob show --account-name {} --account-key="YQ==" -c foo -n bar.txt '.format(storage_account))
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_account_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_account_scenarios.py
@@ -658,7 +658,7 @@ class StorageAccountTests(StorageScenarioMixin, ScenarioTest):
         ])
 
         # Table service
-        with self.assertRaisesRegexp(CLIError, "incorrect usage: for table service, the supported version for logging is `1.0`"):
+        with self.assertRaisesRegex(CLIError, "incorrect usage: for table service, the supported version for logging is `1.0`"):
             self.cmd('storage logging update --services t --log r --retention 1 '
                      '--version 2.0 --connection-string {}'.format(connection_string))
 
@@ -698,7 +698,7 @@ class StorageAccountTests(StorageScenarioMixin, ScenarioTest):
 
         blob_connection_string = self.cmd(
             'storage account show-connection-string -g {} -n {} -otsv'.format(resource_group, blob_storage)).output
-        with self.assertRaisesRegexp(CLIError, "Your storage account doesn't support logging"):
+        with self.assertRaisesRegex(CLIError, "Your storage account doesn't support logging"):
             self.cmd('storage logging show --services q --connection-string {}'.format(blob_connection_string))
 
         # PremiumStorage doesn't support logging for some services
@@ -708,7 +708,7 @@ class StorageAccountTests(StorageScenarioMixin, ScenarioTest):
 
         premium_connection_string = self.cmd(
             'storage account show-connection-string -g {} -n {} -otsv'.format(resource_group, premium_storage)).output
-        with self.assertRaisesRegexp(CLIError, "Your storage account doesn't support logging"):
+        with self.assertRaisesRegex(CLIError, "Your storage account doesn't support logging"):
             self.cmd('storage logging show --services q --connection-string {}'.format(premium_connection_string))
 
     @ResourceGroupPreparer()
@@ -1689,7 +1689,7 @@ class BlobServicePropertiesTests(StorageScenarioMixin, ScenarioTest):
         self.cmd('storage account blob-service-properties show -n {sa} -g {rg}', checks=[
             self.check('defaultServiceVersion', None)])
 
-        with self.assertRaisesRegexp(InvalidArgumentValueError, 'Valid example: 2008-10-27'):
+        with self.assertRaisesRegex(InvalidArgumentValueError, 'Valid example: 2008-10-27'):
             self.cmd('storage account blob-service-properties update --default-service-version 2018 -n {sa} -g {rg}')
 
         self.cmd('storage account blob-service-properties update --default-service-version 2018-11-09 -n {sa} -g {rg}',
@@ -1757,7 +1757,7 @@ class FileServicePropertiesTests(StorageScenarioMixin, ScenarioTest):
         with self.assertRaises(ValidationError):
             self.cmd('{cmd} update --enable-delete-retention true -n {sa} -g {rg}')
 
-        with self.assertRaisesRegexp(ValidationError, "Delete Retention Policy hasn't been enabled,"):
+        with self.assertRaisesRegex(ValidationError, "Delete Retention Policy hasn't been enabled,"):
             self.cmd('{cmd} update --delete-retention-days 1 -n {sa} -g {rg} -n {sa} -g {rg}')
 
         with self.assertRaises(ValidationError):
@@ -1787,7 +1787,7 @@ class FileServicePropertiesTests(StorageScenarioMixin, ScenarioTest):
             'cmd': 'storage account file-service-properties'
         })
 
-        with self.assertRaisesRegexp(ResourceExistsError, "SMB Multichannel is not supported for the account."):
+        with self.assertRaisesRegex(ResourceExistsError, "SMB Multichannel is not supported for the account."):
             self.cmd('{cmd} update --mc -n {sa2} -g {rg}')
 
         self.cmd('{cmd} show -n {sa} -g {rg}').assert_with_checks(
@@ -1910,13 +1910,13 @@ class StorageAccountPrivateEndpointScenarioTest(ScenarioTest):
 
         self.cmd('storage account private-endpoint-connection show --account-name {sa} -g {rg} --name {sa_pec_name}',
                  checks=self.check('id', '{sa_pec_id}'))
-        with self.assertRaisesRegexp(CLIError, 'Your connection is already approved. No need to approve again.'):
+        with self.assertRaisesRegex(CLIError, 'Your connection is already approved. No need to approve again.'):
             self.cmd('storage account private-endpoint-connection approve --account-name {sa} -g {rg} --name {sa_pec_name}')
 
         self.cmd('storage account private-endpoint-connection reject --account-name {sa} -g {rg} --name {sa_pec_name}',
                  checks=[self.check('privateLinkServiceConnectionState.status', 'Rejected')])
 
-        with self.assertRaisesRegexp(CLIError, 'You cannot approve the connection request after rejection.'):
+        with self.assertRaisesRegex(CLIError, 'You cannot approve the connection request after rejection.'):
             self.cmd('storage account private-endpoint-connection approve --account-name {sa} -g {rg} --name {sa_pec_name}')
 
         self.cmd('storage account private-endpoint-connection delete --id {sa_pec_id} -y')

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_adls_gen2_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_adls_gen2_scenarios.py
@@ -376,7 +376,7 @@ class StorageADLSGen2Tests(StorageScenarioMixin, ScenarioTest):
 
         # Upload File to an existing non-empty file with default overwrite=false
         new_local_file = self.create_temp_file(512)
-        with self.assertRaisesRegexp(CLIError, 'You cannot upload to an existing non-empty file with overwrite=false.'):
+        with self.assertRaisesRegex(CLIError, 'You cannot upload to an existing non-empty file with overwrite=false.'):
             self.storage_cmd('storage fs file upload -p {} -f {} -s "{}"', account_info, file_path, filesystem,
                              new_local_file)
 
@@ -419,7 +419,7 @@ class StorageADLSGen2Tests(StorageScenarioMixin, ScenarioTest):
         import os
         self.assertEqual(1, sum(len(f) for r, d, f in os.walk(local_dir)))
 
-        with self.assertRaisesRegexp(CLIError, "The specified path already exists. Please change to a valid path."):
+        with self.assertRaisesRegex(CLIError, "The specified path already exists. Please change to a valid path."):
             self.storage_cmd('storage fs file download -p {} -f {} -d "{}" --overwrite false', account_info, file_path,
                              filesystem, local_dir)
 
@@ -486,7 +486,7 @@ class StorageADLSGen2Tests(StorageScenarioMixin, ScenarioTest):
 
         expiry = (datetime.utcnow() + timedelta(hours=1)).strftime('%Y-%m-%dT%H:%MZ')
 
-        with self.assertRaisesRegexp(CLIError, "incorrect usage: specify --as-user when --auth-mode login"):
+        with self.assertRaisesRegex(CLIError, "incorrect usage: specify --as-user when --auth-mode login"):
             self.cmd('storage fs generate-sas --account-name {} -n {} --expiry {} --permissions r --https-only '
                      '--auth-mode login'.format(storage_account, f, expiry))
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_scenarios.py
@@ -168,7 +168,7 @@ class StorageBlobUploadTests(StorageScenarioMixin, ScenarioTest):
         local_dir = self.create_temp_dir()
         account_info = self.get_account_info(resource_group, storage_account)
         from azure.cli.core.azclierror import FileOperationError
-        with self.assertRaisesRegexp(FileOperationError, 'File is expected, not a directory'):
+        with self.assertRaisesRegex(FileOperationError, 'File is expected, not a directory'):
             self.storage_cmd('storage blob download -c mycontainer -n myblob -f "{}"', account_info, local_dir)
 
     @ResourceGroupPreparer()
@@ -460,7 +460,7 @@ class StorageBlobUploadTests(StorageScenarioMixin, ScenarioTest):
 
         self.storage_cmd('storage blob upload -c {} -n {} -f "{}"', account_info, c, b, local_file)
         from azure.common import AzureException
-        with self.assertRaisesRegexp(AzureException, "NoPendingCopyOperation"):
+        with self.assertRaisesRegex(AzureException, "NoPendingCopyOperation"):
             self.storage_cmd('storage blob copy cancel -c {} -b {} --copy-id {}', account_info, c, b, copy_id)
 
     @ResourceGroupPreparer()
@@ -486,7 +486,7 @@ class StorageBlobUploadTests(StorageScenarioMixin, ScenarioTest):
 
         expiry = (datetime.utcnow() + timedelta(hours=1)).strftime('%Y-%m-%dT%H:%MZ')
 
-        with self.assertRaisesRegexp(CLIError, "incorrect usage: specify --as-user when --auth-mode login"):
+        with self.assertRaisesRegex(CLIError, "incorrect usage: specify --as-user when --auth-mode login"):
             self.cmd('storage blob generate-sas --account-name {} -n {} -c {} --expiry {} --permissions r --https-only '
                      '--auth-mode login'.format(storage_account, b, c, expiry))
 
@@ -524,7 +524,7 @@ class StorageBlobUploadTests(StorageScenarioMixin, ScenarioTest):
 
         # test 403
         from azure.core.exceptions import ClientAuthenticationError
-        with self.assertRaisesRegexp(ClientAuthenticationError, "Authentication failure"):
+        with self.assertRaisesRegex(ClientAuthenticationError, "Authentication failure"):
             self.cmd('storage blob show --account-name {} --account-key="YQ==" -c foo -n bar.txt '.format(storage_account))
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_container_rm_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_container_rm_scenarios.py
@@ -37,7 +37,7 @@ class StorageContainerRmScenarios(ScenarioTest):
 
         # Create container using existing name while setting fail-on-exist true
         from knack.util import CLIError
-        with self.assertRaisesRegexp(CLIError, 'The specified container already exists.'):
+        with self.assertRaisesRegex(CLIError, 'The specified container already exists.'):
             self.cmd(
                 'storage container-rm create --storage-account {sa} -g {rg} -n {container_name} --fail-on-exist').get_output_in_json()
 
@@ -124,7 +124,7 @@ class StorageContainerRmScenarios(ScenarioTest):
         self.assertEqual(self.cmd('storage container-rm list --storage-account {storage_account_id}').get_output_in_json(), [])
 
         # 7. Test show command (the container doesn't exist).
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('storage container-rm show --storage-account {sa} -g {rg} -n {container_name}')
 
         # 8. Test exists command (the container doesn't exist).

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_file_rm_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_file_rm_scenarios.py
@@ -91,7 +91,7 @@ class StorageFileShareRmScenarios(StorageScenarioMixin, ScenarioTest):
         self.kwargs.update({
             'non_exist_share_name': non_exist_share_name
         })
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('storage share-rm show --storage-account {sa} -g {rg} -n {non_exist_share_name}')
 
         # 5. Test update command.
@@ -224,7 +224,7 @@ class StorageFileShareRmScenarios(StorageScenarioMixin, ScenarioTest):
             JMESPathCheck('length(@)', 1)
         })
 
-        with self.assertRaisesRegexp(SystemExit, '3'):
+        with self.assertRaisesRegex(SystemExit, '3'):
             self.cmd('storage share-rm show --storage-account {sa} -g {rg} -n {share} --snapshot {snapshot}')
 
         self.cmd('storage share-rm delete --storage-account {sa} -g {rg} -n {share} -y')

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_validators.py
@@ -176,11 +176,11 @@ class TestCmdModuleStorageValidators(unittest.TestCase):
                          'arg': CLICommandArgument(dest='arg', argtype=arg_type)}
 
         validate_container_name = get_not_none_validator('container_name')
-        with self.assertRaisesRegexp(InvalidArgumentValueError, 'Argument --container-name/-c should be specified'):
+        with self.assertRaisesRegex(InvalidArgumentValueError, 'Argument --container-name/-c should be specified'):
             validate_container_name(cmd, Namespace(container_name=''))
 
         validate_arg = get_not_none_validator('arg')
-        with self.assertRaisesRegexp(InvalidArgumentValueError, 'Argument --arg should be specified'):
+        with self.assertRaisesRegex(InvalidArgumentValueError, 'Argument --arg should be specified'):
             validate_arg(cmd, Namespace(arg=None))
 
         validate_arg(cmd, Namespace(arg=0))

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_commands.py
@@ -1762,7 +1762,7 @@ class SecretsScenarioTest(ScenarioTest):  # pylint: disable=too-many-instance-at
         })
 
         message = 'Secret is missing vaultCertificates array or it is empty at index 0'
-        with self.assertRaisesRegexp(CLIError, message):
+        with self.assertRaisesRegex(CLIError, message):
             self.cmd('vm create -g {rg} -n {vm} --admin-username {admin} --authentication-type {auth} --image {image} --ssh-key-value \'{ssh_key}\' -l {loc} --secrets \'{secrets}\'')
 
         time.sleep(60)
@@ -1794,7 +1794,7 @@ class SecretsScenarioTest(ScenarioTest):  # pylint: disable=too-many-instance-at
 
         message = 'Secret is missing certificateStore within vaultCertificates array at secret index 0 and ' \
                   'vaultCertificate index 0'
-        with self.assertRaisesRegexp(CLIError, message):
+        with self.assertRaisesRegex(CLIError, message):
             self.cmd('vm create -g {rg} -n {vm} --admin-username {admin} --admin-password VerySecret!12 --image {image} -l {loc} --secrets \'{secrets}\'')
 
         time.sleep(60)

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_commands.py
@@ -1166,7 +1166,7 @@ class VMSSCreatePublicIpPerVm(ScenarioTest):  # pylint: disable=too-many-instanc
     #     })
 
     #     message = 'Secret is missing vaultCertificates array or it is empty at index 0'
-    #     with self.assertRaisesRegexp(CLIError, message):
+    #     with self.assertRaisesRegex(CLIError, message):
     #         self.cmd('vm create -g {rg} -n {vm} --admin-username {admin} --authentication-type {auth} --image {image} --ssh-key-value \'{ssh_key}\' -l {loc} --secrets \'{secrets}\' --nsg-rule NONE')
 
     #     vault_out = self.cmd('keyvault create -g {rg} -n {vault} -l {loc} --enabled-for-deployment true --enabled-for-template-deployment true').get_output_in_json()
@@ -1201,7 +1201,7 @@ class VMSSCreatePublicIpPerVm(ScenarioTest):  # pylint: disable=too-many-instanc
 
     #     message = 'Secret is missing certificateStore within vaultCertificates array at secret index 0 and ' \
     #               'vaultCertificate index 0'
-    #     with self.assertRaisesRegexp(CLIError, message):
+    #     with self.assertRaisesRegex(CLIError, message):
     #         self.cmd('vm create -g {rg} -n {vm} --admin-username {admin} --admin-password VerySecret!12 --image {image} -l {loc} --secrets \'{secrets}\' --nsg-rule NONE')
 
     #     vault_out = self.cmd(

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_image_builder_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_image_builder_commands.py
@@ -513,7 +513,7 @@ class ImageTemplateTest(ScenarioTest):
     def test_defer_only_commands(self, resource_group, resource_group_location):
         def _ensure_cmd_raises_defer_error(self, cmds):
             for cmd in cmds:
-                with self.assertRaisesRegexp(CLIError, "This command requires --defer"):
+                with self.assertRaisesRegex(CLIError, "This command requires --defer"):
                     self.cmd(cmd)
 
         self._identity_role(resource_group)

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -852,7 +852,7 @@ class VMManagedDiskScenarioTest(ScenarioTest):
         # in different region, it should default copyStart as True
         # TODO: should not throw exception after feature GA
         from azure.core.exceptions import ResourceExistsError
-        with self.assertRaisesRegexp(ResourceExistsError, 'CopyStart creation is not supported for this subscription'):
+        with self.assertRaisesRegex(ResourceExistsError, 'CopyStart creation is not supported for this subscription'):
             self.cmd('snapshot create -g {rg} -n {snapshot2} --source {disk} -l eastus')
 
     """ Disable temporarily
@@ -3117,7 +3117,7 @@ class SecretsScenarioTest(ScenarioTest):  # pylint: disable=too-many-instance-at
         })
 
         message = 'Secret is missing vaultCertificates array or it is empty at index 0'
-        with self.assertRaisesRegexp(CLIError, message):
+        with self.assertRaisesRegex(CLIError, message):
             self.cmd('vm create -g {rg} -n {vm} --admin-username {admin} --authentication-type {auth} --image {image} --ssh-key-value \'{ssh_key}\' -l {loc} --secrets \'{secrets}\' --nsg-rule NONE')
 
         vault_out = self.cmd('keyvault show -g {rg} -n {vault}').get_output_in_json()
@@ -3151,7 +3151,7 @@ class SecretsScenarioTest(ScenarioTest):  # pylint: disable=too-many-instance-at
 
         message = 'Secret is missing certificateStore within vaultCertificates array at secret index 0 and ' \
                   'vaultCertificate index 0'
-        with self.assertRaisesRegexp(CLIError, message):
+        with self.assertRaisesRegex(CLIError, message):
             self.cmd('vm create -g {rg} -n {vm} --admin-username {admin} --admin-password VerySecret!12 --image {image} -l {loc} --secrets \'{secrets}\' --nsg-rule NONE')
 
         vault_out = self.cmd('keyvault show -g {rg} -n {vault}').get_output_in_json()
@@ -6985,7 +6985,7 @@ class VMVMSSAddApplicationTestScenario(ScenarioTest):
 
         # wrong length of config-overrides
         message = 'usage error: --app-config-overrides should have the same number of items as --application-version-ids'
-        with self.assertRaisesRegexp(ArgumentUsageError, message):
+        with self.assertRaisesRegex(ArgumentUsageError, message):
             self.cmd('vm application set -g {rg} -n {vm} --app-version-ids {vid1} {vid2} --app-config-overrides {config}')
 
         self.cmd('vm application set -g {rg} -n {vm} --app-version-ids {vid1} {vid2} --app-config-overrides null {config}', checks=[
@@ -7071,7 +7071,7 @@ class VMVMSSAddApplicationTestScenario(ScenarioTest):
 
         # wrong length of config-overrides
         message = 'usage error: --app-config-overrides should have the same number of items as --application-version-ids'
-        with self.assertRaisesRegexp(ArgumentUsageError, message):
+        with self.assertRaisesRegex(ArgumentUsageError, message):
             self.cmd('vmss application set -g {rg} -n {vmss} --app-version-ids {vid1} {vid2} --app-config-overrides {config}')
 
         self.cmd('vmss application set -g {rg} -n {vmss} --app-version-ids {vid1} {vid2} --app-config-overrides null {config}', checks=[


### PR DESCRIPTION
**Description**<!--Mandatory-->

According to https://docs.python.org/3/library/unittest.html#deprecated-aliases, `assertRaisesRegexp` has been replaced with `assertRaisesRegex`.

`pytest` now files `DeprecationWarning` in Python 3.10 for `assertRaisesRegexp` (https://github.com/Azure/azure-cli/pull/20195):

```
> pytest src/azure-cli-core/azure/cli/core/tests/test_profile.py

azure/cli/core/tests/test_profile.py::TestProfile::test_get_auth_info_for_logged_in_service_principal
  D:\cli\py310\lib\site-packages\win32\lib\pywintypes.py:51: DeprecationWarning: getargs: The 'u' format is deprecated. Use 'U' instead.
    found = _win32sysloader.GetModuleFilename(filename)

azure/cli/core/tests/test_profile.py::TestProfile::test_get_login_credentials_aux_tenants
  D:\cli\azure-cli\src\azure-cli-core\azure\cli\core\tests\test_profile.py:935: DeprecationWarning: Please use assertRaisesRegex instead.
    with self.assertRaisesRegexp(CLIError,

azure/cli/core/tests/test_profile.py::TestProfile::test_get_raw_token_in_cloud_console
  D:\cli\azure-cli\src\azure-cli-core\azure\cli\core\tests\test_profile.py:1171: DeprecationWarning: Please use assertRaisesRegex instead.
    with self.assertRaisesRegexp(CLIError, 'Cloud Shell'):

azure/cli/core/tests/test_profile.py::TestProfile::test_get_raw_token_msi_system_assigned
  D:\cli\azure-cli\src\azure-cli-core\azure\cli\core\tests\test_profile.py:1138: DeprecationWarning: Please use assertRaisesRegex instead.
    with self.assertRaisesRegexp(CLIError, "MSI"):
```
