### PR TITLE
{Packaging} Do not add `post` to version for `release*` branches

### DIFF
--- a/scripts/release/pypi/build.sh
+++ b/scripts/release/pypi/build.sh
@@ -27,7 +27,7 @@ script_dir=`cd $(dirname $BASH_SOURCE[0]); pwd`
 # If you want to keep the version number while building, make your branch name start with 'release',
 # such as 'release-mariner'.
 
-# https://stackoverflow.com/questions/2172352/in-bash-how-can-i-check-if-a-string-begins-with-some-value
+# https://stackoverflow.com/a/2172367/2199657
 if [[ "$branch" != release* ]]; then
     . $script_dir/../../ci/version.sh post`date -u '+%Y%m%d%H%M%S'`
 fi

--- a/scripts/release/pypi/build.sh
+++ b/scripts/release/pypi/build.sh
@@ -22,7 +22,13 @@ pip list
 
 script_dir=`cd $(dirname $BASH_SOURCE[0]); pwd`
 
-if [[ "$branch" != "release" ]]; then
+# A postfix like 'post20211202065946' is added to version number, so that during tests, pip installs the built wheel.
+# https://github.com/Azure/azure-cli/pull/19079
+# If you want to keep the version number while building, make your branch name start with 'release',
+# such as 'release-mariner'.
+
+# https://stackoverflow.com/questions/2172352/in-bash-how-can-i-check-if-a-string-begins-with-some-value
+if [[ "$branch" != release* ]]; then
     . $script_dir/../../ci/version.sh post`date -u '+%Y%m%d%H%M%S'`
 fi
 


### PR DESCRIPTION
**Description**<!--Mandatory-->

Refine https://github.com/Azure/azure-cli/pull/19079.

Currently, we don't want to build Mariner RPM for `dev`, `release` branches (https://github.com/Azure/azure-cli/pull/20061). This change will allow an ad-hoc build from `release-marine` branch, without adding `postxxx` postfix to the version.

See comments for more details.
