### PR TITLE
{Packaging} Prioritize official package over the dist one

### DIFF
--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -83,6 +83,10 @@ setup() {
     fi
     echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ ${CLI_REPO} main" \
         > /etc/apt/sources.list.d/azure-cli.list
+    echo 'Package: azure-cli
+Pin: origin "packages.microsoft.com"
+Pin-Priority: 1001' \
+        > /etc/apt/preferences.d/azure-cli
     apt-get update
     set +v
 


### PR DESCRIPTION
**Description**
The unofficial package can have a version that is greater than
the official one, and the latest version is installed by default.

Solve by assigning the official repository high priority.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
