### PR TITLE
{RDBMS} Fix PHP wrong connection strings

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/custom.py
@@ -820,7 +820,7 @@ def get_connection_string(cmd, client, server_name='{server}', database_name='{d
             'jdbc': "jdbc:mysql://{host}:3306/{database}?user={user}@{server}&password={password}",
             'node.js': "var conn = mysql.createConnection({{host: '{host}', user: '{user}@{server}',"
                        "password: {password}, database: {database}, port: 3306}});",
-            'php': "host={host} port=3306 dbname={database} user={user}@{server} password={password}",
+            'php': "$con=mysqli_init(); [mysqli_ssl_set($con, NULL, NULL, {{ca-cert filename}}, NULL, NULL);] mysqli_real_connect($con, '{host}', '{user}@{server}', '{password}', '{database}', 3306);",
             'python': "cnx = mysql.connector.connect(user='{user}@{server}', password='{password}', host='{host}', "
                       "port=3306, database='{database}')",
             'ruby': "client = Mysql2::Client.new(username: '{user}@{server}', password: '{password}', "
@@ -873,7 +873,7 @@ def get_connection_string(cmd, client, server_name='{server}', database_name='{d
             'jdbc': "jdbc:mariadb://{host}:3306/{database}?user={user}@{server}&password={password}",
             'node.js': "var conn = mysql.createConnection({{host: '{host}', user: '{user}@{server}',"
                        "password: {password}, database: {database}, port: 3306}});",
-            'php': "host={host} port=3306 dbname={database} user={user}@{server} password={password}",
+            'php': "$con=mysqli_init(); [mysqli_ssl_set($con, NULL, NULL, {{ca-cert filename}}, NULL, NULL);] mysqli_real_connect($con, '{host}', '{user}@{server}', '{password}', '{database}', 3306);",
             'python': "cnx = mysql.connector.connect(user='{user}@{server}', password='{password}', host='{host}', "
                       "port=3306, database='{database}')",
             'ruby': "client = Mysql2::Client.new(username: '{user}@{server}', password: '{password}', "

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
@@ -611,7 +611,7 @@ def _create_mysql_connection_strings(host, user, password, database):
                        "spring.datasource.password={password}",
         'node.js': "var conn = mysql.createConnection({{host: '{host}', user: '{user}', "
                    "password: {password}, database: {database}, port: 3306}});",
-        'php': "host={host} port=3306 dbname={database} user={user} password={password}",
+        'php': "$con=mysqli_init(); [mysqli_ssl_set($con, NULL, NULL, {{ca-cert filename}}, NULL, NULL);] mysqli_real_connect($con, '{host}', '{user}', '{password}', '{database}', 3306);",
         'python': "cnx = mysql.connector.connect(user='{user}', password='{password}', host='{host}', "
                   "port=3306, database='{database}')",
         'ruby': "client = Mysql2::Client.new(username: '{user}', password: '{password}', "


### PR DESCRIPTION
Hi.


This PR fixes bug described in #20563 where connection strings outputted by `az` are wrong for mysql (and mariadb).

Indeed, before this commit, the following was outputted for PHP:

```php
host=foo-mysql-server.mysql.database.azure.com port=3306 dbname={database} user={username}@foo-mysql-server password={password}
```

Now, a connection string which permits connection is printed:

```php
$con=mysqli_init(); [mysqli_ssl_set($con, NULL, NULL, {ca-cert filename}, NULL, NULL);] mysqli_real_connect($con, 'fran92-mysql-server.mysql.database.azure.com, '{username}@fran92-mysql-server', '{password}', '{database}', 3306);
```

You can test it using the following (be sure to be logged to azure before):

```bash
$ rg="fix-php-connection-string${RANDOM}"
$ user='fix'
$ read -s password
$ server='fix-mysql-server'
$ db='fix-mysql-db'
$ ip=$(curl ifconfig.me)
$ # Use either development az or /usr/bin/az
$ az group create -l westeurope -g $rg
$ az mysql server create -l westeurope -g $rg -n $server -u $user -p $password
$ az mysql db create -g $rg -s $server -n $db
$ az mysql server firewall-rule create -g $rg -s $server -n 'firewall-rule' --start-ip-address $ip --end-ip-address $ip
$ # Force use development az
$ ./bin/python3 ./src/azure-cli/az mysql server show-connection-string -s $server -d $db -u $user -p $password -o json | jq .connectionStrings.php | jq .connectionStrings.php
"$con=mysqli_init(); [mysqli_ssl_set($con, NULL, NULL, {ca-cert filename}, NULL, NULL);] mysqli_real_connect($con, 'fix-mysql-server.mysql.database.azure.com', 'fix@fix-mysql-server', 'SuperSecretPassword1!', 'fix-mysql-db', 3306);"
$ docker run -it --rm --name my-running-script php:7.4-cli bash
# Run this inside container.
$ docker-php-ext-install mysqli && docker-php-ext-enable mysqli
$ curl https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem > cert.pem
$ php -r "$con = mysqli_init(); mysqli_ssl_set($con, NULL, NULL, 'cert.pem', NULL, NULL); mysqli_real_connect($con, 'fix-mysql-server.mysql.database.azure.com', 'fix@fix-mysql-server', 'SuperSecretPassword1!', 'fix-mysql-db', 3306); echo mysqli_get_host_info($con);"
# It should display the following:
fix-mysql-server.mysql.database.azure.com via TCP/IP
$ exit
# Outside of container
$ az groupe delete -n $rg --no-wait --yes
```

Best regards.