### PR TITLE
{Packaging} Bump `humanfriendly` to 10.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -48,7 +48,7 @@ DEPENDENCIES = [
     'azure-cli-telemetry==1.0.6.*',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',
-    'humanfriendly>=4.7,<10.0',
+    'humanfriendly~=10.0',
     'jmespath',
     'knack~=0.9.0',
     'msal-extensions>=0.3.0,<0.4',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -100,7 +100,7 @@ colorama==0.4.4
 ConfigArgParse==0.14.0
 cryptography==3.3.2
 fabric==2.4.0
-humanfriendly==9.1
+humanfriendly==10.0
 idna==2.8
 invoke==1.2.0
 isodate==0.6.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -101,7 +101,7 @@ ConfigArgParse==0.14.0
 cryptography==3.3.2
 distro==1.6.0
 fabric==2.4.0
-humanfriendly==9.1
+humanfriendly==10.0
 idna==2.8
 invoke==1.2.0
 isodate==0.6.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -99,7 +99,7 @@ chardet==3.0.4
 colorama==0.4.4
 cryptography==3.3.2
 fabric==2.4.0
-humanfriendly==9.1
+humanfriendly==10.0
 idna==2.8
 invoke==1.2.0
 isodate==0.6.0
@@ -124,7 +124,6 @@ PyGithub==1.55
 PyJWT==2.1.0
 PyNaCl==1.4.0
 pyOpenSSL==19.0.0
-pyreadline==2.1
 python-dateutil==2.8.0
 pywin32==302
 requests-oauthlib==1.2.0


### PR DESCRIPTION
**Description**<!--Mandatory-->

The stale [`pyreadline`](https://pypi.org/project/pyreadline/) (last released at Sep 16, 2015) causes failure in PyCharm when using `pytest`:

```
Traceback (most recent call last):
  File "C:\Program Files\JetBrains\PyCharm Community Edition 2021.2.3\plugins\python-ce\helpers\pycharm\_jb_pytest_runner.py", line 51, in <module>
    sys.exit(pytest.main(args, plugins_to_load + [Plugin]))
  File "D:\cli\py310\lib\site-packages\_pytest\config\__init__.py", line 143, in main
    config = _prepareconfig(args, plugins)
  ...
  File "D:\cli\py310\lib\site-packages\pyreadline\modes\basemode.py", line 162, in _bind_key
    if not callable(func):
  File "D:\cli\py310\lib\site-packages\pyreadline\py3k_compat.py", line 8, in callable
    return isinstance(x, collections.Callable)
AttributeError: module 'collections' has no attribute 'Callable'
```

`pyreadline` is required by the old `humanfriendly`:

```
> pipdeptree -p pyreadline -r
pyreadline==2.1
  - humanfriendly==9.1 [requires: pyreadline]
    - azure-cli-core==2.30.0 [requires: humanfriendly>=4.7,<10.0]
      - azure-cli==2.30.0 [requires: azure-cli-core==2.30.0]
```

In new `humanfriendly`, it uses `pyreadline3` (https://github.com/xolox/python-humanfriendly/commit/9f9f271a9d39c7088ddfd4a1af62a997b1c6d7eb).
