### PR TITLE
{Packaging} Pin `cffi` to 1.14.6 for RPM

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -680,9 +680,6 @@ jobs:
 
 - job: BuildYumPackage
   displayName: Build Yum Package
-
-  dependsOn: BuildPythonWheel
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
   pool:
     vmImage: 'ubuntu-20.04'
   steps:

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -43,8 +43,11 @@ A great cloud needs great tools; we're excited to introduce Azure CLI,
 # Create a fully instantiated virtual environment, ready to use the CLI.
 %{python_cmd} -m venv %{buildroot}%{cli_lib_dir}
 source %{buildroot}%{cli_lib_dir}/bin/activate
-%{python_cmd} -m pip install --upgrade pip==21.0.1
+%{python_cmd} -m pip install --upgrade pip
 source %{repo_path}/scripts/install_full.sh
+
+# cffi 1.15.0 doesn't work with RPM: https://foss.heptapod.net/pypy/cffi/-/issues/513
+%{python_cmd} -m pip install cffi==1.14.6
 
 deactivate
 


### PR DESCRIPTION
## Symptom

After

- #20517

CI task **Build Rpm Package** fails when installing the built `azure-cli-dev.rpm`:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1227167&view=logs&jobId=eefb80ef-df2c-51d4-a735-8b3fa596bf12&j=eefb80ef-df2c-51d4-a735-8b3fa596bf12&t=6f9a8c49-480f-5696-065d-31253d9c4238

```
error: Failed dependencies:
	libffi-d58a691e.so.8.1.0(LIBFFI_BASE_8.0)(64bit) is needed by azure-cli-2.31.0-1.el7.x86_64
	libffi-d58a691e.so.8.1.0(LIBFFI_CLOSURE_8.0)(64bit) is needed by azure-cli-2.31.0-1.el7.x86_64
The command '/bin/sh -c rpm -i ./azure-cli-dev.rpm &&     az --version' returned a non-zero code: 1
```

Looks like what the built RPM package requires differs from what it provides.

```
# rpm --query --requires --package azure-cli-2.31.0-1.el7.x86_64.rpm
config(azure-cli) = 2.31.0-1.el7
ld-linux-x86-64.so.2()(64bit)
ld-linux-x86-64.so.2(GLIBC_2.3)(64bit)
libc.so.6()(64bit)
libc.so.6(GLIBC_2.2.5)(64bit)
libc.so.6(GLIBC_2.3)(64bit)
libc.so.6(GLIBC_2.3.2)(64bit)
libc.so.6(GLIBC_2.3.4)(64bit)
libc.so.6(GLIBC_2.4)(64bit)
libc.so.6(GLIBC_2.6)(64bit)
libc.so.6(GLIBC_2.7)(64bit)
libffi-d58a691e.so.8.1.0()(64bit)
libffi-d58a691e.so.8.1.0(LIBFFI_BASE_8.0)(64bit)
libffi-d58a691e.so.8.1.0(LIBFFI_CLOSURE_8.0)(64bit)
libpthread.so.0()(64bit)
libpthread.so.0(GLIBC_2.2.5)(64bit)
libpython3.6m.so.1.0()(64bit)
python3
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rtld(GNU_HASH)
rpmlib(PayloadIsXz) <= 5.2-1

# rpm --query --provides --package azure-cli-2.31.0-1.el7.x86_64.rpm
azure-cli = 2.31.0-1.el7
azure-cli(x86-64) = 2.31.0-1.el7
config(azure-cli) = 2.31.0-1.el7
libffi-d58a691e.so.8.1.0()(64bit)
libffi.so.8(LIBFFI_BASE_8.0)(64bit)
libffi.so.8(LIBFFI_CLOSURE_8.0)(64bit)
libffi.so.8(LIBFFI_COMPLEX_8.0)(64bit)
libffi.so.8(LIBFFI_GO_CLOSURE_8.0)(64bit)
```

(RPM man page: https://man7.org/linux/man-pages/man8/rpm.8.html)

This issue has been reported to `cffi`: https://foss.heptapod.net/pypy/cffi/-/issues/513

## Context

Some other tricky things:

- Python 3.6 will be deprecated very soon on 2021-12-23 (https://www.python.org/downloads/), but CentOS official repo currently only has Python 3.6.
- CentOS 8 will be deprecated very soon on 2021-12-31, leaving the old CentOS 7 be the only supported stable distribution (https://wiki.centos.org/About/Product).

Also see:

- https://community.home-assistant.io/t/python-support-on-centos-after-version-3-6-deprecation/146830
- https://thehackernews.com/2021/09/moving-forward-after-centos-8-eol.html

Some other resources that may be related:

- https://github.com/libffi/libffi/pull/544
- https://rpmfind.net/linux/rpm2html/search.php?query=libffi-devel
- https://rpmfind.net/linux/rpm2html/search.php?query=libffi.so.8(LIBFFI_BASE_8.0)(64bit)

## Change

Revert `cffi` to the old [1.14.6](https://pypi.org/project/cffi/1.14.6/) to unblock RPM and Mariner builds (https://github.com/Azure/azure-cli/pull/20584).

```
# pip3 install cffi==1.14.6

# find / -name libffi*
/usr/lib64/libffi.so.6.0.1
/usr/lib64/libffi.so.6
/usr/local/lib64/python3.6/site-packages/cffi.libs/libffi-c643fa1a.so.6.0.4
```
