### PR TITLE
{Graph} Only add `filter` query string when its value is non-empty

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -604,7 +604,7 @@ def list_apps(cmd, app_id=None, display_name=None, identifier_uri=None, query_fi
     if identifier_uri:
         sub_filters.append("identifierUris/any(s:s eq '{}')".format(identifier_uri))
 
-    result = client.applications.list(filter=(' and '.join(sub_filters)))
+    result = client.applications.list(filter=' and '.join(sub_filters) if sub_filters else None)
     if sub_filters or include_all:
         return list(result)
 
@@ -647,7 +647,7 @@ def list_sps(cmd, spn=None, display_name=None, query_filter=None, show_mine=None
     if display_name:
         sub_filters.append("startswith(displayName,'{}')".format(display_name))
 
-    result = client.service_principals.list(filter=(' and '.join(sub_filters)))
+    result = client.service_principals.list(filter=' and '.join(sub_filters) if sub_filters else None)
 
     if sub_filters or include_all:
         return result
@@ -675,7 +675,7 @@ def list_users(client, upn=None, display_name=None, query_filter=None):
     if display_name:
         sub_filters.append("startswith(displayName,'{}')".format(display_name))
 
-    return client.list(filter=(' and ').join(sub_filters))
+    return client.list(filter=' and '.join(sub_filters) if sub_filters else None)
 
 
 def create_user(client, user_principal_name, display_name, password,
@@ -756,7 +756,7 @@ def list_groups(client, display_name=None, query_filter=None):
         sub_filters.append(query_filter)
     if display_name:
         sub_filters.append("startswith(displayName,'{}')".format(display_name))
-    return client.list(filter=(' and ').join(sub_filters))
+    return client.list(filter=' and '.join(sub_filters) if sub_filters else None)
 
 
 def list_group_owners(cmd, group_id):


### PR DESCRIPTION
## Description

`az ad sp list` fails in **Azure Stack** environment:

```
> az ad sp list
Error occurred in request., RetryError: HTTPSConnectionPool(host='graph.redmond.azurestack.corp.microsoft.com', port=443): Max retries exceeded with url: /d48c9ef1-e46d-4148-b41e-ca95b463f5a8/servicePrincipals?$filter=&api-version=1.6 (Caused by ResponseError('too many 500 error responses'))
```

This is because `filter=` query string is set but its value is empty string `''`.

```py
>>> ' and '.join([])
''
```

Directly calling AD Graph API gives:

```
> az rest -m get -u '"https://graph.redmond.azurestack.corp.microsoft.com/d48c9ef1-e46d-4148-b41e-ca95b463f5a8/servicePrincipals?$filter=&api-version=1.6"' --verbose
Request URL: 'https://graph.redmond.azurestack.corp.microsoft.com/d48c9ef1-e46d-4148-b41e-ca95b463f5a8/servicePrincipals?$filter=&api-version=1.6'
Request method: 'GET'
...
Response status: 500
...
Response content:
{
  "error":{
    "code":"InternalServerError","message":"An application error occurred on the server."
  }
}
```

Even though public AD Graph does accept such usage and there is no rule against such usage (https://www.rfc-editor.org/rfc/rfc3986#section-3.4), query string with empty value is considered non-conventional.

## Change

Only set `filter` query string if its value is non-empty.

## Testing Guide
```
az cloud register -n azs-redmond --endpoint-resource-manager https://management.redmond.azurestack.corp.microsoft.com/ --profile 2020-09-01-hybrid
az cloud set -n azs-redmond

az login
az ad sp list --debug

msrest.http_logger: Request URL: 'https://graph.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/servicePrincipals?api-version=1.6'
msrest.http_logger: Request method: 'GET'
...
msrest.http_logger: Response status: 200
```
