### PR TITLE
{App Config} Fix #12668860, #12668922: Fix validations while importing kvset

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_help.py
@@ -148,7 +148,7 @@ examples:
   - name: Import all keys to another App Configuration using your 'az login' credentials.
     text: az appconfig kv import -s appconfig --endpoint https://myappconfiguration.azconfig.io --auth-mode login --src-endpoint https://anotherappconfiguration.azconfig.io --src-auth-mode login --src-key * --src-label * --preserve-labels
   - name: Import all keys and feature flags from a file using the appconfig/kvset format.
-    text: az appconfig kv import -n MyAppConfiguration --label test -s file --path D:/abc.json --format json --profile appconfig/kvset
+    text: az appconfig kv import -n MyAppConfiguration -s file --path D:/abc.json --format json --profile appconfig/kvset
 """
 
 helps['appconfig kv list'] = """

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -1107,7 +1107,7 @@ def __validate_import_tags(kv):
     if kv.tags:
         for tag_key, tag_value in kv.tags.items():
             if not isinstance(tag_value, str):
-                logger.warning("The value for the tag '{0}' for key '{1}' is not a string. It will be converted to a string.".format(tag_key, kv.key))
+                logger.warning("The value for the tag '{%s}' for key '{%s}' is not a string. It will be converted to a string.", tag_key, kv.key)
                 return
 
 

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -1112,11 +1112,14 @@ def __validate_import_config_setting(config_setting):
         return False
 
     if config_setting.value and not isinstance(config_setting.value, str):
-        logger.warning("The 'value' for the key '{%s}' is not a string. It will be converted to a string.", config_setting.key)
+        logger.warning("The 'value' for the key '{%s}' is not a string. This key-value will not be imported.", config_setting.key)
+        return False
     if config_setting.content_type and not isinstance(config_setting.content_type, str):
-        logger.warning("The 'content_type' for the key '{%s}' is not a string. It will be converted to a string.", config_setting.key)
+        logger.warning("The 'content_type' for the key '{%s}' is not a string. This key-value will not be imported.", config_setting.key)
+        return False
     if config_setting.label and not isinstance(config_setting.label, str):
-        logger.warning("The 'label' for the key '{%s}' is not a string. It will be converted to a string.", config_setting.key)
+        logger.warning("The 'label' for the key '{%s}' is not a string. This key-value will not be imported.", config_setting.key)
+        return False
 
     return __validate_import_tags(config_setting)
 
@@ -1129,7 +1132,8 @@ def __validate_import_tags(kv):
     if kv.tags:
         for tag_key, tag_value in kv.tags.items():
             if not isinstance(tag_value, str):
-                logger.warning("The value for the tag '{%s}' for key '{%s}' is not a string. It will be converted to a string.", tag_key, kv.key)
+                logger.warning("The value for the tag '{%s}' for key '{%s}' is not in a valid format. This key-value will not be imported.", tag_key, kv.key)
+                return False
     return True
 
 

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -1123,7 +1123,7 @@ def __validate_import_config_setting(config_setting):
 
 def __validate_import_tags(kv):
     if kv.tags and not isinstance(kv.tags, dict):
-        logger.warning("The value of the 'tags' for key '{%s}' is not an object. This key-value will not be imported.", kv.key)
+        logger.warning("The format of 'tags' for key '%s' is not valid. This key-value will not be imported.", kv.key)
         return False
 
     if kv.tags:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -1029,11 +1029,11 @@ def __import_kvset_from_file(client, path, yes):
     if KVSetConstants.KVSETRootElementName not in new_kvset:
         raise FileOperationError("file '{0}' is not in a valid '{1}' format.".format(path, ImportExportProfiles.KVSET))
 
-    kvset_from_file = [ConfigurationSetting(key=kv['key'] if 'key' in kv else None,
-                                            label=kv['label'] if 'label' in kv else None,
-                                            content_type=kv['content_type'] if 'content_type' in kv else None,
-                                            value=kv['value'] if 'value' in kv else None,
-                                            tags=kv['tags'] if 'tags' in kv else None)
+    kvset_from_file = [ConfigurationSetting(key=kv.get('key', None),
+                                            label=kv.get('label', None),
+                                            content_type=kv.get('content_type', None),
+                                            value=kv.get('value', None),
+                                            tags=kv.get('tags', None))
                        for kv in new_kvset[KVSetConstants.KVSETRootElementName]]
 
     kvset_to_import = []

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=line-too-long,too-many-nested-blocks,too-many-lines
+# pylint: disable=line-too-long,too-many-nested-blocks,too-many-lines,too-many-return-statements
 
 import io
 import json


### PR DESCRIPTION
**Description**
* Fixes [#12668922](https://msazure.visualstudio.com/Azure%20AppConfig/_workitems/edit/12668922/) Added validations to the command `az appconfig import` when `appconfig/kvset` profile is used and tags are not in string format.
* Fixes [#12668860](https://msazure.visualstudio.com/Azure%20AppConfig/_workitems/edit/12668860/) Handled cases where optional parameters were present in the import file for `az appconfig import` command and `appconfig/kvset` profile was used for import.

---

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).