### PR TITLE
{AKS} Avoid unnecessary graph API call and refine error message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -4366,16 +4366,17 @@ class AKSContext:
         """
         return self._get_enable_local_accounts(enable_validation=True)
 
-    def get_client_id_from_identity_or_sp_profile(self) -> str:
-        """Helper function to obtain the value of client_id from identity_profile or service_principal_profile.
+    def get_assignee_from_identity_or_sp_profile(self) -> (str, bool):
+        """Helper function to obtain the value of assignee from identity_profile or service_principal_profile.
 
         Note: This is not a parameter of aks_update, and it will not be decorated into the `mc` object.
 
-        If client_id cannot be obtained, raise an UnknownError.
+        If assignee cannot be obtained, raise an UnknownError.
 
-        :return: string
+        :return: string, bool
         """
-        client_id = None
+        assignee = None
+        is_service_principal = False
         if check_is_msi_cluster(self.mc):
             if self.mc.identity_profile is None or self.mc.identity_profile["kubeletidentity"] is None:
                 raise UnknownError(
@@ -4384,13 +4385,15 @@ class AKSContext:
                     "You can manually grant or revoke permission to the identity named "
                     "<ClUSTER_NAME>-agentpool in MC_ resource group to access ACR."
                 )
-            client_id = self.mc.identity_profile["kubeletidentity"].client_id
+            assignee = self.mc.identity_profile["kubeletidentity"].object_id
+            is_service_principal = False
         elif self.mc and self.mc.service_principal_profile is not None:
-            client_id = self.mc.service_principal_profile.client_id
+            assignee = self.mc.service_principal_profile.client_id
+            is_service_principal = True
 
-        if not client_id:
+        if not assignee:
             raise UnknownError('Cannot get the AKS cluster\'s service principal.')
-        return client_id
+        return assignee, is_service_principal
 
 
 class AKSCreateDecorator:
@@ -4675,7 +4678,7 @@ class AKSCreateDecorator:
                 service_principal_profile = mc.service_principal_profile
                 _ensure_aks_acr(
                     self.cmd,
-                    client_id=service_principal_profile.client_id,
+                    assignee=service_principal_profile.client_id,
                     acr_name_or_id=attach_acr,
                     # not actually used
                     subscription_id=self.context.get_subscription_id(),
@@ -5507,22 +5510,24 @@ class AKSUpdateDecorator:
         self._ensure_mc(mc)
 
         subscription_id = self.context.get_subscription_id()
-        client_id = self.context.get_client_id_from_identity_or_sp_profile()
+        assignee, is_service_principal = self.context.get_assignee_from_identity_or_sp_profile()
         attach_acr = self.context.get_attach_acr()
         detach_acr = self.context.get_detach_acr()
 
         if attach_acr:
             _ensure_aks_acr(self.cmd,
-                            client_id=client_id,
+                            assignee=assignee,
                             acr_name_or_id=attach_acr,
-                            subscription_id=subscription_id)
+                            subscription_id=subscription_id,
+                            is_service_principal = is_service_principal)
 
         if detach_acr:
             _ensure_aks_acr(self.cmd,
-                            client_id=client_id,
+                            assignee=assignee,
                             acr_name_or_id=detach_acr,
                             subscription_id=subscription_id,
-                            detach=True)
+                            detach=True,
+                            is_service_principal = is_service_principal)
 
     def update_sku(self, mc: ManagedCluster) -> ManagedCluster:
         """Update sku (uptime sla) for the ManagedCluster object.

--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -5519,7 +5519,7 @@ class AKSUpdateDecorator:
                             assignee=assignee,
                             acr_name_or_id=attach_acr,
                             subscription_id=subscription_id,
-                            is_service_principal = is_service_principal)
+                            is_service_principal=is_service_principal)
 
         if detach_acr:
             _ensure_aks_acr(self.cmd,
@@ -5527,7 +5527,7 @@ class AKSUpdateDecorator:
                             acr_name_or_id=detach_acr,
                             subscription_id=subscription_id,
                             detach=True,
-                            is_service_principal = is_service_principal)
+                            is_service_principal=is_service_principal)
 
     def update_sku(self, mc: ManagedCluster) -> ManagedCluster:
         """Update sku (uptime sla) for the ManagedCluster object.

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -4255,7 +4255,7 @@ class AKSContextTestCase(unittest.TestCase):
         with self.assertRaises(MutuallyExclusiveArgumentError):
             ctx_2.get_enable_local_accounts()
 
-    def test_get_client_id_from_identity_or_sp_profile(self):
+    def test_get_assignee_from_identity_or_sp_profile(self):
         # default
         ctx_1 = AKSContext(
             self.cmd,
@@ -4265,7 +4265,7 @@ class AKSContextTestCase(unittest.TestCase):
         )
         # fail on no mc attached and no client id found
         with self.assertRaises(UnknownError):
-            ctx_1.get_client_id_from_identity_or_sp_profile()
+            ctx_1.get_assignee_from_identity_or_sp_profile()
 
         # custom value
         ctx_2 = AKSContext(
@@ -4281,7 +4281,7 @@ class AKSContextTestCase(unittest.TestCase):
         ctx_2.attach_mc(mc_2)
         # fail on kubelet identity not found
         with self.assertRaises(UnknownError):
-            ctx_2.get_client_id_from_identity_or_sp_profile()
+            ctx_2.get_assignee_from_identity_or_sp_profile()
 
         # custom value
         ctx_3 = AKSContext(
@@ -4295,13 +4295,14 @@ class AKSContextTestCase(unittest.TestCase):
             identity=self.models.ManagedClusterIdentity(type="UserAssigned"),
             identity_profile={
                 "kubeletidentity": self.models.UserAssignedIdentity(
-                    client_id="test_client_id"
+                    client_id="test_client_id",
+                    object_id = "test_object_id"
                 )
             },
         )
         ctx_3.attach_mc(mc_3)
         self.assertEqual(
-            ctx_3.get_client_id_from_identity_or_sp_profile(), "test_client_id"
+            ctx_3.get_assignee_from_identity_or_sp_profile(), ("test_object_id", False)
         )
 
         # custom value
@@ -4319,7 +4320,7 @@ class AKSContextTestCase(unittest.TestCase):
         )
         ctx_4.attach_mc(mc_4)
         self.assertEqual(
-            ctx_4.get_client_id_from_identity_or_sp_profile(), "test_client_id"
+            ctx_4.get_assignee_from_identity_or_sp_profile(), ("test_client_id", True)
         )
 
 
@@ -4865,7 +4866,7 @@ class AKSCreateDecoratorTestCase(unittest.TestCase):
         ) as ensure_assignment:
             dec_3.process_attach_acr(mc_3)
         ensure_assignment.assert_called_once_with(
-            self.cmd, "test_service_principal", "test_registry_id", False
+            self.cmd, "test_service_principal", "test_registry_id", False, True
         )
 
     def test_set_up_network_profile(self):
@@ -6511,13 +6512,13 @@ class AKSUpdateDecoratorTestCase(unittest.TestCase):
                 [
                     call(
                         self.cmd,
-                        client_id="test_client_id",
+                        assignee="test_client_id",
                         acr_name_or_id="test_attach_acr",
                         subscription_id="test_subscription_id",
                     ),
                     call(
                         self.cmd,
-                        client_id="test_client_id",
+                        assignee="test_client_id",
                         acr_name_or_id="test_detach_acr",
                         subscription_id="test_subscription_id",
                         detach=True,

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -6469,6 +6469,7 @@ class AKSUpdateDecoratorTestCase(unittest.TestCase):
             identity_profile={
                 "kubeletidentity": self.models.UserAssignedIdentity(
                     client_id="test_client_id",
+                    object_id="test_object_id"
                 )
             },
         )
@@ -6497,6 +6498,7 @@ class AKSUpdateDecoratorTestCase(unittest.TestCase):
             identity_profile={
                 "kubeletidentity": self.models.UserAssignedIdentity(
                     client_id="test_client_id",
+                    object_id="test_object_id"
                 )
             },
         )
@@ -6512,16 +6514,18 @@ class AKSUpdateDecoratorTestCase(unittest.TestCase):
                 [
                     call(
                         self.cmd,
-                        assignee="test_client_id",
+                        assignee="test_object_id",
                         acr_name_or_id="test_attach_acr",
                         subscription_id="test_subscription_id",
+                        is_service_principal=False,
                     ),
                     call(
                         self.cmd,
-                        assignee="test_client_id",
+                        assignee="test_object_id",
                         acr_name_or_id="test_detach_acr",
                         subscription_id="test_subscription_id",
                         detach=True,
+                        is_service_principal=False,
                     ),
                 ]
             )
@@ -7770,3 +7774,4 @@ class AKSUpdateDecoratorTestCase(unittest.TestCase):
             {},
             False,
         )
+


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Two things:
1. For MSI clusters, when attaching ACR, the operation "resolving client ID to object ID" is not necessary. We can directly get the object ID from managed cluster properties. This PR removes this unnecessary operation.
2. Refines the error message when resolving object ID hits error.
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
