### PR TITLE
{Packaging} Fix Mariner docker file to build azure-cli rpm cleanly

### DIFF
--- a/scripts/release/rpm/Dockerfile.mariner
+++ b/scripts/release/rpm/Dockerfile.mariner
@@ -4,7 +4,7 @@ FROM cblmariner.azurecr.io/base/core:${tag} AS build-env
 ARG cli_version=dev
 
 RUN tdnf update -y
-RUN tdnf install -y rpm-build gcc libffi-devel python3-devel openssl-devel make diffutils patch dos2unix python3-virtualenv perl
+RUN tdnf install -y binutils file rpm-build gcc libffi-devel python3-devel openssl-devel make diffutils patch dos2unix python3-virtualenv perl
 
 WORKDIR /azure-cli
 


### PR DESCRIPTION
**Description**
Mariner distro `azure-cli` rpm build is showing issues and not building cleanly because of missing `binutils` and `file` packages:

- `strip` binary which is a part of `binutils` package
- `file` which is present in `file` package are used at `%__os_install_post` phase and required in Mariner image. 

Without them, CI for https://github.com/Azure/azure-cli/pull/20584 shows lots of failures:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1224670&view=logs&j=2d99a3ea-3a85-5049-e806-894016b5c578&t=51344c07-eaf5-5613-2089-f5e3d0d22243&l=732

```
+ /usr/lib/rpm/brp-strip-unneeded /bin/strip
find: 'file': No such file or directory
find: 'file': No such file or directory
find: 'file': No such file or directory
```

Adding required binutils and file packages for Mariner Docker file.

**Testing Guide**
Built locally Mariner variant of azure-cli rpm successfully with no issues.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
