### PR TITLE
[ARM] `az deployment sub/tenant/mg create`: Fix the `KeyError: 'resourceGroup'` in outputting results in table format when deploying non-resource group level resources

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/commands.py
@@ -43,14 +43,18 @@ def transform_resource_list(result):
     return transformed
 
 
-# Resource group deployment commands
 def transform_deployment(result):
     r = result
-    return OrderedDict([('Name', r['name']),
-                        ('ResourceGroup', r['resourceGroup']),
-                        ('State', r['properties']['provisioningState']),
-                        ('Timestamp', r['properties']['timestamp']),
-                        ('Mode', r['properties']['mode'])])
+    format_result = OrderedDict([('Name', r['name']),
+                                 ('State', r['properties']['provisioningState']),
+                                 ('Timestamp', r['properties']['timestamp']),
+                                 ('Mode', r['properties']['mode'])])
+
+    # For deployments that are not under the resource group level, the return data does not contain 'resourceGroup'
+    if 'resourceGroup' in r and r['resourceGroup']:
+        format_result['ResourceGroup'] = r['resourceGroup']
+
+    return format_result
 
 
 def transform_deployments_list(result):


### PR DESCRIPTION
Issue: #17744

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
For deployments that are not under the resource group level, the return data does not contain 'resourceGroup'. Therefore, the `KeyError: 'resourceGroup'` will appear in the original code



**Testing Guide**
<!--Example commands with explanations.-->
Local test results

![Screenshot 2021-11-22 152917](https://user-images.githubusercontent.com/16612065/142824780-568319d3-7cda-4a5f-a2b8-caf2d698b54b.png)
![Screenshot 2021-11-22 152939](https://user-images.githubusercontent.com/16612065/142824788-023bd35f-a146-451d-a42a-6bd24cef7fc0.png)
![Screenshot 2021-11-22 153506](https://user-images.githubusercontent.com/16612065/142824857-4c3a4346-9fd0-4372-89cb-514dcd7ca8b8.png)


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
