### PR TITLE
[AKS] `az aks create`: Fix issue that `--attach-acr` parameter can't work

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -1954,18 +1954,20 @@ class AKSContext:
         # this parameter does not need dynamic completion
         # validation
         if self.decorator_mode == DecoratorMode.CREATE and attach_acr:
-            if self._get_enable_managed_identity(enable_validation=False) and self.get_no_wait():
-                raise MutuallyExclusiveArgumentError(
-                    "When --attach-acr and --enable-managed-identity are both specified, "
-                    "--no-wait is not allowed, please wait until the whole operation succeeds."
-                )
-                # Attach acr operation will be handled after the cluster is created
-            # newly added check, check whether client_id exists before creating role assignment
-            service_principal, _ = self._get_service_principal_and_client_secret(read_only=True)
-            if not service_principal:
-                raise RequiredArgumentMissingError(
-                    "No service principal provided to create the acrpull role assignment for acr."
-                )
+            if self._get_enable_managed_identity(enable_validation=False):
+                if self.get_no_wait():
+                    raise MutuallyExclusiveArgumentError(
+                        "When --attach-acr and --enable-managed-identity are both specified, "
+                        "--no-wait is not allowed, please wait until the whole operation succeeds."
+                    )
+                    # Attach acr operation will be handled after the cluster is created
+            else:
+                # newly added check, check whether client_id exists before creating role assignment
+                service_principal, _ = self._get_service_principal_and_client_secret(read_only=True)
+                if not service_principal:
+                    raise RequiredArgumentMissingError(
+                        "No service principal provided to create the acrpull role assignment for acr."
+                    )
         return attach_acr
 
     def get_detach_acr(self) -> Union[str, None]:

--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -1955,12 +1955,12 @@ class AKSContext:
         # validation
         if self.decorator_mode == DecoratorMode.CREATE and attach_acr:
             if self._get_enable_managed_identity(enable_validation=False):
+                # Attach acr operation will be handled after the cluster is created
                 if self.get_no_wait():
                     raise MutuallyExclusiveArgumentError(
                         "When --attach-acr and --enable-managed-identity are both specified, "
                         "--no-wait is not allowed, please wait until the whole operation succeeds."
                     )
-                    # Attach acr operation will be handled after the cluster is created
             else:
                 # newly added check, check whether client_id exists before creating role assignment
                 service_principal, _ = self._get_service_principal_and_client_secret(read_only=True)

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -1697,7 +1697,19 @@ class AKSContextTestCase(unittest.TestCase):
             self.models,
             decorator_mode=DecoratorMode.UPDATE,
         )
-        ctx_4.get_attach_acr()
+        self.assertEqual(ctx_4.get_attach_acr(), "test_attach_acr")
+
+        # custom value
+        ctx_5 = AKSContext(
+            self.cmd,
+            {
+                "attach_acr": "test_attach_acr",
+                "enable_managed_identity": True,
+            },
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        self.assertEqual(ctx_5.get_attach_acr(), "test_attach_acr")
 
     def test_get_detach_acr(self):
         # default


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fix the issue that `--attach-acr` option would raise an error "No service principal provided to create the acrpull role assignment for acr." in `az aks create` when using managed identity or user assigned identity.

The code bug was introduced in [PR #19429](https://github.com/Azure/azure-cli/pull/19429) and [PR #19509](https://github.com/Azure/azure-cli/pull/19509). In the process of refactoring the implementation of `aks create`, we added an additional check when processing the option `--attach-acr` to verify whether service principal exists when managed identity is not enabled. However, when managed identity is enabled, we still check for the existence of service principal by mistake, which resulted in this error.

May refer the hotfix [PR #20405](https://github.com/Azure/azure-cli/pull/20405).

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
