### PR TITLE
{Auth} Rename option `token_encryption` to `encrypt_token_cache`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -864,6 +864,7 @@ def _create_identity_instance(cli_ctx, *args, **kwargs):
 
     # Only enable encryption for Windows (for now).
     fallback = sys.platform.startswith('win32')
-    encrypt = cli_ctx.config.getboolean('core', 'token_encryption', fallback=fallback)
+    # encrypt_token_cache affects both MSAL token cache and service principal entries.
+    encrypt = cli_ctx.config.getboolean('core', 'encrypt_token_cache', fallback=fallback)
 
     return Identity(*args, encrypt=encrypt, **kwargs)

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -53,7 +53,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         :param tenant_id: Tenant GUID, like 00000000-0000-0000-0000-000000000000. If unspecified, default to
             'organizations'.
         :param client_id: Client ID of the CLI application.
-        :param encrypt:  Whether to encrypt token cache and service principal entries.
+        :param encrypt:  Whether to encrypt MSAL token cache and service principal entries.
         """
         self.authority = authority
         self.tenant_id = tenant_id


### PR DESCRIPTION
**Description**<!--Mandatory-->

Rename option `token_encryption` to `encrypt_token_cache` per the internal discussion email:

- _Naming for the option to disable token encryption_

> While we do store Service Principal credentials, we call the location the **Token Cache** and this would also give an added benefit of an accurate description of what the config is doing. Encrypting the file and not just a token?

⚠ This option is still experimental and subject to change until it is announced at https://docs.microsoft.com/en-us/cli/azure/azure-cli-configuration