### PR TITLE
{keyvault} Fix empty default policy when using table or tsv

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 from collections.abc import Iterable
 from azure.cli.command_modules.keyvault._validators import KeyEncryptionDataType
+from azure.cli.core._output import (get_output_format, set_output_format)
 
 
 def multi_transformers(*transformers):
@@ -19,6 +20,20 @@ def keep_max_results(output, **command_args):
     if maxresults:
         return list(output)[:maxresults]
     return output
+
+
+def force_json_output(result, **command_args):
+    if 'cmd' not in command_args:
+        return result
+
+    ctx = command_args['cmd'].cli_ctx
+
+    output_format = get_output_format(ctx)
+
+    if output_format == 'table' or output_format == 'tsv':
+        set_output_format(ctx, 'json')
+
+    return result
 
 
 def filter_out_managed_resources(output, **command_args):  # pylint: disable=unused-argument

--- a/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
@@ -12,7 +12,7 @@ from azure.cli.command_modules.keyvault._client_factory import (
     get_client, get_client_factory, Clients, is_azure_stack_profile)
 
 from azure.cli.command_modules.keyvault._transformers import (
-    extract_subresource_name, filter_out_managed_resources,
+    extract_subresource_name, force_json_output, filter_out_managed_resources,
     multi_transformers, transform_key_decryption_output, keep_max_results,
     transform_key_output, transform_key_encryption_output)
 
@@ -259,7 +259,7 @@ def load_command_table(self, _):
         g.keyvault_command('set-attributes', 'update_certificate', transform=extract_subresource_name())
         g.keyvault_custom('import', 'import_certificate', transform=extract_subresource_name())
         g.keyvault_custom('download', 'download_certificate')
-        g.keyvault_custom('get-default-policy', 'get_default_policy')
+        g.keyvault_custom('get-default-policy', 'get_default_policy', transform=force_json_output)
 
     with self.command_group('keyvault certificate pending', data_entity.command_type) as g:
         g.keyvault_command('merge', 'merge_certificate', transform=extract_subresource_name())


### PR DESCRIPTION
Hi.

This PR fixes bug described in #20589 where output is empty when using table or tsv as output mode.

So, in this PR, I detected if, for this specific subcommand, output mode is either table or tsv and force set json instead.

You can test it using the following (be sure to be logged to azure before):

```bash
$ ./bin/python3 ./src/azure-cli/az keyvault certificate get-default-policy -o table
{
  "issuerParameters": {
    "certificateTransparency": null,
    "name": "Self"
  },
  "keyProperties": {
    "curve": null,
    "exportable": true,
    "keySize": 2048,
    "keyType": "RSA",
    "reuseKey": true
  },
  "lifetimeActions": [
    {
      "action": {
        "actionType": "AutoRenew"
      },
      "trigger": {
        "daysBeforeExpiry": 90
      }
    }
  ],
  "secretProperties": {
    "contentType": "application/x-pkcs12"
  },
  "x509CertificateProperties": {
    "keyUsage": [
      "cRLSign",
      "dataEncipherment",
      "digitalSignature",
      "keyEncipherment",
      "keyAgreement",
      "keyCertSign"
    ],
    "subject": "CN=CLIGetDefaultPolicy",
    "validityInMonths": 12
  }
}
$ ./bin/python3 ./src/azure-cli/az keyvault certificate get-default-policy -o tsv
# Same output than above.
```

Best regards.