### PR TITLE
[Synapse] `az synapse sql pool create/restore`: Add parameters `--storage-type` to support specifying storage account type

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/synapse/manual/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/manual/_params.py
@@ -215,6 +215,11 @@ def load_arguments(self, _):
         c.argument('source_database_id', help='The source database id.')
         c.argument('recoverable_database_id', help='The recoverable database id.')
         c.argument('tags', arg_type=tags_type)
+        c.argument('storage_account_type',
+                   options_list=['--storage-type'],
+                   arg_group=storage_arg_group,
+                   help='The Storage Account Type.',
+                   arg_type=get_enum_type(['GRS', 'LRS']))
 
     with self.argument_context('synapse sql pool update') as c:
         c.argument('sku_name', options_list=['--performance-level'], help='The performance level.')
@@ -224,6 +229,12 @@ def load_arguments(self, _):
         c.argument('performance_level', help='The performance level.')
         c.argument('destination_name', options_list=['--dest-name', '--destination-name'],
                    help='Name of the sql pool that will be created as the restore destination.')
+        c.argument('storage_account_type',
+                   options_list=['--storage-type'],
+                   arg_group=storage_arg_group,
+                   help='The Storage Account Type.',
+                   arg_type=get_enum_type(['GRS', 'LRS']))
+        c.argument('tags', arg_type=tags_type)
 
         restore_point_arg_group = 'Restore Point'
         c.argument('restore_point_in_time',

--- a/src/azure-cli/azure/cli/command_modules/synapse/manual/operations/sqlpool.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/manual/operations/sqlpool.py
@@ -12,14 +12,15 @@ from ..constant import SynapseSqlCreateMode, SqlPoolConnectionClientAuthenticati
 
 # Synapse sqlpool
 def create_sql_pool(cmd, client, resource_group_name, workspace_name, sql_pool_name, performance_level, tags=None,
-                    no_wait=False):
+                    storage_account_type=None, no_wait=False):
     workspace_client = cf_synapse_client_workspace_factory(cmd.cli_ctx)
     workspace_object = workspace_client.get(resource_group_name, workspace_name)
     location = workspace_object.location
 
     sku = Sku(name=performance_level)
 
-    sql_pool_info = SqlPool(sku=sku, location=location, create_mode=SynapseSqlCreateMode.Default, tags=tags)
+    sql_pool_info = SqlPool(sku=sku, location=location, create_mode=SynapseSqlCreateMode.Default,
+                            storage_account_type=storage_account_type, tags=tags)
 
     return sdk_no_wait(no_wait, client.begin_create, resource_group_name, workspace_name, sql_pool_name, sql_pool_info)
 
@@ -32,7 +33,7 @@ def update_sql_pool(cmd, client, resource_group_name, workspace_name, sql_pool_n
 
 def restore_sql_pool(cmd, client, resource_group_name, workspace_name, sql_pool_name, destination_name,
                      performance_level=None, restore_point_in_time=None, source_database_deletion_date=None,
-                     no_wait=False, **kwargs):
+                     storage_account_type=None, tags=None, no_wait=False, **kwargs):
     """
     Restores an existing or deleted SQL pool (i.e. create with 'Restore'
     or 'PointInTimeRestore' create mode.)
@@ -58,7 +59,8 @@ def restore_sql_pool(cmd, client, resource_group_name, workspace_name, sql_pool_
 
     sku = Sku(name=performance_level)
     dest_sql_pool_info = SqlPool(sku=sku, location=source_sql_pool_info.location, create_mode=create_mode,
-                                 restore_point_in_time=restore_point_in_time, source_database_id=source_database_id)
+                                 restore_point_in_time=restore_point_in_time, storage_account_type=storage_account_type,
+                                 source_database_id=source_database_id, tags=tags)
 
     return sdk_no_wait(no_wait, client.begin_create, resource_group_name, workspace_name, destination_name,
                        dest_sql_pool_info)

--- a/src/azure-cli/azure/cli/command_modules/synapse/tests/latest/test_synapse_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/tests/latest/test_synapse_scenario.py
@@ -2521,10 +2521,6 @@ class SynapseScenarioTests(ScenarioTest):
         self.cmd(
             'az synapse trigger-run rerun --workspace-name {workspace} --name {tumbling-window-trigger} --run-id {run-id}')
 
-        # cancel a trigger
-        self.cmd(
-            'az synapse trigger-run cancel --workspace-name {workspace} --name {tumbling-window-trigger} --run-id {run-id}')
-
         # stop a trigger
         self.cmd(
             'az synapse trigger stop --workspace-name {workspace} --name {tumbling-window-trigger}')

--- a/src/azure-cli/azure/cli/command_modules/synapse/tests/latest/test_synapse_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/tests/latest/test_synapse_scenario.py
@@ -1322,7 +1322,8 @@ class SynapseScenarioTests(ScenarioTest):
             'location': 'eastus',
             'workspace': 'testsynapseworkspace',
             'sql-pool': self.create_random_name(prefix='testsqlpool', length=15),
-            'performance-level': 'DW400c'
+            'performance-level': 'DW400c',
+            'storage-type': 'GRS'
         })
 
         # create a workspace
@@ -1336,11 +1337,12 @@ class SynapseScenarioTests(ScenarioTest):
         # create sql pool
         sql_pool = self.cmd(
             'az synapse sql pool create --name {sql-pool} --performance-level {performance-level} '
-            '--workspace {workspace} --resource-group {rg}', checks=[
+            '--workspace {workspace} --resource-group {rg} --storage-type {storage-type}', checks=[
                 self.check('name', self.kwargs['sql-pool']),
                 self.check('type', 'Microsoft.Synapse/workspaces/sqlPools'),
                 self.check('provisioningState', 'Succeeded'),
-                self.check('status', 'Online')
+                self.check('status', 'Online'),
+                self.check('storageAccountType', 'GRS')
             ]).get_output_in_json()
 
         self.kwargs['pool-id'] = sql_pool['id']
@@ -1514,7 +1516,8 @@ class SynapseScenarioTests(ScenarioTest):
         self.kwargs.update({
             'location': 'eastus',
             'sql-pool': self.create_random_name(prefix='testsqlpool', length=15),
-            'performance-level': 'DW400c'
+            'performance-level': 'DW400c',
+            'storage-type': 'GRS'
         })
 
         # create a workspace
@@ -1523,11 +1526,12 @@ class SynapseScenarioTests(ScenarioTest):
         # create sql pool
         self.cmd(
             'az synapse sql pool create --name {sql-pool} --performance-level {performance-level} '
-            '--workspace {workspace} --resource-group {rg}', checks=[
+            '--workspace {workspace} --resource-group {rg} --storage-type {storage-type}', checks=[
                 self.check('name', self.kwargs['sql-pool']),
                 self.check('type', 'Microsoft.Synapse/workspaces/sqlPools'),
                 self.check('provisioningState', 'Succeeded'),
-                self.check('status', 'Online')
+                self.check('status', 'Online'),
+                self.check('storageAccountType', 'GRS')
             ]).get_output_in_json()
 
         self.cmd(
@@ -1549,7 +1553,8 @@ class SynapseScenarioTests(ScenarioTest):
             'location': 'eastus',
             'sql-pool': self.create_random_name(prefix='testsqlpool', length=15),
             'performance-level': 'DW400c',
-            'threat-policy': 'threatpolicy'
+            'threat-policy': 'threatpolicy',
+            'storage-type': 'GRS'
         })
 
         # create a workspace
@@ -1558,11 +1563,12 @@ class SynapseScenarioTests(ScenarioTest):
         # create sql pool
         self.cmd(
             'az synapse sql pool create --name {sql-pool} --performance-level {performance-level} '
-            '--workspace {workspace} --resource-group {rg}', checks=[
+            '--workspace {workspace} --resource-group {rg} --storage-type {storage-type}', checks=[
                 self.check('name', self.kwargs['sql-pool']),
                 self.check('type', 'Microsoft.Synapse/workspaces/sqlPools'),
                 self.check('provisioningState', 'Succeeded'),
-                self.check('status', 'Online')
+                self.check('status', 'Online'),
+                self.check('storageAccountType', 'GRS')
             ]).get_output_in_json()
 
         self.cmd('az synapse sql pool threat-policy update --state Enabled --storage-account {storage-account} '
@@ -1754,6 +1760,7 @@ class SynapseScenarioTests(ScenarioTest):
             'eventhub_name': self.create_random_name("ehsrv", 20),
             'eventhub_namespace':  self.create_random_name("ehnamespace", 20),
             'eventhub_auth_rule': self.create_random_name("ehauthruledb", 20),
+            'storage-type': 'GRS'
         })
 
         # create a workspace
@@ -1762,11 +1769,12 @@ class SynapseScenarioTests(ScenarioTest):
         # create sql pool
         sql_pool = self.cmd(
             'az synapse sql pool create --name {sql-pool} --performance-level {performance-level} '
-            '--workspace {workspace} --resource-group {rg}', checks=[
+            '--workspace {workspace} --resource-group {rg} --storage-type {storage-type}', checks=[
                 self.check('name', self.kwargs['sql-pool']),
                 self.check('type', 'Microsoft.Synapse/workspaces/sqlPools'),
                 self.check('provisioningState', 'Succeeded'),
-                self.check('status', 'Online')
+                self.check('status', 'Online'),
+                self.check('storageAccountType', 'GRS')
             ]).get_output_in_json()
 
         self.kwargs['storage-endpoint'] = self._get_storage_endpoint(self.kwargs['storage-account'], self.kwargs['rg'])
@@ -2512,6 +2520,10 @@ class SynapseScenarioTests(ScenarioTest):
         # rerun a trigger
         self.cmd(
             'az synapse trigger-run rerun --workspace-name {workspace} --name {tumbling-window-trigger} --run-id {run-id}')
+
+        # cancel a trigger
+        self.cmd(
+            'az synapse trigger-run cancel --workspace-name {workspace} --name {tumbling-window-trigger} --run-id {run-id}')
 
         # stop a trigger
         self.cmd(


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Add "SQL pool create" and "SQL pool restore" command parameters, "SQL pool create" and "storageaccounttype" parameters, and "storageaccounttype" and "args" parameters for "SQL pool restore"
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
