### PR TITLE
{Core} Migrate spinner for progress bar

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/progress.py
+++ b/src/azure-cli-core/azure/cli/core/commands/progress.py
@@ -5,7 +5,7 @@
 from __future__ import division
 import sys
 
-import humanfriendly
+from humanfriendly.terminal.spinners import Spinner
 
 BAR_LEN = 70
 EMPTY_LINE = ' ' * BAR_LEN
@@ -115,7 +115,7 @@ class IndeterminateStandardOut(ProgressViewBase):
         :param args: dictionary containing key 'message'
         """
         if self.spinner is None:
-            self.spinner = humanfriendly.Spinner(  # pylint: disable=no-member
+            self.spinner = Spinner(  # pylint: disable=no-member
                 label='In Progress', stream=self.out, hide_cursor=False)
         msg = args.get('message', 'In Progress')
         try:
@@ -179,7 +179,7 @@ class IndeterminateProgressBar:
         self.message = message
         self.hook = self.cli_ctx.get_progress_controller(
             det=False,
-            spinner=humanfriendly.Spinner(  # pylint: disable=no-member
+            spinner=Spinner(  # pylint: disable=no-member
                 label='Running',
                 stream=sys.stderr,
                 hide_cursor=False))


### PR DESCRIPTION
Fix #20607

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

> DeprecationWarning: humanfriendly.Spinner was moved to humanfriendly.terminal.spinners.Spinner, please update your imports
    spinner=humanfriendly.Spinner(  # pylint: disable=no-member

Migrate spinner for progress bar to suppress the DeprecationWarning of spinner in pytest

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
