### PR TITLE
{CI} Re-enable Python 3.9 tests

### DIFF
--- a/azure-pipelines-full-tests.yml
+++ b/azure-pipelines-full-tests.yml
@@ -24,8 +24,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -46,8 +46,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -68,8 +68,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -90,8 +90,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -398,8 +398,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -419,8 +419,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -443,8 +443,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -468,8 +468,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -489,8 +489,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -510,8 +510,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -531,8 +531,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -878,8 +878,8 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      # Python39:
-      #   python.version: '3.9'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   pool:


### PR DESCRIPTION
**Description**<!--Mandatory-->

According to 

- https://github.com/actions/virtual-environments
- https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#python

Azure Pipelines' agents have taken Python 3.9.9. We should re-enable Python 3.9 tests disabled by 
- https://github.com/Azure/azure-cli/pull/20287.
