### PR TITLE
{CI} Disable tests for extensions depending on different `kubernetes` versions

### DIFF
--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -19,7 +19,7 @@ output=$(az extension list-available --query [].name -otsv)
 exit_code=0
 
 # azure-cli-ml: https://github.com/Azure/azure-cli-extensions/issues/826
-ignore_list='azure-cli-ml fzf'
+ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s'
 
 for ext in $output; do
     echo


### PR DESCRIPTION
## Symptom

CI fails with

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1204020&view=logs&jobId=dec4b9a0-9c0f-52f1-3e08-6456fce2bf62&j=dec4b9a0-9c0f-52f1-3e08-6456fce2bf62&t=98b838e2-1481-5123-a5d1-63f080201667

```
  File "/opt/az/azcliextensions/arcdata/azext_arcdata/sqlmi/custom.py", line 15, in <module>
    import azext_arcdata.core.kubernetes as kubernetes_util
  File "/opt/az/azcliextensions/arcdata/azext_arcdata/core/kubernetes.py", line 15, in <module>
    from kubernetes.client.exceptions import ApiException
ModuleNotFoundError: No module named 'kubernetes.client.exceptions'
```

## Debug

In `scripts/ci/test_extensions.sh`, add a debug line

```
find /opt/az -name kubernetes
```

before

```
az self-test --debug
```

We can see the output to be

```
find /opt/az -name kubernetes
/opt/az/azcliextensions/connectedk8s/kubernetes
/opt/az/azcliextensions/arcappliance/kubernetes
/opt/az/azcliextensions/arcdata/kubernetes
```

Using a docker image locally, we can see

```
> docker run -it mcr.microsoft.com/azure-cli

# az extension add -n connectedk8s
# az extension add -n arcappliance
# az extension add -n arcdata

# find ~/.azure/cliextensions -name kubernetes*
/root/.azure/cliextensions/arcappliance/kubernetes
/root/.azure/cliextensions/arcappliance/kubernetes-11.0.0.dist-info
/root/.azure/cliextensions/connectedk8s/kubernetes
/root/.azure/cliextensions/connectedk8s/kubernetes-11.0.0.dist-info
/root/.azure/cliextensions/arcdata/kubernetes
/root/.azure/cliextensions/arcdata/azext_arcdata/kubernetes_sdk
/root/.azure/cliextensions/arcdata/azext_arcdata/core/kubernetes.py
/root/.azure/cliextensions/arcdata/azext_arcdata/core/__pycache__/kubernetes.cpython-39.pyc
/root/.azure/cliextensions/arcdata/kubernetes-12.0.1.dist-info

# ls /root/.azure/cliextensions/connectedk8s/kubernetes/client
__init__.py       api               apis              models
__pycache__       api_client.py     configuration.py  rest.py

# ls /root/.azure/cliextensions/arcdata/kubernetes/client
__init__.py       api               apis              exceptions.py     rest.py
__pycache__       api_client.py     configuration.py  models
```

**`kubernetes-12.0.1` contains a new module `exceptions.py` not existing in `kubernetes-11.0.0`. When multiple `kubernetes`s appear on `sys.path`, only the first one is honored.**

## Fix

To treat these extensions equally without discrimination, disable all 3 extensions.

## Proposal

- We should consider making an allow list, instead of ignore list for extensions testing.
- `az extension add` should be able to detect conflicting dependencies.